### PR TITLE
feat: support openai-compatible rollout and add an unittest for prepare_mb_list

### DIFF
--- a/.github/workflows/test-areal-grpo.yml
+++ b/.github/workflows/test-areal-grpo.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: areal-tests-${{ github.ref }}
+  group: areal-grpo-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-areal-grpo.yml
+++ b/.github/workflows/test-areal-grpo.yml
@@ -1,0 +1,45 @@
+name: GRPO Integration Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: areal-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  grpo-integration-tests:
+    environment:
+      name: AReaL-unittests
+    permissions:
+      contents: read
+    runs-on: gpu
+    timeout-minutes: 7200
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: |
+          source examples/env/scripts/setup-pip-deps.sh
+
+      - name: Wait for 2 free GPUs
+        timeout-minutes: 7200
+        run: |
+          until [[ $(echo "$CUDA_VISIBLE_DEVICES" | tr ',' '\n' | wc -l) -ge 2 ]]; do
+            CUDA_VISIBLE_DEVICES="$(nvidia-smi --query-gpu=index,memory.free,memory.total --format=csv,noheader,nounits | awk -F',' '$2/$3 >= 0.90 {print $1}' | tr '\n' ',' | sed 's/,$//')"
+            sleep 1
+          done
+
+          echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES" >> "$GITHUB_ENV"
+
+      - name: Run GRPO integration tests
+        env:
+          CI: true
+        run: |
+          TOKENIZERS_PARALLELISM=false pytest -s -vv areal/tests/grpo/

--- a/.github/workflows/test-areal-sft.yml
+++ b/.github/workflows/test-areal-sft.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: areal-tests-${{ github.ref }}
+  group: areal-sft-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-areal-sft.yml
+++ b/.github/workflows/test-areal-sft.yml
@@ -1,4 +1,4 @@
-name: Test AReaL
+name: SFT Integration Tests
 
 on:
   pull_request:
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: areal-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test-areal:
+  sft-integration-tests:
     environment:
       name: AReaL-unittests
     permissions:
@@ -38,7 +38,8 @@ jobs:
 
           echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES" >> "$GITHUB_ENV"
 
-      - env:
+      - name: Run SFT integration tests
+        env:
           CI: true
         run: |
-          TOKENIZERS_PARALLELISM=false pytest -s -vv areal/tests
+          TOKENIZERS_PARALLELISM=false pytest -s -vv areal/tests/sft/

--- a/.github/workflows/test-areal-unit.yml
+++ b/.github/workflows/test-areal-unit.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: areal-tests-${{ github.ref }}
+  group: areal-unit-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-areal-unit.yml
+++ b/.github/workflows/test-areal-unit.yml
@@ -1,0 +1,45 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: areal-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    environment:
+      name: AReaL-unittests
+    permissions:
+      contents: read
+    runs-on: gpu
+    timeout-minutes: 7200
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: |
+          source examples/env/scripts/setup-pip-deps.sh
+
+      - name: Wait for 2 free GPUs
+        timeout-minutes: 7200
+        run: |
+          until [[ $(echo "$CUDA_VISIBLE_DEVICES" | tr ',' '\n' | wc -l) -ge 2 ]]; do
+            CUDA_VISIBLE_DEVICES="$(nvidia-smi --query-gpu=index,memory.free,memory.total --format=csv,noheader,nounits | awk -F',' '$2/$3 >= 0.90 {print $1}' | tr '\n' ',' | sed 's/,$//')"
+            sleep 1
+          done
+
+          echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES" >> "$GITHUB_ENV"
+
+      - name: Run unit tests
+        env:
+          CI: true
+        run: |
+          TOKENIZERS_PARALLELISM=false pytest -s -vv areal/tests/test_*.py

--- a/.github/workflows/test-areal.yml
+++ b/.github/workflows/test-areal.yml
@@ -41,4 +41,4 @@ jobs:
       - env:
           CI: true
         run: |
-          TOKENIZERS_PARALLELISM=true pytest -s -vv areal/tests
+          TOKENIZERS_PARALLELISM=false pytest -s -vv areal/tests

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -81,6 +81,15 @@ class GenerationHyperparameters:
             "help": "One or multiple stop words. Generation will stop if one of these words is sampled."
         },
     )
+    frequency_penalty: float = field(
+        default=0.0,
+        metadata={
+            "help": (
+                "Penalizes tokens based on their frequency in generation so far. "
+                "Must be between -2 and 2 where negative numbers encourage repeatment."
+            )
+        },
+    )
 
     def new(self, **kwargs):
         args = asdict(self)

--- a/areal/api/workflow_api.py
+++ b/areal/api/workflow_api.py
@@ -160,7 +160,6 @@ class WorkflowExecutor:
                 # Collect done results
                 for task in done:
                     traj = await task
-
                     if isinstance(traj, dict) and all(
                         isinstance(v, CompletionWithTokenLogpReward)
                         for v in traj.values()

--- a/areal/api/workflow_api.py
+++ b/areal/api/workflow_api.py
@@ -6,7 +6,7 @@ import threading
 import time
 import traceback
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import torch.distributed as dist
 import uvloop
@@ -21,6 +21,7 @@ from realhf.base import logging
 
 if TYPE_CHECKING:
     from areal.api.engine_api import InferenceEngine
+    from areal.experimental.openai.client import CompletionWithTokenLogpReward
 
 logger = logging.getLogger("areal.workflow_api")
 
@@ -32,7 +33,7 @@ class RolloutWorkflow:
 
     async def arun_episode(
         self, engine: "InferenceEngine", data: Dict[str, Any]
-    ) -> TensorDict | None:
+    ) -> Union[TensorDict, None, Dict[str, "CompletionWithTokenLogpReward"]]:
         """Run a single episode of the workflow.
 
         `None` implies that this trajectory is rejected and will not be used for training.
@@ -157,7 +158,19 @@ class WorkflowExecutor:
                 # Collect done results
                 for task in done:
                     traj = await task
-                    traj: TensorDict
+                    from areal.experimental.openai.client import (
+                        CompletionWithTokenLogpReward,
+                    )
+                    from areal.utils.data import concat_padded_tensors
+
+                    if isinstance(traj, dict) and all(
+                        isinstance(v, CompletionWithTokenLogpReward)
+                        for v in traj.values()
+                    ):
+                        traj = concat_padded_tensors(
+                            [v.to_tensor_dict() for v in traj.values()]
+                        )
+                    assert traj is None or isinstance(traj, TensorDict), traj
                     task_rid = task.get_name()
                     with self.lock:
                         rollout_tasks.pop(task_rid)

--- a/areal/api/workflow_api.py
+++ b/areal/api/workflow_api.py
@@ -188,7 +188,7 @@ class WorkflowExecutor:
                             "Output queue full. Please increase queue_size."
                         )
 
-                await asyncio.sleep(0.5)
+                await asyncio.sleep(1)
         except Exception:
             traceback.print_exc()
         finally:

--- a/areal/api/workflow_api.py
+++ b/areal/api/workflow_api.py
@@ -188,7 +188,7 @@ class WorkflowExecutor:
                             "Output queue full. Please increase queue_size."
                         )
 
-                await asyncio.sleep(1)
+                await asyncio.sleep(0.5)
         except Exception:
             traceback.print_exc()
         finally:

--- a/areal/api/workflow_api.py
+++ b/areal/api/workflow_api.py
@@ -16,12 +16,14 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from areal.api.cli_args import InferenceEngineConfig
 from areal.api.engine_api import InferenceEngine
 from areal.api.io_struct import RolloutStat
+from areal.experimental.openai.types import (
+    CompletionWithTokenLogpReward,
+)
 from areal.utils.data import concat_padded_tensors
 from realhf.base import logging
 
 if TYPE_CHECKING:
     from areal.api.engine_api import InferenceEngine
-    from areal.experimental.openai.client import CompletionWithTokenLogpReward
 
 logger = logging.getLogger("areal.workflow_api")
 
@@ -33,7 +35,7 @@ class RolloutWorkflow:
 
     async def arun_episode(
         self, engine: "InferenceEngine", data: Dict[str, Any]
-    ) -> Union[TensorDict, None, Dict[str, "CompletionWithTokenLogpReward"]]:
+    ) -> Union[TensorDict, None, Dict[str, CompletionWithTokenLogpReward]]:
         """Run a single episode of the workflow.
 
         `None` implies that this trajectory is rejected and will not be used for training.
