### PR TITLE
fix:launch_server.py: error: unrecognized arguments: --max-loaded-lor…

### DIFF
--- a/examples/env/setup-pip-deps.sh
+++ b/examples/env/setup-pip-deps.sh
@@ -4,7 +4,7 @@ pip install -U pip
 pip uninstall pynvml cugraph-dgl dask-cuda cugraph-service-server raft-dask cugraph cuml cugraph-pyg -y
 pip install torch==2.7.1 torchaudio==2.7.1 torchvision==0.22.1 "deepspeed>=0.17.2" pynvml
 pip install flashinfer-python==0.2.7.post1 --no-build-isolation
-pip install "sglang[all]>=0.5.3.post1"
+pip install "sglang[all]>=0.5.2"
 pip install megatron-core==0.11.0 nvidia-ml-py
 pip install git+https://github.com/garrett4wade/cugae --no-build-isolation --verbose
 pip install "flash-attn<=2.8.2" --no-build-isolation


### PR DESCRIPTION
when i run the "python3 -m areal.launcher.local examples/math/gsm8k_grpo.py --config examples/math/gsm8k_grpo.yaml experiment_name=<your experiment name> trial_name=<your trial name>" , it occurs that "launch_server.py: error: unrecognized arguments: --max-loaded-loras 1",after i update the version of SGlang,it could be fixed