### PR TITLE
Support using SwanLab for experiment tracking

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -99,9 +99,13 @@ python3 training/main_sync_ppo.py --help
 
 We recommend using Weights & Biases (wandb) for monitoring. Run `wandb login` or set the `WANDB_API_KEY` environment variable. Set `wandb.mode=True` in your configuration to upload training statistics.
 
+Alternatively, you can use SwanLab for monitoring. Run swanlab login or set the `SWANLAB_API_KEY` environment variable. Set `swanlab.mode=True` in your configuration to upload training statistics.
+
 You can also use TensorBoard by setting the `tensorboard.path` parameter.
 
 The main log will be saved to `${fileroot}/logs/${USER}/${experiment_name}/${trial_name}/main.log` and contains the statistics uploaded to wandb.
+
+If SwanLab is enabled, logs will be saved to the directory specified by `swanlab.logdir`.
 
 ### Key Training Statistics
 

--- a/evaluation/requirements.txt
+++ b/evaluation/requirements.txt
@@ -15,3 +15,5 @@ prettytable
 timeout-decorator
 timeout_decorator
 wandb
+swanlab
+swanboard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dependencies = [
     "colorlog",
     "psutil",
     "pynvml",
+    "swanlab==0.6.2",
+    "swanboard==0.1.8b1",
     
     # Performance and compression
     "ninja",

--- a/realhf/api/cli_args.py
+++ b/realhf/api/cli_args.py
@@ -847,6 +847,15 @@ class WandBConfig:
     tags: Optional[List[str]] = None
     config: Optional[Dict] = None
 
+@dataclass
+class SwanlabConfig:
+    project: Optional[str] = None
+    name: Optional[str] = None
+    config: Optional[Dict] = None
+    logdir: Optional[str] = None
+    mode: Optional[str] = "local"
+    api_key: str = None
+
 
 @dataclass
 class TensorBoardConfig:
@@ -951,6 +960,10 @@ class BaseExperimentConfig:
         default_factory=WandBConfig,
         metadata={"help": "Weights & Biases configuration."},
     )