@@ -158,10 +160,6 @@ class WorkflowExecutor:
                 # Collect done results
                 for task in done:
                     traj = await task
-                    from areal.experimental.openai.client import (
-                        CompletionWithTokenLogpReward,
-                    )
-                    from areal.utils.data import concat_padded_tensors
 
                     if isinstance(traj, dict) and all(
                         isinstance(v, CompletionWithTokenLogpReward)

--- a/areal/engine/base_hf_engine.py
+++ b/areal/engine/base_hf_engine.py
@@ -213,8 +213,10 @@ class BaseHFEngine(TrainEngine):
 
     def destroy(self):
         """Destroy the engine and release GPU memory."""
-        del self.optimizer
-        del self.model
+        if hasattr(self, "optimizer"):
+            del self.optimizer
+        if hasattr(self, "model"):
+            del self.model
         gc.collect()
         torch.cuda.empty_cache()
         gc.collect()

--- a/areal/engine/sglang_remote.py
+++ b/areal/engine/sglang_remote.py
@@ -114,6 +114,7 @@ class RemoteSGLangEngine(InferenceEngine):
             "max_new_tokens": gconfig.max_new_tokens,
             "temperature": 0.0 if gconfig.greedy else gconfig.temperature,
             "stop_token_ids": stop_token_ids,
+            "frequency_penalty": gconfig.frequency_penalty,
         }
         if stop:
             sample_params["stop"] = stop

--- a/areal/experimental/openai/__init__.py
+++ b/areal/experimental/openai/__init__.py
@@ -1,0 +1,2 @@
+from .client import ArealOpenAI  # noqa
+from .types import CompletionWithTokenLogpReward  # noqa

