### PR TITLE
[FIX] fix compute logp temperature

### DIFF
--- a/areal/README.md
+++ b/areal/README.md
@@ -368,17 +368,17 @@ class PPOActor:
     def __init__(self, config: PPOActorConfig, engine: TrainEngine):
         self.config = config
         self.engine = engine
+        self.temperature = config.temperature
 
     @torch.no_grad()
     def compute_logp(
         self,
         data: dict[str, Any],
-        temperature: float | None = None,
     ) -> torch.Tensor | None:
 
         def calc_logprobs(logits, input_data):
             labels = torch.roll(input_data["input_ids"], shifts=-1, dims=-1)
-            logprobs = gather_logprobs(logits, labels, temperature or 1.0)
+            logprobs = gather_logprobs(logits, labels, self.temperature)
             return logprobs
 
         self.engine.eval()

--- a/areal/engine/ppo/actor.py
+++ b/areal/engine/ppo/actor.py
@@ -72,14 +72,13 @@ class PPOActor:
     def compute_logp(
         self,
         data: dict[str, Any],
-        temperature: float | None = None,
     ) -> torch.Tensor:
         def calc_logprobs(logits, input_data):
             labels = input_data.get(
                 "rolled_input_ids",
                 torch.roll(input_data["input_ids"], shifts=-1, dims=-1),
             )
-            logprobs = gather_logprobs(logits, labels, temperature or 1.0)
+            logprobs = gather_logprobs(logits, labels, self.temperature)
             return logprobs
 
         self.engine.eval()


### PR DESCRIPTION
## Description

This PR refactors the `PPOActor.compute_logp` method to use the temperature value from the configuration instead of accepting it as a method parameter. This change simplifies the API by making temperature a consistent instance-level configuration rather than a per-call parameter.

The changes include:
1. **`areal/engine/ppo/actor.py`**: Removed the `temperature` parameter from `compute_logp` method and use `self.temperature` (from config) instead
2. **`areal/README.md`**: Updated the example code in the documentation to reflect this change

## Related Issue

N/A


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

N/A

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
