### PR TITLE
[Bug Fix] Revert generating `requirements.txt` step using `uv` in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,14 +68,3 @@ repos:
         pass_filenames: false
         always_run: false
         require_serial: true
-
-  # Generate requirements.txt with uv
-  - repo: https://github.com/astral-sh/uv-pre-commit
-    # uv version.
-    rev: 0.9.5
-    hooks:
-      # Compile requirements
-      - id: pip-compile
-        name: Compile requirements.txt using uv
-        files: ^requirements\.txt|pyproject\.toml$
-        args: [pyproject.toml, -o, requirements.txt]


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does -->

This pull request makes a small change to the `.pre-commit-config.yaml` file by removing the configuration for the `uv-pre-commit` hook, which was used to generate `requirements.txt` files.

* Removed the `uv-pre-commit` repository and its `pip-compile` hook configuration from `.pre-commit-config.yaml`, so requirements will no longer be automatically compiled using `uv`.

The reason is that when running `uv pip compile` it checks python package dependency on local platforms, which raises errors on Mac or Windows.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

None.

Fixes #(issue)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->