--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -1,0 +1,342 @@
+import os
+import time
+import uuid
+from collections import defaultdict
+from copy import deepcopy
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Tuple, Union
+
+import numpy as np
+from openai import AsyncOpenAI
+from openai._types import NOT_GIVEN, Body, NotGiven
+from openai.resources.chat.completions.completions import (
+    AsyncCompletions as BaseAsyncCompletions,
+)
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    ChatCompletionToolParam,
+)
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+from openai.types.chat.chat_completion_tool_choice_option_param import (
+    ChatCompletionToolChoiceOptionParam,
+)
+from openai.types.completion_usage import CompletionUsage
+from openai.types.shared_params.metadata import Metadata
+
+from areal.api.cli_args import GenerationHyperparameters
+from areal.api.io_struct import ModelRequest
+from areal.experimental.openai.tool_call_parser import process_tool_calls
+from areal.experimental.openai.types import CompletionWithTokenLogpReward
+
+if TYPE_CHECKING:
+    from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
+
+    from areal.api.engine_api import InferenceEngine
+
+# reset OpenAI keys when using the wrapped client.
+os.environ["OPENAI_API_KEY"] = "none"
+os.environ["OPENAI_BASE_URL"] = "none"
+
+
+class AsyncCompletionsWithReward(BaseAsyncCompletions):
+    """Extended AsyncCompletions that adds caching and reward functionality."""
+
+    # Class-level set to track which parameters have been warned about (shared across all instances)
+    _warned_parameters: Set[str] = set()
+
+    def __init__(
+        self,
+        client,
+        engine: "InferenceEngine",
+        tokenizer: "PreTrainedTokenizerFast",
+        cache: Dict[str, CompletionWithTokenLogpReward],
+        tool_call_parser: Optional[str] = None,
+    ):
+        super().__init__(client)
+        self.engine = engine
+        self.tokenizer = tokenizer
+        self.tool_call_parser = tool_call_parser
+        self._cache = cache
+
+    async def create(
+        self,
+        *,
+        messages: Iterable[ChatCompletionMessageParam],
+        frequency_penalty: Optional[float] | NotGiven = NOT_GIVEN,
+        max_completion_tokens: Optional[int] | NotGiven = NOT_GIVEN,
+        max_tokens: Optional[int] | NotGiven = NOT_GIVEN,
+        metadata: Optional[Metadata] | NotGiven = NOT_GIVEN,
+        stop: Union[Optional[str], List[str], None] | NotGiven = NOT_GIVEN,
+        store: Optional[bool] | NotGiven = NOT_GIVEN,
+        temperature: Optional[float] | NotGiven = NOT_GIVEN,
+        tool_choice: ChatCompletionToolChoiceOptionParam | NotGiven = NOT_GIVEN,
+        tools: Iterable[ChatCompletionToolParam] | NotGiven = NOT_GIVEN,
+        top_p: Optional[float] | NotGiven = NOT_GIVEN,
+        extra_body: Body | None = None,
+    ) -> ChatCompletion:
+        """Override create method to use AReaL engine and cache responses."""
+        # Extract and validate supported parameters
+        messages_list = list(messages)
+        if not messages_list:
+            raise ValueError("messages cannot be empty")
+        if extra_body is None:
+            extra_body = {}
+        # Convert messages to prompt format
+        tools = tools if tools is not NOT_GIVEN else None
+        prompt_token_ids = self.tokenizer.apply_chat_template(
+            messages_list,
+            tools=tools,
+            add_generation_prompt=True,
+            tokenize=True,
+            **extra_body.get("chat_template_kwargs", {}),
+        )
+
+        temp = 1.0 if temperature is NOT_GIVEN else (temperature or 0.0)
+        max_new_tokens = 512
+        if max_tokens is not NOT_GIVEN and max_tokens is not None:
+            max_new_tokens = max_tokens - len(prompt_token_ids)
+            if max_new_tokens <= 0:
+                raise RuntimeError(
+                    "max_tokens must be greater than the number of prompt tokens"
+                )
+        if max_completion_tokens is not NOT_GIVEN and max_completion_tokens is not None:
+            max_new_tokens = min(max_new_tokens, max_completion_tokens)
+
+        top_p_val = 1.0 if top_p is NOT_GIVEN else (top_p or 1.0)
+        stop_tokens = None if stop is NOT_GIVEN else stop
+
+        if frequency_penalty is NOT_GIVEN or frequency_penalty is None:
+            frequency_penalty = 0.0
+
+        # Create generation config
+        gconfig = GenerationHyperparameters(
+            n_samples=1,
+            temperature=temp,
+            max_new_tokens=max_new_tokens,
+            top_p=top_p_val,
+            stop=(
+                stop_tokens
+                if isinstance(stop_tokens, list)
+                else [stop_tokens] if stop_tokens else None
+            ),
+            greedy=temp == 0,
+            frequency_penalty=frequency_penalty,
+            stop_token_ids=list(
+                set([self.tokenizer.eos_token_id, self.tokenizer.pad_token_id])
+            ),
+        )
+
+        model_request = ModelRequest(
+            input_ids=prompt_token_ids,
+            gconfig=gconfig,
+            rid=str(uuid.uuid4()),
+            metadata=metadata,
+            tokenizer=self.tokenizer,
+        )
+
+        # Call inference engine
+        response = await self.engine.agenerate(model_request)
+
+        # Convert response to OpenAI format
+        completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
+        current_time = int(time.time())
+
+        output_text = self.tokenizer.decode(response.output_tokens)
+
+        # Parse tool calls.
+        tool_calls = None
+        if tool_choice != "none" and tools:
+            tool_calls, output_text, response.stop_reason = process_tool_calls(
+                output_text,
+                tools,
+                self.tool_call_parser,
+                response.stop_reason,
+            )
+
+        # Create proper ChatCompletion object with all required fields
+        chat_completion = ChatCompletion(
+            id=completion_id,
+            choices=[
+                Choice(
+                    finish_reason=response.stop_reason,
+                    index=0,
+                    logprobs=None,  # For simplicity
+                    message=ChatCompletionMessage(
+                        content=output_text,
+                        role="assistant",
+                        tool_calls=tool_calls,
+                    ),
+                )
+            ],
+            created=current_time,
+            model="None",
+            object="chat.completion",
+            service_tier=None,
+            system_fingerprint=None,
+            usage=CompletionUsage(
+                completion_tokens=len(response.output_tokens),
+                prompt_tokens=len(response.input_tokens),
+                total_tokens=len(response.input_tokens) + len(response.output_tokens),
+            ),
+        )
+
+        if store is NOT_GIVEN or store:
+            # Cache the completion with its input messages
+            self._cache[completion_id] = CompletionWithTokenLogpReward(
+                completion=deepcopy(chat_completion),
+                response=response,  # Should not deepcopy response because of tokenizer
+                messages=deepcopy(messages_list),  # Store a copy of the input messages
+            )
+        return chat_completion
+
+
+class ArealOpenAI(AsyncOpenAI):
+    """Extended AsyncOpenAI client that uses AReaL's inference engine and supports reward setting."""
+
+    def __init__(
+        self,
+        engine: "InferenceEngine",
+        tokenizer: "PreTrainedTokenizerFast",
+        tool_call_parser: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.engine = engine
+        self.tokenizer = tokenizer
+        self.tool_call_parser = tool_call_parser
+        self._completion_cache: Dict[str, CompletionWithTokenLogpReward] = {}
+
+        # Override chat.completions with our extended implementation
+        self.chat.completions = AsyncCompletionsWithReward(
+            self,
+            engine,
+            tokenizer,
+            self._completion_cache,
+            tool_call_parser=self.tool_call_parser,
+        )
+
+    def get_completions(
+        self, completion_id: str
+    ) -> Optional[CompletionWithTokenLogpReward]:
+        """Get completion with its reward from cache."""
+        return self._completion_cache.get(completion_id)
+
+    def set_reward(self, completion_id: str, reward: float) -> None:
+        """Set reward for a specific completion by its ID."""
+        if completion_id not in self._completion_cache:
+            raise KeyError(f"Completion with ID {completion_id} not found in cache")
+        self._completion_cache[completion_id].reward = reward
+
+    def export_completions(
+        self, turn_discount: float = 1.0
+    ) -> Dict[str, CompletionWithTokenLogpReward]:
+        """Export all completions with rewards after backpropagation."""
+
+        # Step 1: Build tree structure based on role prefix relationships
+        children = defaultdict(list)  # parent_id -> [child_ids]
+        parents = {}  # child_id -> parent_id
+        roots = set()  # completion_ids with no parents
+
+        # Convert messages to role sequence for easier comparison
+        def get_role_sequence(messages: List[dict]) -> Tuple[str, ...]:
+            return tuple(msg.get("role", "user") for msg in messages)
+
+        # Build role sequences for all completions
+        completion_roles = {}
+        for completion_id, completion_data in self._completion_cache.items():
+            completion_roles[completion_id] = get_role_sequence(
+                completion_data.messages
+            )
+
+        # Find parent-child relationships based on role prefix matching
+        completion_ids = list(self._completion_cache.keys())
+        for i, child_id in enumerate(completion_ids):
+            child_roles = completion_roles[child_id]
+            parent_found = False
+
+            for j, potential_parent_id in enumerate(completion_ids):
+                if i == j:
+                    continue
+                parent_roles = completion_roles[potential_parent_id]
+
+                # Check if parent_roles is a prefix of child_roles
+                if (
+                    len(parent_roles) < len(child_roles)
+                    and child_roles[: len(parent_roles)] == parent_roles
+                ):
+
+                    # Find the best parent (longest prefix)
+                    if child_id not in parents or len(parent_roles) >= len(
+                        completion_roles[parents[child_id]]
+                    ):
+                        # Remove from previous parent if exists
+                        if child_id in parents and len(parent_roles) > len(
+                            completion_roles[parents[child_id]]
+                        ):
+                            old_parent = parents[child_id]
+                            children[old_parent].remove(child_id)
+
+                        parents[child_id] = potential_parent_id
+                        children[potential_parent_id].append(child_id)
+                        parent_found = True
+
+            if not parent_found:
+                roots.add(child_id)
+
+        # Step 2: Perform topological sorting on each tree
+        def topological_sort_tree(root_id: str) -> List[str]:
+            """Perform DFS-based topological sort starting from root."""
+            visited = set()
+            stack = []
+
+            def dfs(node_id: str):
+                if node_id in visited:
+                    return
+                visited.add(node_id)
+
+                # Visit all children first (post-order)
+                for child_id in children[node_id]:
+                    dfs(child_id)
+
+                # Add current node to stack after visiting children
+                stack.append(node_id)
+
+            dfs(root_id)
+            return stack
+
+        # Get topological order for all trees
+        topo_order = []
+        for root_id in roots:
+            topo_order.extend(topological_sort_tree(root_id))
+
+        # Step 3: Backpropagate rewards from leaves to roots
+        # Process nodes in topological order (leaves first, since topological_sort_tree returns post-order)
+        for completion_id in topo_order:
+            completion_data = self._completion_cache[completion_id]
+
+            # If this is a leaf node with a reward, keep it
+            if len(children[completion_id]) == 0:
+                # This is a leaf - its reward should already be set
+                if completion_data.reward is None:
+                    completion_data.reward = 0
+                continue
+
+            # Calculate reward as discounted sum from children
+            child_rewards = [
+                self._completion_cache[child_id].reward
+                for child_id in children[completion_id]
+            ]
+            if completion_data.reward is None:
+                completion_data.reward = 0.0
+            # Find the highest level/the minimum reward
+            # Do not overwrite the existing reward if explicitly set
+            child_non_none_rewards = list(
+                filter(lambda x: x is not None, child_rewards)
+            )
+            if len(child_non_none_rewards) > 0:
+                completion_data.reward += turn_discount * np.mean(
+                    child_non_none_rewards
+                )
+
+        return self._completion_cache.copy()

--- a/areal/experimental/openai/tool_call_parser.py
+++ b/areal/experimental/openai/tool_call_parser.py
@@ -1,0 +1,55 @@
+import traceback
+import uuid
+from typing import Any, List, Optional
+
+from openai.types.chat.chat_completion_message_function_tool_call import (
+    ChatCompletionMessageFunctionToolCall,
+    Function,
+)
+
+from realhf.base import logging
+
+logger = logging.getLogger("Tool Call Parser")
+
+
+# Modified from sglang
+def process_tool_calls(
+    text: str,
+    tools: List[Any],
+    tool_call_parser: Optional[str],
+    finish_reason: str,
+) -> tuple[Optional[List[ChatCompletionMessageFunctionToolCall]], str, str]:
+    """Process tool calls in the response"""
+    from sglang.srt.entrypoints.openai.protocol import Function as SglFunction
+    from sglang.srt.entrypoints.openai.protocol import Tool as SglTool
+    from sglang.srt.function_call.function_call_parser import FunctionCallParser
+
+    tools = [
+        SglTool(type=tool["type"], function=SglFunction(**tool["function"]))
+        for tool in tools
+    ]
+
+    parser = FunctionCallParser(tools, tool_call_parser)
+    if parser.has_tool_call(text):
+        if finish_reason == "stop":
+            finish_reason = "tool_calls"
+        try:
+            text, call_info_list = parser.parse_non_stream(text)
+            tool_calls = [
+                ChatCompletionMessageFunctionToolCall(
+                    type="function",
+                    id=f"call_{uuid.uuid4().hex[:24]}",
+                    function=Function(
+                        name=call_info.name, arguments=call_info.parameters
+                    ),
+                )
+                for call_info in call_info_list
+            ]
+            return tool_calls, text, finish_reason
+        except Exception as e:
+            logger.error(f"Tool call parsing error: {e}")
+            traceback.print_exc()
+            # Return error but don't fail the whole request
+            return None, text, finish_reason
+
+    return None, text, finish_reason

--- a/areal/experimental/openai/types.py
+++ b/areal/experimental/openai/types.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import torch
+from openai.types.chat import ChatCompletion
+from tensordict import TensorDict
+
+from areal.api.io_struct import ModelResponse
+
+
+@dataclass
+class CompletionWithTokenLogpReward:
+    """Internal structure to store completion with its reward."""
+
+    completion: ChatCompletion
+    response: ModelResponse
+    messages: List[dict] = field(default_factory=list)
+    reward: Optional[float] = None
+
+    def to_tensor_dict(self) -> TensorDict:
+        resp = self.response
+        seq = resp.input_tokens + resp.output_tokens
+        logprobs = [0.0] * resp.input_len + resp.output_logprobs
+        loss_mask = [0] * resp.input_len + [1] * resp.output_len
+        versions = [-1] * resp.input_len + resp.output_versions
+        reward = self.reward
+        assert reward is not None
+        res = dict(
+            # unsqueeze to add an additional batch dimension
+            input_ids=torch.tensor(seq).unsqueeze(0),
+            loss_mask=torch.tensor(loss_mask).unsqueeze(0),
+            logprobs=torch.tensor(logprobs).unsqueeze(0),
+            versions=torch.tensor(versions).unsqueeze(0),
+            attention_mask=torch.ones(len(seq), dtype=torch.bool).unsqueeze(0),
+            # reward
+            rewards=torch.tensor([float(reward)]),
+        )
+        return TensorDict(res, batch_size=[1])

--- a/areal/experimental/tests/test_openai.py
+++ b/areal/experimental/tests/test_openai.py
@@ -1,0 +1,660 @@
+# This file tests the functionality of our customized OpenAI client.
+# The client should be able to generate completions and correctly assign rewards with back-propagation.
+import asyncio
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+import requests
+
+from areal.api.cli_args import SGLangConfig
+from areal.experimental.openai import ArealOpenAI
+from areal.utils import network
+from realhf.api.core.data_api import load_hf_tokenizer
+
+EXPR_NAME = "test_openai"
+TRIAL_NAME = "trial_0"
+MODEL_PATH = "/storage/testing/models/Qwen__Qwen3-1.7B/"
+if not os.path.exists(MODEL_PATH):
+    MODEL_PATH = "Qwen/Qwen2-0.5B"
+PORT, DIST_PORT = network.find_free_ports(2)
+HOST = network.gethostip()
+# set a large timeout since we may need to download the model from hub
+RUN_SERVER_TIMEOUT = 180
+
+
+def check_server_health(base_url):
+    try:
+        response = requests.get(f"{base_url}/health", timeout=30)
+        return response.status_code == 200
+    except requests.exceptions.RequestException as e:
+        return False
+
+
+@pytest.fixture(scope="module")
+def sglang_server():
+    from realhf.base import seeding
+
+    seeding.set_random_seed(1, EXPR_NAME)
+    cmd = SGLangConfig.build_cmd(
+        sglang_config=SGLangConfig(
+            skip_tokenizer_init=True,
+            model_path=MODEL_PATH,
+            mem_fraction_static=0.3,
+        ),
+        host=HOST,
+        port=PORT,
+        tp_size=1,
+        base_gpu_id=0,
+        dist_init_addr=f"{HOST}:{DIST_PORT}",
+    )
+    # Launch process
+    cmd = cmd.replace("\\\n", " ").replace("\\", " ")
+    process = subprocess.Popen(
+        cmd.split(),
+        text=True,
+        stdout=sys.stdout,
+        stderr=sys.stdout,
+    )
+    base_url = f"http://{HOST}:{PORT}"
+    tik = time.time()
+    while time.time() - tik < RUN_SERVER_TIMEOUT:
+        if check_server_health(base_url):
+            break
+        time.sleep(1)
+    if time.time() - tik > RUN_SERVER_TIMEOUT:
+        raise RuntimeError("server launch failed")
+    yield
+    process.terminate()
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    return load_hf_tokenizer(MODEL_PATH)
+
+
+@pytest.fixture
+def openai_client(sglang_server, tokenizer):
+    from areal.api.cli_args import InferenceEngineConfig
+    from areal.engine.sglang_remote import RemoteSGLangEngine
+
+    config = InferenceEngineConfig(
+        experiment_name=EXPR_NAME,
+        trial_name=TRIAL_NAME,
+        max_concurrent_rollouts=2,
+        consumer_batch_size=2,
+    )
+    os.environ["AREAL_LLM_SERVER_ADDRS"] = f"{HOST}:{PORT}"
+    engine = RemoteSGLangEngine(config)
+    engine.initialize(None, None)
+    yield ArealOpenAI(engine=engine, tokenizer=tokenizer, tool_call_parser="qwen25")
+    engine.destroy()
+
+
+@pytest.mark.asyncio
+async def test_single_turn_rollout(openai_client):
+    c = await openai_client.chat.completions.create(
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"},
+        ]
+    )
+    openai_client.set_reward(c.id, reward=0.5)
+    completions = openai_client.export_completions()
+    assert len(completions) == 1
+    assert completions[c.id].reward == 0.5
+
+
+@pytest.mark.asyncio
+async def test_multi_round_conversation(openai_client):
+    """Test multi-round conversation with reward backpropagation."""
+    # Round 1
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What is the capital of France?"},
+    ]
+    c1 = await openai_client.chat.completions.create(messages=messages)
+
+    # Round 2 - extends the conversation
+    messages += [
+        {"role": "assistant", "content": c1.choices[0].message.content},
+        {"role": "user", "content": "What about Germany?"},
+    ]
+    c2 = await openai_client.chat.completions.create(messages=messages)
+
+    # Round 3 - further extends the conversation
+    messages += [
+        {"role": "assistant", "content": c2.choices[0].message.content},
+        {"role": "user", "content": "And Italy?"},
+    ]
+    c3 = await openai_client.chat.completions.create(messages=messages)
+
+    # Set rewards - only the final completion gets explicit reward
+    openai_client.set_reward(c3.id, reward=2.0)
+
+    # Export completions with reward backpropagation
+    completions = openai_client.export_completions(turn_discount=0.9)
+
+    # Verify structure
+    assert len(completions) == 3
+
+    # Verify reward backpropagation: c3 is leaf,
+    # c2 gets discounted reward from c3, c1 gets discounted reward from c2
+    assert completions[c3.id].reward == 2.0
+    assert completions[c2.id].reward == 0.9 * 2.0  # discounted from c3
+    assert completions[c1.id].reward == 0.9 * (0.9 * 2.0)  # discounted from c2
+
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather in a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA",
+                    },
+                    "unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                        "description": "Temperature unit",
+                    },
+                },
+                "required": ["location"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "calculate",
+            "description": "Perform basic arithmetic calculations",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {
+                        "type": "string",
+                        "description": "Mathematical expression to evaluate, e.g. '2 + 2'",
+                    }
+                },
+                "required": ["expression"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_fact",
+            "description": "Get an interesting fact about a number",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "type": "integer",
+                        "description": "The number to get a fact about",
+                    }
+                },
+                "required": ["number"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_time",
+            "description": "Get current time in a timezone",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "timezone": {
+                        "type": "string",
+                        "description": "Timezone, e.g. 'America/New_York'",
+                    },
+                },
+                "required": ["timezone"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "translate",
+            "description": "Translate text to another language",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string", "description": "Text to translate"},
+                    "target_language": {
+                        "type": "string",
+                        "description": "Target language code",
+                    },
+                },
+                "required": ["text", "target_language"],
+            },
+        },
+    },
+]
+
+
+@pytest.mark.asyncio
+async def test_single_round_tool_calling(openai_client):
+    """Test single-round conversation with tool calling."""
+
+    c = await openai_client.chat.completions.create(
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a helpful assistant with access to weather information.",
+            },
+            {"role": "user", "content": "What's the weather like in San Francisco?"},
+        ],
+        tools=tools,
+        tool_choice="auto",
+    )
+
+    # Check if tool call was made (might depend on model capability)
+    assert c.id is not None
+    assert c.choices[0].message.role == "assistant"
+    assert c.choices[0].message.tool_calls is not None
+    assert c.choices[0].finish_reason == "tool_calls"
+
+    openai_client.set_reward(c.id, reward=1.5)
+    completions = openai_client.export_completions()
+
+    assert len(completions) == 1
+    assert completions[c.id].reward == 1.5
+
+
+@pytest.mark.asyncio
+async def test_multi_round_tool_calling(openai_client):
+    """Test multi-round conversation with tool calling across rounds."""
+
+    # Round 1 - Initial tool call request
+    c1 = await openai_client.chat.completions.create(
+        messages=[
+            {"role": "system", "content": "You are a helpful calculator assistant."},
+            {"role": "user", "content": "Calculate 15 * 7"},
+        ],
+        tools=tools,
+        tool_choice="auto",
+    )
+
+    # Simulate tool call response
+    tool_response = "105"
+
+    # Round 2 - Continue with tool result and new request
+    c2 = await openai_client.chat.completions.create(
+        messages=[
+            {"role": "system", "content": "You are a helpful calculator assistant."},
+            {"role": "user", "content": "Calculate 15 * 7"},
+            {"role": "assistant", "content": c1.choices[0].message.content},
+            {"role": "tool", "content": tool_response, "tool_call_id": "mock_call_id"},
+            {
+                "role": "user",
+                "content": "Now get an interesting fact about this number",
+            },
+        ],
+        tools=tools,
+        tool_choice="auto",
+    )
+
+    # Round 3 - Final response with fact
+    c3 = await openai_client.chat.completions.create(
+        messages=[
+            {"role": "system", "content": "You are a helpful calculator assistant."},
+            {"role": "user", "content": "Calculate 15 * 7"},
+            {"role": "assistant", "content": c1.choices[0].message.content},
+            {"role": "tool", "content": tool_response, "tool_call_id": "mock_call_id"},
+            {
+                "role": "user",
+                "content": "Now get an interesting fact about this number",
+            },
+            {"role": "assistant", "content": c2.choices[0].message.content},
+            {
+                "role": "tool",
+                "content": "105 is divisible by 3, 5, 7, 15, 21, and 35!",
+                "tool_call_id": "mock_call_id_2",
+            },
+            {"role": "user", "content": "Thank you!"},
+        ]
+    )
+
+    # Set rewards
+    openai_client.set_reward(c2.id, reward=1.0)
+    openai_client.set_reward(c3.id, reward=2.0)
+
+    completions = openai_client.export_completions(turn_discount=0.8)
+
+    assert len(completions) == 3
+    # c3 is leaf: gets explicit reward
+    assert completions[c3.id].reward == 2.0
+    # c2 gets explicit reward + discounted reward from c3
+    assert completions[c2.id].reward == 1.0 + 0.8 * 2.0
+    # c1 gets discounted reward from c2
+    assert completions[c1.id].reward == 0.8 * (1.0 + 0.8 * 2.0)
+
+
+@pytest.mark.asyncio
+async def test_parallel_tool_calling(openai_client):
+    """Test parallel tool calling within a single round."""
+
+    # Single request that could trigger multiple tool calls
+    c1 = await openai_client.chat.completions.create(
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a helpful assistant that can check weather, time, and translate text.",
+            },
+            {
+                "role": "user",
+                "content": "I need you to check the weather in Tokyo, get the current time in Japan, and translate 'hello world' to Japanese. Please do all of these.",
+            },
+        ],
+        tools=tools,
+        tool_choice="auto",
+    )
+
+    # Check the response structure
+    assert c1.id is not None
+    assert c1.choices[0].message.role == "assistant"
+
+    # Even if parallel tool calling isn't supported by the model,
+    # we can test the caching and reward system
+    openai_client.set_reward(c1.id, reward=3.0)
+
+    # Test with tool responses in follow-up
+    c2 = await openai_client.chat.completions.create(
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a helpful assistant that can check weather, time, and translate text.",
+            },
+            {
+                "role": "user",
+                "content": "I need you to check the weather in Tokyo, get the current time in Japan, and translate 'hello world' to Japanese. Please do all of these.",
+            },
+            {"role": "assistant", "content": c1.choices[0].message.content},
+            {"role": "tool", "content": "Sunny, 25°C", "tool_call_id": "weather_call"},
+            {"role": "tool", "content": "14:30 JST", "tool_call_id": "time_call"},
+            {
+                "role": "tool",
+                "content": "こんにちは世界",
+                "tool_call_id": "translate_call",
+            },
+            {"role": "user", "content": "Perfect, thank you!"},
+        ]
+    )
+
+    openai_client.set_reward(c2.id, reward=2.0)
+
+    completions = openai_client.export_completions(turn_discount=0.9)
+
+    assert len(completions) == 2
+    # c2 is leaf
+    assert completions[c2.id].reward == 2.0
+    # c1 gets explicit reward + discounted reward from c2
+    assert completions[c1.id].reward == 3.0 + 0.9 * 2.0
+
+
+def strip_thinking_tags(content: str) -> str:
+    """Remove thinking tags and their content from a message."""
+    import re
+
+    # Remove <think>...</think> blocks (including multi-line)
+    pattern = r"<think>.*?</think>"
+    cleaned = re.sub(pattern, "", content, flags=re.DOTALL)
+    # Clean up extra whitespace
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned
+
+
+@pytest.mark.asyncio
+async def test_multi_round_conversation_with_thinking(openai_client):
+    """Test multi-round conversation where thinking content is excluded from subsequent rounds."""
+
+    # Round 1 - Model generates response with thinking
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful assistant. Use <think></think> tags for your internal thoughts.",
+        },
+        {"role": "user", "content": "What is 15 * 24? Please think step-by-step."},
+    ]
+    c1 = await openai_client.chat.completions.create(messages=messages, max_tokens=1024)
+
+    # Round 2 - Strip thinking from previous response
+    cleaned_assistant_content = strip_thinking_tags(c1.choices[0].message.content)
+    messages += [
+        {"role": "assistant", "content": cleaned_assistant_content},
+        {
+            "role": "user",
+            "content": "Now what is 360 divided by 12? Please think step-by-step.",
+        },
+    ]
+    c2 = await openai_client.chat.completions.create(messages=messages, max_tokens=1024)
+
+    # Round 3 - Continue conversation, stripping thinking from previous response
+    cleaned_assistant_content_2 = strip_thinking_tags(c2.choices[0].message.content)
+    messages += [
+        {"role": "assistant", "content": cleaned_assistant_content_2},
+        {
+            "role": "user",
+            "content": "Great! Can you explain why division by 12 gave us 30?  Please think step-by-step.",
+        },
+    ]
+    c3 = await openai_client.chat.completions.create(messages=messages, max_tokens=1024)
+
+    # Verify conversation history
+    stored_messages_c2 = openai_client.get_completions(c2.id).messages
+    stored_messages_c3 = openai_client.get_completions(c3.id).messages
+
+    # Verify thinking tags are stripped from assistant messages
+    for msg_list in [stored_messages_c2, stored_messages_c3]:
+        for msg in msg_list:
+            if msg.get("role") == "assistant":
+                content = msg.get("content", "")
+                assert "<think>" not in content
+                assert "</think>" not in content
+
+    # Test reward system
+    openai_client.set_reward(c2.id, reward=1.5)
+    openai_client.set_reward(c3.id, reward=2.5)
+
+    completions = openai_client.export_completions(turn_discount=0.85)
+
+    assert len(completions) == 3
+    # c3 is leaf
+    assert completions[c3.id].reward == 2.5
+    # c2 gets explicit reward + discounted reward from c3
+    assert completions[c2.id].reward == 1.5 + 0.85 * 2.5
+    # c1 gets discounted reward from c2
+    assert completions[c1.id].reward == 0.85 * (1.5 + 0.85 * 2.5)
+
+
+@pytest.mark.asyncio
+async def test_multi_round_conversation_with_thinking_and_tool_calling(openai_client):
+    """Test multi-round conversation with both thinking and tool calling, ensuring thinking is stripped but tool calls are preserved."""
+
+    # Round 1 - Model thinks before making a tool call
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful assistant with calculation abilities. Use <think></think> tags for your internal thoughts.",
+        },
+        {
+            "role": "user",
+            "content": "I need to calculate the area of a rectangle that is 25 meters long and 18 meters wide. Please think step-by-step.",
+        },
+    ]
+    c1 = await openai_client.chat.completions.create(
+        messages=messages, tools=tools, tool_choice="auto", max_tokens=1024
+    )
+
+    # Round 2 - Provide tool result and ask follow-up, stripping thinking from previous response
+    cleaned_content_1 = strip_thinking_tags(c1.choices[0].message.content)
+    messages += [
+        {
+            "role": "assistant",
+            "content": cleaned_content_1,
+            "tool_calls": c1.choices[0].message.tool_calls,
+        },
+        {"role": "tool", "content": "450", "tool_call_id": "calc_call_1"},
+        {
+            "role": "user",
+            "content": "Perfect! Now what if I want to carpet this room and carpet costs $15 per square meter? Please think step-by-step.",
+        },
+    ]
+    c2 = await openai_client.chat.completions.create(
+        messages=messages, tools=tools, tool_choice="auto", max_tokens=1024
+    )
+
+    # Round 3 - Continue with tool result
+    cleaned_content_2 = strip_thinking_tags(c2.choices[0].message.content)
+    messages += [
+        {
+            "role": "assistant",
+            "content": cleaned_content_2,
+            "tool_calls": c2.choices[0].message.tool_calls,
+        },
+        {"role": "tool", "content": "6750", "tool_call_id": "calc_call_2"},
+        {
+            "role": "user",
+            "content": "That's quite expensive! What would be the cost per square foot instead?  Please think step-by-step.",
+        },
+    ]
+    c3 = await openai_client.chat.completions.create(messages=messages, max_tokens=1024)
+
+    # Verify conversation history
+    stored_messages_c2 = openai_client.get_completions(c2.id).messages
+    stored_messages_c3 = openai_client.get_completions(c3.id).messages
+
+    # Verify thinking tags are stripped from assistant messages
+    for msg_list in [stored_messages_c2, stored_messages_c3]:
+        for msg in msg_list:
+            if msg.get("role") == "assistant":
+                content = msg.get("content", "")
+                assert "<think>" not in content
+                assert "</think>" not in content
+
+    # Verify tool calls are preserved (check that tool messages exist in history)
+    tool_messages_found = False
+    for msg in stored_messages_c3:
+        if msg.get("role") == "tool":
+            tool_messages_found = True
+            break
+    assert (
+        tool_messages_found
+    ), "Tool messages should be preserved in conversation history"
+
+    # Test reward system with thinking + tool calling
+    openai_client.set_reward(c1.id, reward=1.0)
+    openai_client.set_reward(c2.id, reward=2.0)
+    openai_client.set_reward(c3.id, reward=1.5)
+
+    completions = openai_client.export_completions(turn_discount=0.9)
+
+    assert len(completions) == 3
+    # c3 is leaf
+    assert completions[c3.id].reward == 1.5  # 1.5 + 0.8
+    # c2 gets explicit reward + discounted reward from c3
+    assert completions[c2.id].reward == 2.0 + 0.9 * 1.5
+    # c1 gets explicit reward + discounted reward from c2
+    assert completions[c1.id].reward == 1.0 + 0.9 * (2.0 + 0.9 * 1.5)
+
+
+@pytest.mark.asyncio
+async def test_parallel_responses_with_merged_results(openai_client):
+    """Test collecting parallel LLM responses with same history but different questions, then merging them."""
+
+    # Base conversation history
+    base_messages = [
+        {"role": "system", "content": "You are a helpful research assistant."},
+        {
+            "role": "user",
+            "content": "I'm planning a trip to Japan. Can you help me with some information?",
+        },
+    ]
+
+    c0 = await openai_client.chat.completions.create(messages=base_messages)
+
+    base_messages = base_messages + [
+        {
+            "role": "assistant",
+            "content": "I'd be happy to help you plan your trip to Japan! What specific information would you like to know?",
+        }
+    ]
+
+    # Different parallel questions about the trip
+    parallel_questions = [
+        "What are the best months to visit for cherry blossoms?",
+        "What are some must-try traditional Japanese foods?",
+        "What cultural etiquette should I be aware of?",
+        "What are the most popular tourist destinations?",
+    ]
+
+    # Create parallel completion tasks with the same history but different questions
+    async def create_completion_with_question(question):
+        messages = base_messages + [{"role": "user", "content": question}]
+        return await openai_client.chat.completions.create(
+            messages=messages, max_tokens=128
+        )
+
+    # Execute all completions in parallel
+    parallel_tasks = [create_completion_with_question(q) for q in parallel_questions]
+    parallel_completions = await asyncio.gather(*parallel_tasks)
+
+    # Verify we got responses for all questions
+    assert len(parallel_completions) == 4
+    for i, completion in enumerate(parallel_completions):
+        assert completion.id is not None
+        assert completion.choices[0].message.role == "assistant"
+        assert len(completion.choices[0].message.content) > 0
+        # Set individual rewards for each parallel response
+        openai_client.set_reward(completion.id, reward=1.0 + i * 0.5)
+
+    # Now create a final completion that merges the insights from parallel responses
+    merged_messages = base_messages
+    for q, c in zip(parallel_questions, parallel_completions):
+        merged_messages += [
+            {"role": "user", "content": q},
+            {"role": "assistant", "content": c.choices[0].message.content},
+        ]
+    merged_messages = merged_messages + [
+        {
+            "role": "user",
+            "content": "Based on all the information about visiting Japan, please provide a comprehensive summary covering: cherry blossom timing, food recommendations, cultural etiquette, and top destinations.",
+        }
+    ]
+
+    final_completion = await openai_client.chat.completions.create(
+        messages=merged_messages, temperature=0.3, max_tokens=4096
+    )
+
+    # Set reward for the final merged response
+    openai_client.set_reward(final_completion.id, reward=3.0)
+
+    # Export completions to verify the reward structure
+    completions = openai_client.export_completions(turn_discount=0.8)
+
+    # Verify we have all completions (1 base + 4 parallel + 1 final)
+    assert len(completions) == 6
+
+    # Verify final completion gets its reward + final reward
+    assert completions[final_completion.id].reward == 3.0  # 3.0 + 2.0
+
+    # Verify parallel completions have their individual rewards + final reward
+    expected_rewards = [1.0, 1.5, 2.0, 2.5]  # individual rewards
+    r = 0.0
+    for i, completion in enumerate(parallel_completions):
+        assert completions[completion.id].reward == expected_rewards[i] + 3.0 * 0.8
+        r += completions[completion.id].reward
+
+    assert completions[c0.id].reward == 0.8 * r / len(
+        parallel_completions
+    )  # discounted from final completion

