### PR TITLE
fix: The shape of attention_mask itself gets changed when removing pads

### DIFF
--- a/areal/utils/redistributor.py
+++ b/areal/utils/redistributor.py
@@ -40,8 +40,9 @@ def redistribute(
     # Remove pad positions
     for d in all_data:
         l = d["attention_mask"].sum(-1).max().item()
+        attn_mask_shape = d["attention_mask"].shape
         for k, v in d.items():
-            if v.shape[:2] == d["attention_mask"].shape[:2]:
+            if v.shape[:2] == attn_mask_shape[:2]:
                 d[k] = v[:, :l]
 
     # No capacity limit leads to balanced partition across this group


### PR DESCRIPTION
The shape of `d["attention_mask"]` ifself gets changed when removing pad positions. So if some `d[key]` goes after `d["attention_mask"]`, their pad positions are not removed.

Cache the shape of `d["attention_mask"]` in advance.