### PR TITLE
doc: update AReaL design doc with the current dev status

### DIFF
--- a/areal/README.md
+++ b/areal/README.md
@@ -110,7 +110,7 @@ the composition pattern:
   responses per prompt
 
 New algorithms and application-level agents should be implemented at this layer. If you
-are familar with Rust or Go, the algorithm implementations in AReaL are actually
+are familiar with Rust or Go, the algorithm implementations in AReaL are actually
 [traits](https://doc.rust-lang.org/book/ch10-02-traits.html) or
 [interfaces](https://go.dev/tour/methods/9). We essentially attach the
 algorithm-specific functionalities to a specific training backend, which is considered


### PR DESCRIPTION
## Description

This pull request significantly revises the AReaL README to clarify the project's design philosophy, architecture, and usage patterns. The documentation now emphasizes the algorithm-first approach, updates terminology to reflect the current codebase, and provides clearer, more accurate examples of system usage and extensibility. The changes also modernize type annotations and improve descriptions of the code structure.

**Major documentation and conceptual updates:**

- **Refined Design Philosophy and Principles:**
  - Rewrites the motivation section to focus on AReaL’s algorithm-first approach, emphasizing lightweight customization, effortless scaling, and ecosystem integration. The design principles are clarified and modernized to reflect current best practices.
  - Updates terminology throughout from "AReaL-lite" to "AReaL" and clarifies the distinction between layers in the architecture.

- **Expanded and Updated Architecture Section:**
  - Provides clearer descriptions of the API, backend, customization, and entry point layers, including new backend adapters and a stronger emphasis on backend-agnostic algorithm implementations.
  - Explicitly discourages base class logic in the API layer, advocating for composition and dependency injection patterns.

**Improved usage examples and entry point patterns:**

- **Modernized Example Code and Patterns:**
  - Updates example code snippets for both single-controller and SPMD patterns, aligning them with the current codebase and clarifying which parts are conceptual versus implemented. Adds notes to prevent confusion. [[1]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL179-R189) [[2]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL217-R225) [[3]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL240-R250) [[4]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL263-R275) [[5]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL290-R300)
  - Updates launcher command examples for Ray and Slurm to reflect current usage and clarify resource allocation. [[1]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL143-R140) [[2]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL156-R149)

**Code and API documentation improvements:**

- **Consistent Type Annotations and API Signatures:**
  - Updates type hints throughout the documentation to use Python 3.9+ style (e.g., `dict[str, Any]`), and clarifies function signatures and return types for core classes like `TrainEngine` and `PPOActor`. [[1]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL333-R351) [[2]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL357-R363) [[3]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL370-R376) [[4]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL386-R396) [[5]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL411-R416)

These changes collectively make the documentation more accessible, accurate, and aligned with the current and future direction of the AReaL project.

- Refined design philosophy, principles, and motivation
- Updated architecture and layering descriptions, including backend and customization layers [[1]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL84-R59) [[2]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL101-R126)
- Modernized example code for entry point patterns and launcher usage [[1]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL179-R189) [[2]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL217-R225) [[3]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL240-R250) [[4]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL263-R275) [[5]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL290-R300) [[6]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL143-R140) [[7]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL156-R149)
- Improved API documentation and type annotations for clarity and consistency [[1]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL333-R351) [[2]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL357-R363) [[3]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL370-R376) [[4]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL386-R396) [[5]](diffhunk://#diff-aee7ea2b8235fcc6a6cb414666c65001ae11c7efc4eecfc23dcd171ed0a24a3eL411-R416)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [ ] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [x] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

## Additional Context

This PR is a side effect of #567