--- a/areal/experimental/workflow/multi_turn_v2.py
+++ b/areal/experimental/workflow/multi_turn_v2.py
@@ -1,0 +1,143 @@
+import asyncio
+import os
+import uuid
+from copy import deepcopy
+
+import aiofiles
+import aiofiles.os
+import colorama
+from transformers import PreTrainedTokenizerFast
+
+from areal.api.cli_args import GenerationHyperparameters
+from areal.api.engine_api import InferenceEngine
+from areal.api.reward_api import AsyncRewardWrapper
+from areal.api.workflow_api import RolloutWorkflow
+from areal.experimental.openai import ArealOpenAI
+from realhf.base import logging, stats_tracker
+
+logger = logging.getLogger("Multi-Turn workflow")
+
+
+class MultiTurnWorkflow(RolloutWorkflow):
+    def __init__(
+        self,
+        reward_fn,
+        gconfig: GenerationHyperparameters,
+        tokenizer: PreTrainedTokenizerFast,
+        max_turns: int,
+        turn_discount: float,
+        rollout_stat_scope: str = "rollout",
+        dump_dir: str | None = None,
+    ):
+        self.reward_fn = reward_fn
+        self.gconfig = gconfig
+        self.tokenizer = tokenizer
+        self.max_turns = max_turns
+        self.turn_discount = turn_discount
+        self.async_reward_fn = AsyncRewardWrapper(reward_fn)
+        self.dump_dir = dump_dir
+        self.rollout_stat_scope = rollout_stat_scope
+        if self.dump_dir is not None and not os.path.exists(self.dump_dir):
+            os.makedirs(self.dump_dir, exist_ok=True)
+
+        self.reflection_msg = [
+            {
+                "role": "user",
+                "content": "Your answer is either wrong or not parsable to the reward function. You may misunderstand the original question. "
+                "Please carefully read the original question, check the preivous errors, and try to answer it again.",
+            }
+        ]
+
+    async def _run_one_episode(self, engine: InferenceEngine, data, rid):
+        client = ArealOpenAI(engine=engine, tokenizer=self.tokenizer)
+        messages = deepcopy(data["messages"])
+        # Run multi-turn rollout until correct
+        t = reward = 0
+        discount = 1
+        while reward == 0 and t < self.max_turns:
+            # Send generate request to get the response.
+            _comp = await client.chat.completions.create(
+                messages=messages,
+                frequency_penalty=self.gconfig.frequency_penalty,
+                max_completion_tokens=self.gconfig.max_new_tokens,
+                stop=self.gconfig.stop,
+                store=True,
+                temperature=self.gconfig.temperature,
+                top_p=self.gconfig.top_p,
+            )
+            # _comp is an openai ChatCompletion object
+            # but we also need to fetch the saved token IDs
+            comp = client.get_completions(_comp.id)
+            reward = await self.async_reward_fn(
+                self.tokenizer.apply_chat_template(
+                    messages, tokenize=False, add_generation_prompt=True
+                ),
+                _comp.choices[0].message.content,
+                comp.response.input_tokens,
+                comp.response.output_tokens,
+                **data,
+            )
+            # Increase counter
+            t += 1
+            # Amend a prompt if the previous answer is incorrect
+            if reward == 0 and t < self.max_turns:
+                messages += [
+                    {
+                        "role": "assistant",
+                        "content": _comp.choices[0].message.content,
+                    }
+                ]
+                messages += self.reflection_msg
+                discount *= self.turn_discount
+
+        reward = float(reward * discount)
+
+        # Log reward.
+        stats_tracker.get(self.rollout_stat_scope).scalar(reward=reward, num_turns=t)
+
+        client.set_reward(_comp.id, reward)
+        return client.export_completions(turn_discount=0.0), comp
+
+    async def arun_episode(self, engine: InferenceEngine, data):
+        rid = uuid.uuid4().hex
+        tasks = [
+            self._run_one_episode(engine, data, rid)
+            for _ in range(self.gconfig.n_samples)
+        ]
+        results = await asyncio.gather(*tasks)
+
+        if self.dump_dir is not None:
+            version = engine.get_version()
+            dump_path = os.path.join(self.dump_dir, str(version))
+            await aiofiles.os.makedirs(dump_path, exist_ok=True)
+            # Get the unique identifier for this prompt
+            qid = None
+            for key in ["query_id", "id", "qid"]:
+                qid = data.get(key, None)
+                if qid is not None:
+                    break
+            qid = qid or uuid.uuid4().hex
+
+            # Dump rollout to file
+            file_path = os.path.join(dump_path, f"{qid}.txt")
+            async with aiofiles.open(file_path, "a") as f:
+                n_samples = self.gconfig.n_samples
+                for i, (_, comp) in enumerate(results):
+                    sl = comp.response.input_len + comp.response.output_len
+                    r = comp.reward
+                    p = comp.messages
+                    c = comp.completion.choices[0].message.content
+                    info = "\n".join(
+                        [
+                            f"idx: {i + 1} / {n_samples}, seqlen: {sl}, reward is {r}.",
+                            f"prompt is \n{colorama.Fore.YELLOW + colorama.Style.DIM}{p}{colorama.Style.RESET_ALL}",
+                            f"sequence is: \n{colorama.Fore.YELLOW + colorama.Style.DIM}{c}{colorama.Style.RESET_ALL}",
+                        ]
+                    )
+                    await f.write(info + "\n")
+
+        data = [res[0] for res in results]
+        ret = {}
+        for d in data:
+            ret.update(d)
+        return ret

