### PR TITLE
Fix a bug of preparing Ulysses inputs for loss function in PPO

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -401,7 +401,6 @@ class FSDPEngine(BaseHFEngine):
         for pad_length, padded_mb_input, mb_input in zip(
             mb_list.padding_lengths, mb_list.padded_mbs, mb_list.mbs
         ):
-            ulysses_pad_size = 0
             if self.parallel_helper.sp_size > 1:
                 input_ids = padded_mb_input["input_ids"]
                 position_ids = padded_mb_input.get("position_ids", None)
@@ -410,7 +409,7 @@ class FSDPEngine(BaseHFEngine):
                     (
                         ulysses_input_ids,
                         ulysses_position_ids,
-                        ulysses_pad_size,
+                        _,
                     ) = ulysses_pad(
                         input_ids, position_ids, sp_size=self.parallel_helper.sp_size
                     )
@@ -419,7 +418,7 @@ class FSDPEngine(BaseHFEngine):
                     (
                         ulysses_input_ids,
                         ulysses_position_ids,
-                        ulysses_pad_size,
+                        _,
                     ) = ulysses_pad_and_slice_inputs(
                         input_ids,
                         position_ids,
@@ -433,7 +432,10 @@ class FSDPEngine(BaseHFEngine):
                     ulysses_position_ids = ulysses_position_ids.contiguous()
 
                 inputs = ulysses_prepare_inputs(
-                    padded_mb_input, ulysses_input_ids, ulysses_position_ids, self.parallel_helper.sp_size
+                    padded_mb_input,
+                    ulysses_input_ids,
+                    ulysses_position_ids,
+                    self.parallel_helper.sp_size,
                 )
             else:
                 inputs = padded_mb_input
@@ -536,7 +538,10 @@ class FSDPEngine(BaseHFEngine):
                     ulysses_position_ids = ulysses_position_ids.contiguous()
 
                 inputs = ulysses_prepare_inputs(
-                    padded_mb_input, ulysses_input_ids, ulysses_position_ids, self.parallel_helper.sp_size
+                    padded_mb_input,
+                    ulysses_input_ids,
+                    ulysses_position_ids,
+                    self.parallel_helper.sp_size,
                 )
             else:
                 inputs = padded_mb_input

--- a/areal/engine/ppo/actor.py
+++ b/areal/engine/ppo/actor.py
@@ -305,7 +305,9 @@ def grpo_loss_fn(
     )
     old_logp = input_data["logprobs"]
     advantages = input_data["advantages"]
-    loss_mask = input_data["loss_mask"].bool()
+    # Use unsliced/full loss_mask.
+    # Ulysses SP will slice loss_mask in ulysses_prepare_inputs().
+    loss_mask = input_data["full_loss_mask"].bool()
     prox_logp = input_data["prox_logp"]
 
     logprobs, entropy = gather_logprobs_entropy(logits, labels, temperature)


### PR DESCRIPTION
This pull request refactors how loss masks and input slicing are handled in the Ulysses pipeline, with a focus on improving clarity and correctness for distributed (SP) training. The main changes ensure that the full (unsliced) loss mask is preserved for the loss function, while the sliced version is used for model inputs. Additionally, the code for preparing and slicing inputs has been clarified and made more robust.

**Loss mask handling improvements:**

* The loss function (`grpo_loss_fn` in `actor.py`) now uses `full_loss_mask` instead of the sliced `loss_mask`, ensuring the loss is computed on the correct mask. The slicing of `loss_mask` is now delegated to `ulysses_prepare_inputs`.

* In `ulysses_prepare_inputs` (`ulysses.py`), when processing the `loss_mask` key, the code now saves the full (unsliced) version as `full_loss_mask` for use in the loss function, and also stores the sliced version for model inputs.

**Input preparation and slicing:**

* The `ulysses_prepare_inputs` function has been refactored for clarity, with improved logic for which tensors to slice and how to handle keys like `values`, `returns`, and `loss_mask`. This includes a more robust check for tensor types and shapes.

* The function signatures and calls to `ulysses_prepare_inputs` have been updated throughout the codebase (in both `fsdp_engine.py` and `ulysses.py`) to use multi-line arguments for clarity and maintain consistent parameter ordering. [[1]](diffhunk://#diff-a0d0670c0725a58e05550c63233df81ddc97d72d979170d0b5945910cb33d9abL436-R438) [[2]](diffhunk://#diff-a0d0670c0725a58e05550c63233df81ddc97d72d979170d0b5945910cb33d9abL539-R544) [[3]](diffhunk://#diff-c31c34b1a90e886b96e05ea64c1cc05501bc85c19a49464ef3150603999a4df2L228-R233)

**Minor cleanups:**

* Unused variables related to padding size have been removed in `fsdp_engine.py`, simplifying the code and reducing potential confusion. [[1]](diffhunk://#diff-a0d0670c0725a58e05550c63233df81ddc97d72d979170d0b5945910cb33d9abL404) [[2]](diffhunk://#diff-a0d0670c0725a58e05550c63233df81ddc97d72d979170d0b5945910cb33d9abL413-R412) [[3]](diffhunk://#diff-a0d0670c0725a58e05550c63233df81ddc97d72d979170d0b5945910cb33d9abL422-R421)