### PR TITLE
fix: use per-rank jsonl instead of file lock in case that NFS does not support it

### DIFF
--- a/areal/tools/perf_trace_converter.py
+++ b/areal/tools/perf_trace_converter.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 from collections.abc import Sequence
+from glob import glob
 from pathlib import Path
 
 
@@ -24,19 +25,41 @@ def _load_events(path: Path) -> list[dict]:
     return events
 
 
+def _resolve_trace_files(source: Path) -> list[Path]:
+    if source.is_file():
+        return [source]
+    if source.is_dir():
+        return sorted(p for p in source.glob("*.jsonl") if p.is_file())
+    matches = [Path(p) for p in glob(str(source), recursive=True)]
+    files = [p for p in matches if p.is_file()]
+    return sorted(files)
+
+
 def convert_jsonl_to_chrome_trace(
     input_path: str | os.PathLike[str],
     output_path: str | os.PathLike[str] | None = None,
     *,
     display_time_unit: str = "ms",
 ) -> dict:
-    """Convert newline-delimited trace events into Chrome Trace JSON."""
+    """Convert newline-delimited trace events into Chrome Trace JSON.
 
-    source = Path(input_path)
-    if not source.is_file():  # pragma: no cover - defensive guard
-        raise FileNotFoundError(f"Input trace file not found: {source}")
+    The ``input_path`` may point to a single JSONL file, a directory containing
+    per-rank JSONL files, or a glob pattern. All matching files are concatenated
+    in lexical order before emitting the Chrome trace payload.
+    """
 
-    events = _load_events(source)
+    sources = _resolve_trace_files(Path(input_path))
+    if not sources:
+        raise FileNotFoundError(f"No trace files matched input path: {input_path}")
+
+    events: list[dict] = []
+    for path in sources:
+        events.extend(_load_events(path))
+
+    events.sort(
+        key=lambda event: (event.get("ts", 0), event.get("pid", 0), event.get("tid", 0))
+    )
+
     chrome_trace = {
         "traceEvents": events,
         "displayTimeUnit": display_time_unit,
@@ -55,7 +78,14 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Convert PerfTracer JSONL output into Chrome Trace JSON format.",
     )
-    parser.add_argument("input", type=str, help="Path to the PerfTracer JSONL file")
+    parser.add_argument(
+        "input",
+        type=str,
+        help=(
+            "Path, directory, or glob pattern for PerfTracer JSONL files "
+            "(per-rank outputs allowed)"
+        ),
+    )
     parser.add_argument(
         "output",
         type=str,


### PR DESCRIPTION
## Description

This pull request improves the flexibility and correctness of PerfTracer trace file handling, especially for multi-rank and batch processing scenarios. The main changes include supporting directories and glob patterns as input sources, ensuring per-rank trace file naming, and updating file writing logic for consistency.

**Trace file input handling improvements:**

* Added `_resolve_trace_files` to support single files, directories, and glob patterns as input sources for trace conversion, allowing batch processing and per-rank trace files to be handled seamlessly.
* Updated the CLI help text for the input argument to clarify that it accepts files, directories, or glob patterns.

**Per-rank trace file support:**

* Introduced `_rank_qualified_filename` and updated `_default_trace_path` to generate per-rank filenames, ensuring trace files are uniquely named for each rank. All relevant tracer initialization and configuration calls now use this logic. [[1]](diffhunk://#diff-640a8d711111cc9561fcf5f6a0404263f41ab3abf2b6634119b31bd06cba9f88R67-R73) [[2]](diffhunk://#diff-640a8d711111cc9561fcf5f6a0404263f41ab3abf2b6634119b31bd06cba9f88R102) [[3]](diffhunk://#diff-640a8d711111cc9561fcf5f6a0404263f41ab3abf2b6634119b31bd06cba9f88L103-R111) [[4]](diffhunk://#diff-640a8d711111cc9561fcf5f6a0404263f41ab3abf2b6634119b31bd06cba9f88L458-R465) [[5]](diffhunk://#diff-640a8d711111cc9561fcf5f6a0404263f41ab3abf2b6634119b31bd06cba9f88L482-R493) [[6]](diffhunk://#diff-640a8d711111cc9561fcf5f6a0404263f41ab3abf2b6634119b31bd06cba9f88L503-R514)

**File writing consistency:**

* Simplified file writing by using a single `fout.write(f"{line}\n")` statement, improving readability and consistency in both `flush` and `save` methods. [[1]](diffhunk://#diff-640a8d711111cc9561fcf5f6a0404263f41ab3abf2b6634119b31bd06cba9f88L318-R326) [[2]](diffhunk://#diff-640a8d711111cc9561fcf5f6a0404263f41ab3abf2b6634119b31bd06cba9f88L604-R615)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [x] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [ ] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