--- a/areal/tests/test_packed_vs_padded_consistency.py
+++ b/areal/tests/test_packed_vs_padded_consistency.py
@@ -105,7 +105,7 @@ VISION_H = 336
 
 QWEN25_VL_PATH = "/storage/openpsi/models/Qwen2.5-VL-3B-Instruct"
 if not os.path.exists(QWEN25_VL_PATH):
-    QWEN25_VL_PATH = "Qwen2.5-VL-3B-Instruct"
+    QWEN25_VL_PATH = "Qwen/Qwen2.5-VL-3B-Instruct"
 
 
 @pytest.fixture(params=[QWEN25_VL_PATH])

--- a/areal/tests/test_packed_vs_padded_consistency.py
+++ b/areal/tests/test_packed_vs_padded_consistency.py
@@ -1,0 +1,207 @@
+import os
+
+import pytest
+import torch
+from tensordict import TensorDict
+from torch.testing import assert_close
+
+from areal.api.cli_args import TrainEngineConfig
+from areal.engine.base_hf_engine import BaseHFEngine
+from areal.utils.data import concat_padded_tensors
+from areal.utils.network import find_free_ports
+from realhf.api.core.data_api import load_hf_processor_and_tokenizer
+
+BS = 4
+MAX_ANSWER_LEN = 16
+MAX_PROMPT_LEN = 8
+VOCAB_SIZE = 100
+
+
+@pytest.fixture
+def mock_padded_llm_data():
+    """Generate mock padded input data."""
+    prompt_lens = torch.randint(1, MAX_PROMPT_LEN, size=(BS,))
+    answer_lens = torch.randint(1, MAX_ANSWER_LEN, size=(BS,))
+    all_data = []
+
+    for prompt_len, ans_len in zip(prompt_lens, answer_lens):
+        prompt_len = int(prompt_len)
+        ans_len = int(ans_len)
+        seq = dict(
+            input_ids=torch.randint(
+                0, VOCAB_SIZE, size=(prompt_len + ans_len,)
+            ).unsqueeze(0),
+            loss_mask=torch.tensor([0] * prompt_len + [1] * ans_len).unsqueeze(0),
+            attention_mask=torch.tensor([1] * (prompt_len + ans_len)).unsqueeze(0),
+        )
+        all_data.append(TensorDict(seq, batch_size=[1]))
+
+    return concat_padded_tensors(all_data).cuda()
+
+
+QWEN3_PATH = "/storage/testing/models/Qwen__Qwen3-1.7B/"
+if not os.path.exists(QWEN3_PATH):
+    QWEN3_PATH = "Qwen/Qwen3-1.7B"
+QWEN25_PATH = "/storage/openpsi/models/Qwen__Qwen2.5-1.5B/"
+if not os.path.exists(QWEN25_PATH):
+    QWEN25_PATH = "Qwen/Qwen2.5-1.5B"
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    [QWEN3_PATH, QWEN25_PATH],
+)
+def test_llm_consistency(model_path, mock_padded_llm_data):
+    os.environ["RANK"] = str(0)
+    os.environ["WORLD_SIZE"] = str(1)
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(find_free_ports(1)[0])
+    os.environ["LOCAL_RANK"] = str(0)
+
+    config = TrainEngineConfig(
+        path=model_path,
+        dtype="bfloat16",
+        attn_impl="flash_attention_2",
+        gradient_checkpointing=False,
+        disable_dropout=True,
+        init_from_scratch=True,
+        optimizer=None,
+    )
+    engine = BaseHFEngine(config)
+    engine.create_process_group()
+    engine.create_device_model()
+    engine.initialized = True
+
+    # Prepare padded input
+    padded_input = mock_padded_llm_data.clone()
+
+    # Get packed input using prepare_mb_list
+    mb_list = engine.prepare_mb_list(padded_input)
+    assert len(mb_list.mbs) == 1
+
+    with torch.no_grad():
+        padded_logits = engine.model(
+            input_ids=padded_input["input_ids"],
+            attention_mask=padded_input["attention_mask"],
+            position_ids=padded_input["position_ids"],
+        ).logits
+        seqlens = padded_input["attention_mask"].sum(1)
+        x1 = []
+        for i, s in enumerate(seqlens):
+            x1.append(padded_logits[i, :s])
+        x1 = torch.cat(x1)
+
+        mb = mb_list.padded_mbs[0]
+        pad_len = mb_list.padding_lengths[0]
+        x2 = engine.model(**mb).logits.squeeze(0)[:-pad_len]
+
+        assert x1.shape == x2.shape, (x1.shape, x2.shape)
+
+        assert_close(x1, x2, atol=2e-1, rtol=2e-1)
+
+
+VISION_W = 336
+VISION_H = 336
+
+QWEN25_VL_PATH = "/storage/openpsi/models/Qwen2.5-VL-3B-Instruct"
+if not os.path.exists(QWEN25_VL_PATH):
+    QWEN25_VL_PATH = "Qwen2.5-VL-3B-Instruct"
+
+
+@pytest.fixture(params=[QWEN25_VL_PATH])
+def mock_padded_vlm_data(request):
+    model_path = request.param
+    # TODO: create mock vlm image data
+    prompt_lens = torch.randint(1, MAX_PROMPT_LEN, size=(BS,))
+    answer_lens = torch.randint(1, MAX_ANSWER_LEN, size=(BS,))
+
+    all_data = []
+
+    processor, tokenizer = load_hf_processor_and_tokenizer(model_path)
+
+    for prompt_len, ans_len in zip(prompt_lens, answer_lens):
+
+        image = torch.randint(0, 255, size=(1, 3, VISION_H, VISION_W)).float() / 255.0
+        image_token = "<|vision_start|><|image_pad|><|vision_end|>"
+        processed_input = processor(text=image_token, images=image, return_tensors="pt")
+
+        image_input_id = processed_input["input_ids"].squeeze(0)
+
+        prompt_len = int(prompt_len) + int(image_input_id.shape[0])
+        ans_len = int(ans_len)
+        input_ids = torch.cat(
+            [
+                torch.randint(
+                    0, VOCAB_SIZE, size=(prompt_len + ans_len - len(image_input_id),)
+                ),
+                image_input_id,
+            ]
+        )
+
+        seq = dict(
+            input_ids=input_ids.unsqueeze(0),
+            pixel_values=processed_input["pixel_values"].unsqueeze(0),
+            image_grid_thw=processed_input["image_grid_thw"],
+            loss_mask=torch.tensor([0] * prompt_len + [1] * ans_len).unsqueeze(0),
+            attention_mask=torch.tensor([1] * (prompt_len + ans_len)).unsqueeze(0),
+        )
+        all_data.append(TensorDict(seq, batch_size=[1]))
+
+    return concat_padded_tensors(all_data).cuda()
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    [QWEN25_VL_PATH],
+)
+def test_vlm_consistency(model_path, mock_padded_vlm_data):
+    os.environ["RANK"] = str(0)
+    os.environ["WORLD_SIZE"] = str(1)
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(find_free_ports(1)[0])
+    os.environ["LOCAL_RANK"] = str(0)
+
+    config = TrainEngineConfig(
+        path=model_path,
+        dtype="bfloat16",
+        attn_impl="flash_attention_2",
+        gradient_checkpointing=False,
+        disable_dropout=True,
+        init_from_scratch=False,
+        optimizer=None,
+    )
+
+    engine = BaseHFEngine(config)
+    engine.create_process_group()
+    engine.create_device_model()
+    engine.initialized = True
+
+    padded_input = mock_padded_vlm_data.clone()
+
+    # Get packed input
+    mb_list = engine.prepare_mb_list(padded_input)
+    assert len(mb_list.mbs) == 1
+
+    with torch.no_grad():
+        # Padded logits
+        padded_logits = engine.model(
+            input_ids=padded_input["input_ids"],
+            pixel_values=padded_input["pixel_values"],
+            image_grid_thw=padded_input["image_grid_thw"],
+            attention_mask=padded_input["attention_mask"],
+        ).logits
+
+        # Extract valid sequence logits
+        seqlens = padded_input["attention_mask"].sum(1)
+        x1 = []
+        for i, s in enumerate(seqlens):
+            x1.append(padded_logits[i, :s])
+        x1 = torch.cat(x1)
+
+        # Packed logits
+        mb = mb_list.padded_mbs[0]
+        pad_len = mb_list.padding_lengths[0]
+        x2 = engine.model(**mb).logits.squeeze(0)[:-pad_len]
+
+        assert x1.shape == x2.shape, f"Shape mismatch: {x1.shape} vs {x2.shape}"
+        assert_close(x1, x2, atol=2e-1, rtol=2e-1)

