### PR TITLE
fix: extends NCCL group timeout coverage

### DIFF
--- a/areal/thirdparty/vllm/vllm_worker_extension.py
+++ b/areal/thirdparty/vllm/vllm_worker_extension.py
@@ -1,10 +1,9 @@
-from typing import List
-
 import torch
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader import get_model_loader
 
 from areal.platforms import current_platform
+from areal.utils.constants import DIST_GROUP_DEFAULT_TIMEOUT
 from areal.utils.distributed import init_custom_process_group
 
 logger = init_logger("vllm_worker_extension")
@@ -38,7 +37,7 @@ class VLLMWorkerExtension:
             return False, error_msg
 
     def set_weight_meta(
-        self, names: List[str], dtypes: List[str], shapes: List[List[int]]
+        self, names: list[str], dtypes: list[str], shapes: list[list[int]]
     ):
         logger.info("start set weights meta")
         self.areal_weight_meta_names = names
@@ -67,7 +66,7 @@ class VLLMWorkerExtension:
                 )
                 self.model_runner.model.load_weights(weights=[(name, tensor)])
             self.sync()
-            return True, f"Success"
+            return True, "Success"
         except Exception as e:
             error_msg = f"Failed to update parameter! {e}."
             logger.error(error_msg)
@@ -82,7 +81,7 @@ class VLLMWorkerExtension:
         backend: str,
         group_name: str,
     ):
-        if getattr(self, "weight_update_group", None) != None:
+        if getattr(self, "weight_update_group", None) is not None:
             return True, "Success"
         try:
             self.weight_update_group = init_custom_process_group(
@@ -91,8 +90,9 @@ class VLLMWorkerExtension:
                 init_method=f"tcp://{master_address}:{master_port}",
                 rank=self.rank + rank_offset,
                 group_name=group_name,
+                timeout=DIST_GROUP_DEFAULT_TIMEOUT,
             )
-            return True, f"Success"
+            return True, "Success"
         except Exception as e:
             error_msg = f"Failed to init group! {e}."
             logger.error(error_msg)

--- a/areal/utils/constants.py
+++ b/areal/utils/constants.py
@@ -1,0 +1,5 @@
+import datetime
+
+# For large models, generation may consume more than 7200s.
+# We set a large value to avoid timeout issues during generation.
+DIST_GROUP_DEFAULT_TIMEOUT = datetime.timedelta(seconds=7200)

--- a/areal/utils/fsdp/grad.py
+++ b/areal/utils/fsdp/grad.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import List
 
 import torch
 import torch.distributed as dist
@@ -34,7 +33,7 @@ except ImportError:
         import warnings
 
         warnings.warn(
-            f"Transformer Engine and Apex are not installed. "
+            "Transformer Engine and Apex are not installed. "
             "Falling back to local implementations of multi_tensor_applier, "
             "multi_tensor_l2norm, and multi_tensor_scale"
         )
@@ -76,7 +75,7 @@ def is_param_not_tensor_parallel_duplicate(param, tensor_parallel_rank: int):
     return True
 
 
