### PR TITLE
disable radix cache for sglang by default

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -541,7 +541,7 @@ class SGLangConfig:
     random_seed: int = 1
     skip_tokenizer_init: bool = False
     disable_cuda_graph: bool = False
-    disable_radix_cache: bool = False
+    disable_radix_cache: bool = True
     disable_cuda_graph_padding: bool = False
     enable_nccl_nvls: bool = False
     disable_outlines_disk_cache: bool = False

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -479,7 +479,7 @@ https://github.com/sgl-project/sglang for detailed documentation.
 | `random_seed`                     | integer                 | `1`          | -           |
 | `skip_tokenizer_init`             | boolean                 | `False`      | -           |
 | `disable_cuda_graph`              | boolean                 | `False`      | -           |
-| `disable_radix_cache`             | boolean                 | `False`      | -           |
+| `disable_radix_cache`             | boolean                 | `True`       | -           |
 | `disable_cuda_graph_padding`      | boolean                 | `False`      | -           |
 | `enable_nccl_nvls`                | boolean                 | `False`      | -           |
 | `disable_outlines_disk_cache`     | boolean                 | `False`      | -           |


### PR DESCRIPTION
SGLang's radix cache will sometimes harm learning efficiency, probably due to the improper cache flushing and pause calls during AReaL's weight update. As a result, the learning curve may suddenly collapse in the middle stage of training.

This PR disables radix cache by default. According to previous benchmarks, it will hardly decrease generation throughput in long-context (e.g., 8k+) scenarios, but largely stablize training.