### PR TITLE
fix: enable gradient checkpointing by default

### DIFF
--- a/examples/alignment/hhrlhf_rw.yaml
+++ b/examples/alignment/hhrlhf_rw.yaml
@@ -23,7 +23,7 @@ model:
   init_from_scratch: false
   is_critic: true
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 4096

--- a/examples/camel/config.yaml
+++ b/examples/camel/config.yaml
@@ -41,7 +41,7 @@ actor:
   path: Qwen/Qwen2-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 16384

--- a/examples/countdown/train_config.yaml
+++ b/examples/countdown/train_config.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-3B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 8192

--- a/examples/experimental/prox_approx/gsm8k_grpo_prox_approx.yaml
+++ b/examples/experimental/prox_approx/gsm8k_grpo_prox_approx.yaml
@@ -37,7 +37,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/experimental/prox_approx/gsm8k_grpo_prox_approx_eval.yaml
+++ b/examples/experimental/prox_approx/gsm8k_grpo_prox_approx_eval.yaml
@@ -37,7 +37,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/lora/gsm8k_grpo_lora.yaml
+++ b/examples/lora/gsm8k_grpo_lora.yaml
@@ -39,7 +39,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/lora/gsm8k_grpo_lora_vllm.yaml
+++ b/examples/lora/gsm8k_grpo_lora_vllm.yaml
@@ -40,7 +40,7 @@ actor:
   path: ./model/Qwen3-0.6B
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_dapo_dynamic_bs.yaml
+++ b/examples/math/gsm8k_dapo_dynamic_bs.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_drgrpo.yaml
+++ b/examples/math/gsm8k_drgrpo.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_grpo.yaml
+++ b/examples/math/gsm8k_grpo.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_gspo.yaml
+++ b/examples/math/gsm8k_gspo.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_liteppo.yaml
+++ b/examples/math/gsm8k_liteppo.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_m2po.yaml
+++ b/examples/math/gsm8k_m2po.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_ppo.yaml
+++ b/examples/math/gsm8k_ppo.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_reinforce.yaml
+++ b/examples/math/gsm8k_reinforce.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_reinforce_baseline.yaml
+++ b/examples/math/gsm8k_reinforce_baseline.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_rloo.yaml
+++ b/examples/math/gsm8k_rloo.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/math/gsm8k_sft.yaml
+++ b/examples/math/gsm8k_sft.yaml
@@ -21,7 +21,7 @@ model:
   trial_name: ${trial_name}
   path: Qwen/Qwen3-1.7B
   init_from_scratch: false
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 4096

--- a/examples/multi-turn-math/config.yaml
+++ b/examples/multi-turn-math/config.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 16384

--- a/examples/openai-agents/config.yaml
+++ b/examples/openai-agents/config.yaml
@@ -41,7 +41,7 @@ actor:
   path: Qwen/Qwen2-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 16384

--- a/examples/single-controller/gsm8k_grpo.yaml
+++ b/examples/single-controller/gsm8k_grpo.yaml
@@ -44,7 +44,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/single-controller/gsm8k_sft.yaml
+++ b/examples/single-controller/gsm8k_sft.yaml
@@ -20,7 +20,7 @@ model:
   trial_name: ${trial_name}
   path: Qwen/Qwen3-1.7B
   init_from_scratch: false
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 4096

--- a/examples/skypilot/gsm8k_grpo_ray.yaml
+++ b/examples/skypilot/gsm8k_grpo_ray.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 4096

--- a/examples/tir/tir_math_config.yaml
+++ b/examples/tir/tir_math_config.yaml
@@ -35,7 +35,7 @@ actor:
   path: Qwen/Qwen2.5-Math-1.5B
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240

--- a/examples/vlm/clevr_count_70k_grpo.yaml
+++ b/examples/vlm/clevr_count_70k_grpo.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-VL-3B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 4096

--- a/examples/vlm/clevr_count_70k_sft.yaml
+++ b/examples/vlm/clevr_count_70k_sft.yaml
@@ -21,7 +21,7 @@ model:
   trial_name: ${trial_name}
   path: Qwen/Qwen2-VL-7B
   init_from_scratch: false
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 4096

--- a/recipe/AEnt/configs/gsm8k_aent_grpo.yaml
+++ b/recipe/AEnt/configs/gsm8k_aent_grpo.yaml
@@ -38,7 +38,7 @@ actor:
   path: Qwen/Qwen2.5-1.5B-Instruct
   init_from_scratch: false
   disable_dropout: true
-  gradient_checkpointing: false
+  gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
     max_tokens_per_mb: 10240


### PR DESCRIPTION
## Description

Enable gradient checkpointing by default in examples.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

