### PR TITLE
fix: access weight_update_mode from config.actor for GRPOConfig (#482)

### DIFF
--- a/areal/tests/test_model_utils.py
+++ b/areal/tests/test_model_utils.py
@@ -1,0 +1,195 @@
+"""Unit tests for areal.utils.model module."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from areal.api.cli_args import (
+    BaseExperimentConfig,
+    ClusterSpecConfig,
+    GRPOConfig,
+    PPOActorConfig,
+    PPOConfig,
+    PPOCriticConfig,
+    RWConfig,
+    SFTConfig,
+    TrainEngineConfig,
+)
+from areal.api.io_struct import WeightUpdateMeta
+from areal.utils.model import get_model_update_meta
+
+
+@dataclass
+class InvalidConfig(BaseExperimentConfig):
+    """Invalid config for testing - missing actor/model attribute."""
+
+    pass
+
+
+def _create_base_cluster_config(fileroot="/tmp/areal_test"):
+    """Helper to create a cluster config with common test values."""
+    cluster = ClusterSpecConfig()
+    cluster.fileroot = fileroot
+    return cluster
+
+
+def create_grpo_config(
+    experiment_name="test_experiment",
+    trial_name="test_trial",
+    allocation_mode="sglang.d4p1t1+d4p1t1",
+    weight_update_mode="disk",
+    fileroot="/tmp/areal_test",
+):
+    """Factory to create a GRPOConfig with sensible test defaults."""
+    config = GRPOConfig()
+    config.experiment_name = experiment_name
+    config.trial_name = trial_name
+    config.allocation_mode = allocation_mode
+    config.cluster = _create_base_cluster_config(fileroot)
+    config.actor = PPOActorConfig()
+    config.actor.weight_update_mode = weight_update_mode
+    return config
+
+
+def create_ppo_config(
+    experiment_name="test_experiment",
+    trial_name="test_trial",
+    allocation_mode="vllm.d4p1t2+d8p1t1",
+    weight_update_mode="disk",
+    fileroot="/tmp/areal_test",
+):
+    """Factory to create a PPOConfig with sensible test defaults."""
+    config = PPOConfig()
+    config.experiment_name = experiment_name
+    config.trial_name = trial_name
+    config.allocation_mode = allocation_mode
+    config.cluster = _create_base_cluster_config(fileroot)
+    config.actor = PPOActorConfig()
+    config.actor.weight_update_mode = weight_update_mode
+    config.critic = PPOCriticConfig()
+    return config
+
+
+def create_sft_config(
+    experiment_name="test_experiment",
+    trial_name="test_trial",
+    allocation_mode="d8p1t1",
+    weight_update_mode="disk",
+    fileroot="/tmp/areal_test",
+):
+    """Factory to create an SFTConfig with sensible test defaults."""
+    config = SFTConfig()
+    config.experiment_name = experiment_name
+    config.trial_name = trial_name
+    config.allocation_mode = allocation_mode
+    config.cluster = _create_base_cluster_config(fileroot)
+    config.model = TrainEngineConfig()
+    config.model.weight_update_mode = weight_update_mode
+    return config
+
+
+def create_rw_config(
+    experiment_name="test_experiment",
+    trial_name="test_trial",
+    allocation_mode="d8p1t1",
+    weight_update_mode="disk",
+    fileroot="/tmp/areal_test",
+):
+    """Factory to create an RWConfig with sensible test defaults."""
+    config = RWConfig()
+    config.experiment_name = experiment_name
+    config.trial_name = trial_name
+    config.allocation_mode = allocation_mode
+    config.cluster = _create_base_cluster_config(fileroot)
+    config.model = TrainEngineConfig()
+    config.model.weight_update_mode = weight_update_mode
+    return config
+
+
+class TestGetModelUpdateMeta:
+    """Tests for get_model_update_meta function."""
+
+    @pytest.mark.parametrize(
+        "config_factory,weight_update_mode,expected_type",
+        [
+            (create_grpo_config, "disk", "disk"),
+            (create_ppo_config, "disk", "disk"),
+            (create_sft_config, "disk", "disk"),
+            (create_rw_config, "disk", "disk"),
+            (create_grpo_config, "fsdp_xccl", "nccl"),
+            (create_ppo_config, "fsdp_xccl", "nccl"),
+            (create_sft_config, "fsdp_xccl", "nccl"),
+            (create_rw_config, "fsdp_xccl", "nccl"),
+        ],
+        ids=[
+            "GRPO-disk",
+            "PPO-disk",
+            "SFT-disk",
+            "RW-disk",
+            "GRPO-fsdp_xccl",
+            "PPO-fsdp_xccl",
+            "SFT-fsdp_xccl",
+            "RW-fsdp_xccl",
+        ],
+    )
+    def test_get_model_update_meta_modes(
+        self, config_factory, weight_update_mode, expected_type
+    ):
+        """Test get_model_update_meta with various configs and modes."""
+        config = config_factory(weight_update_mode=weight_update_mode)
+
+        result = get_model_update_meta(config)
+
+        assert isinstance(result, WeightUpdateMeta)
+        assert result.type == expected_type
+
+        if expected_type == "disk":
+            assert config.cluster.fileroot in result.path
+            assert config.experiment_name in result.path
+            assert config.trial_name in result.path
+
+    def test_invalid_config_type(self):
+        """Test that passing TrainEngineConfig directly raises TypeError."""
+        config = TrainEngineConfig()
+        config.experiment_name = "test_experiment"
+        config.trial_name = "test_trial"
+        config.weight_update_mode = "disk"
+
+        with pytest.raises(TypeError) as exc_info:
+            get_model_update_meta(config)
+
+        assert "must be BaseExperimentConfig" in str(exc_info.value)
+        assert "TrainEngineConfig" in str(exc_info.value)
+
+    def test_config_without_actor_or_model(self):
+        """Test that config without actor or model attribute raises ValueError."""
+        config = InvalidConfig()
+        config.experiment_name = "test_experiment"
+        config.trial_name = "test_trial"
+        config.allocation_mode = "d8p1t1"
+        config.cluster = ClusterSpecConfig()
+
+        with pytest.raises(ValueError) as exc_info:
+            get_model_update_meta(config)
+
+        assert "must have either 'actor' or 'model' attribute" in str(exc_info.value)
+
+    def test_regression_issue_482(self):
+        """Regression test for issue #482 - GRPOConfig with vLLM training.
+
+        This test verifies that the bug reported in issue #482 is fixed.
+        The bug was: AttributeError: 'GRPOConfig' object has no attribute 'weight_update_mode'
+        The fix accesses config.actor.weight_update_mode instead.
+        """
+        config = create_grpo_config(
+            experiment_name="boba_grpo_vllm_16_gpus",
+            trial_name="trial_0",
+            allocation_mode="vllm.d4p1t2+d8p1t1",
+            fileroot="/tmp/areal",
+        )
+
+        # This should not raise AttributeError
+        result = get_model_update_meta(config)
+
+        assert isinstance(result, WeightUpdateMeta)
+        assert result.type == "disk"


### PR DESCRIPTION
 ## Description

  Fixed `AttributeError` in `get_model_update_meta()` when called with `GRPOConfig`. The function now correctly accesses `weight_update_mode` from `config.actor` (for GRPO/PPO) or `config.model` (for SFT/RW) instead of assuming it exists at the config's top level.
  Also added comprehensive unit tests covering all config types and both weight update modes.

  ## Related Issue

  Fixes #482

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Code refactoring (no functional changes)
  - [ ] Performance improvement
  - [x] Test coverage improvement

  ## Checklist

  - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [x] I have run formatting tools (pre-commit or manual)
  - [x] I have run relevant unit tests and they pass
  - [x] I have added tests for new functionality
  - [x] I have updated documentation if needed
  - [x] My branch is up to date with main
  - [ ] This PR introduces breaking changes (if yes, fill out details below)
  - [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
  - [x] No critical issues raised by AI reviewers (`/gemini review`)

  **Breaking Change Details (if applicable):**

  N/A

  ## Additional Context

  **Changes:**
  - Updated `areal/utils/model.py::get_model_update_meta()` to properly extract `weight_update_mode` from the engine config (`config.actor` or `config.model`)
  - Added type validation and comprehensive docstring
  - Created `areal/tests/test_model_utils.py` with 8 test cases covering:
    - GRPOConfig with disk and fsdp_xccl modes
    - PPOConfig, SFTConfig, RWConfig with disk mode
    - Error handling for invalid config types
    - Regression test for issue #482

  **Root Cause:**
  The function assumed all configs had `weight_update_mode` at the top level, but `GRPOConfig` and `PPOConfig` store it in `config.actor.weight_update_mode`, while `SFTConfig` and `RWConfig` store it in `config.model.weight_update_mode`.

  ---

  **Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in [GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!