### PR TITLE
Fix batch size in example `examples/vlm/clevr_count_70k_grpo.yaml`

### DIFF
--- a/examples/vlm/clevr_count_70k_grpo.yaml
+++ b/examples/vlm/clevr_count_70k_grpo.yaml
@@ -98,7 +98,7 @@ sglang:
 
 # datasets
 train_dataset:
-  batch_size: 32
+  batch_size: 28
   shuffle: true
   pin_memory: true
   num_workers: 4
@@ -106,7 +106,7 @@ train_dataset:
   type: rl
 
 valid_dataset:
-  batch_size: 32
+  batch_size: 28
   shuffle: true
   pin_memory: true
   num_workers: 4


### PR DESCRIPTION
## Description

In example `examples/vlm/clevr_count_70k_grpo.yaml`, change the batch size to 28 to match the allocation d7. Otherwise it cannot start. 

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