--- a/areal/tests/test_sglang_engine.py
+++ b/areal/tests/test_sglang_engine.py
@@ -149,7 +149,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
         engine.submit(data, workflow=workflow)
 
     # wait for some time
-    time.sleep(3)
+    time.sleep(5)
     assert engine.workflow_executor.output_queue.qsize() == min(bs * 2, bs * (ofp + 1))
 
     # Update model version
@@ -160,7 +160,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
     for _ in range(bs * 2):
         engine.submit(data, workflow=workflow)
     # wait for some time
-    time.sleep(3)
+    time.sleep(5)
     assert engine.workflow_executor.output_queue.qsize() == min(bs * 4, bs * (ofp + 2))
 
     # exit

--- a/areal/tests/test_sglang_engine.py
+++ b/areal/tests/test_sglang_engine.py
@@ -132,7 +132,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
     engine.initialize(None, None)
 
     gconfig = GenerationHyperparameters(
-        max_new_tokens=16, greedy=False, n_samples=n_samples
+        max_new_tokens=2, greedy=False, n_samples=n_samples
     )
     tokenizer = load_hf_tokenizer(MODEL_PATH)
 
@@ -149,7 +149,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
         engine.submit(data, workflow=workflow)
 
     # wait for some time
-    time.sleep(7)
+    time.sleep(3)
     assert engine.workflow_executor.output_queue.qsize() == min(bs * 2, bs * (ofp + 1))
 
     # Update model version
