### PR TITLE
feat: support single controller and balance batch

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -948,6 +948,16 @@ class DatasetConfig:
     drop_last: bool = field(
         default=True, metadata={"help": "Drop the last incomplete batch"}
     )
+    single_rank_load: bool = field(
+        default=False,
+        metadata={"help": "Use single rank rollout send/recive or not"},
+    )
+    balance_batch: bool = field(
+        default=False,
+        metadata={
+            "help": "balance all rollouts across dp ranks by total tokens.now, it works only when single_rank_load was set true."
+        },
+    )
     max_length: int | None = field(
         default=None,
         metadata={

--- a/areal/engine/sglang_remote.py
+++ b/areal/engine/sglang_remote.py
@@ -17,11 +17,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 
 from areal.api.cli_args import InferenceEngineConfig
 from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import (
-    ModelRequest,
-    ModelResponse,
-    WeightUpdateMeta,
-)
+from areal.api.io_struct import ModelRequest, ModelResponse, WeightUpdateMeta
 from areal.api.workflow_api import RolloutWorkflow, WorkflowExecutor
 from areal.platforms import current_platform
 from areal.utils import logging, name_resolve, names
@@ -385,12 +381,14 @@ class RemoteSGLangEngine(InferenceEngine):
         workflow: Optional[RolloutWorkflow] = None,
         workflow_builder: Optional[Callable] = None,
         should_accept: Callable | None = None,
+        single_rank_load: bool = False,
     ):
         return self.workflow_executor.prepare_batch(
             dataloader=dataloader,
             workflow=workflow,
             workflow_builder=workflow_builder,
             should_accept=should_accept,
+            single_rank_load=single_rank_load,
         )
 
     def pause(self):

--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -17,11 +17,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 
 from areal.api.cli_args import InferenceEngineConfig
 from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import (
-    ModelRequest,
-    ModelResponse,
-    WeightUpdateMeta,
-)
+from areal.api.io_struct import ModelRequest, ModelResponse, WeightUpdateMeta
 from areal.api.workflow_api import RolloutWorkflow, WorkflowExecutor
 from areal.platforms import current_platform
 from areal.utils import logging, name_resolve, names
@@ -361,12 +357,14 @@ class RemotevLLMEngine(InferenceEngine):
         workflow: Optional[RolloutWorkflow] = None,
         workflow_builder: Optional[Callable] = None,
         should_accept: Callable | None = None,
+        single_rank_load: bool = False,
     ):
         return self.workflow_executor.prepare_batch(
             dataloader=dataloader,
             workflow=workflow,
             workflow_builder=workflow_builder,
             should_accept=should_accept,
+            single_rank_load=single_rank_load,
         )
 
     def pause(self):

--- a/areal/tests/test_utils.py
+++ b/areal/tests/test_utils.py
@@ -3,6 +3,7 @@ import torch
 
 from areal.api.cli_args import MicroBatchSpec
 from areal.utils.data import (
+    balance_batch,
     pack_tensor_dict,
     pad_and_stack_tensors_along_first_dim,
     pad_sequences_to_tensors,
@@ -69,3 +70,65 @@ def test_micro_batch_split(mock_padded_data, n_mbs, max_tokens_per_mb):
         assert torch.allclose(x, packed_data[key])
         y = pad_and_stack_tensors_along_first_dim(xs)
         assert torch.allclose(mock_padded_data[key], y)
+
+
+def mock_rollout_data(bs, max_prompt_len, max_answer_len):
+    prompt_lens = torch.randint(1, max_prompt_len, size=(bs,))
+    answer_lens = torch.randint(1, max_answer_len, size=(bs,))
+    all_data = []
+    for prompt_len, ans_len in zip(prompt_lens, answer_lens):
+        prompt_len = int(prompt_len)
+        ans_len = int(ans_len)
+        seq = dict(
+            input_ids=torch.randint(0, VOCAB_SIZE, size=(prompt_len + ans_len,)),
+            loss_mask=torch.tensor([0] * prompt_len + [1] * ans_len),
+            logprobs=torch.randn(prompt_len + ans_len),
+            position_ids=torch.arange(prompt_len + ans_len),
+        )
+        all_data.append(seq)
+    return pad_sequences_to_tensors(all_data)
+
+
+def similar_by_cv(numbers):
+    mean = sum(numbers) / len(numbers)
+    std_dev = (sum((x - mean) ** 2 for x in numbers) / len(numbers)) ** 0.5
+    cv = std_dev / mean
+    return cv
+
+
+@pytest.mark.parametrize(
+    "gbs,max_prompt_len,max_answer_len",
+    [(32, 512, 2048), (32, 512, 4096), (64, 512, 4096)],
+)
+@pytest.mark.parametrize("dp_num", [4, 8, 16])
+def test_balance_batch(dp_num, gbs, max_prompt_len, max_answer_len):
+    mbs = gbs // dp_num
+    tensordict_list = []
+    for i in range(dp_num):
+        tensordict_list.append(mock_rollout_data(mbs, max_prompt_len, max_answer_len))
+    total_tokens_per_rank_original = []
+    for batch in tensordict_list:
+        batch_size = batch["attention_mask"].shape[0]
+        assert batch_size == mbs
+        total_tokens = sum(
+            batch["attention_mask"].view(batch_size, -1).sum(-1).tolist()
+        )
+        total_tokens_per_rank_original.append(total_tokens)
+    batches = balance_batch(tensordict_list, dp_num)
+    batch_per_rank = [batch for batch in batches]
+    total_tokens_per_rank = []
+    for batch in batch_per_rank:
+        batch_size = batch["attention_mask"].shape[0]
+        assert batch_size == mbs
+        total_tokens = sum(
+            batch["attention_mask"].view(batch_size, -1).sum(-1).tolist()
+        )
+        total_tokens_per_rank.append(total_tokens)
+    cv_original = similar_by_cv(total_tokens_per_rank_original)
+    cv_balance = similar_by_cv(total_tokens_per_rank)
+    print(
+        f"-----cv_original {cv_original} total_tokens_per_rank_original  {total_tokens_per_rank_original}"
+    )
+    print(f"-----cv_balance {cv_balance} total_tokens_per_rank {total_tokens_per_rank}")
+    print("*****************************************************")
+    assert cv_original >= cv_balance

--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -175,6 +175,7 @@ class RecoverHandler:
         tokenizer: PreTrainedTokenizerFast | None = None,
         processor: AutoProcessor | None = None,
         base_model_path: str | None = None,
+        single_rank_load: bool = False,
     ):
         if self.config.mode == "disabled":
             return
