### PR TITLE
[FIX] Initialize llm_addrs in Slurm launcher for SFT jobs

### DIFF
--- a/areal/launcher/slurm.py
+++ b/areal/launcher/slurm.py
@@ -442,6 +442,7 @@ def slurm_main(config, run_id: int = 0):
         logger.info(f"Saved experiment metadata to {metadata_file}")
 
     n_backend_nodes = 0
+    llm_addrs = []
 
     if allocation_mode.gen_backend in ("sglang", "vllm"):
         # Launcher should launch llm servers according to allocation mode.


### PR DESCRIPTION
## Description

This PR fixes a bug in the Slurm launcher where `llm_addrs` was not initialized when running SFT jobs that don't use sglang or vllm backends.


## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

N/A

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

N/A
______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