@@ -160,7 +160,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
     for _ in range(bs * 2):
         engine.submit(data, workflow=workflow)
     # wait for some time
-    time.sleep(5)
+    time.sleep(3)
     assert engine.workflow_executor.output_queue.qsize() == min(bs * 4, bs * (ofp + 2))
 
     # exit

--- a/areal/tests/test_sglang_engine.py
+++ b/areal/tests/test_sglang_engine.py
@@ -149,7 +149,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
         engine.submit(data, workflow=workflow)
 
     # wait for some time
-    time.sleep(5)
+    time.sleep(7)
     assert engine.workflow_executor.output_queue.qsize() == min(bs * 2, bs * (ofp + 1))
 
     # Update model version
@@ -160,7 +160,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
     for _ in range(bs * 2):
         engine.submit(data, workflow=workflow)
     # wait for some time
-    time.sleep(5)
+    time.sleep(7)
     assert engine.workflow_executor.output_queue.qsize() == min(bs * 4, bs * (ofp + 2))
 
     # exit

--- a/areal/tests/test_sglang_engine.py
+++ b/areal/tests/test_sglang_engine.py
@@ -149,7 +149,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
         engine.submit(data, workflow=workflow)
 
     # wait for some time
-    time.sleep(7)
+    time.sleep(10)
     assert engine.workflow_executor.output_queue.qsize() == min(bs * 2, bs * (ofp + 1))
 
     # Update model version