-def get_main_grads_for_grad_norm(params, tensor_parallel_rank: int) -> List[Tensor]:
+def get_main_grads_for_grad_norm(params, tensor_parallel_rank: int) -> list[Tensor]:
     return [
         param.grad
         for param in params
@@ -87,7 +86,7 @@ def get_main_grads_for_grad_norm(params, tensor_parallel_rank: int) -> List[Tens
 
 # Adapted from Megatron-LM
 def get_grad_norm_fp32(
-    grads_for_norm: List[Tensor] | Tensor,
+    grads_for_norm: list[Tensor] | Tensor,
     data_parallel_group: ProcessGroup,
     model_parallel_group: ProcessGroup,
     norm_type: float = 2.0,
@@ -157,7 +156,7 @@ def get_grad_norm_fp32(
 
 # Adapted from Megatron-LM
 def clip_grad_by_total_norm_fp32(
-    parameters: List[nn.Parameter],
+    parameters: list[nn.Parameter],
     max_norm: int | float,
     total_norm: float,
 ):
@@ -198,7 +197,7 @@ def clip_grad_by_total_norm_fp32(
 
 
 def fsdp2_clip_grad_norm(
-    parameters: List[nn.Parameter],
+    parameters: list[nn.Parameter],
     nd_device_mesh: DeviceMesh,
     max_norm: float,
     norm_type: float = 2.0,

--- a/areal/utils/nccl.py
+++ b/areal/utils/nccl.py
@@ -1,5 +1,0 @@
-import datetime
-
-# For large models, generation may consume more than 3600s.
-# We set a large value to avoid NCCL timeout issues during generaiton.
-NCCL_DEFAULT_TIMEOUT = datetime.timedelta(seconds=7200)


### PR DESCRIPTION
## Description

This pull request standardizes and improves the handling of distributed process group timeouts across the codebase. It replaces the previous `NCCL_DEFAULT_TIMEOUT` with a new, more general `DIST_GROUP_DEFAULT_TIMEOUT` constant and ensures that all distributed process groups use this unified timeout value. Additionally, it introduces a utility to patch default timeouts in PyTorch distributed, improves type hints, and makes minor code cleanups.

**Distributed timeout standardization and improvements:**

* Introduced a new `DIST_GROUP_DEFAULT_TIMEOUT` constant in `areal/utils/constants.py` to replace the old `NCCL_DEFAULT_TIMEOUT`, setting a unified timeout for all distributed process groups. [[1]](diffhunk://#diff-7b0410c4b6ef6bb6aaaf8142cdf0f4ee12df0179db8ada81c429fa8c756f7d38R1-R5) [[2]](diffhunk://#diff-04f6e9c4fe4c245e2defddc43cc10071d2c2882926f0ec281c753c54f855d458L1-L5)
* Updated all process group initializations in `base_hf_engine.py`, `fsdp_engine.py`, `megatron_engine.py`, `vllm_worker_extension.py`, and test scripts to use `DIST_GROUP_DEFAULT_TIMEOUT` instead of `NCCL_DEFAULT_TIMEOUT`. [[1]](diffhunk://#diff-298ed14340a03f615bd08f7ee2d38c6245e63ee94413870671afd8457ca1d1bdR118-R134) [[2]](diffhunk://#diff-298ed14340a03f615bd08f7ee2d38c6245e63ee94413870671afd8457ca1d1bdL45) [[3]](diffhunk://#diff-a0d0670c0725a58e05550c63233df81ddc97d72d979170d0b5945910cb33d9abL57) [[4]](diffhunk://#diff-a0d0670c0725a58e05550c63233df81ddc97d72d979170d0b5945910cb33d9abL383-R383) [[5]](diffhunk://#diff-ee2b0a343ccdab3736c77b01d789277175cb3861e2416ebcaeeffa038c126ce3R245-R252) [[6]](diffhunk://#diff-ee2b0a343ccdab3736c77b01d789277175cb3861e2416ebcaeeffa038c126ce3L265-R276) [[7]](diffhunk://#diff-ee2b0a343ccdab3736c77b01d789277175cb3861e2416ebcaeeffa038c126ce3L293-R298) [[8]](diffhunk://#diff-ee2b0a343ccdab3736c77b01d789277175cb3861e2416ebcaeeffa038c126ce3L626-R631) [[9]](diffhunk://#diff-eb454a9f62f2cb2848ba259caa97899817d8bd537aca338a4fa9c6f347d8809eL92-R97) [[10]](diffhunk://#diff-fe2a6a5b1bee3d9c0413cfd5cb79379b651e4d9b196041891d5750d455e5b387R93-R95)
* Added a `patch_dist_group_timeout` utility in `areal/utils/distributed.py` to patch PyTorch's default process group timeouts at runtime, and called it before group creation. [[1]](diffhunk://#diff-6187e68f130a404b36945fa9165d1c23844fc31517cc0a30cea5d80f26348a40R1-R21) [[2]](diffhunk://#diff-298ed14340a03f615bd08f7ee2d38c6245e63ee94413870671afd8457ca1d1bdR37) [[3]](diffhunk://#diff-298ed14340a03f615bd08f7ee2d38c6245e63ee94413870671afd8457ca1d1bdR118-R134)

**Type hint and code quality improvements:**

* Updated type hints from `List[...]` to the modern `list[...]` syntax in several files for consistency and Python 3.9+ compatibility. [[1]](diffhunk://#diff-fe2a6a5b1bee3d9c0413cfd5cb79379b651e4d9b196041891d5750d455e5b387L41-R40) [[2]](diffhunk://#diff-80dc517d4264f7998837737b152933d16c436e5c2674591a9c466a34f77b2b9cL79-R78) [[3]](diffhunk://#diff-80dc517d4264f7998837737b152933d16c436e5c2674591a9c466a34f77b2b9cL90-R89) [[4]](diffhunk://#diff-80dc517d4264f7998837737b152933d16c436e5c2674591a9c466a34f77b2b9cL160-R159) [[5]](diffhunk://#diff-80dc517d4264f7998837737b152933d16c436e5c2674591a9c466a34f77b2b9cL201-R200)
* Removed unnecessary imports and made minor code cleanups (e.g., string formatting, assertion improvements, and error handling). [[1]](diffhunk://#diff-80dc517d4264f7998837737b152933d16c436e5c2674591a9c466a34f77b2b9cL37-R36) [[2]](diffhunk://#diff-6187e68f130a404b36945fa9165d1c23844fc31517cc0a30cea5d80f26348a40L26-R45) [[3]](diffhunk://#diff-fe2a6a5b1bee3d9c0413cfd5cb79379b651e4d9b196041891d5750d455e5b387L70-R69) [[4]](diffhunk://#diff-fe2a6a5b1bee3d9c0413cfd5cb79379b651e4d9b196041891d5750d455e5b387L85-R84) [[5]](diffhunk://#diff-a0d0670c0725a58e05550c63233df81ddc97d72d979170d0b5945910cb33d9abL142-R142) [[6]](diffhunk://#diff-eb454a9f62f2cb2848ba259caa97899817d8bd537aca338a4fa9c6f347d8809eL127-R135)

**Test and third-party updates:**

* Updated the Ulysses correctness test and VLLM worker extension to use the new timeout constant and improved error handling. [[1]](diffhunk://#diff-eb454a9f62f2cb2848ba259caa97899817d8bd537aca338a4fa9c6f347d8809eL92-R97) [[2]](diffhunk://#diff-eb454a9f62f2cb2848ba259caa97899817d8bd537aca338a4fa9c6f347d8809eL127-R135) [[3]](diffhunk://#diff-fe2a6a5b1bee3d9c0413cfd5cb79379b651e4d9b196041891d5750d455e5b387R93-R95)

These changes make distributed training more robust and maintainable by ensuring consistent timeout behavior and improving code clarity.

## Related Issue


Fixes #(issue)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)

