### PR TITLE
fix update weights from disk in FSDP engine

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -420,7 +420,10 @@ class FSDPEngine(BaseHFEngine):
             )
         self.rollout_engine = engine
 
-        if meta.type != "disk" and not self.weight_update_group_initialized:
+        if (
+            meta.type == current_platform.communication_backend
+            and not self.weight_update_group_initialized
+        ):
             self._init_weight_update_from_distributed(meta)
             self.weight_update_group_initialized = True
 


### PR DESCRIPTION
1. Skip initializing weight update groups when using disk-based update.
2. Write `name_resolve` entry first then wait for results.

NOTE: The same fix for the megatron engine will be applied in #324.