### PR TITLE
[Fix]Fix pyproject.toml for only install flash-attn on cuda.

### DIFF
--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -50,7 +50,7 @@ docker run -it --name areal-node1 \
    /bin/bash
 git clone https://github.com/inclusionAI/AReaL
 cd AReaL
-pip install -e .
+pip install -e .[cuda]
 ```
 
 ### Option 2: Custom Environment Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
     "mbridge==0.13.0",
     "flashinfer-python==0.3.1",
     "sglang[all]==0.5.2",
-    "flash-attn==2.8.3",
     "vllm==0.10.2",
     "peft",
     "qwen_agent",
@@ -167,9 +166,14 @@ docs = [
     "jupyter-book",
 ]
 
+cuda = [
+    "flash-attn==2.8.3",
+]
+
 all = [
     "areal[dev]",
     "areal[docs]",
+    "areal[cuda]",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description

Move flash-attn from default to optional `cuda` group. Modify `pip install -e .` with `pip install -e .[cuda]`

## Related Issue

[<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->](https://github.com/inclusionAI/AReaL/issues/505)

Fixes #[BUG]NPU应将下AReal环境安装失败

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [ ] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)
