### PR TITLE
[FIX]: allocation mode LLM_SERVER_ONLY error

### DIFF
--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -191,11 +191,11 @@ class AllocationMode:
 
     @staticmethod
     def extract_gen_alloc(allocation_mode: str) -> Dict:
-        pattern = re.compile(r"(?:vllm|sglang)\.(.+?)")
+        pattern = re.compile(r"(?:vllm|sglang)\.(.+)")
         m = pattern.match(allocation_mode)
         if not m:
             return {}
-        return AllocationMode.extract_parallelism_strategy(m.group(1))
+        return AllocationMode.extract_parallelism_strategy(m.group(1))["*"]
 
     @staticmethod
     def extract_decoupled_alloc(allocation_mode: str) -> Dict:


### PR DESCRIPTION
Fix the error below using allocation mode LLM_SERVER_ONLY 
```
raise NotImplementedError(f"Failed to parse allocation: {allocation_mode}")
NotImplementedError: Failed to parse allocation: sglang.d4p1t1
```
All four of these modes have been tested and will not have an impact on other modes.