### PR TITLE
Decouple the mean&std advantage normalization (Trick Dr. GRPO and LitePPO)

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -314,15 +314,6 @@ class PPOActorConfig(TrainEngineConfig):
     gae_lambda: float = field(
         default=1.0, metadata={"help": "Lambda parameter for GAE"}
     )
-    # adv_norm: bool = field(
-    #     default=True, metadata={"help": "Enable advantage normalization globally"}
-    # )
-    # group_adv_norm: bool = field(
-    #     default=False,
-    #     metadata={
-    #         "help": "Normalize advantages within each prompt group rather than globally"
-    #     },
-    # )
 
     # KL Control
     kl_ctl: float = field(default=0.1, metadata={"help": "KL divergence coefficient"})

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -16,6 +16,30 @@ from areal.utils.fs import get_user_tmp
 
 
 @dataclass
+class AdvNormConfig:
+    """Configuration for advantage normalization."""
+
+    mean_level: str = field(
+        default="batch",
+        metadata={
+            "help": "mean_level for advantage normalization. options: batch, group, none"
+        },
+    )
+    std_level: str = field(
+        default="batch",
+        metadata={
+            "help": "std_level for advantage normalization. options: batch, group, none"
+        },
+    )
+    mode: bool = field(
+        default=True, metadata={"help": "whether to use advantage normalization"}
+    )
+    group_size: int = field(
+        default=1, metadata={"help": "group_size for advantage normalization"}
+    )
+
+
+@dataclass
 class MicroBatchSpec:
     """Specification for splitting micro-batches during training."""
 
@@ -227,6 +251,7 @@ class TrainEngineConfig:
     optimizer: Optional[OptimizerConfig] = field(
         default=None, metadata={"help": "Optimizer configuration"}
     )
