### PR TITLE
fix(launcher): improve error handling and node calculation in ray.py

### DIFF
--- a/areal/launcher/ray.py
+++ b/areal/launcher/ray.py
@@ -49,6 +49,11 @@ def run_func(file_path, function_name, *args, **kwargs):
 
     # Load the module from file path
     spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None:
+        raise FileNotFoundError(
+            f"Cannot load module from file path '{file_path}'. "
+            f"Please ensure the file exists and the path is correct."
+        )
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
@@ -371,7 +376,7 @@ def ray_main(config, run_id: int = 0):
         # Launcher should launch SGLang servers according to allocation mode.
         config.sglang = to_structured_cfg(config.sglang, SGLangConfig)
         n_sglang_servers = allocation_mode.gen.dp_size
-        n_sglang_nodes = allocation_mode.gen.world_size // n_gpus_per_node
+        n_sglang_nodes = max(1, allocation_mode.gen.world_size // n_gpus_per_node)
         node_group_size = max(1, allocation_mode.gen_instance_size // n_gpus_per_node)
         n_servers_per_node = max(n_sglang_servers // n_sglang_nodes, 1)
         cross_nodes = allocation_mode.gen_instance_size > n_gpus_per_node


### PR DESCRIPTION
# fix(launcher): improve error handling and node calculation in ray.py

## Description

This PR improves the robustness of `areal/launcher/ray.py` by adding better error handling and fixing a potential division issue:

1. **Added null check for module spec**: In the `run_func()` function, added validation to ensure the module spec is not None before attempting to load it. This prevents crashes when an invalid file path is provided and gives users a clear, descriptive error message.

2. **Fixed n_sglang_nodes calculation**: Changed the calculation from `allocation_mode.gen.world_size // n_gpus_per_node` to `max(1, allocation_mode.gen.world_size // n_gpus_per_node)` to ensure at least 1 node is always assigned. This prevents potential division by zero errors and improves robustness when `world_size < n_gpus_per_node`.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [ ] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A - This is a bug fix with no breaking changes.


