### PR TITLE
fix: override workflow_executor property in MockInferenceEngine

### DIFF
--- a/areal/tests/test_engine_api_workflow_resolution.py
+++ b/areal/tests/test_engine_api_workflow_resolution.py
@@ -37,10 +37,16 @@ class MockInferenceEngine(InferenceEngine):
     """Mock inference engine for testing workflow resolution"""
 
     def __init__(self):
-        self.workflow_executor = Mock()
-        self.workflow_executor.submit = Mock()
-        self.workflow_executor.rollout_batch = Mock(return_value={"result": "batch"})
-        self.workflow_executor.prepare_batch = Mock(return_value={"result": "prepared"})
+        self._workflow_executor = Mock()
+        self._workflow_executor.submit = Mock()
+        self._workflow_executor.rollout_batch = Mock(return_value={"result": "batch"})
+        self._workflow_executor.prepare_batch = Mock(
+            return_value={"result": "prepared"}
+        )
+
+    @property
+    def workflow_executor(self):
+        return self._workflow_executor
 
     def submit(
         self,


### PR DESCRIPTION
## Description

The base class InferenceEngine defines workflow_executor as a read-only property without a setter. Override it with a proper getter/setter pair to allow setting the mock workflow executor in tests.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