@@ -196,6 +197,8 @@ class RecoverHandler:
             )
 
         self.last_step_info = step_info
+        if single_rank_load and dist.is_initialized() and dist.get_rank() != 0:
+            return
         recover_info = RecoverInfo(
             last_step_info=self.last_step_info,
             saver_info=saver.state_dict(),

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -72,6 +72,7 @@ For detailed examples, see the experiment configurations in the `examples/` dire
 ### Others
 
 - [Scheduler Configuration](section-scheduler)
+- [vLLM Configuration](section-v-llm)
 
 ______________________________________________________________________
 
@@ -558,16 +559,18 @@ https://docs.vllm.ai/en/stable/api/index.html for detailed documentation.
 
 Configuration for dataset loading and preprocessing.
 
-| Parameter     | Type            | Default      | Description                                                                      |
-| ------------- | --------------- | ------------ | -------------------------------------------------------------------------------- |
-| `path`        | string          | **Required** | Path to the dataset. Can be a local path or a HuggingFace dataset name.          |
-| `type`        | string          | **Required** | Type of training method, e.g., 'sft', 'rl', etc.                                 |
-| `batch_size`  | integer         | `1`          | Batch size for the dataloader                                                    |
-| `shuffle`     | boolean         | `True`       | Whether to shuffle the dataset                                                   |
-| `pin_memory`  | boolean         | `False`      | Pin memory for faster data loading (set True for GPU training)                   |
-| `num_workers` | integer         | `0`          | Number of worker processes for data loading                                      |
-| `drop_last`   | boolean         | `True`       | Drop the last incomplete batch                                                   |
-| `max_length`  | integer \| None | `None`       | Maximum token length of sequences in dataset. Longer sequences are filtered out. |
+| Parameter          | Type            | Default      | Description                                                                                                 |
+| ------------------ | --------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `path`             | string          | **Required** | Path to the dataset. Can be a local path or a HuggingFace dataset name.                                     |
+| `type`             | string          | **Required** | Type of training method, e.g., 'sft', 'rl', etc.                                                            |
+| `batch_size`       | integer         | `1`          | Batch size for the dataloader                                                                               |
+| `shuffle`          | boolean         | `True`       | Whether to shuffle the dataset                                                                              |
+| `pin_memory`       | boolean         | `False`      | Pin memory for faster data loading (set True for GPU training)                                              |
+| `num_workers`      | integer         | `0`          | Number of worker processes for data loading                                                                 |
+| `drop_last`        | boolean         | `True`       | Drop the last incomplete batch                                                                              |
+| `single_rank_load` | boolean         | `False`      | Use single rank rollout send/recive or not                                                                  |
+| `balance_batch`    | boolean         | `False`      | balance all rollouts across dp ranks by total tokens.now, it works only when single_rank_load was set true. |
+| `max_length`       | integer \| None | `None`       | Maximum token length of sequences in dataset. Longer sequences are filtered out.                            |
 
 (section-cluster)=
 
@@ -748,3 +751,29 @@ Configuration for worker scheduling. Used in the single-controller mode. Experim
 | `reward_functioncall_config`  | `Dict` | **Required**                        | -           |
 | `reward_model_path`           | string | `""`                                | -           |
 | `reward_model_service_url`    | string | `"http://localhost:30000/classify"` | -           |
+
+(section-v-llm)=
+
+## vLLM Configuration
+
+Configuration for vLLM runtime.
+
+| Parameter                | Type            | Default                                                             | Description |
+| ------------------------ | --------------- | ------------------------------------------------------------------- | ----------- |
+| `model`                  | string          | `""`                                                                | -           |
+| `seed`                   | integer         | `1`                                                                 | -           |
+| `skip_tokenizer_init`    | boolean         | `False`                                                             | -           |
+| `enforce_eager`          | boolean         | `True`                                                              | -           |
+| `dtype`                  | string          | `"bfloat16"`                                                        | -           |
+| `max_num_seqs`           | integer         | `256`                                                               | -           |
+| `block_size`             | integer         | `16`                                                                | -           |
+| `swap_space`             | integer         | `4`                                                                 | -           |
+| `cpu_offload_gb`         | float           | `0`                                                                 | -           |
+| `max_seq_len_to_capture` | integer         | `32768`                                                             | -           |
+| `disable_sliding_window` | boolean         | `True`                                                              | -           |
+| `max_model_len`          | integer \| None | `32768`                                                             | -           |
+| `enable_chunked_prefill` | boolean         | `False`                                                             | -           |
+| `enable_prefix_caching`  | boolean         | `False`                                                             | -           |
+| `gpu_memory_utilization` | float           | `0.9`                                                               | -           |
+| `worker_extension_cls`   | string          | `"areal.thirdparty.vllm.vllm_worker_extension.VLLMWorkerExtension"` | -           |
+| `enable_sleep_mode`      | boolean         | `False`                                                             | -           |

--- a/examples/math/boba_grpo.py
+++ b/examples/math/boba_grpo.py
@@ -17,6 +17,7 @@ from areal.utils import logging, seeding, stats_tracker
 from areal.utils.data import (
     broadcast_tensor_container,
     cycle_dataloader,
+    distributed_batch,
     tensor_container_to,
 )
 from areal.utils.device import log_gpu_stats
@@ -79,6 +80,10 @@ def boba_reward_fn(
     return label
 
 
+def is_init_dataloader(single_rank_load, rank) -> bool:
+    return (single_rank_load and rank == 0) or (not single_rank_load)
+
+
 def main(args):
     config, _ = load_expr_config(args, GRPOConfig)
     config: GRPOConfig
@@ -92,20 +97,30 @@ def main(args):
     seeding.set_random_seed(config.seed, key=f"trainer{rank}")
     allocation_mode = AllocationMode.from_str(config.allocation_mode)
     parallel_strategy = allocation_mode.train
-    train_dataset = get_boba_math_dataset(
-        config.train_dataset.path, tokenizer, rank=rank, world_size=world_size
-    )
+    if config.train_dataset.single_rank_load:
+        train_dataset = get_boba_math_dataset(
+            config.train_dataset.path, tokenizer, rank=0, world_size=1
+        )
+    else:
+        train_dataset = get_boba_math_dataset(
+            config.train_dataset.path, tokenizer, rank=rank, world_size=world_size
+        )
+
     # Create dataset and dataloaders
-    train_dataloader = StatefulDataLoader(
-        train_dataset,
-        batch_size=config.train_dataset.batch_size,
-        shuffle=config.train_dataset.shuffle,
-        num_workers=config.train_dataset.num_workers,
-        collate_fn=lambda x: x,
-        drop_last=config.train_dataset.drop_last,
-    )
-    config.rollout.consumer_batch_size *= world_size
-    config.rollout.max_concurrent_rollouts *= world_size
+    if is_init_dataloader(config.train_dataset.single_rank_load, rank):
+        train_dataloader = StatefulDataLoader(
+            train_dataset,
+            batch_size=config.train_dataset.batch_size,
+            shuffle=config.train_dataset.shuffle,
+            num_workers=config.train_dataset.num_workers,
+            collate_fn=lambda x: x,
+            drop_last=config.train_dataset.drop_last,
+        )
+        config.rollout.consumer_batch_size *= world_size
+        config.rollout.max_concurrent_rollouts *= world_size
+    else:
+        # Create empty datqaloader for other ranks when using single rank load
+        train_dataloader = StatefulDataLoader([])
 
     actor = FSDPPPOActor(config=config.actor)
     actor.create_process_group(parallel_strategy=parallel_strategy)
@@ -114,6 +129,9 @@ def main(args):
     dateset_len_tensor = torch.tensor(
         [train_dataset_len], dtype=torch.long, device=device
     )
+    # When using single_rank_load all ranks need to know the dataset length
+    if config.train_dataset.single_rank_load:
+        dist.broadcast(dateset_len_tensor, src=0)
     train_dataset_len = dateset_len_tensor.item()
     ft_spec = FinetuneSpec(
         total_train_epochs=config.total_train_epochs,
@@ -140,6 +158,8 @@ def main(args):
     # NOTE: Weight update meta only requires address and free port of rank 0,
     # but `WeightUpdateMeta.from_fsdp_xccl` has to be executed on all ranks
     weight_update_meta = get_model_update_meta(config, actor)
+    if config.train_dataset.single_rank_load:
+        dist.broadcast_object_list(weight_update_meta, src=0)
     weight_update_meta = weight_update_meta[0]
 
     # Create rollout workflow
@@ -182,8 +202,10 @@ def main(args):
     total_epochs = config.total_train_epochs
     steps_per_epoch = train_dataset_len
     max_steps = total_epochs * steps_per_epoch
+    # Initialize cycle_dataloader
+    if is_init_dataloader(config.train_dataset.single_rank_load, rank):
+        data_generator = cycle_dataloader(train_dataloader)
 
-    data_generator = cycle_dataloader(train_dataloader)
     for global_step in range(start_step, max_steps):
         if stop_step and global_step >= stop_step:
             logger.info("Training stopped at step %d", global_step)
@@ -197,30 +219,51 @@ def main(args):
             epoch_step=step,
             steps_per_epoch=steps_per_epoch,
         )
+        batch = None
+        if is_init_dataloader(config.train_dataset.single_rank_load, rank):
+            with stats_tracker.record_timing("rollout"):
+                if actor.is_data_parallel_head():
+                    if config.async_training:
+                        batch = rollout.prepare_batch(
+                            train_dataloader,
+                            workflow=workflow,
+                            should_accept=lambda sample: True,
+                            single_rank_load=config.train_dataset.single_rank_load,
+                        )
+                    else:
+                        try:
+                            data = next(data_generator)
+                        except StopIteration:
+                            data_generator = iter(train_dataloader)
+                            data = next(data_generator)
+                            batch = rollout.rollout_batch(
+                                data=data,
+                                workflow=workflow,
+                                should_accept=lambda sample: True,
+                            )
+                    if not config.train_dataset.single_rank_load:
+                        batch = tensor_container_to(batch, actor.device)
+                if not config.train_dataset.single_rank_load:
+                    batch = broadcast_tensor_container(
+                        batch,
+                        src_rank=actor.current_data_parallel_head(),
+                        group=actor.context_and_model_parallel_group,
+                    )
 
-        with stats_tracker.record_timing("rollout"):
-            batch = None
-            if actor.is_data_parallel_head():
-                if config.async_training:
-                    batch = rollout.prepare_batch(
-                        train_dataloader,
-                        workflow=workflow,
-                        should_accept=lambda sample: True,
-                    )
-                else:
-                    batch = rollout.rollout_batch(
-                        next(data_generator),
-                        workflow=workflow,
-                        should_accept=lambda sample: True,
-                    )
-                batch = tensor_container_to(batch, actor.device)
-            batch = broadcast_tensor_container(
-                batch,
-                src_rank=actor.current_data_parallel_head(),
-                group=actor.context_and_model_parallel_group,
-            )
         # Create barrier to synchronize all rollout processes.
         dist.barrier(device_ids=[actor.device.index])
+
+        # After rollout finishing, broadcast rollout data to each rank when using single rank load
+        if config.train_dataset.single_rank_load:
+            batch = distributed_batch(
+                batch,
+                rank,
+                config.train_dataset.batch_size,
+                device,
+                world_size,
+                config.train_dataset.balance_batch,
+            )
+            batch = tensor_container_to(batch, actor.device)
         current_platform.synchronize()
 
         if config.actor.recompute_logprob or config.actor.use_decoupled_loss:
@@ -273,6 +316,7 @@ def main(args):
                 stats_logger,
                 train_dataloader,
                 tokenizer=tokenizer,
+                single_rank_load=config.train_dataset.single_rank_load,
             )
         stats_logger.commit(epoch, step, global_step, stats)
 


### PR DESCRIPTION
## Overview
1. Add single-control mode, enabled by setting `single_rank_load=True`. This feature avoid possible timeouts caused by severe imbalance in rollout results across trainer DP ranks when `max_concurrent_rollouts` and `max_head_offpolicyness `are large.

2. Introduce DP load-balancing for single-control mode, inspired by [verl's seqlen balancer](https://github.com/volcengine/verl/blob/main/verl/utils/seqlen_balancing.py). The algorithm actively rebalances workload among DP ranks, ensuring more even utilization and improving performance.