+    swanlab: SwanlabConfig =field(
+        default_factory=SwanlabConfig,
+        metadata={"help": "Weights & Biases configuration."},
+    )
     tensorboard: TensorBoardConfig = field(
         default_factory=TensorBoardConfig,
         metadata={"help": "TensorBoard configuration. Only 'path' field required."},
@@ -1026,7 +1039,7 @@ class BaseExperimentConfig:
         default=False,
         metadata={
             "help": "Enable automatic evaluation during training. "
-            "Results logged to disk and WandB (if active)."
+            "Results logged to disk and WandB or Swanlab(if active)."
         },
     )
     auto_eval_config: AutomaticEvaluator = field(

--- a/realhf/api/core/system_api.py
+++ b/realhf/api/core/system_api.py
@@ -13,6 +13,7 @@ from realhf.api.cli_args import (
     ExperimentSaveEvalControl,
     TensorBoardConfig,
     WandBConfig,
+    SwanlabConfig,
 )
 from realhf.api.core.config import (
     AgentAbstraction,
@@ -254,6 +255,7 @@ class ExperimentScheduling:
 class ExperimentConfig:
     exp_ctrl: ExperimentSaveEvalControl
     wandb: WandBConfig
+    swanlab: SwanlabConfig
     tensorboard: TensorBoardConfig
     # dataflow
     model_rpcs: List[dfg.MFCDef]

--- a/realhf/apps/main.py
+++ b/realhf/apps/main.py
@@ -94,7 +94,7 @@ def main_start(args, job_group_id: str = "", recover_count: int = 0):
         raise RuntimeError("Experiment initial setup failed.") from e
 
     evaluator = (
-        AutomaticEvaluator(exp_cfg.evaluator, exp_cfg.wandb)
+        AutomaticEvaluator(exp_cfg.evaluator, exp_cfg.wandb, exp_cfg.swanlab)
         if exp_cfg.auto_eval
         else None
     )

--- a/realhf/base/logging.py
+++ b/realhf/base/logging.py
@@ -142,7 +142,7 @@ def getLogger(
 
 
 _LATEST_WANDB_STEP = 0
-
+_LATEST_SWANLAB_STEP = 0
 
 def log_wandb_tensorboard(data, step=None, summary_writer=None):
     import wandb
@@ -154,6 +154,20 @@ def log_wandb_tensorboard(data, step=None, summary_writer=None):
         _LATEST_WANDB_STEP = max(_LATEST_WANDB_STEP, step)
 
     wandb.log(data, step=step)
+    if summary_writer is not None:
+        for key, val in data.items():
+            summary_writer.add_scalar(f"{key}", val, step)
+
+def log_swanlab_tensorboard(data, step=None, summary_writer=None):
+    import swanlab
+
+    global _LATEST_SWANLAB_STEP
+    if step is None:
+        step = _LATEST_SWANLAB_STEP
+    else:
+        _LATEST_SWANLAB_STEP = max(_LATEST_SWANLAB_STEP, step)
+
+    swanlab.log(data, step=step)
     if summary_writer is not None:
         for key, val in data.items():
             summary_writer.add_scalar(f"{key}", val, step)

--- a/realhf/experiments/async_exp/async_rl_exp.py
+++ b/realhf/experiments/async_exp/async_rl_exp.py
@@ -331,6 +331,7 @@ class AsyncRLExperimentConfig(CommonExperimentConfig, AsyncRLOptions):
         return ExperimentConfig(
             exp_ctrl=self.exp_ctrl,
             wandb=self.wandb,
+            swanlab=self.swanlab,
             tensorboard=self.tensorboard,
             # NOTE: master and model worker only see RPCs without generation
             model_rpcs=[

--- a/realhf/experiments/common/common.py
+++ b/realhf/experiments/common/common.py
@@ -564,6 +564,7 @@ class CommonExperimentConfig(BaseExperimentConfig, Experiment):
         return ExperimentConfig(
             exp_ctrl=self.exp_ctrl,
             wandb=self.wandb,
+            swanlab=self.swanlab,
             tensorboard=self.tensorboard,
             model_rpcs=[rpc_alloc.rpc for rpc_alloc in rpc_allocs],
             model_worker=model_worker,

--- a/realhf/experiments/common/ppo_math_exp.py
+++ b/realhf/experiments/common/ppo_math_exp.py
@@ -370,6 +370,7 @@ class PPOMATHConfig(CommonExperimentConfig, PPOMATHExperimentOptions):
         return ExperimentConfig(
             exp_ctrl=self.exp_ctrl,
             wandb=self.wandb,
+            swanlab=self.swanlab,
             tensorboard=self.tensorboard,
             model_rpcs=[rpc_alloc.rpc for rpc_alloc in rpc_allocs],
             model_worker=model_worker,

--- a/realhf/system/model_function_call.py
+++ b/realhf/system/model_function_call.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from typing import Dict, Hashable, List, Set, Tuple
 
 import wandb
+import swanlab
 from tensorboardX import SummaryWriter
 
 import realhf.api.core.config as config_api
@@ -447,6 +448,11 @@ class ModelFunctionCall:
                     step=ctrl.step_info.global_step,
                     summary_writer=self.summary_writer,
                 )
+                logging.log_swanlab_tensorboard(
+                    res,
+                    step=ctrl.step_info.global_step,
+                    summary_writer=self.summary_writer,
+                )
             elif isinstance(res, list):
                 for j, r in enumerate(res):
                     logger.info(
@@ -454,6 +460,11 @@ class ModelFunctionCall:
                     )
                     offset = len(res) * ctrl.step_info.global_step
                     logging.log_wandb_tensorboard(
+                        r,
+                        step=offset + j,
+                        summary_writer=self.summary_writer,
+                    )
+                    logging.log_swanlab_tensorboard(
                         r,
                         step=offset + j,
                         summary_writer=self.summary_writer,
@@ -469,7 +480,10 @@ class ModelFunctionCall:
             time_stats,
             summary_writer=self.summary_writer,
         )
-
+        logging.log_swanlab_tensorboard(
+            time_stats,
+            summary_writer=self.summary_writer,
+        )
         logger.info(
             f"Model rpc {rpc.name} finished. "
             f"Request-reply time {time.perf_counter() - tik:.4f}s. "

--- a/realhf/system/worker_base.py
+++ b/realhf/system/worker_base.py
@@ -580,7 +580,9 @@ class Worker:
         )
         expr_config.lazy_init()
         self.wandb_config = expr_config.wandb
+        self.swanlab_config = expr_config.swanlab
         os.environ["WANDB_MODE"] = self.wandb_config.mode
+        os.environ["SWANLAB_MODE"] = self.swanlab_config.mode
         self.tensorboard_config = expr_config.tensorboard
         config = expr_config.resolve_worker_config(
             self.__worker_type, self.__worker_index

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,3 +69,5 @@ word2number
 Pebble
 timeout-decorator
 prettytable
+swanlab==0.6.2
+swanboard==0.1.8b1

--- a/training/configs/async-ppo.yaml
+++ b/training/configs/async-ppo.yaml
@@ -14,6 +14,13 @@ wandb:
   notes: null
   tags: null
   config: null
+swanlab:
+  mode: disabled
+  api_key: null
+  project: null
+  name: null
+  config: null
+  logdir: null
 tensorboard:
   path: null
 recover_mode: auto

--- a/training/configs/sft.yaml
+++ b/training/configs/sft.yaml
@@ -14,6 +14,13 @@ wandb:
   notes: null
   tags: null
   config: null
+swanlab:
+  mode: disabled
+  api_key: null
+  project: null
+  name: null
+  config: null
+  logdir: null
 tensorboard:
   path: null
 recover_mode: auto

--- a/training/configs/sync-ppo.yaml
+++ b/training/configs/sync-ppo.yaml
@@ -14,6 +14,13 @@ wandb:
   notes: null
   tags: null
   config: null
+swanlab:
+  mode: disabled
+  api_key: null
+  project: null
+  name: null
+  config: null
+  logdir: null
 tensorboard:
   path: null
 recover_mode: auto

--- a/training/utils.py
+++ b/training/utils.py
@@ -90,6 +90,7 @@ class RayWorker:
             worker_info.experiment_name, worker_info.trial_name
         )
         self.worker.wandb_config = expr_config.wandb
+        self.worker.swanlab_config = expr_config.swanlab
         self.worker.tensorboard_config = expr_config.tensorboard
         self.logger = logging.getLogger(f"{self.worker_type} {idx}", "benchmark")
         self.logger.info(f"Configuring {self.worker_type}...")
@@ -125,6 +126,7 @@ def _run_experiment(exp_cfg, expr_name, trial_name):
     # Initialize ray in the Ray cluster
     env_vars = constants.get_env_vars(
         WADNB_MODE=exp_cfg.wandb.mode,
+        SWANLAB_MODE=exp_cfg.swanlab.mode,
         REAL_MODE="ray",
         REAL_RECOVER_RUN="0",
         REAL_SAVE_RECOVER_STATES="1",


### PR DESCRIPTION
A significant number of users are unable to access wandb due to network restrictions and are more accustomed to using the localized tool SwanLab. To improve the project's usability and local compatibility, this PR adds support for integrating with SwanLab.