### PR TITLE
fix-influence-trajectories

### DIFF
--- a/examples/multi-turn-math/train.py
+++ b/examples/multi-turn-math/train.py
@@ -74,7 +74,7 @@ class MultiTurnMathAgent:
         self.async_reward_fn = AsyncRewardWrapper(gsm8k_reward_fn)
 
     async def run_agent(self, data, client: ArealOpenAI):
-        messages = data["messages"]
+        messages = data["messages"].copy()
         num_turns_left = self.max_turns
         completions = []
         while num_turns_left > 0:


### PR DESCRIPTION
**Fix for Multiple Trajectory Interference in Multi-Turn-Math Example**

This PR resolves the issue of different trajectories of the same sample influencing each other in the multi-turn-math training file by ensuring that each trajectory has an independent copy of the messages object.

For more details, see: https://github.com/inclusionAI/AReaL/issues/432