### PR TITLE
Fix missing imports in experimental/api/cli_args.py

### DIFF
--- a/areal/experimental/api/cli_args.py
+++ b/areal/experimental/api/cli_args.py
@@ -1,4 +1,13 @@
-from areal.api.cli_args import *
+from dataclasses import dataclass, field
+from typing import List
+
+from areal.api.cli_args import (
+    BaseExperimentConfig,
+    GenerationHyperparameters,
+    InferenceEngineConfig,
+    PPOActorConfig,
+    TrainEngineConfig,
+)
 
 
 # TODO: Select useful options, add documentation string when moving out of experimental
@@ -14,7 +23,7 @@ class DistributedDataParallelConfig:
     align_param_gather: bool = False
     use_distributed_optimizer: bool = True
     check_for_nan_in_grad: bool = False
-    bucket_size: Optional[int] = None
+    bucket_size: int | None = None
     average_in_collective: bool = False
     fp8_param_gather: bool = False
 
@@ -55,11 +64,11 @@ class MegatronEngineConfig:
     use_deterministic_algorithms: bool = False
 
     # Gradient checkpointing options, only effective when gradient_checkpointing=True
-    recompute_granularity: Optional[str] = "full"
-    recompute_method: Optional[str] = "uniform"
-    recompute_num_layers: Optional[int] = 1
-    distribute_saved_activations: Optional[bool] = None
-    recompute_modules: Optional[List[str]] = None
+    recompute_granularity: str | None = "full"
+    recompute_method: str | None = "uniform"
+    recompute_num_layers: int | None = 1
+    distribute_saved_activations: bool | None = None
+    recompute_modules: List[str] | None = None
 
 
 @dataclass


### PR DESCRIPTION
This pull request refactors type annotations in the experimental CLI arguments module to use Python 3.10+ union syntax (`| None`) instead of `Optional`, and updates import statements for clarity. These changes modernize the codebase and improve readability.

Type annotation modernization:

* Replaced all instances of `Optional[...]` with the more concise `type | None` union syntax in the `DistributedDataParallelConfig` and `MegatronEngineConfig` classes. [[1]](diffhunk://#diff-93869537105b16f9b3368cdf3258949964156cd7c3e6fa0223c4e79467dfbad9L17-R26) [[2]](diffhunk://#diff-93869537105b16f9b3368cdf3258949964156cd7c3e6fa0223c4e79467dfbad9L58-R71)

Import improvements:

* Updated import statements to explicitly import required classes from `areal.api.cli_args`, removing wildcard imports and adding necessary standard library imports (`dataclass`, `field`, `List`).