### PR TITLE
fix: vlm input slicing

### DIFF
--- a/areal/core/dist_rollout.py
+++ b/areal/core/dist_rollout.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -34,9 +34,12 @@ def _slice_tensor_dict(data: dict[str, Any], start: int, end: int) -> dict[str, 
     if "attention_mask" in data:
         batch_size = data["attention_mask"].shape[0]
     for key, value in data.items():
-        if key == 'multi_modal_input':
-            sliced_data[key] = value[start:end]
-        elif torch.is_tensor(value) and value.shape[0] == batch_size:
+        if (
+            torch.is_tensor(value)
+            and value.shape[0] == batch_size
+            or isinstance(value, Iterable)
+            and len(value) == batch_size
+        ):
             sliced_data[key] = value[start:end]
         else:
             sliced_data[key] = value


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does -->

This PR fixes a bug in `areal/core/dist_rollout.py` where the function `_slice_tensor_dict` does **not** slice the `multi_modal_input`. As a result, training with datasets containing **variable-sized images** produces incorrect image-to-token alignment and may cause shape mismatches that crash training.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #620 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

<!-- Describe what breaks and how users should migrate -->

