### PR TITLE
fix: catch tool call parse errors, fall back to no tool calls

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import uuid
 from collections.abc import Iterable
@@ -301,8 +302,11 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
                     self.tool_call_parser,
                     response.stop_reason,
                 )
-        except Exception as e:
-            logger.warning(f"Failed to parse tool calls from output text: {e}")
+        except json.JSONDecodeError as e:
+            logger.warning(
+                f"Failed to parse tool calls from output text: {e}, output_text:\n"
+                f"{output_text}"
+            )
 
         # Create proper ChatCompletion object with all required fields
         output_message = ChatCompletionMessage(
@@ -558,8 +562,11 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
                     engine_resp.stop_reason,
                     use_responses=True,
                 )
-        except Exception as e:
-            logger.warning(f"Failed to parse tool calls from output text: {e}")
+        except json.JSONDecodeError as e:
+            logger.warning(
+                f"Failed to parse tool calls from output text: {e}, output_text:\n"
+                f"{output_text}"
+            )
 
         # Extract reasoning tokens from output
         reasoning_token_count = self._count_reasoning_tokens(output_text)


### PR DESCRIPTION
## Description

If LLM generates output text that cannot be parsed as tool calls, an exception will be raised.
This PR catches such exception and fall back the results to be no tool calls.

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
