### PR TITLE
[FIX] reduce reward timeout warning

### DIFF
--- a/areal/api/reward_api.py
+++ b/areal/api/reward_api.py
@@ -28,9 +28,9 @@ def _get_device_count_safely() -> int:
                 ]
                 if devices:
                     return len(devices)
-    except (OSError, ValueError):
+    except (OSError, ValueError) as e:
         # /dev doesn't exist or can't read (e.g., Windows, macOS)
-        pass
+        logger.debug(f"Could not read device list from /dev, using fallback: {e}")
 
     # Fallback: assume 8 devices for cautious max_workers calculation
     return 8


### PR DESCRIPTION
## Description

This PR adds support for controlling the number of workers in `AsyncRewardWrapper`'s ProcessPoolExecutor to reduce reward timeout warnings.

This prevents warnings when ProcessPoolExecutor is created with too many workers (typically when `max_workers=None` defaults to CPU count, which can be excessive in distributed training scenarios).

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

N/A

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