@@ -160,7 +160,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
     for _ in range(bs * 2):
         engine.submit(data, workflow=workflow)
     # wait for some time
-    time.sleep(7)
+    time.sleep(5)
     assert engine.workflow_executor.output_queue.qsize() == min(bs * 4, bs * (ofp + 2))
 
     # exit

--- a/areal/tests/test_sglang_engine.py
+++ b/areal/tests/test_sglang_engine.py
@@ -114,7 +114,7 @@ def test_remote_sglang_rollout(sglang_server, n_samples):
     engine.destroy()
 
 
-@pytest.mark.parametrize("ofp", [1, 2, 4, 8, 16])
+@pytest.mark.parametrize("ofp", [1, 4, 16])
 @pytest.mark.parametrize("bs", [2, 4])
 @pytest.mark.parametrize("n_samples", [2, 1])
 def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
@@ -149,7 +149,7 @@ def test_remote_sglang_staleness_control(sglang_server, bs, ofp, n_samples):
         engine.submit(data, workflow=workflow)
 
     # wait for some time
-    time.sleep(5)
+    time.sleep(7)
     assert engine.workflow_executor.output_queue.qsize() == min(bs * 2, bs * (ofp + 1))
 
     # Update model version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     "tensordict",
     "pybase64",
     "msgspec",
+    "openai==1.99.6",
     
     # Monitoring and logging
     "wandb",

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,3 +79,4 @@ deepspeed>=0.17.2
 pybase64
 msgspec
 transformers==4.54.0
+openai==1.99.6


### PR DESCRIPTION
## OpenAI-Compatible Rollout

We created a client with a similar API as OpenAI's python client. This client inputs "messages" and output "ChatCompletions", but additionally stores the input and output token IDs for later RL training. The client also exposes an API `set_reward` to assign reward for each input-output pair. 

At the end of the workflow, the user should call `export_completions` to export all data (i.e., input-output pairs) used for training. This method also triggers reward-backpropagation based on the automatically generated message tree for multi-turn conversations. Finally, all input-output-reward tuples are used as the RL training data.

The benefit of using this type of API is that users no longer need to construct token IDs and masks manually. We can ensure the correctness by only using message-based inference APIs.

## Others

1. Create an unit-test for prepare_mb_list to assert the correctness of data packing.