### PR TITLE
refact: expose workflow executor in inference engine

### DIFF
--- a/areal/api/engine_api.py
+++ b/areal/api/engine_api.py
@@ -332,11 +332,6 @@ class TrainEngine(abc.ABC):
 
 
 class InferenceEngine(abc.ABC):
-    @property
-    def workflow_executor(self) -> WorkflowExecutor:
-        """Get the workflow executor of the inference engine."""
-        raise NotImplementedError()
-
     def initialize(self, *args, **kwargs):
         """Initialize environments and launch the background thread for asynchronous distributed inference.
 
@@ -354,6 +349,11 @@ class InferenceEngine(abc.ABC):
 
     def destroy(self):
         """Destroy the engine and release GPU memory for the local inference engine."""
+        raise NotImplementedError()
+
+    @property
+    def workflow_executor(self) -> WorkflowExecutor:
+        """Get the workflow executor of the inference engine."""
         raise NotImplementedError()
 
     def launch_server(self, server_args: dict[str, Any]) -> LocalInfServerInfo:

--- a/areal/core/remote_inf_engine.py
+++ b/areal/core/remote_inf_engine.py
@@ -293,26 +293,6 @@ class RemoteInfEngine(InferenceEngine):
         self._workflow_executor: WorkflowExecutor | None = None
         self.local_server_processes: list[LocalInfServerInfo] = []
 
-    @property
-    def executor(self) -> ProcessPoolExecutor:
-        if self._executor is None:
-            raise RuntimeError("Executor is not initialized")
-        return self._executor
-
-    @executor.setter
-    def executor(self, executor: ProcessPoolExecutor):
-        self._executor = executor
-
-    @property
-    def workflow_executor(self) -> WorkflowExecutor:
-        if self._workflow_executor is None:
-            raise RuntimeError("WorkflowExecutor is not initialized")
-        return self._workflow_executor
-
-    @workflow_executor.setter
-    def workflow_executor(self, workflow_executor: WorkflowExecutor):
-        self._workflow_executor = workflow_executor
-
     def _create_session(self) -> aiohttp.ClientSession:
         """Create a ClientSession for the current asyncio coroutine.
 
@@ -458,6 +438,30 @@ class RemoteInfEngine(InferenceEngine):
             self._executor.shutdown()
         if len(self.local_server_processes) > 0:
             self.teardown_server()
+
+    @property
+    def executor(self) -> ProcessPoolExecutor:
+        """Get the process pool executor of the inference engine."""
+        if self._executor is None:
+            raise RuntimeError("Executor is not initialized")
+        return self._executor
+
+    @executor.setter
+    def executor(self, executor: ProcessPoolExecutor):
+        """Set the process pool executor of the inference engine."""
+        self._executor = executor
+
+    @property
+    def workflow_executor(self) -> WorkflowExecutor:
+        """Get the workflow executor of the inference engine."""
+        if self._workflow_executor is None:
+            raise RuntimeError("WorkflowExecutor is not initialized")
+        return self._workflow_executor
+
+    @workflow_executor.setter
+    def workflow_executor(self, workflow_executor: WorkflowExecutor):
+        """Set the workflow executor of the inference engine."""
+        self._workflow_executor = workflow_executor
 
     def set_version(self, version):
         """Set the current weight version."""

--- a/areal/engine/sglang_remote.py
+++ b/areal/engine/sglang_remote.py
@@ -226,10 +226,6 @@ class RemoteSGLangEngine(InferenceEngine):
         # Pure composition - create internal engine with SGLang backend
         self._engine = RemoteInfEngine(config, SGLangBackend())
 
-    @property
-    def workflow_executor(self) -> WorkflowExecutor:
-        return self._engine.workflow_executor
-
     def initialize(
         self,
         engine_id: str | None = None,
@@ -242,6 +238,11 @@ class RemoteSGLangEngine(InferenceEngine):
     def destroy(self):
         """Destroy the engine and clean up resources."""
         return self._engine.destroy()
+
+    @property
+    def workflow_executor(self) -> WorkflowExecutor:
+        """Get the workflow executor of the inference engine."""
+        return self._engine.workflow_executor
 
     def set_version(self, version: int):
         """Set the current weight version."""

--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -222,10 +222,6 @@ class RemotevLLMEngine(InferenceEngine):
         # lora already initialized when use_lora=true during init, by design, for vLLM
         self._engine.lora_initialized = config.use_lora
 
-    @property
-    def workflow_executor(self) -> WorkflowExecutor:
-        return self._engine.workflow_executor
-
     def initialize(
         self,
         engine_id: str | None = None,
@@ -238,6 +234,11 @@ class RemotevLLMEngine(InferenceEngine):
     def destroy(self):
         """Destroy the engine and clean up resources."""
         return self._engine.destroy()
+
+    @property
+    def workflow_executor(self) -> WorkflowExecutor:
+        """Get the workflow executor of the inference engine."""
+        return self._engine.workflow_executor
 
     def set_version(self, version: int):
         """Set the current weight version."""


### PR DESCRIPTION
## Description

Expose the workflow executor in the inference engine, so that the staleness manager can be accessed outside.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
