### PR TITLE
chore: add engine IDs to differentiate different ranks in logs

### DIFF
--- a/areal/api/engine_api.py
+++ b/areal/api/engine_api.py
@@ -9,7 +9,6 @@ from tensordict import TensorDict
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from areal.api.io_struct import (
-    FinetuneSpec,
     ModelRequest,
     ModelResponse,
     ParamSpec,
@@ -39,7 +38,7 @@ class Scheduling:
 
 class TrainEngine(abc.ABC):
 
-    def initialize(self, addr: str | None, ft_spec: FinetuneSpec | None):
+    def initialize(self, *args, **kwargs):
         """Initialize environments for distributed training and load models."""
         raise NotImplementedError()
 
@@ -158,7 +157,7 @@ class TrainEngine(abc.ABC):
 
 class InferenceEngine(abc.ABC):
 
-    def initialize(self, addr: str | None, ft_spec):
+    def initialize(self, *args, **kwargs):
         """Initialize environments for distributed inference and load models."""
         raise NotImplementedError()
 

--- a/areal/experimental/autotp_engine.py
+++ b/areal/experimental/autotp_engine.py
@@ -5,7 +5,8 @@ import torch.distributed as dist
 from safetensors.torch import save_file
 
 from areal.api.cli_args import TrainEngineConfig
-from areal.api.engine_api import FinetuneSpec, SaveLoadMeta, WeightUpdateMeta
+from areal.api.engine_api import SaveLoadMeta, WeightUpdateMeta
+from areal.api.io_struct import FinetuneSpec
 from areal.engine.base_hf_engine import BaseHFEngine
 from areal.utils import logging
 from areal.utils.nccl import NCCL_DEFAULT_TIMEOUT

--- a/areal/experimental/megatron_engine.py
+++ b/areal/experimental/megatron_engine.py
@@ -21,8 +21,8 @@ from tensordict import TensorDict
 
 from areal.api.alloc_mode import MegatronParallelStrategy, ParallelStrategy
 from areal.api.cli_args import MicroBatchSpec
-from areal.api.engine_api import FinetuneSpec, TrainEngine
-from areal.api.io_struct import ParamSpec, SaveLoadMeta, WeightUpdateMeta
+from areal.api.engine_api import TrainEngine
+from areal.api.io_struct import FinetuneSpec, ParamSpec, SaveLoadMeta, WeightUpdateMeta
 from areal.experimental.api.cli_args import (
     ExperimentalTrainEngineConfig as TrainEngineConfig,
 )
@@ -49,8 +49,6 @@ from areal.utils.data import (
 from areal.utils.hf_utils import load_hf_tokenizer
 from areal.utils.model import disable_dropout_in_model
 from areal.utils.nccl import NCCL_DEFAULT_TIMEOUT
-
-logger = logging.getLogger("MegatronEngine")
 
 
 class MegatronEngine(TrainEngine):
@@ -110,7 +108,7 @@ class MegatronEngine(TrainEngine):
         self.tokenizer = load_hf_tokenizer(self.config.path)
         self.bridge = mbridge.AutoBridge.from_pretrained(self.config.path)
         self.bridge.dtype = self.dtype
-        logger.info(
+        self.logger.info(
             "Using mbridge to create models and hf model save/load in MegatronEngine."
         )
 
@@ -181,6 +179,8 @@ class MegatronEngine(TrainEngine):
         )
         # Set megatron model parallel seed
         tensor_parallel.model_parallel_cuda_manual_seed(self.seed)
+
+        self.logger = logging.getLogger(f"[Megatron Engine Rank {dist.get_rank()}]")
 
     def _init_context_and_model_parallel_group(self):
         # Initialize context and model parallel groups, which are only used in AReaL
@@ -451,7 +451,7 @@ class MegatronEngine(TrainEngine):
             align_sequences=True,
             align_to_multiple_of=align_to_multiple_of,
         )
-        logger.info(
+        self.logger.info(
             f"Microbatch #tokens (rank {dist.get_rank()}): {mb_list.group_lens}, aligned to: {mb_list.align_to_lengths}, "
             f"padded to: {mb_list.padded_to_lengths}, padding lengths: {mb_list.padding_lengths}."
         )


### PR DESCRIPTION
+ Changes the signature of `initialize` for `TrainEngine` and `InferenceEngine`. We don't need a unified signature for different backends.

+ Modifies the logger name used in engines. Now the logger name contains rank information.