### PR TITLE
fix: update weight format handling for MegatronEngine in recover.py

### DIFF
--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -272,6 +272,7 @@ class RecoverHandler:
     def _get_weight_format(self, engine: TrainEngine) -> str:
         from areal.experimental.megatron_engine import MegatronEngine
 
+        # TODO: Enable DCP format for FSDP
         return "dcp" if isinstance(engine, MegatronEngine) else "hf"
 
     def _save_checkpoint(


### PR DESCRIPTION
This pull request updates checkpoint handling in `areal/utils/recover.py` to add support for the `MegatronEngine`. The main change is that the code now selects the appropriate weight format when saving or loading checkpoints, depending on the engine type.

**Engine-specific checkpoint format handling:**

* Imported `MegatronEngine` from `areal.experimental.megatron_engine` to enable engine type checks.
* Updated both `_save_checkpoint` and `_load_checkpoint` functions to use `"dcp"` as the `weight_format` when the engine is an instance of `MegatronEngine`, otherwise defaulting to `"hf"`. [[1]](diffhunk://#diff-341f9e473347f8f9559f562b703efabfd41ab423402e05cb87fe4a1eb80ea8f4R287-R289) [[2]](diffhunk://#diff-341f9e473347f8f9559f562b703efabfd41ab423402e05cb87fe4a1eb80ea8f4R318-R320)

```
Traceback (most recent call last):
  File "/storage/openpsi/users/zhangwentai.zwt/workspace/AReaL/workflow.py", line 568, in <module>
    main(sys.argv[1:])
  File "/storage/openpsi/users/zhangwentai.zwt/workspace/AReaL/workflow.py", line 533, in main
    recover_handler.dump(
  File "/storage/openpsi/users/zhangwentai.zwt/workspace/AReaL/areal/utils/recover.py", line 189, in dump
    self._save_checkpoint(
  File "/storage/openpsi/users/zhangwentai.zwt/workspace/AReaL/areal/utils/recover.py", line 296, in _save_checkpoint
    engine.save(meta)
  File "/storage/openpsi/users/zhangwentai.zwt/workspace/AReaL/areal/experimental/megatron_engine.py", line 678, in save
    not meta.with_optim
AssertionError: HF format does not support optimizer state saving, please use DCP format instead.
```