### PR TITLE
[Feat] Add device agnostic feature

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -11,6 +11,7 @@ from hydra import compose as hydra_compose
 from hydra import initialize as hydra_init
 from omegaconf import MISSING, DictConfig, OmegaConf
 
+from areal.platforms import current_platform
 from areal.utils import name_resolve, pkg_version
 from areal.utils.fs import get_user_tmp
 
@@ -480,7 +481,7 @@ class SGLangConfig:
             tokenizer_mode="auto",
             load_format="auto",
             trust_remote_code=True,
-            device="cuda",
+            device=current_platform.device_type,
             is_embedding=False,
             # Other runtime options
             tp_size=tp_size,

--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -10,6 +10,7 @@ from transformers import PreTrainedTokenizerFast
 
 from areal.api.alloc_mode import AllocationMode
 from areal.api.cli_args import GenerationHyperparameters
+from areal.platforms import current_platform
 from areal.utils.network import find_free_ports, gethostip
 
 if TYPE_CHECKING:
@@ -131,7 +132,7 @@ class WeightUpdateMeta:
     ):
         param_specs = fsdp_engine.get_param_specs(weight_chunked_mem_mb)
         return cls(
-            type="nccl",
+            type=current_platform.communication_backend,
             alloc_mode=allocation_mode,
             nccl_master_address=gethostip(),
             nccl_master_port=find_free_ports(1)[0],

--- a/areal/engine/base_hf_engine.py
+++ b/areal/engine/base_hf_engine.py
@@ -21,6 +21,7 @@ from areal.api.alloc_mode import ParallelStrategy
 from areal.api.cli_args import TrainEngineConfig
 from areal.api.engine_api import TrainEngine
 from areal.api.io_struct import FinetuneSpec
+from areal.platforms import current_platform
 from areal.utils import logging
 from areal.utils.data import (
     MicroBatchList,
@@ -121,7 +122,7 @@ class BaseHFEngine(TrainEngine):
             # NOTE: device_id **SHOULD NOT** be passed into init_process_group,
             # otherwise initializing the NCCL weight update group will be wrong!
             dist.init_process_group(
-                backend="nccl",
+                backend=current_platform.communication_backend,
                 timeout=NCCL_DEFAULT_TIMEOUT,
             )
             self.own_global_group = True
@@ -132,7 +133,7 @@ class BaseHFEngine(TrainEngine):
         self.logger = logging.getLogger(f"[HF Engine Rank {dist.get_rank()}]")
 
     def create_device_model(self):
-        torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+        current_platform.set_device(int(os.environ["LOCAL_RANK"]))
         self.device = torch.device(int(os.environ["LOCAL_RANK"]))
 
         dtype = getattr(torch, self.config.dtype)
@@ -151,7 +152,7 @@ class BaseHFEngine(TrainEngine):
             )
 
             tik = time.perf_counter()
-            with torch.device("cuda"):
+            with torch.device(current_platform.device_type):
                 model = AutoModelForImageTextToText.from_pretrained(
                     pretrained_model_name_or_path=self.config.path,
                     trust_remote_code=True,
@@ -163,7 +164,7 @@ class BaseHFEngine(TrainEngine):
         else:
             self.tokenizer = load_hf_tokenizer(self.config.path)
             tik = time.perf_counter()
-            with torch.device("cuda"):
+            with torch.device(current_platform.device_type):
                 if self.config.init_from_scratch:
                     # initialize scratch model from config
                     # NOTE: VLM cannot directly load state dict using this
@@ -251,7 +252,7 @@ class BaseHFEngine(TrainEngine):
         if hasattr(self, "model"):
             del self.model
         gc.collect()
-        torch.cuda.empty_cache()
+        current_platform.empty_cache()
         gc.collect()
         dist.destroy_process_group(self.context_and_model_parallel_group)
         dist.destroy_process_group(self.parallelism_group)

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -28,6 +28,7 @@ from areal.api.cli_args import TrainEngineConfig
 from areal.api.io_struct import FinetuneSpec, ParamSpec, SaveLoadMeta, WeightUpdateMeta
 from areal.engine.base_hf_engine import BaseHFEngine
 from areal.models.transformers.ulyssess_patch import apply_monkey_patch
+from areal.platforms import current_platform
 from areal.utils import datapack, logging, name_resolve, names, pkg_version
 from areal.utils.data import (
     pack_tensor_dict,
@@ -124,13 +125,13 @@ class FSDPEngine(BaseHFEngine):
         )
 
         self.fsdp_tp_device_mesh = init_device_mesh(
-            "cuda",
+            current_platform.device_type,
             mesh_shape=(self.dp_world_size * self.sp_world_size, self.tp_world_size),
             mesh_dim_names=("fsdp", "tp"),
         )
 
         nd_device_mesh = init_device_mesh(
-            "cuda",
+            current_platform.device_type,
             mesh_shape=(self.dp_world_size, self.sp_world_size, self.tp_world_size),
             mesh_dim_names=("dp", "sp", "tp"),
         )
@@ -337,7 +338,7 @@ class FSDPEngine(BaseHFEngine):
                 self._init_distributed_weight_update(meta)
             self._update_weights_from_distributed(meta.nccl_param_specs)
             dist.barrier(device_ids=[self.device.index])
-            torch.cuda.synchronize()
+            current_platform.synchronize()
         elif meta.type == "disk":
             self._save_model_to_hf(meta.path, self.tokenizer, self.processor)
             # dist.barrier() are called when _save_model_to_hf finished
@@ -359,7 +360,7 @@ class FSDPEngine(BaseHFEngine):
         os.environ["TORCHELASTIC_USE_AGENT_STORE"] = str(False)
         if dist.get_rank() == 0:
             self.weight_update_group = init_custom_process_group(
-                backend="nccl",
+                backend=current_platform.communication_backend,
                 world_size=meta.alloc_mode.gen.world_size + 1,
                 init_method=f"tcp://{meta.nccl_master_address}:{meta.nccl_master_port}",
                 rank=0,
@@ -387,7 +388,7 @@ class FSDPEngine(BaseHFEngine):
                     dist.broadcast(tensor, src=0, group=self.weight_update_group)
                 del tensor
             dist.barrier(device_ids=[self.device.index])
-            torch.cuda.synchronize()
+            current_platform.synchronize()
 
     def _bin_pack_param_specs(
         self, param_specs: List[ParamSpec], chunked_mem_mb=1024

--- a/areal/engine/sglang_remote.py
+++ b/areal/engine/sglang_remote.py
@@ -23,6 +23,7 @@ from areal.api.io_struct import (
     WeightUpdateMeta,
 )
 from areal.api.workflow_api import RolloutWorkflow, WorkflowExecutor
+from areal.platforms import current_platform
 from areal.utils import logging, name_resolve, names
 from areal.utils.http import arequest_with_retry, get_default_connector
 
@@ -465,7 +466,7 @@ async def ainit_weights_update_group(
         "master_port": str(meta.nccl_master_port),
         "rank_offset": rank_offset,
         "world_size": meta.alloc_mode.gen.world_size + 1,
-        "backend": "nccl",
+        "backend": current_platform.communication_backend,
         "group_name": meta.nccl_group_name,
     }
     res = await arequest_with_retry(

--- a/areal/experimental/autotp_engine.py
+++ b/areal/experimental/autotp_engine.py
@@ -8,6 +8,7 @@ from areal.api.cli_args import TrainEngineConfig
 from areal.api.engine_api import SaveLoadMeta, WeightUpdateMeta
 from areal.api.io_struct import FinetuneSpec
 from areal.engine.base_hf_engine import BaseHFEngine
+from areal.platforms import current_platform
 from areal.utils import logging
 from areal.utils.nccl import NCCL_DEFAULT_TIMEOUT
 from areal.utils.save_load import (
@@ -33,7 +34,7 @@ class DeepSpeedAutoTPEngine(BaseHFEngine):
 
         world_size = int(os.environ.get("WORLD_SIZE"))
         deepspeed.init_distributed(
-            dist_backend="nccl",
+            dist_backend=current_platform.communication_backend,
             world_size=world_size,
             timeout=NCCL_DEFAULT_TIMEOUT,
         )

--- a/areal/experimental/model/hf_save.py
+++ b/areal/experimental/model/hf_save.py
@@ -15,6 +15,7 @@ from megatron.core import parallel_state as mpu
 from safetensors.torch import save_file
 from torch.distributed._functional_collectives import all_gather_into_tensor_coalesced
 
+from areal.platforms import current_platform
 from areal.utils import logging
 
 logger = logging.getLogger("HF WeightsSaver")
@@ -147,7 +148,7 @@ def save_weights_to_hf_with_mbridge_fast(
             if "_extra_state" not in x and "expert_bias" in x and x not in existing_keys
         ]
         for name in extra_keys:
-            param = state_dicts[vpp_rank][name].to(torch.cuda.current_device())
+            param = state_dicts[vpp_rank][name].to(current_platform.current_device())
             global_name = local_to_global_maps[vpp_rank][name]
             weight_specs.append(
                 McoreDistributedWeightSpec(

--- a/areal/platforms/__init__.py
+++ b/areal/platforms/__init__.py
@@ -1,0 +1,42 @@
+import torch
+
+import areal.utils.logging as logging
+
+from .cpu import CpuPlatform
+from .cuda import CudaPlatform
+from .platform import Platform
+from .unknown import UnknownPlatform
+
+logger = logging.getLogger("Platform init")
+
+
+def _init_platform() -> Platform:
+    """
+    Detect and initialize the appropriate platform based on available devices.
+    Priority:
+    1. CUDA (NVIDIA)
+    2. TODO: NPU (if torch_npu is installed)
+    3. CPU (fallback)
+    Returns:
+        An instance of a subclass of Platform corresponding to the detected hardware.
+    """
+    if torch.cuda.is_available():
+        device_name = torch.cuda.get_device_name().upper()
+        logger.info(f"Detected CUDA device: {device_name}")
+        if "NVIDIA" in device_name:
+            logger.info("Initializing CUDA platform (NVIDIA).")
+            return CudaPlatform()
+        logger.warning("Unrecognized CUDA device. Falling back to UnknownPlatform.")
+        return UnknownPlatform()
+    else:
+        logger.info("No supported accelerator detected. Initializing CPU platform.")
+        return CpuPlatform()
+
+
+# Global singleton representing the current platform in use.
+current_platform: Platform = _init_platform()
+
+__all__ = [
+    "Platform",
+    "current_platform",
+]

--- a/areal/platforms/cpu.py
+++ b/areal/platforms/cpu.py
@@ -1,0 +1,17 @@
+from .platform import Platform
+
+
+class CpuPlatform(Platform):
+    device_name: str = "CPU"
+    device_type: str = "cpu"
+    dispatch_key: str = "CPU"
+    ray_device_key: str = "CPU"
+    communication_backend: str = "gloo"
+
+    @classmethod
+    def clear_cublas_workspaces(cls) -> None:
+        pass
+
+    @classmethod
+    def get_custom_env_vars(cls) -> dict:
+        return {}

--- a/areal/platforms/cuda.py
+++ b/areal/platforms/cuda.py
@@ -1,0 +1,61 @@
+import torch
+
+import areal.utils.logging as logging
+
+from .platform import Platform
+
+logger = logging.getLogger("CUDA Platform")
+
+
+class CudaPlatform(Platform):
+    device_name: str = "NVIDIA"
+    device_type: str = "cuda"
+    dispatch_key: str = "CUDA"
+    ray_device_key: str = "GPU"
+    device_control_env_var: str = "CUDA_VISIBLE_DEVICES"
+    ray_experimental_noset: str = "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"
+    communication_backend: str = "nccl"
+
+    @classmethod
+    def clear_cublas_workspaces(cls) -> None:
+        torch._C._cuda_clearCublasWorkspaces()
+
+    @classmethod
+    def get_vllm_worker_class(clas):
+        try:
+            from vllm import envs
+
+            if envs.VLLM_USE_V1:
+                from vllm.v1.worker.gpu_worker import Worker
+
+                logger.info("Successfully imported vLLM V1 Worker.")
+                return Worker
+            else:
+                from vllm.worker.worker import Worker
+
+                logger.info("Successfully imported vLLM V0 Worker.")
+                return Worker
+        except ImportError as e:
+            logger.error(
+                "Failed to import vLLM Worker. "
+                "Make sure vLLM is installed correctly: %s",
+                e,
+            )
+            raise RuntimeError(
+                "vLLM is not installed or not properly configured."
+            ) from e
+
+    @classmethod
+    def set_allocator_settings(cls) -> None:
+        torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+
+    @classmethod
+    def get_custom_env_vars(cls) -> dict:
+        env_vars = {
+            # "RAY_DEBUG": "legacy"
+            "TORCHINDUCTOR_COMPILE_THREADS": "2",
+            "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+            "NCCL_CUMEM_ENABLE": "0",  # https://github.com/NVIDIA/nccl/issues/1234
+            "NCCL_NVLS_ENABLE": "0",
+        }
+        return env_vars

--- a/areal/platforms/platform.py
+++ b/areal/platforms/platform.py
@@ -1,0 +1,141 @@
+import os
+
+import torch
+
+import areal.utils.logging as logging
+
+logger = logging.getLogger("Platform")
+
+
+class Platform:
+    """
+    A unified abstraction for different hardware platforms (e.g., GPU, NPU).
+    Design Overview
+    ----------------
+    1. Device-Agnostic Abstraction
+       Hardware platforms differ in how they are registered with PyTorch or Ray.
+       This class standardizes platform metadata such as `dispatch_key`, `ray_device_key`,
+       and device visibility control variables to simplify cross-platform scheduling.
+    2. Lazy Attribute Access
+       Dynamically delegates unknown attributes to the `torch.<device_type>` submodule.
+       This provides clean access to device-specific PyTorch APIs without redundancy.
+    3. Extensible Interface
+       Subclasses must implement:
+       - `clear_cublas_workspaces`: to release or reuse low-level library workspaces.
+       - `get_vllm_worker_class`: to specify the vLLM Ray worker class.
+       - `set_allocator_settings`: to configure platform-specific memory allocators.
+    """
+
+    # High-level platform name, used for readability and logging.
+    # Examples: "NVIDIA", "ASCEND"
+    device_name: str
+
+    # Corresponding torch module name
+    # Examples: "cuda", "npu"
+    device_type: str
+
+    # available dispatch keys:
+    # check https://github.com/pytorch/pytorch/blob/313dac6c1ca0fa0cde32477509cce32089f8532a/torchgen/model.py#L134 # noqa
+    # use "CPU" as a fallback for platforms not registered in PyTorch
+    # Examples: "CUDA", "PrivateUse1"
+    dispatch_key: str
+
+    # available ray device keys:
+    # https://github.com/ray-project/ray/blob/10ba5adadcc49c60af2c358a33bb943fb491a171/python/ray/_private/ray_constants.py#L438 # noqa
+    # empty string means the device does not support ray
+    # Examples: "GPU", "NPU"
+    ray_device_key: str
+
+    # platform-agnostic way to specify the device control environment variable,
+    # .e.g. CUDA_VISIBLE_DEVICES for CUDA.
+    # hint: search for "get_visible_accelerator_ids_env_var" in
+    # https://github.com/ray-project/ray/tree/master/python/ray/_private/accelerators # noqa
+    # Examples: "CUDA_VISIBLE_DEVICES", "ASCEND_VISIBLE_DEVICES"
+    device_control_env_var: str
+
+    # Optional Ray experimental config
+    # Some accelerators require specific flags in Ray start parameters;
+    # leave blank if not needed
+    # Example: "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"
+    ray_experimental_noset: str
+
+    # Communication backend for distributed training
+    # Examples: "nccl", "hccl"
+    communication_backend: str
+
+    def __getattr__(self, key: str):
+        """Fallback attribute accessor for device-specific Torch modules.
+        This method is called when the requested attribute `key` is not found
+        in the current instance. It attempts to retrieve the attribute from
+        the corresponding `torch.<device_type>` module (e.g., torch.cuda, torch.xpu).
+        If the attribute exists on the device module, it returns it.
+        Otherwise, it logs a warning and returns None.
+        Args:
+            key (str): The name of the attribute to access.
+        Returns:
+            Any: The requested attribute from the Torch device module if found;
+                otherwise, None.
+        """
+        device = getattr(torch, self.device_type, None)
+        if device is not None and hasattr(device, key):
+            return getattr(device, key)
+        else:
+            logger.warning(
+                "Current platform %s does not have '%s'" " attribute.",
+                self.device_type,
+                key,
+            )
+            return None
+
+    @classmethod
+    def clear_cublas_workspaces(cls) -> None:
+        raise NotImplementedError()
+
+    @classmethod
+    def get_vllm_worker_class(cls):
+        """Return the custom vLLM WorkerWrapper class used in Ray."""
+        raise NotImplementedError()
+
+    @classmethod
+    def set_allocator_settings(cls) -> None:
+        """Configure memory allocator settings based on the device type."""
+        raise NotImplementedError()
+
+    @classmethod
+    def get_custom_env_vars(cls) -> dict:
+        """
+        Return custom environment variables specific to the platform.
+        Returns:
+            dict: A dictionary of environment variable key-value pairs.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def update_env_vars_for_visible_devices(
+        cls, env_vars: dict, gpu_ranks: list
+    ) -> None:
+        """
+        Update environment variables to control device visibility.
+        Args:
+            env_vars (dict): Dictionary of current environment variables to modify.
+            gpu_ranks (list): List of device IDs to expose to the process.
+        Behavior:
+            - Sets the platform-specific visibility environment variable.
+            - Sets the corresponding Ray experimental flag if needed.
+        """
+        visible_devices_env_vars = {
+            cls.device_control_env_var: ",".join(map(str, gpu_ranks)),
+            cls.ray_experimental_noset: "1",
+        }
+        env_vars.update(visible_devices_env_vars)
+
+    @classmethod
+    def get_visible_devices(cls) -> list:
+        """
+        Return the list of currently visible device IDs.
+        Returns:
+            list: A list of device ID strings parsed from the visibility environment variable.
+        """
+        if cls.device_control_env_var is not None:
+            return os.environ.get(cls.device_control_env_var, "").split(",")
+        return []

--- a/areal/platforms/platform.py
+++ b/areal/platforms/platform.py
@@ -108,7 +108,7 @@ class Platform:
         Returns:
             dict: A dictionary of environment variable key-value pairs.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @classmethod
     def update_env_vars_for_visible_devices(

--- a/areal/platforms/unknown.py
+++ b/areal/platforms/unknown.py
@@ -1,0 +1,57 @@
+import torch
+
+import areal.utils.logging as logging
+
+from .platform import Platform
+
+logger = logging.getLogger("Unknown Platform")
+
+
+class UnknownPlatform(Platform):
+    device_name: str = "UNKNOWN"
+    device_type: str = "cuda"
+    dispatch_key: str = "CUDA"
+    ray_device_key: str = "GPU"
+    device_control_env_var: str = "CUDA_VISIBLE_DEVICES"
+    ray_experimental_noset: str = "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"
+    communication_backend: str = "nccl"
+
+    @classmethod
+    def clear_cublas_workspaces(cls) -> None:
+        torch._C._cuda_clearCublasWorkspaces()
+
+    @classmethod
+    def get_vllm_worker_class(clas):
+        try:
+            from vllm import envs
+
+            if envs.VLLM_USE_V1:
+                from vllm.v1.worker.gpu_worker import Worker
+
+                logger.info("Successfully imported vLLM V1 Worker.")
+                return Worker
+            else:
+                from vllm.worker.worker import Worker
+
+                logger.info("Successfully imported vLLM V0 Worker.")
+                return Worker
+        except ImportError as e:
+            logger.error(
+                "Failed to import vLLM Worker. "
+                "Make sure vLLM is installed correctly: %s",
+                e,
+            )
+            raise RuntimeError(
+                "vLLM is not installed or not properly configured."
+            ) from e
+
+    @classmethod
+    def set_allocator_settings(cls) -> None:
+        torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+
+    @classmethod
+    def get_custom_env_vars(cls) -> dict:
+        env_vars = {
+            "TORCHINDUCTOR_COMPILE_THREADS": "2",
+        }
+        return env_vars

--- a/areal/tests/grpo/entrypoint.py
+++ b/areal/tests/grpo/entrypoint.py
@@ -16,6 +16,7 @@ from areal.api.cli_args import GRPOConfig
 from areal.api.io_struct import FinetuneSpec, WeightUpdateMeta
 from areal.engine.ppo.actor import FSDPPPOActor
 from areal.engine.sglang_remote import RemoteSGLangEngine
+from areal.platforms import current_platform
 from areal.reward.math_parser import process_results
 from areal.utils import seeding
 from areal.utils.data import broadcast_tensor_container
@@ -119,7 +120,7 @@ def main() -> None:
             )
 
             dist.barrier(device_ids=[actor.device.index])
-            torch.cuda.synchronize()
+            current_platform.synchronize()
 
             batch["ref_logp"] = ref.compute_logp(batch)
 
@@ -137,7 +138,7 @@ def main() -> None:
             if future is not None:
                 future.result()
             dist.barrier(device_ids=[actor.device.index])
-            torch.cuda.synchronize()
+            current_platform.synchronize()
             rollout.resume()
             actor.set_version(global_step + 1)
             rollout.set_version(global_step + 1)

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -12,6 +12,7 @@ from einops import rearrange
 from tensordict import TensorDict
 
 from areal.api.cli_args import MicroBatchSpec
+from areal.platforms import current_platform
 from areal.utils import datapack, logging
 
 logger = logging.getLogger("data utils")
@@ -862,7 +863,9 @@ def broadcast_tensor(tensor: torch.Tensor | None, src_rank=0, group=None):
         dtype = metadata["dtype"]
         device_type = metadata["device_type"]
         device = (
-            torch.device("cpu") if device_type == "cpu" else torch.cuda.current_device()
+            torch.device("cpu")
+            if device_type == "cpu"
+            else current_platform.current_device()
         )
         # Create tensor with the received shape and dtype
         tensor = torch.empty(tensor_shape, dtype=dtype, device=device)

--- a/areal/utils/device.py
+++ b/areal/utils/device.py
@@ -6,6 +6,7 @@ from typing import Tuple
 import torch
 import torch.distributed as dist
 
+from areal.platforms import current_platform
 from areal.utils import logging
 
 logger = logging.getLogger(__file__)
@@ -43,9 +44,9 @@ def gpu_count():
         return 0
     elif platform.system() == "Windows":
         try:
-            import torch
+            pass
 
-            return torch.cuda.device_count()
+            return current_platform.device_count()
         except ImportError:
             return 0
     else:

--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -4,7 +4,6 @@ import os
 import pickle
 from typing import Dict, List
 
-import torch
 import torch.distributed as dist
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor, PreTrainedTokenizerFast
@@ -12,6 +11,7 @@ from transformers import AutoProcessor, PreTrainedTokenizerFast
 from areal.api.cli_args import RecoverConfig
 from areal.api.engine_api import InferenceEngine, TrainEngine
 from areal.api.io_struct import FinetuneSpec, SaveLoadMeta, StepInfo, WeightUpdateMeta
+from areal.platforms import current_platform
 from areal.utils import logging, timeutil
 from areal.utils.evaluator import Evaluator
 from areal.utils.saver import Saver
@@ -262,7 +262,7 @@ class RecoverHandler:
                 if dist.get_rank() == 0:
                     future.result()
                 dist.barrier(device_ids=[update_engine.device.index])
-                torch.cuda.synchronize()
+                current_platform.synchronize()
                 inference_engine.resume()
                 update_engine.set_version(global_step + 1)
                 inference_engine.set_version(global_step + 1)

--- a/areal/utils/seeding.py
+++ b/areal/utils/seeding.py
@@ -6,6 +6,8 @@ import numpy as np
 import torch
 import transformers
 
+from areal.platforms import current_platform
+
 _SEED = None
 _BASE_SEED = None
 _SHUFFLER = None
@@ -25,10 +27,10 @@ def set_random_seed(base_seed: int, key: str) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    if torch.cuda.is_available():
+    if current_platform.is_available():
         # NOTE: Here we does not call `manual_seed_all`.
         # Because when launching with torchrun `manual_seed_all` will set seed for all GPUs.
-        torch.cuda.manual_seed(seed)
+        current_platform.manual_seed(seed)
 
 
 def get_seed() -> int:

--- a/examples/math/gsm8k_grpo.py
+++ b/examples/math/gsm8k_grpo.py
@@ -3,7 +3,6 @@ import os
 import sys
 from copy import deepcopy
 
-import torch
 import torch.distributed as dist
 from torchdata.stateful_dataloader import StatefulDataLoader
 
@@ -13,6 +12,7 @@ from areal.api.io_struct import FinetuneSpec, StepInfo, WeightUpdateMeta
 from areal.dataset import get_custom_dataset
 from areal.engine.ppo.actor import FSDPPPOActor
 from areal.engine.sglang_remote import RemoteSGLangEngine
+from areal.platforms import current_platform
 from areal.utils import seeding, stats_tracker
 from areal.utils.data import broadcast_tensor_container
 from areal.utils.device import log_gpu_stats
@@ -198,7 +198,7 @@ def main(args):
             )
         # Create barrier to synchronize all rollout processes.
         dist.barrier(device_ids=[actor.device.index])
-        torch.cuda.synchronize()
+        current_platform.synchronize()
 
         if config.actor.recompute_logprob or config.actor.use_decoupled_loss:
             with stats_tracker.record_timing("recompute_logp"):
@@ -233,7 +233,7 @@ def main(args):
             if dist.get_rank() == 0:
                 future.result()
             dist.barrier(device_ids=[actor.device.index])
-            torch.cuda.synchronize()
+            current_platform.synchronize()
 
             actor.set_version(global_step + 1)
             rollout.set_version(global_step + 1)
@@ -273,7 +273,7 @@ def main(args):
             )
 
         dist.barrier(device_ids=[actor.device.index])
-        torch.cuda.synchronize()
+        current_platform.synchronize()
 
         # Upload statistics to the logger (e.g., wandb)
         stats[0].update(
@@ -282,7 +282,7 @@ def main(args):
         stats_logger.commit(epoch, step, global_step, stats)
 
         dist.barrier(device_ids=[actor.device.index])
-        torch.cuda.synchronize()
+        current_platform.synchronize()
 
         # Resume rollout
         rollout.resume()


### PR DESCRIPTION
This PR introduces a device-agnostic feature that enables AReaL with broader support for running on multiple hardware backends. The implementation follows the existing architecture and attempt to avoidsany backend-specific assumptions.

- The changes are designed to be general and do not affect the behavior of existing supported CUDA devices.

- This will enable our use case to run the codebase seamlessly on multiple devices, including Ascend, for which support is actively being developed.

- Modifications have been validated to be compliant with the current device platform layer.

This PR replaces a previous one and includes some minor modifications. Thank you for your understanding.