### PR TITLE
feat: support different api format conversion for gconfig, delay imports for cli args

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -228,6 +228,7 @@ class GenerationHyperparameters:
         elif api_format == "responses":
             mapping["max_new_tokens"] = "max_output_tokens"
         elif api_format == "openai-agents":
+            # NOTE: max_tokens in openai-agents means `max_new_tokens` in sglang/vllm. This is not a bug
             mapping["max_new_tokens"] = "max_tokens"
         else:
             raise ValueError(f"Unsupported API format: {api_format}")


### PR DESCRIPTION
## Description

Support different conversions for GenerationHyperparameters, to OpenAI completions, responses and openai agents model settings.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
