### PR TITLE
fix: fixes CLI docs import order

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -465,6 +465,7 @@ Controls text generation behavior for rollout.
 | `stop_token_ids`    | list of integer        | **Required** | Stop generation when encountering these token IDs.                                                                                    |
 | `stop`              | list of string \| None | `None`       | One or multiple stop words. Generation will stop if one of these words is sampled.                                                    |
 | `frequency_penalty` | float                  | `0.0`        | Penalizes tokens based on their frequency in generation so far. Must be between -2 and 2 where negative numbers encourage repetition. |
+| `lora_name`         | string                 | `""`         | Lora name to be used for this generation.                                                                                             |
 
 (section-inference-engine)=
 
@@ -489,6 +490,7 @@ Configuration for inference servers, including offpolicyness control.
 | `pause_grace_period`      | float                                               | `0.0`           | The grace period after calling /pause_generation. Wait until all requests have been dropped.                                                                                                                                                                                         |
 | `scheduling_spec`         | `tuple`                                             | **Required**    | inference engine schedule specs. Can accept 1 or 2 SchedulingSpec: if 1 spec provided, it's used for both worker and engine, engine is embedded in the worker; if 2 specs provided, first one is for worker, second one is for engine. Currently only used by the RolloutController. |
 | `scheduling_strategy`     | [`SchedulingStrategy`](section-scheduling-strategy) | **Required**    | The scheduling strategy of this TrainEngine, either separation or colocation. Currently only used by the RolloutController.                                                                                                                                                          |
+| `use_lora`                | boolean                                             | `False`         | Whether to use LoRA. Should be same as actors LORA option.                                                                                                                                                                                                                           |
 
 (section-sg-lang)=
 
@@ -585,6 +587,8 @@ https://docs.vllm.ai/en/stable/api/index.html for detailed documentation.
 | `worker_extension_cls`         | string          | `"areal.thirdparty.vllm.vllm_worker_extension.VLLMWorkerExtension"` | -           |
 | `enable_sleep_mode`            | boolean         | `False`                                                             | -           |
 | `uvicorn_log_level`            | string          | `"warning"`                                                         | -           |
+| `enable_lora`                  | boolean         | `False`                                                             | -           |
+| `lora_modules`                 | string          | `""`                                                                | -           |
 
 (section-train-dataset)=
 

--- a/docs/generate_cli_docs.py
+++ b/docs/generate_cli_docs.py
@@ -18,11 +18,11 @@ from typing import Any, Union, get_args, get_origin
 import mdformat
 from omegaconf import MISSING as OMEGACONF_MISSING
 
-import areal.api.cli_args as cli_args_module
-
 # Add the project root to the path so we can import areal
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
+
+import areal.api.cli_args as cli_args_module  # noqa: E402
 
 
 def discover_dataclasses() -> dict[str, Any]:


### PR DESCRIPTION
## Description

Ensures the CLI args module imports only after the project root is added to sys.path so the docs generator keeps resolving project code reliably while silencing the linter warning.

## Related Issue

Fixes #645

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
