### PR TITLE
fix: fix the deprecated usage of tuple slicing, wandb's start_method, and transformers's dtype

### DIFF
--- a/areal/engine/base_hf_engine.py
+++ b/areal/engine/base_hf_engine.py
@@ -154,7 +154,7 @@ class BaseHFEngine(TrainEngine):
                 model = AutoModelForImageTextToText.from_pretrained(
                     pretrained_model_name_or_path=self.config.path,
                     trust_remote_code=True,
-                    torch_dtype=dtype,
+                    dtype=dtype,
                     attn_implementation=self.config.attn_impl,
                 )
                 if self.config.disable_dropout:
@@ -179,40 +179,35 @@ class BaseHFEngine(TrainEngine):
 
     def _create_llm_actor_or_critic(self):
         dtype = getattr(torch, self.config.dtype)
-        if not self.config.is_critic:
-            if self.config.init_from_scratch:
-                # initialize model from config
-                # NOTE: VLM cannot directly load state dict using this
-                # random initialized model, so otherwise we call
-                # from_pretrained rather than loading weights into this random model.
-                model = AutoModelForCausalLM.from_config(
-                    self.model_config,
-                    torch_dtype=dtype,
-                    attn_implementation=self.config.attn_impl,
-                )
-            else:
-                model = AutoModelForCausalLM.from_pretrained(
-                    pretrained_model_name_or_path=self.config.path,
-                    trust_remote_code=True,
-                    torch_dtype=dtype,
-                    attn_implementation=self.config.attn_impl,
-                )
+
+        if self.config.is_critic:
+            model_class = AutoModelForTokenClassification
+            model_kwargs = {"num_labels": 1}
         else:
-            if self.config.init_from_scratch:
-                model = AutoModelForTokenClassification.from_config(
-                    self.model_config,
-                    torch_dtype=dtype,
-                    num_labels=1,
-                    attn_implementation=self.config.attn_impl,
-                )
-            else:
-                model = AutoModelForTokenClassification.from_pretrained(
-                    pretrained_model_name_or_path=self.config.path,
-                    trust_remote_code=True,
-                    torch_dtype=dtype,
-                    num_labels=1,
-                    attn_implementation=self.config.attn_impl,
-                )
+            model_class = AutoModelForCausalLM
+            model_kwargs = {}
+
+        common_kwargs = {
+            "dtype": dtype,
+            "attn_implementation": self.config.attn_impl,
+        }
+        model_kwargs.update(common_kwargs)
+
+        if self.config.init_from_scratch:
+            # initialize model from config
+            # NOTE: VLM cannot directly load state dict using this
+            # random initialized model, so otherwise we call
+            # from_pretrained rather than loading weights into this random model.
+            model = model_class.from_config(
+                self.model_config,
+                **model_kwargs,
+            )
+        else:
+            model = model_class.from_pretrained(
+                pretrained_model_name_or_path=self.config.path,
+                trust_remote_code=True,
+                **model_kwargs,
+            )
         return model
 
     def destroy(self):

--- a/areal/utils/stats_logger.py
+++ b/areal/utils/stats_logger.py
@@ -65,7 +65,6 @@ class StatsLogger:
             force=True,
             id=f"{self.config.experiment_name}_{self.config.trial_name}_{suffix}",
             resume="allow",
-            settings=wandb.Settings(start_method="fork"),
         )
 
         swanlab_config = self.config.swanlab

--- a/areal/utils/ulysses.py
+++ b/areal/utils/ulysses.py
@@ -100,7 +100,7 @@ def _unpad_tensor(x: Tensor, dim: int, padding_size: int) -> Tensor:
         return x
     slc = [slice(None)] * len(x.shape)
     slc[dim] = slice(0, -padding_size)
-    return x[slc]
+    return x[tuple(slc)]
 
 
 def slice_input_tensor(
@@ -118,7 +118,7 @@ def slice_input_tensor(
     parts = x.size(dim) // sp_world_size
     slc = [slice(None)] * len(x.shape)
     slc[dim] = slice(sp_rank * parts, (sp_rank + 1) * parts)
-    return x[slc].contiguous()
+    return x[tuple(slc)].contiguous()
 
 
 def all_to_all_tensor(

--- a/evaluation/model_utils.py
+++ b/evaluation/model_utils.py
@@ -228,7 +228,7 @@ def load_hf_lm_and_tokenizer(
         # defaul load in float16
         model = AutoModelForCausalLM.from_pretrained(
             model_name_or_path,
-            torch_dtype=torch.float16,
+            dtype=torch.float16,
             device_map=device_map,
             trust_remote_code=True,
             use_safetensors=use_safetensors,

--- a/examples/docs/debug/cmp_rollout.py
+++ b/examples/docs/debug/cmp_rollout.py
@@ -27,7 +27,7 @@ def image2base64(images: List[ImageObject] | ImageObject) -> List[str] | str:
 model_id = "google/gemma-3-4b-it"
 
 model = Gemma3ForConditionalGeneration.from_pretrained(
-    model_id, torch_dtype=torch.bfloat16
+    pretrained_model_name_or_path=model_id, dtype=torch.bfloat16
 ).to("cuda")
 model.eval()
 


### PR DESCRIPTION
This pull request updates several model-loading and tensor manipulation functions across the codebase to improve consistency and correctness. The main change is standardizing the use of the `dtype` argument instead of `torch_dtype` when loading models, which aligns with recent library updates and prevents potential type mismatches. Additionally, tensor slicing operations are made more robust by ensuring slices are always passed as tuples.

### Model loading and initialization updates

* Replaced the `torch_dtype` argument with `dtype` in all calls to HuggingFace model loading functions (`from_pretrained` and `from_config`) in `areal/engine/base_hf_engine.py`, `evaluation/model_utils.py`, and `examples/docs/debug/cmp_rollout.py`, ensuring compatibility with the latest library conventions. [[1]](diffhunk://#diff-298ed14340a03f615bd08f7ee2d38c6245e63ee94413870671afd8457ca1d1bdL157-R157) [[2]](diffhunk://#diff-298ed14340a03f615bd08f7ee2d38c6245e63ee94413870671afd8457ca1d1bdL190-R212) [[3]](diffhunk://#diff-e08d6606cfa799ea7563575f31ba68863d7c19e60a81cbd1cdb92c928d3cd2beL231-R231) [[4]](diffhunk://#diff-2c7e6f6f25fdf162491bbcf972f33011c49d4abad73794b7e3aa7eb0a3d06ef4L30-R30)
* https://github.com/huggingface/transformers/pull/39782

### Tensor slicing improvements

* Updated tensor slicing in `areal/utils/ulysses.py` to always pass slices as tuples, preventing indexing errors and improving code clarity. [[1]](diffhunk://#diff-c31c34b1a90e886b96e05ea64c1cc05501bc85c19a49464ef3150603999a4df2L103-R103) [[2]](diffhunk://#diff-c31c34b1a90e886b96e05ea64c1cc05501bc85c19a49464ef3150603999a4df2L121-R121)
* https://github.com/pytorch/pytorch/commit/a6401cb5aa51622045c3f9a03b2cebef236e4182

### Logging configuration

* Removed the explicit `wandb.Settings(start_method="fork")` argument in the `init` function of `areal/utils/stats_logger.py`, simplifying the logging configuration.
* https://github.com/wandb/wandb/pull/9837