### PR TITLE
FEAT: Decoupled CLIP ratio (DAPO Trick-I)

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -275,8 +275,8 @@ class PPOActorConfig(TrainEngineConfig):
     eps_clip: float = field(
         default=0.2, metadata={"help": "Clipping factor for policy ratio"}
     )
-    eps_clip_higher: float = field(
-        default=0.28, metadata={"help": "Clipping factor for policy ratio"}
+    eps_clip_higher: Optional[float] = field(
+        default=None, metadata={"help": "Clipping factor (higher value) for policy ratio. Defaults is None. When eps_clip_higher is setted (decouppled), eps_clip will be used as the lower value."}
     )
     c_clip: Optional[float] = field(
         default=None,

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -275,6 +275,9 @@ class PPOActorConfig(TrainEngineConfig):
     eps_clip: float = field(
         default=0.2, metadata={"help": "Clipping factor for policy ratio"}
     )
+    eps_clip_higher: float = field(
+        default=0.28, metadata={"help": "Clipping factor for policy ratio"}
+    )
     c_clip: Optional[float] = field(
         default=None,
         metadata={

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -276,7 +276,10 @@ class PPOActorConfig(TrainEngineConfig):
         default=0.2, metadata={"help": "Clipping factor for policy ratio"}
     )
     eps_clip_higher: Optional[float] = field(
-        default=None, metadata={"help": "Clipping factor (higher value) for policy ratio. Defaults is None. When eps_clip_higher is setted (decouppled), eps_clip will be used as the lower value."}
+        default=None,
+        metadata={
+            "help": "Clipping factor (higher value) for policy ratio. Defaults is None. When eps_clip_higher is setted (decouppled), eps_clip will be used as the lower value."
+        },
     )
     c_clip: Optional[float] = field(
         default=None,

--- a/areal/engine/ppo/actor.py
+++ b/areal/engine/ppo/actor.py
@@ -226,6 +226,7 @@ class PPOActor:
                     grpo_loss_fn,
                     temperature=self.temperature,
                     eps_clip=self.config.eps_clip,
+                    eps_clip_higher=self.config.eps_clip_higher,
                     c_clip=self.config.c_clip,
                     behav_imp_weight_cap=self.config.behav_imp_weight_cap,
                 ),
@@ -262,6 +263,7 @@ def grpo_loss_fn(
     input_data: Dict,
     temperature: float,
     eps_clip: float,
+    eps_clip_higher: float | None,
     c_clip: float | None,
     behav_imp_weight_cap: float | None,
 ):
@@ -282,6 +284,7 @@ def grpo_loss_fn(
         old_logprobs=old_logp,
         advantages=advantages,
         eps_clip=eps_clip,
+        eps_clip_higher=eps_clip_higher,
         loss_mask=loss_mask,
         c_clip=c_clip,
         proximal_logprobs=prox_logp,

--- a/areal/utils/functional.py
+++ b/areal/utils/functional.py
@@ -126,6 +126,7 @@ def ppo_actor_loss_fn(
     advantages: torch.Tensor,
     eps_clip: float,
     loss_mask: torch.Tensor,
+    eps_clip_higher: Optional[float] = None,
     c_clip: Optional[float] = None,
     behav_imp_weight_cap: Optional[float] = None,
 ) -> Tuple[torch.Tensor, Dict]:
@@ -139,7 +140,12 @@ def ppo_actor_loss_fn(
     """
     loss_mask_count = loss_mask.count_nonzero() or 1
     ratio = torch.where(loss_mask, torch.exp(logprobs - proximal_logprobs), 0)
-    clipped_ratio = torch.clamp(ratio, 1.0 - eps_clip, 1.0 + eps_clip)
+    if eps_clip_higher is not None:
+        assert eps_clip_higher > eps_clip, "eps_clip_higher must be greater than eps_clip"
+        eps_clip_lower = eps_clip
+    else:
+        eps_clip_higher = eps_clip_lower = eps_clip
+    clipped_ratio = torch.clamp(ratio, 1.0 - eps_clip_lower, 1.0 + eps_clip_higher)
     pg_loss1 = -advantages * ratio
     pg_loss2 = -advantages * clipped_ratio
     clip_mask = pg_loss1.detach() < pg_loss2.detach()

--- a/areal/utils/functional.py
+++ b/areal/utils/functional.py
@@ -144,7 +144,7 @@ def ppo_actor_loss_fn(
     clipped_ratio = torch.clamp(
         ratio,
         1.0 - eps_clip,
-        1.0 + eps_clip if eps_clip_higher is None else eps_clip_higher,
+        1.0 + (eps_clip if eps_clip_higher is None else eps_clip_higher),
     )
 
     pg_loss1 = -advantages * ratio

--- a/areal/utils/functional.py
+++ b/areal/utils/functional.py
@@ -146,6 +146,7 @@ def ppo_actor_loss_fn(
         1.0 - eps_clip,
         1.0 + eps_clip if eps_clip_higher is None else eps_clip_higher,
     )
+
     pg_loss1 = -advantages * ratio
     pg_loss2 = -advantages * clipped_ratio
     clip_mask = pg_loss1.detach() < pg_loss2.detach()

--- a/areal/utils/functional.py
+++ b/areal/utils/functional.py
@@ -140,12 +140,12 @@ def ppo_actor_loss_fn(
     """
     loss_mask_count = loss_mask.count_nonzero() or 1
     ratio = torch.where(loss_mask, torch.exp(logprobs - proximal_logprobs), 0)
-    if eps_clip_higher is not None:
-        assert eps_clip_higher > eps_clip, "eps_clip_higher must be greater than eps_clip"
-        eps_clip_lower = eps_clip
-    else:
-        eps_clip_higher = eps_clip_lower = eps_clip
-    clipped_ratio = torch.clamp(ratio, 1.0 - eps_clip_lower, 1.0 + eps_clip_higher)
+
+    clipped_ratio = torch.clamp(
+        ratio,
+        1.0 - eps_clip,
+        1.0 + eps_clip if eps_clip_higher is None else eps_clip_higher,
+    )
     pg_loss1 = -advantages * ratio
     pg_loss2 = -advantages * clipped_ratio
     clip_mask = pg_loss1.detach() < pg_loss2.detach()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,6 @@ authors = [
 maintainers = [
     {name = "AReaL Team"},
 ]
-[project.urls]
-"Homepage" = "https://github.com/inclusionAI/AReaL"
-"Repository" = "https://github.com/inclusionAI/AReaL"
-"Documentation" = "https://inclusionai.github.io/AReaL/intro.html"
-"Bug Tracker" = "https://github.com/inclusionAI/AReaL/issues"
 keywords = [
     "distributed-systems",
     "reinforcement-learning",
@@ -156,6 +151,12 @@ all = [
     "areal[dev]",
     "areal[docs]",
 ]
+
+[project.urls]
+"Homepage" = "https://github.com/inclusionAI/AReaL"
+"Repository" = "https://github.com/inclusionAI/AReaL"
+"Documentation" = "https://inclusionai.github.io/AReaL/intro.html"
+"Bug Tracker" = "https://github.com/inclusionAI/AReaL/issues"
 
 [tool.setuptools.dynamic]
 version = {attr = "areal.__version__"}


### PR DESCRIPTION
In this PR, I decouple the CLIP ratio used to compute PPO loss, as one of the trick from DAPO.


To maximize availability, I did not change the `eps_clip` key. I only added eps_clip_higer and decoupled it when it has a value.

Please review
