### PR TITLE
fix: add missing device_control_env_var to CpuPlatform

### DIFF
--- a/areal/platforms/cpu.py
+++ b/areal/platforms/cpu.py
@@ -21,3 +21,15 @@ class CpuPlatform(Platform):
     @classmethod
     def synchronize(cls) -> None:
         raise NotImplementedError()
+
+    @classmethod
+    def update_env_vars_for_visible_devices(
+        cls, env_vars: dict, gpu_ranks: list
+    ) -> None:
+        # No-op for CPU platform
+        pass
+
+    @classmethod
+    def get_visible_devices(cls) -> list:
+        # No-devices for CPU platform
+        return []


### PR DESCRIPTION
## Description

CpuPlatform was missing the device_control_env_var and ray_experimental_noset class attributes, causing AttributeError when CUDA initialization fails and the system falls back to CPU platform during Slurm launcher startup.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [ ] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
