### PR TITLE
[Feat] Add rollout scale-up support

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -929,6 +929,29 @@ class InferenceEngineConfig:
 
 
 @dataclass
+class ScalingConfig:
+    """Configuration for dynamic scaling of inference/training servers."""
+
+    enable_scaling: bool = field(
+        default=False,
+        metadata={"help": "Whether scaling is enabled (True/False)."},
+    )
+
+    mode: str = field(
+        default="manual",
+        metadata={
+            "help": "Scaling mode — can be 'manual' or 'auto'.",
+            "choices": ["manual", "auto"],
+        },
+    )
+
+    scaling_controller_port: int = field(
+        default=8899,
+        metadata={"help": "HTTP port for the scale-up service endpoint."},
+    )
+
+
+@dataclass
 class _Timer:
     experiment_name: str = MISSING
     trial_name: str = MISSING
@@ -1340,6 +1363,8 @@ class BaseExperimentConfig:
     launcher: LauncherConfig = field(default_factory=LauncherConfig)
 
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
+
+    scaling: ScalingConfig = field(default_factory=ScalingConfig)
 
 
 @dataclass

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -83,6 +83,8 @@ class FSDPEngine(BaseHFEngine):
         self.rank: int
         self.dp_head: int
         self.dp_rank: int
+        self.scaling_count = 0
+        self.create_group_count = 0
 
     @property
     def data_parallel_group(self) -> dist.ProcessGroup:
@@ -376,14 +378,21 @@ class FSDPEngine(BaseHFEngine):
             )
             self.weight_update_group = init_custom_process_group(
                 backend=current_platform.communication_backend,
-                world_size=meta.alloc_mode.gen.world_size + 1,
+                world_size=meta.alloc_mode.gen.world_size + 1 + self.scaling_count,
                 init_method=f"tcp://{meta.nccl_master_address}:{meta.nccl_master_port}",
                 rank=0,
-                group_name=meta.nccl_group_name,
+                group_name=meta.nccl_group_name + str(self.create_group_count),
                 timeout=DIST_GROUP_DEFAULT_TIMEOUT,
             )
 
+            self.create_group_count += 1
             fut.result()
+            self.rollout_engine._engine.backend.create_group_count += 1
+
+    def _re_init_weight_update_from_distributed(self, meta: WeightUpdateMeta):
+        self.weight_update_group_initialized = False
+        self._init_weight_update_from_distributed(meta)
+        self.weight_update_group_initialized = True
 
     @trace_perf("fsdp_engine.update_weights_from_distributed", category="comm")
     def _update_weights_from_distributed(self, meta: WeightUpdateMeta):

--- a/areal/launcher/ray.py
+++ b/areal/launcher/ray.py
@@ -354,18 +354,12 @@ class RayLauncher:
 
 def main():
     ray.init(address="auto")
-    config, _ = parse_cli_args(sys.argv[1:])
-    config_path = None
-    args = sys.argv[1:]
+    config, config_file = parse_cli_args(sys.argv[1:])
     config.scaling = to_structured_cfg(config.scaling, ScalingConfig)
     # Check whether enable scaling or not
     if config.scaling.enable_scaling:
-        if "--config" in args:
-            idx = args.index("--config")
-            if idx + 1 < len(args):
-                config_path = args[idx + 1]
         try:
-            launch_scale_common(config_path)
+            launch_scale_common(str(config_file))
         except Exception as e:
             logger.info(f"[RayLauncher] Warning: Failed to scaler.py: {e}")
     ray_main(config, run_id=0)

--- a/areal/launcher/ray.py
+++ b/areal/launcher/ray.py
@@ -1,6 +1,8 @@
 import importlib.util
+import os
 import pathlib
 import re
+import subprocess
 import sys
 import time
 from collections.abc import Callable
