### PR TITLE
chore: add hint for the breaking change of allocation mode

### DIFF
--- a/areal/api/alloc_mode.py
+++ b/areal/api/alloc_mode.py
@@ -1197,8 +1197,8 @@ class _LLMParallelParser:
 
             err_hint = """
 Hints:
-1. The parsing logic disallows dots and replaces them with colons from commit cd0003d, e.g., use "sglang:d4+fsdp:d4" instead of "sglang.d4+fsdp.d4";
-2. Check https://inclusionai.github.io/AReaL/tutorial/megatron.html for allowed syntax and examples with complext MoE models.
+1. The parsing logic requires colons instead of dots to separate backends from dimensions, e.g., use "sglang:d4+fsdp:d4" instead of "sglang.d4+fsdp.d4".
+2. Check https://inclusionai.github.io/AReaL/tutorial/megatron.html for allowed syntax and examples with complex MoE models.
 """
             raise ValueError(f"Parsing error: {e}\n{err_hint}")
 


### PR DESCRIPTION
## Description

N/A

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [ ] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

<img width="1698" height="576" alt="image" src="https://github.com/user-attachments/assets/2feb998d-16ff-4133-bdf9-bd3a1171052b" />
