### PR TITLE
[FIX] handle ResponseOutputTextParam in OpenAI Responses API client

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -318,10 +318,14 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
                     )
                 elif isinstance(item["content"], Iterable):
                     for content in item["content"]:
-                        if isinstance(content, dict):
-                            # Convert tool output format if needed
-                            converted = _convert_tool_output_format(content)
-                            messages_list.append(deepcopy(converted))
+                        if (
+                            isinstance(content, dict)
+                            and content.get("type") == "output_text"
+                            and "text" in content
+                        ):
+                            messages_list.append(
+                                {"role": item["role"], "content": content["text"]},
+                            )
                         else:
                             raise ValueError("Unsupported content format")
                 else:


### PR DESCRIPTION
## Description

This PR fixes the handling of `ResponseOutputTextParam` items in the `AsyncResponsesWithReward.create` method. Previously, the code attempted to convert all dictionary content through `_convert_tool_output_format`, which was designed for `function_call_output` types. This caused incorrect processing of `ResponseOutputTextParam` items from the OpenAI Responses API.

This ensures that content items with `output_text` format are correctly converted to the message list format expected by the tokenizer chat template.

## Related Issue

N/A


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

N/A

## Additional Context

N/A

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!

