### PR TITLE
bug fix: correctly shuffling data with distributed sampler

### DIFF
--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1068,17 +1068,11 @@ def bcast_mb_list(
 def cycle_dataloader(dataloader: StatefulDataLoader):
     """Cycle through a dataloader indefinitely."""
     epoch = 0
-    if isinstance(dataloader.sampler, DistributedSampler):
-        dataloader.sampler.set_epoch(epoch)
-    g = iter(dataloader)
     while True:
-        try:
-            yield next(g)
-        except StopIteration:
-            epoch += 1
-            if isinstance(dataloader.sampler, DistributedSampler):
-                dataloader.sampler.set_epoch(epoch)
-            g = iter(dataloader)
+        if isinstance(dataloader.sampler, DistributedSampler):
+            dataloader.sampler.set_epoch(epoch)
+        yield from dataloader
+        epoch += 1
 
 
 class Normalization:


### PR DESCRIPTION
## Description

[PyTorch documentation](https://docs.pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler) says we must call `set_epoch` for `DistributedSampler` to correctly shuffle data, which is true.

This PR modifys `cycle_dataloader` to set epoch counts correctly.

Simple test script:

```python
from torch.utils.data import DistributedSampler
from torchdata.stateful_dataloader import StatefulDataLoader

dataset = [1, 2, 3, 4, 5, 6, 7]
dataloader = StatefulDataLoader(
    dataset,
    batch_size=2,
    sampler=DistributedSampler(
        dataset,
        2,
        0,
        shuffle=True,
        drop_last=False,
    ),
    collate_fn=(lambda x: x),
)
from areal.utils.data import cycle_dataloader

cnt = 0
for x in cycle_dataloader(dataloader):
    print(x)
    cnt += 1
    if cnt > 10:
        break
```

Without change, the above script will produce identical batches in each epoch:

```bash
python3 test.py 
[5, 6]
[3, 2]
[5, 6]
[3, 2]
[5, 6]
[3, 2]
[5, 6]
[3, 2]
[5, 6]
[3, 2]
[5, 6]
```

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [ ] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
