### PR TITLE
Fix several syntax warning related to invalid escape sequence

### DIFF
--- a/realhf/impl/dataset/math_parser.py
+++ b/realhf/impl/dataset/math_parser.py
@@ -289,7 +289,6 @@ def strip_string(string, skip_unit=False):
 
     # remove percentage
     string = string.replace("\\%", "")
-    string = string.replace("\%", "")
     string = string.replace("%", "")
 
     # " 0." equivalent to " ." and "{0." equivalent to "{." Alternatively, add "0" if "." is the start of the string
@@ -399,7 +398,7 @@ def extract_answer(pred_str, data_name, use_last_number=True):
         pred = pred_str.split("答案是")[1].strip().split("\n\n")[0].strip()
     else:  # use the last number
         if use_last_number:
-            pattern = "-?\d*\.?\d+"
+            pattern = r"-?\d*\.?\d+"
             pred = re.findall(pattern, pred_str.replace(",", ""))
             if len(pred) >= 1:
                 pred = pred[-1]

--- a/realhf/impl/model/parallelism/tensor_parallel/modules.py
+++ b/realhf/impl/model/parallelism/tensor_parallel/modules.py
@@ -1122,7 +1122,7 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
 
         vocab_size = exp_logits.size(-1)
         if label_smoothing > 0:
-            """
+            r"""
             We'd like to assign 1 / (K - 1) probability mass to every index that is not the ground truth.
             = (1 - alpha) * y_gt + alpha * mean(y_{i for i != gt})
             = (1 - alpha) * y_gt + (alpha / (K - 1)) * \sum_{i != gt} y_i


### PR DESCRIPTION
by using raw strings or properly escaping the backslashes.

```log
AReaL/realhf/impl/dataset/math_parser.py:292: SyntaxWarning: invalid escape sequence '\%'
  string = string.replace("\%", "")
AReaL/realhf/impl/dataset/math_parser.py:402: SyntaxWarning: invalid escape sequence '\d'
  pattern = "-?\d*\.?\d+"
AReaL/realhf/impl/model/parallelism/tensor_parallel/modules.py:1125: SyntaxWarning: invalid escape sequence '\s'
```