@@ -18,6 +20,7 @@ from areal.api.cli_args import (
     ClusterSpecConfig,
     LauncherConfig,
     RecoverConfig,
+    ScalingConfig,
     SGLangConfig,
     parse_cli_args,
     to_structured_cfg,
@@ -41,7 +44,23 @@ logger = logging.getLogger("RayLauncher")
 RAY_WAIT_CHECK_TIME_INTERVAL = 5  # seconds
 DEFAULT_MAIN_FUNC_NAME = "main"
 RAY_LAUNCHER = None
-RECOVER_TIME_INTERVAL = 10  # seconds
+RECOVER_TIME_INTERVAL = 10  # second
+
+
+def launch_scale_common(config_path: str):
+    """Launch scale_common.py as a background subprocess without blocking."""
+    script_path = str(
+        pathlib.Path(__file__).resolve().parent.joinpath("scaler/scaling_controller.py")
+    )
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    subprocess.Popen(
+        [sys.executable, script_path, config_path],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+        start_new_session=True,
+    )
 
 
 def run_func(file_path, function_name, *args, **kwargs):
@@ -334,8 +353,21 @@ class RayLauncher:
 
 
 def main():
-    ray.init()
+    ray.init(address="auto")
     config, _ = parse_cli_args(sys.argv[1:])
+    config_path = None
+    args = sys.argv[1:]
+    config.scaling = to_structured_cfg(config.scaling, ScalingConfig)
+    # Check whether enable scaling or not
+    if config.scaling.enable_scaling:
+        if "--config" in args:
+            idx = args.index("--config")
+            if idx + 1 < len(args):
+                config_path = args[idx + 1]
+        try:
+            launch_scale_common(config_path)
+        except Exception as e:
+            logger.info(f"[RayLauncher] Warning: Failed to scaler.py: {e}")
     ray_main(config, run_id=0)
 
 

--- a/areal/launcher/scaler/scaling_controller.py
+++ b/areal/launcher/scaler/scaling_controller.py
@@ -115,7 +115,7 @@ shared_state = {
     "cfg": None,
     "config_path": None,
     "num_rollout": None,
-    "Vllm_entry_point": None,
+    "vllm_entry_point": None,
 }
 
 

--- a/areal/launcher/scaler/scaling_controller.py
+++ b/areal/launcher/scaler/scaling_controller.py
@@ -1,3 +1,4 @@
+import importlib.util
 import sys
 import threading
 from pathlib import Path
@@ -31,8 +32,6 @@ def run_func(file_path: str, func_name: str, argv: list[str]):
     Import module by path and invoke the named function with a single `argv` list.
     This matches vllm_server.main(argv) which expects sys.argv[2:]-style args.
     """
-    import importlib.util
-
     module_name = file_path.replace("/", "_").replace(".", "_")
     spec = importlib.util.spec_from_file_location(module_name, file_path)
     module = importlib.util.module_from_spec(spec)
@@ -53,13 +52,12 @@ def scale_up_vllm(
     experiment_name = cfg.experiment_name
     trial_name = cfg.trial_name
 
-    # allocation_mode
     allocation_mode = AllocationMode.from_str(cfg.allocation_mode)
     vllm_tp_size = allocation_mode.gen.tp_size
-    n_existing_servers = allocation_mode.gen.dp_size
+    n_existing_servers = expected - n_new_servers
 
     cpus_per_gpu = cfg.launcher.inference_server_cpus_per_gpu
-    mem_per_gpu = cfg.launcher.inference_server_mem_per_gpu  # MB per GPU
+    mem_per_gpu = cfg.launcher.inference_server_mem_per_gpu
 
     # Submit new servers
     remote_runner = None  # we’ll bind ray.remote per device type
@@ -117,12 +115,13 @@ shared_state = {
     "num_rollout": None,
     "vllm_entry_point": None,
 }
+shared_state_lock = threading.Lock()
 
 
 @app.post("/scale_up")
 async def http_scale_up(request: Request):
     """
-    Manual scale-up endpoint.
+    Scaling controller endpoint.
     Example usage:
       curl -X POST localhost:8899/scale_up \
         -H "Content-Type: application/json" \
@@ -130,61 +129,70 @@ async def http_scale_up(request: Request):
     """
     body = await request.json()
     scaled_k = int(body.get("scaled_k", 1))
-    cfg = shared_state["cfg"]
-    config_path = shared_state["config_path"]
-    num_rollout = shared_state["num_rollout"]
 
-    if cfg is None or config_path is None:
-        return {"status": "error", "msg": "Scale server not initialized yet"}
+    with shared_state_lock:
+        cfg = shared_state["cfg"]
+        config_path = shared_state["config_path"]
+        num_rollout = shared_state["num_rollout"]
+        vllm_entry_point = shared_state["vllm_entry_point"]
+
+        # More complete initialization check
+        if (
+            cfg is None
+            or config_path is None
+            or num_rollout is None
+            or vllm_entry_point is None
+        ):
+            return {"status": "error", "msg": "Scale server not initialized yet"}
+
+        new_total = num_rollout + scaled_k
+        shared_state["num_rollout"] = new_total
 
     try:
         logger.info(f"[HTTP] Received manual scale-up request: {scaled_k}")
-        shared_state["num_rollout"] = num_rollout + scaled_k
-
         name_resolve.add("scale_up_request", {"scaled_k": int(scaled_k)}, replace=True)
+
         scale_up_vllm(
             cfg,
             config_path,
             scaled_k,
-            num_rollout + scaled_k,
-            shared_state["vllm_entry_point"],
+            new_total,
+            vllm_entry_point,
         )
         try:
             name_resolve.delete("scale_up_done")
         except NameEntryNotFoundError:
             pass
 
-        name_resolve.add("scale_up_done", {"step": 0})
-        logger.info(
-            f"[HTTP] Scale-up done. Total rollout={shared_state['num_rollout']}"
-        )
+        name_resolve.add("scale_up_done", {"done": 1})
+        logger.info(f"[HTTP] Scale-up done. Total rollout={new_total}")
         return {
             "status": "ok",
             "scaled_k": scaled_k,
-            "new_total": shared_state["num_rollout"],
+            "new_total": new_total,
         }
     except Exception as e:
         logger.error(f"[HTTP] Scale-up failed: {e}")
         return {"status": "error", "msg": str(e)}
 
 
-def run_http_server():
+def run_http_server(port: int):
     """Run FastAPI server in background thread (non-blocking)."""
-    config = Config(app, host="0.0.0.0", port=HTTP_SCALE_PORT, log_level="info")
+    config = Config(app, host="0.0.0.0", port=port, log_level="info")
     server = Server(config)
 
     def _serve():
-        logger.info(f"[HTTP] Starting manual scale-up server on port {HTTP_SCALE_PORT}")
+        logger.info(f"[HTTP] Starting scaling controller server on port {port}")
         server.run()
 
     t = threading.Thread(target=_serve, daemon=False)
     t.start()
-    logger.info("[HTTP] Manual scale-up service started in background.")
+    logger.info("[HTTP] Scaling controller server started in background.")
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        logger.info("Usage: python scaling_controller.py <config.yaml>")
+        logger.info("Usage: python scaling_controller <config.yaml> ")
         sys.exit(1)
 
     config_path = sys.argv[1]
@@ -193,35 +201,38 @@ if __name__ == "__main__":
     experiment_name = cfg.experiment_name
     trial_name = cfg.trial_name
 
-    # allocation_mode
     allocation_mode = AllocationMode.from_str(cfg.allocation_mode)
-    # Set-the-experiments-configs for rollout ------------------
     num_rollout = allocation_mode.gen.dp_size
 
     # Remove all the keys related to scaling before start the experiment
     try:
         name_resolve.delete("scale_up_request")
     except NameEntryNotFoundError:
-        logger.info("no delete")
+        pass
 
     try:
         name_resolve.delete("scale_up_done")
     except NameEntryNotFoundError:
         pass
-    # Init the ray and conncet it  to existing cluster
+
+    # Init ray and connect it to existing cluster
     ray.init(address="auto", namespace=f"{experiment_name}_{trial_name}")
 
     # Get port for scale up
     cfg.scaling = to_structured_cfg(cfg.scaling, ScalingConfig)
-    HTTP_SCALE_PORT = cfg.scaling.scaling_controller_port
+    port = cfg.scaling.scaling_controller_port
 
-    # Run http for scale-up
-    run_http_server()
-
-    logger.info("[HTTP] Manual scale-up service started in background.")
+    # Resolve vLLM entry point
     vllm_entry_point = str(Path(__file__).resolve().parent.parent / "vllm_server.py")
-    shared_state["cfg"] = cfg
-    shared_state["config_path"] = config_path
-    shared_state["num_rollout"] = num_rollout
-    shared_state["vllm_entry_point"] = vllm_entry_point
+
+    # Initialize shared_state atomically before starting HTTP server
+    with shared_state_lock:
+        shared_state["cfg"] = cfg
+        shared_state["config_path"] = config_path
+        shared_state["num_rollout"] = num_rollout
+        shared_state["vllm_entry_point"] = vllm_entry_point
+
     logger.info(f"[HTTP] num_rollout initialized to {num_rollout}")
+
+    # Run http for scale-up (after shared_state is fully initialized)
+    run_http_server(port)

--- a/areal/launcher/scaler/scaling_controller.py
+++ b/areal/launcher/scaler/scaling_controller.py
@@ -1,0 +1,227 @@
+import sys
+import threading
+from pathlib import Path
+
+import ray
+from fastapi import FastAPI, Request
+from omegaconf import OmegaConf
+from uvicorn import Config, Server
+
+import areal.utils.logging as logging
+from areal.api.alloc_mode import AllocationMode
+from areal.api.cli_args import (
+    ClusterSpecConfig,
+    LauncherConfig,
+    RecoverConfig,
+    ScalingConfig,
+    to_structured_cfg,
+    vLLMConfig,
+)
+from areal.platforms import is_npu_available
+from areal.utils import name_resolve
+from areal.utils.launcher import get_env_vars, wait_llm_server_addrs
+from areal.utils.name_resolve import NameEntryNotFoundError
+
+logger = logging.getLogger("ScaleUpVLLM")
+DEFAULT_MAIN_FUNC_NAME = "main"
+
+
+def run_func(file_path: str, func_name: str, argv: list[str]):
+    """
+    Import module by path and invoke the named function with a single `argv` list.
+    This matches vllm_server.main(argv) which expects sys.argv[2:]-style args.
+    """
+    import importlib.util
+
+    module_name = file_path.replace("/", "_").replace(".", "_")
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    func = getattr(module, func_name)
+    return func(argv)
+
+
+def scale_up_vllm(
+    cfg, config_path: str, n_new_servers: int, expected: int, vllm_entry_point: str
+):
+    # Make sub-configs structured like original launcher
+    cfg.launcher = to_structured_cfg(cfg.launcher, LauncherConfig)
+    cfg.cluster = to_structured_cfg(cfg.cluster, ClusterSpecConfig)
+    cfg.recover = to_structured_cfg(cfg.recover, RecoverConfig)
+    cfg.vllm = to_structured_cfg(cfg.vllm, vLLMConfig)
+    experiment_name = cfg.experiment_name
+    trial_name = cfg.trial_name
+
+    # allocation_mode
+    allocation_mode = AllocationMode.from_str(cfg.allocation_mode)
+    vllm_tp_size = allocation_mode.gen.tp_size
+    n_existing_servers = allocation_mode.gen.dp_size
+
+    cpus_per_gpu = cfg.launcher.inference_server_cpus_per_gpu
+    mem_per_gpu = cfg.launcher.inference_server_mem_per_gpu  # MB per GPU
+
+    # Submit new servers
+    remote_runner = None  # we’ll bind ray.remote per device type
+    futures = []
+    for i in range(n_new_servers):
+        argv = ["--config", config_path]
+        # Env vars same as original launcher for inference servers
+        env_vars = get_env_vars(
+            cfg.cluster.cluster_name, cfg.launcher.inference_server_env_vars
+        )
+
+        if is_npu_available:
+            remote_runner = ray.remote(
+                num_cpus=cpus_per_gpu * vllm_tp_size,
+                resources={"NPU": vllm_tp_size},
+                memory=mem_per_gpu * vllm_tp_size * 1024 * 1024,  # bytes
+                runtime_env={"env_vars": env_vars},
+            )(run_func)
+        else:
+            remote_runner = ray.remote(
+                num_cpus=cpus_per_gpu * vllm_tp_size,
+                num_gpus=vllm_tp_size,
+                memory=mem_per_gpu * vllm_tp_size * 1024 * 1024,  # bytes
+                runtime_env={"env_vars": env_vars},
+            )(run_func)
+
+        fut = remote_runner.remote(vllm_entry_point, DEFAULT_MAIN_FUNC_NAME, argv)
+        futures.append(fut)
+
+        try:
+            ray.get(fut, timeout=5.0)
+        except ray.exceptions.GetTimeoutError:
+            pass
+        except ray.exceptions.RayTaskError as e:
+            logger.info(f"[ERROR] server {n_existing_servers + i} crashed immediately:")
+            logger.info(e)
+            raise
+
+    # Wait until ALL (old + new) servers are registered
+    total_expected = expected
+    vllm_addrs = wait_llm_server_addrs(
+        experiment_name,
+        trial_name,
+        total_expected,
+    )
+
+    logger.info("\n[Scale-Up Completed]")
+    logger.info(f"Total servers expected: {len(vllm_addrs)}")
+
+
+app = FastAPI()
+shared_state = {
+    "cfg": None,
+    "config_path": None,
+    "num_rollout": None,
+    "Vllm_entry_point": None,
+}
+
+
+@app.post("/scale_up")
+async def http_scale_up(request: Request):
+    """
+    Manual scale-up endpoint.
+    Example usage:
+      curl -X POST localhost:8899/scale_up \
+        -H "Content-Type: application/json" \
+        -d '{"scaled_k": 1}'
+    """
+    body = await request.json()
+    scaled_k = int(body.get("scaled_k", 1))
+    cfg = shared_state["cfg"]
+    config_path = shared_state["config_path"]
+    num_rollout = shared_state["num_rollout"]
+
+    if cfg is None or config_path is None:
+        return {"status": "error", "msg": "Scale server not initialized yet"}
+
+    try:
+        logger.info(f"[HTTP] Received manual scale-up request: {scaled_k}")
+        shared_state["num_rollout"] = num_rollout + scaled_k
+
+        name_resolve.add("scale_up_request", {"scaled_k": int(scaled_k)}, replace=True)
+        scale_up_vllm(
+            cfg,
+            config_path,
+            scaled_k,
+            num_rollout + scaled_k,
+            shared_state["vllm_entry_point"],
+        )
+        try:
+            name_resolve.delete("scale_up_done")
+        except NameEntryNotFoundError:
+            pass
+
+        name_resolve.add("scale_up_done", {"step": 0})
+        logger.info(
+            f"[HTTP] Scale-up done. Total rollout={shared_state['num_rollout']}"
+        )
+        return {
+            "status": "ok",
+            "scaled_k": scaled_k,
+            "new_total": shared_state["num_rollout"],
+        }
+    except Exception as e:
+        logger.error(f"[HTTP] Scale-up failed: {e}")
+        return {"status": "error", "msg": str(e)}
+
+
+def run_http_server():
+    """Run FastAPI server in background thread (non-blocking)."""
+    config = Config(app, host="0.0.0.0", port=HTTP_SCALE_PORT, log_level="info")
+    server = Server(config)
+
+    def _serve():
+        logger.info(f"[HTTP] Starting manual scale-up server on port {HTTP_SCALE_PORT}")
+        server.run()
+
+    t = threading.Thread(target=_serve, daemon=False)
+    t.start()
+    logger.info("[HTTP] Manual scale-up service started in background.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        logger.info("Usage: python scaling_controller.py <config.yaml>")
+        sys.exit(1)
+
+    config_path = sys.argv[1]
+    cfg = OmegaConf.load(config_path)
+    name_resolve.reconfigure(cfg.cluster.name_resolve)
+    experiment_name = cfg.experiment_name
+    trial_name = cfg.trial_name
+
+    # allocation_mode
+    allocation_mode = AllocationMode.from_str(cfg.allocation_mode)
+    # Set-the-experiments-configs for rollout ------------------
+    num_rollout = allocation_mode.gen.dp_size
+
+    # Remove all the keys related to scaling before start the experiment
+    try:
+        name_resolve.delete("scale_up_request")
+    except NameEntryNotFoundError:
+        logger.info("no delete")
+
+    try:
+        name_resolve.delete("scale_up_done")
+    except NameEntryNotFoundError:
+        pass
+    # Init the ray and conncet it  to existing cluster
+    ray.init(address="auto", namespace=f"{experiment_name}_{trial_name}")
+
+    # Get port for scale up
+    cfg.scaling = to_structured_cfg(cfg.scaling, ScalingConfig)
+    HTTP_SCALE_PORT = cfg.scaling.scaling_controller_port
+
+    # Run http for scale-up
+    run_http_server()
+
+    logger.info("[HTTP] Manual scale-up service started in background.")
+    vllm_entry_point = str(Path(__file__).resolve().parent.parent / "vllm_server.py")
+    shared_state["cfg"] = cfg
+    shared_state["config_path"] = config_path
+    shared_state["num_rollout"] = num_rollout
+    shared_state["vllm_entry_point"] = vllm_entry_point
+    logger.info(f"[HTTP] num_rollout initialized to {num_rollout}")

--- a/areal/thirdparty/vllm/vllm_worker_extension.py
+++ b/areal/thirdparty/vllm/vllm_worker_extension.py
@@ -82,7 +82,8 @@ class VLLMWorkerExtension:
         group_name: str,
     ):
         if getattr(self, "weight_update_group", None) is not None:
-            return True, "Success"
+            # If the group is there, make the current group None and create a new one for scaling
+            self.weight_update_group = None
         try:
             self.weight_update_group = init_custom_process_group(
                 backend=backend,

--- a/areal/utils/scaling.py
+++ b/areal/utils/scaling.py
@@ -1,0 +1,65 @@
+import ast
+import time
+
+from areal.utils import logging, name_resolve
+from areal.utils.name_resolve import NameEntryNotFoundError
+
+logger = logging.getLogger("Scaler")
+
+
+def handle_scale_up(name_resolve: name_resolve, actor, rollout, weight_update_meta):
+    """
+    Handle scale-up logic when scale_up_request is detected.
+    Requires: name_resolve, actor, rollout.
+    """
+    new_scale = 0
+    req_raw = None
+    try:
+        req_raw = name_resolve.get("scale_up_request")
+        new_scale = ast.literal_eval(req_raw)["scaled_k"]
+    except NameEntryNotFoundError:
+        logger.info("scale_up_request not found")
+        pass  # no request → don't wait
+
+    logger.info(f"scale_up_request {req_raw}")
+
+    if req_raw:
+        # Now wait until scale_up_done is posted from scaler process
+        start = time.time()
+        try:
+            name_resolve.delete("scale_up_request")
+        except NameEntryNotFoundError:
+            pass
+
+        while True:
+            try:
+                done_raw = name_resolve.get("scale_up_done")
+            except NameEntryNotFoundError:
+                done_raw = None
+
+            if done_raw:
+                logger.info(f"[areal] Scale-up finished: {done_raw}")
+                name_resolve.add(
+                    "scale_up_time",
+                    {"time": time.time() - start},
+                    replace=True,
+                )
+
+                try:
+                    name_resolve.delete("scale_up_request")
+                except NameEntryNotFoundError:
+                    pass
+                try:
+                    name_resolve.delete("scale_up_done")
+                except NameEntryNotFoundError:
+                    pass
+                # Increase teh number of scale in rollout engine and actor. To get correct world size
+                actor.scaling_count = actor.scaling_count + new_scale
+                rollout._engine.backend.scaling_count = (
+                    rollout._engine.backend.scaling_count + new_scale
+                )
+                rollout._engine.distributed_weight_update_initialized = False
+                actor._re_init_weight_update_from_distributed(weight_update_meta)
+
+                break
+            time.sleep(0.5)

--- a/examples/math/gsm8k_grpo.py
+++ b/examples/math/gsm8k_grpo.py
@@ -10,14 +10,16 @@ from areal.api.io_struct import FinetuneSpec, StepInfo, WeightUpdateMeta
 from areal.dataset import get_custom_dataset
 from areal.engine.ppo.actor import FSDPPPOActor
 from areal.engine.sglang_remote import RemoteSGLangEngine
+from areal.engine.vllm_remote import RemotevLLMEngine
 from areal.platforms import current_platform
-from areal.utils import seeding, stats_tracker
+from areal.utils import name_resolve, seeding, stats_tracker
 from areal.utils.dataloader import create_dataloader
 from areal.utils.device import log_gpu_stats
 from areal.utils.evaluator import Evaluator
 from areal.utils.hf_utils import load_hf_tokenizer
 from areal.utils.recover import RecoverHandler
 from areal.utils.saver import Saver
+from areal.utils.scaling import handle_scale_up
 from areal.utils.stats_logger import StatsLogger
 from areal.workflow.rlvr import RLVRWorkflow
 
@@ -38,6 +40,9 @@ def main(args):
     allocation_mode = AllocationMode.from_str(config.allocation_mode)
     parallel_strategy = allocation_mode.train
     assert parallel_strategy is not None
+    # Reconfig the name_resolve to connect exisisting name_resolve
+    name_resolve.reconfigure(config.cluster.name_resolve)
+    scale = config.scaling.enable_scaling
 
     # Initialize train engine
     actor = FSDPPPOActor(config=config.actor)
@@ -70,9 +75,14 @@ def main(args):
     )
 
     # Initialize inference engine
-    rollout = RemoteSGLangEngine(config.rollout)
+    if allocation_mode.gen_backend == "vllm":
+        rollout = RemotevLLMEngine(config.rollout)
+        eval_rollout = RemotevLLMEngine(deepcopy(config.rollout))
+    elif allocation_mode.gen_backend == "sglang":
+        rollout = RemoteSGLangEngine(config.rollout)
+        eval_rollout = RemoteSGLangEngine(deepcopy(config.rollout))
     rollout.initialize(train_data_parallel_size=parallel_strategy.dp_size)
-    eval_rollout = RemoteSGLangEngine(deepcopy(config.rollout))
+
     # NOTE: eval does not have any offpolicyness control
     eval_rollout.config.max_head_offpolicyness = int(1e12)
     eval_rollout.initialize()
@@ -178,6 +188,8 @@ def main(args):
 
         # pause inference for updating weights, save, and evaluation
         rollout.pause()
+        if dist.get_rank() == 0 and scale:
+            handle_scale_up(name_resolve, actor, rollout, weight_update_meta)
 
         with stats_tracker.record_timing("update_weights"):
             actor.update_weights(weight_update_meta)

--- a/examples/math/gsm8k_grpo_npu_scale.yaml
+++ b/examples/math/gsm8k_grpo_npu_scale.yaml
@@ -1,0 +1,157 @@
+experiment_name: gsm8k-grpo
+trial_name: trial0
+
+seed: 1
+total_train_epochs: 10
+tokenizer_path: ${actor.path}
+async_training: true
+
+cluster:
+  n_nodes: 1
+  n_gpus_per_node: 8
+  fileroot: /tmp/areal/experiments
+  name_resolve:
+    type: nfs
+    nfs_record_root: /tmp/areal/name_resolve
+
+allocation_mode: vllm.d4p1t1+d4p1t1
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 256
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 2
+  enable_rollout_tracing: false
+
+gconfig:
+  n_samples: 4
+  min_new_tokens: 0
+  max_new_tokens: 1024
+  greedy: false
+  temperature: 1.0
+
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen2.5-1.5B-Instruct
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: false
+  dtype: bfloat16
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer:
+    type: adam
+    lr: 1.70e-5
+    weight_decay: 0.017
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+  backend: fsdp
+  group_size: ${gconfig.n_samples}
+  eps_clip: 0.4
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  behav_imp_weight_cap: 5.0
+  dynamic_sampling: false
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  max_new_tokens: ${gconfig.max_new_tokens}
+
+ref:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  init_from_scratch: false
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer: null
+  backend: fsdp
+
+# VLLM
+vllm:
+  model: ${actor.path}
+  seed: ${seed}
+  skip_tokenizer_init: true
+  dtype: ${actor.dtype}
+  max_model_len: 32768
+  gpu_memory_utilization: 0.8
+
+# datasets
+train_dataset:
+  batch_size: 256
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+  max_length: 1024
+
+valid_dataset:
+  batch_size: 256
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+
+# Utilities
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: disabled
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: 3600
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: disabled
+
+launcher:
+  inference_server_cpus_per_gpu: 4
+  inference_server_mem_per_gpu: 32768
+  trainer_cpus_per_gpu: 4
+  trainer_mem_per_gpu: 32768
+
+scaling:
+  enable_scaling: true
+  mode: manual
+  scaling_controller_port: 8899


### PR DESCRIPTION
## Description

Currently, AReaL implements a static resource allocation scheme, where fixed amounts of devices are allocated to rollout/training stages. This MR introduces **rollout scale-up**, where rollout engines can be added to a running training job. This feature can benefit workloads when the optimal resource allocation ratio changes during training.

### Design Summary

- **Usage**: A user (operator) can request adding rollout workers via an HTTP endpoint while training is running.
- A Ray launcher starts an independent `scaling_controller` that exposes HTTP endpoints for scaling actions.
- On a scale-up request, `scaling_controller` launches additional **generation servers** (validated with a *vLLM-Ascend* backend in our tests, but the design is engine-agnostic).
- Trainers periodically call `handle_scale_up()` (from `utils/scaling.py`) at the **end of each step**:
  1. Check if there is a `scale_up_request`.
  1. Wait until the new generation servers are ready.
  1. When ready, `scaling_controller` posts a `scale_up_done` signal via `name_resolve`.
  1. The trainer calls `actor(fsdp_engine)._re_init_weight_update_from_distributed()`, which in turn invokes `actor._init_weight_update_from_distributed()`. The actor then recreates the process group with the new world size to include the newly added generation servers.
  1. The rollout engine executes `init_weights_update_group()` to **recreate the process group** to include both previous and newly added generation servers.
  1. `remote_inf_engine.py::refresh_addresses()` refreshes endpoints to **old + new** server addresses.
  1. The request dispatcher (`choose_server`) is adjusted so that **at the start of a step** it includes newly added servers when routing requests.

### Workflow (rollout engine scale-up)

1. `POST /scale_up { "scaled_k": K }` received by `scaling_controller`.
1. `scaling_controller` allocates resources and launches **K** new generation servers.
1. New servers are registered and their readiness is tracked.
1. When all **K** generation servers are ready, `scaling_controller` signals `scale_up_done` via `name_resolve`.
1. At the next end-of-step boundary, trainers run `handle_scale_up()` to perform distributed **re-initialization** and **address refresh**.
1. Next step begins with a scaled pool of rollout servers.

### Instructions
1. **Use the provided config:** `examples/math/gsm8k_grpo_npu_scale.yaml`
   - This version has been validated with **Ray** + FSDP training backend + **vLLM-Ascend** generation backend.
1. **Multi-node setup:**
   - Example: 3 nodes × 16 devices each, for a total of 48 devices.
   - Start with `DP=16` for rollout and `DP=16` for training  across 2 nodes in the AReaL YAML config.
   - Initialize Ray on all **3 nodes**, leaving 1 node (16 devices) as headroom for future scaling.
1. **Start training** with the YAML above and ensure `scaling_controller_port` is set.
1. **Trigger scale-up** at any time:
   ```bash
   curl -X POST http://localhost:8899/scale_up \
        -H "Content-Type: application/json" \
        -d '{"scaled_k": 1}'
   ```
   Replace `8899` with the configured `scaling_controller_port` if applicable.
1. **Scaling K > 1:**
   - Multiple rollout servers can be added at once via `scaled_k`.
   - The trainer will block at the end-of-step in `handle_scale_up()` **until all K new servers are ready**. For larger K, expect more startup time before training proceeds.

### Compatibility & Assumptions
- **Engine:** The mechanism is validated with FSDP and vLLM (with vLLM-Ascend) on NPU in this MR.
- **Ray-based orchestration:** We assume using Ray for process launch, name resolution, and resource accounting.
- **Reconfiguration point:** Re-init happens **between steps** to keep on-step logic simple and deterministic.

## Related Issue

N/A

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

N/A