+
     backend: str = ""
     fsdp: FSDPEngineConfig = field(default_factory=FSDPEngineConfig)
     ds_auto_tp: DeepSpeedAutoTPEngineConfig = field(
@@ -239,12 +264,6 @@ class PPOActorConfig(TrainEngineConfig):
     # Core PPO/GRPO Parameters
     group_size: int = field(
         default=1, metadata={"help": "Number of sequences in each group"}
-    )
-    group_adv_norm: bool = field(
-        default=False,
-        metadata={
-            "help": "Normalize advantages within each prompt group rather than globally"
-        },
     )
     ppo_n_minibatches: int = field(
         default=4, metadata={"help": "Number of minibatches for each PPO update"}
@@ -295,9 +314,15 @@ class PPOActorConfig(TrainEngineConfig):
     gae_lambda: float = field(
         default=1.0, metadata={"help": "Lambda parameter for GAE"}
     )
-    adv_norm: bool = field(
-        default=True, metadata={"help": "Enable advantage normalization globally"}
-    )
+    # adv_norm: bool = field(
+    #     default=True, metadata={"help": "Enable advantage normalization globally"}
+    # )
+    # group_adv_norm: bool = field(
+    #     default=False,
+    #     metadata={
+    #         "help": "Normalize advantages within each prompt group rather than globally"
+    #     },
+    # )
 
     # KL Control
     kl_ctl: float = field(default=0.1, metadata={"help": "KL divergence coefficient"})
@@ -345,6 +370,9 @@ class PPOActorConfig(TrainEngineConfig):
     log_agent_stats_keys: List[str] = field(
         default_factory=lambda: [],
         metadata={"help": "Keys of log stats for agent trajectories"},
+    )
+    adv_norm: AdvNormConfig = field(
+        default_factory=AdvNormConfig, metadata={"help": "Optimizer configuration"}
     )
 
 

--- a/areal/engine/ppo/actor.py
+++ b/areal/engine/ppo/actor.py
@@ -1,7 +1,9 @@
 import functools
 from typing import Dict, List, Optional
 
+import numpy as np
 import torch
+import torch.distributed as dist
 from tensordict import TensorDict
 
 from areal.api.cli_args import MicroBatchSpec, PPOActorConfig
@@ -29,12 +31,12 @@ class PPOActor:
         self.reward_clip = config.reward_clip
 
         self.group_reward_norm = config.group_reward_norm
-        self.group_adv_norm = config.group_adv_norm
         self.group_size = config.group_size
 
         self.kl_ctl = config.kl_ctl
 
-        self.adv_norm = config.adv_norm
+        self.adv_norm = AdvNorm(config.adv_norm)
+
         self.discount = config.discount
         self.gae_lambda = config.gae_lambda
         self.mask_no_eos_with_zero = config.mask_no_eos_with_zero
@@ -130,17 +132,8 @@ class PPOActor:
         advantages = torch.stack(advantages_reversed[::-1], dim=1)
 
         # Optionally perform advantage normalization.
-        if self.adv_norm or self.group_adv_norm:
-            if self.group_adv_norm:
-                adv_list = []
-                for i in range(0, bs // self.group_size):
-                    s = slice(i * self.group_size, (i + 1) * self.group_size)
-                    adv = advantages[s]
-                    m = loss_mask[s]
-                    adv_list.append(masked_normalization(adv, m, all_reduce=False))
-                advantages = torch.cat(adv_list, 0)
-            else:
-                advantages = masked_normalization(advantages, loss_mask)
+        if self.adv_norm.mode == True:
+            advantages = self.adv_norm(advantages, loss_mask)
 
         # Store data in the dict.
         data["advantages"] = advantages
@@ -357,3 +350,234 @@ def grpo_loss_fn(
         denominator="clipped_tokens",
     )
     return loss
+
+
+class AdvNorm:
+    """
+    Adaptive Advantage Normalization.
+
+    Supports independent specification of normalization level for mean and std:
+    - "batch": normalize across entire batch (with optional all_reduce in distributed setting)
+    - "group": normalize within fixed-size groups
+    - std_level can be None: only center the data (no scaling)
+
+    If mean_level == std_level, uses original masked_normalization for efficiency.
+    Otherwise, computes mean and std separately and combines.
+
+    Args:
+        mean_level (str): "batch" or "group"
+        std_level (str or None): "batch", "group", or None (no std scaling)
+        group_size (int, optional): required if any level is "group"
+    """
+
+    def __init__(
+        self,
+        advNorm_cfg,
+    ):
+        self.mode = advNorm_cfg.mode
+        if advNorm_cfg.mean_level not in {"batch", "group", "none"}:
+            raise ValueError(
+                f"mean_level must be 'batch', 'group' or 'none', got {advNorm_cfg.mean_level}"
+            )
+        if advNorm_cfg.std_level not in {"batch", "group", "none"}:
+            raise ValueError(
+                f"std_level must be 'batch', 'group', or 'none', got {advNorm_cfg.std_level}"
+            )
+        if (
+            advNorm_cfg.mean_level == "group" or advNorm_cfg.std_level == "group"
+        ) and advNorm_cfg.group_size is None:
+            raise ValueError("group_size must be provided if using group normalization")
+
+        self.mean_level = advNorm_cfg.mean_level
+        self.std_level = advNorm_cfg.std_level
+        self.group_size = advNorm_cfg.group_size
+
+    @torch.no_grad()
+    def __call__(
+        self,
+        advantages: torch.Tensor,
+        loss_mask: Optional[torch.Tensor] = None,
+        eps: float = 1e-5,
+        unbiased: bool = False,
+        high_precision: bool = True,
+        reduce_group=None,
+    ) -> torch.Tensor:
+        """
+        Normalize advantages tensor according to mean_level and std_level.
+
+        Args:
+            advantages (torch.Tensor): [...]
+            loss_mask (torch.Tensor, optional): same shape as advantages
+            eps (float): small constant for numerical stability
+            unbiased (bool): whether to use unbiased variance
+            high_precision (bool): use float64 for computation
+            reduce_group: distributed group for all_reduce
+
+        Returns:
+            normalized advantages (same shape, dtype=float32)
+        """
+        if not self.mode:
+            return advantages
+
+        bs = advantages.size(0)
+
+        # Case: same level → use original masked_normalization to maxize the robust to original code
+        if self.mean_level == self.std_level:
+            if self.mean_level == "batch":
+                return masked_normalization(
+                    advantages,
+                    mask=loss_mask,
+                    unbiased=unbiased,
+                    eps=eps,
+                    high_precision=high_precision,
+                    all_reduce=True,  # follow original code
+                    reduce_group=reduce_group,
+                )
+            else:  # group
+                adv_list = []
+                for i in range(0, bs // self.group_size):
+                    s = slice(i * self.group_size, (i + 1) * self.group_size)
+                    adv = advantages[s]
+                    m = loss_mask[s] if loss_mask is not None else None
+                    adv_list.append(
+                        masked_normalization(
+                            adv,
+                            mask=m,
+                            unbiased=unbiased,
+                            eps=eps,
+                            high_precision=high_precision,
+                            all_reduce=False,  # follow original code
+                            reduce_group=reduce_group,
+                        )
+                    )
+                return torch.cat(adv_list, 0)
+
+        # Cases: mean and std levels differ, or std_level is None
+
+        # Step 1: Compute mean
+        if self.mean_level == "batch":
+            mean = self._compute_mean(
+                advantages, loss_mask, unbiased, high_precision, True, reduce_group
+            )
+        elif self.mean_level == "group":
+            mean = torch.zeros_like(advantages)
+            for i in range(0, bs // self.group_size):
+                s = slice(i * self.group_size, (i + 1) * self.group_size)
+                adv = advantages[s]
+                m = loss_mask[s] if loss_mask is not None else None
+                group_mean = self._compute_mean(
+                    adv, m, unbiased, high_precision, False, reduce_group
+                )
+                mean[s] = group_mean
+        else:
+            mean = torch.zeros_like(advantages)
+
+        # Subtract mean
+        x_centered = advantages - mean
+
+        # Step 2: Compute std
+        if self.std_level == "none":
+            return x_centered.float()
+
+        if self.std_level == "batch":
+            std = self._compute_std(
+                advantages,
+                loss_mask,
+                mean,
+                unbiased,
+                high_precision,
+                True,
+                reduce_group,
+            )
+        else:  # group
+            std = torch.zeros_like(advantages)
+            for i in range(0, bs // self.group_size):
+                s = slice(i * self.group_size, (i + 1) * self.group_size)
+                adv = advantages[s]
+                m = loss_mask[s] if loss_mask is not None else None
+                group_mean_slice = mean[s]  # already computed
+                group_std = self._compute_std(
+                    adv,
+                    m,
+                    group_mean_slice,
+                    unbiased,
+                    high_precision,
+                    False,
+                    reduce_group,
+                )
+                std[s] = group_std
+
+        # Normalize
+        return (x_centered / (std + eps)).float()
+
+    @staticmethod
+    def _compute_mean(
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor],
+        unbiased: bool,
+        high_precision: bool,
+        all_reduce: bool,
+        reduce_group,
+    ) -> torch.Tensor:
+        """Compute mean only, using masked_normalization internals."""
+        dtype = torch.float64 if high_precision else torch.float32
+        x = x.to(dtype)
+        dim = tuple(range(len(x.shape)))
+        if mask is None:
+            factor = torch.tensor(
+                np.prod([x.shape[d] for d in dim]), dtype=dtype, device=x.device
+            )
+        else:
+            mask = mask.to(dtype)
+            x_masked = x * mask
+            factor = mask.sum(dim, keepdim=True)
+            x_sum = x_masked.sum(dim=dim, keepdim=True)
+        if mask is not None:
+            pass
+        else:
+            x_sum = x.sum(dim=dim, keepdim=True)
+
+        if dist.is_initialized() and all_reduce:
+            dist.all_reduce(factor, op=dist.ReduceOp.SUM, group=reduce_group)
+            dist.all_reduce(x_sum, op=dist.ReduceOp.SUM, group=reduce_group)
+
+        mean = x_sum / factor
+        return mean
+
+    @staticmethod
+    def _compute_std(
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor],
+        mean: torch.Tensor,
+        unbiased: bool,
+        high_precision: bool,
+        all_reduce: bool,
+        reduce_group,
+    ) -> torch.Tensor:
+        """Compute std only, given precomputed mean."""
+        dtype = torch.float64 if high_precision else torch.float32
+        x = x.to(dtype)
+        dim = tuple(range(len(x.shape)))
+        if mask is None:
+            factor = torch.tensor(
+                np.prod([x.shape[d] for d in dim]), dtype=dtype, device=x.device
+            )
+        else:
+            mask = mask.to(dtype)
+            x_masked = x * mask
+            factor = mask.sum(dim, keepdim=True)
+            x_centered = x_masked - mean * mask  # only apply mean where mask is 1
+            x_sum_sq = (x_centered**2).sum(dim=dim, keepdim=True)
+        if mask is None:
+            x_centered = x - mean
+            x_sum_sq = (x_centered**2).sum(dim=dim, keepdim=True)
+
+        if dist.is_initialized() and all_reduce:
+            dist.all_reduce(factor, op=dist.ReduceOp.SUM, group=reduce_group)
+            dist.all_reduce(x_sum_sq, op=dist.ReduceOp.SUM, group=reduce_group)
+
+        var = x_sum_sq / factor
+        if unbiased:
+            var *= factor / (factor - 1)
+        std = var.sqrt()
+        return std

--- a/examples/configs/gsm8k_grpo.yaml
+++ b/examples/configs/gsm8k_grpo.yaml
@@ -1,6 +1,6 @@
 experiment_name: gsm8k-grpo
 trial_name: trial0
-allocation_mode: sglang.d1p1t1+d1p1t1
+allocation_mode: sglang.d4p1t1+d4p1t1
 cluster:
   fileroot: /tmp/areal/experiments
   n_nodes: 1
@@ -32,7 +32,7 @@ gconfig:
 actor:
   experiment_name: ${experiment_name}
   trial_name: ${trial_name}
-  path: /mnt/nvme0n1/model_dir/Qwen2.5-1.5B
+  path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
   gradient_checkpointing: false
@@ -90,7 +90,7 @@ sglang:
   dtype: ${actor.dtype}
   max_running_requests: null
   context_length: 32768
-  mem_fraction_static: 0.3
+  mem_fraction_static: 0.8
 
 # datasets
 train_dataset:

--- a/examples/configs/gsm8k_grpo.yaml
+++ b/examples/configs/gsm8k_grpo.yaml
@@ -1,6 +1,6 @@
 experiment_name: gsm8k-grpo
 trial_name: trial0
-allocation_mode: sglang.d4p1t1+d4p1t1
+allocation_mode: sglang.d1p1t1+d1p1t1
 cluster:
   fileroot: /tmp/areal/experiments
   n_nodes: 1
@@ -32,7 +32,7 @@ gconfig:
 actor:
   experiment_name: ${experiment_name}
   trial_name: ${trial_name}
-  path: Qwen/Qwen2.5-1.5B-Instruct
+  path: /mnt/nvme0n1/model_dir/Qwen2.5-1.5B
   init_from_scratch: false
   disable_dropout: true
   gradient_checkpointing: false
@@ -52,7 +52,6 @@ actor:
   backend: fsdp
 
   group_size: ${gconfig.n_samples}
-  group_adv_norm: false
   eps_clip: 0.4
   temperature: ${gconfig.temperature}
   reward_scaling: 10.0
@@ -63,6 +62,13 @@ actor:
   use_decoupled_loss: true
   behav_imp_weight_cap: 5.0
   dynamic_sampling: false
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+    mode: true
+    group_size: ${gconfig.n_samples}
+
+
 
 ref:
   experiment_name: ${experiment_name}
@@ -84,7 +90,7 @@ sglang:
   dtype: ${actor.dtype}
   max_running_requests: null
   context_length: 32768
-  mem_fraction_static: 0.8
+  mem_fraction_static: 0.3
 
 # datasets
 train_dataset:


### PR DESCRIPTION
# Background
In native GRPO, the advantage will take z-score normalization within `group-level`.
However, many algorithms suggest customize the normalization process in more finely.
Such as Dr. Grpo, which removes the std calculation.
<img width="354" height="199" alt="image" src="https://github.com/user-attachments/assets/cebcc214-4bcc-410a-b97c-6108d9f6159d" />

another example is [LitePPO](https://www.alphaxiv.org/abs/2508.08221), which shows _Group-level mean and batch-level standard deviation enable further robust normalization._

# What does this PR do?
This PR introduces a **advantage_norm** class used to finely control the norm process to advantages.

The advantage can be norm by 4 way:

- mean(batch),std(batch): use the z-score norm on batch level
- mean(group),std(group): use the z-score norm ongroup level (native implementation)
- mean(group),std(batch): the mean will be calculated over trajectories in one group, the std will be calculated over trajectories in one batch (contain multiple group)
- mean(batch),std(group): opposite to `mean(group),std(batch)`


Please review.