### PR TITLE
chore: tunes NCCL IB settings

### DIFF
--- a/areal/utils/launcher.py
+++ b/areal/utils/launcher.py
@@ -42,9 +42,11 @@ BASE_ENVIRONS = {
 }
 NA132_ENVIRONS = {
     "NCCL_SOCKET_IFNAME": "bond0",
+    "NCCL_IB_DISABLE": "0",
+    "NCCL_NET": "IB",
     "NCCL_NET_PLUGIN": "",
     "NCCL_IB_GID_INDEX": "3",
-    "NCCL_IB_TIMEOUT": "2",
+    "NCCL_IB_TIMEOUT": "22",
     "NCCL_IB_RETRY_CNT": "7",
     "NCCL_IB_SL": "5",
     "NCCL_IB_TC": "136",
@@ -52,7 +54,6 @@ NA132_ENVIRONS = {
     "NCCL_IB_QPS_PER_CONNECTION": "8",
     "NCCL_SET_THREAD_NAME": "1",
     "NCCL_DEBUG": "WARN",
-    "NCCL_DEBUG_SUBSYS": "INIT,TUNING,GRAPH",
 }
 
 


### PR DESCRIPTION
## Description

Ensures the launcher explicitly opts into IB transport while relaxing timeouts to stabilize NCCL across NA132.

## Related Issue

Fixes #639 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
