### PR TITLE
fix: support deprecated max_tokens usage in client, rename max_tokens to max_total_tokens in completion

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -169,6 +169,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
         frequency_penalty: float | None | NotGiven = NOT_GIVEN,
         max_completion_tokens: int | None | NotGiven = NOT_GIVEN,
         max_tokens: int | None | NotGiven = NOT_GIVEN,
+        max_total_tokens: int | None | NotGiven = NOT_GIVEN,
         metadata: Metadata | None | NotGiven = NOT_GIVEN,
         stop: str | None | list[str] | None | NotGiven = NOT_GIVEN,
         store: bool | None | NotGiven = NOT_GIVEN,
@@ -239,12 +240,23 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
             )
 
         temp = 1.0 if is_omitted(temperature) else (temperature or 0.0)
-        max_new_tokens = None
         if not is_omitted(max_tokens):
-            max_new_tokens = max_tokens - len(prompt_token_ids)
+            # NOTE: support deprecated `max_tokens` usage.
+            if not is_omitted(max_completion_tokens):
+                raise ValueError(
+                    "max_tokens and max_completion_tokens cannot be set at the same time. "
+                    "max_tokens has been deprecated. Please use max_completion_tokens instead. "
+                    "To set the total max tokens, please use max_total_tokens instead."
+                )
+            # NOTE (2025-12-09): the usage of max_tokens has been changed.
+            max_completion_tokens = max_tokens
+
+        max_new_tokens = None
+        if not is_omitted(max_total_tokens):
+            max_new_tokens = max_total_tokens - len(prompt_token_ids)
             if max_new_tokens <= 0:
                 raise RuntimeError(
-                    "max_tokens must be greater than the number of prompt tokens"
+                    "max_total_tokens must be greater than the number of prompt tokens"
                 )
         if not is_omitted(max_completion_tokens):
             if max_new_tokens is None:


### PR DESCRIPTION
The meaning of `max_tokens` in the chat completions API of the current `ArealOpenAI` client is different to the openai API, where `max_tokens` is deprecated in the openai API, and has the same usage as `max_completion_tokens`.

This PR fixes this mismatch by renaming the original `max_tokens` in `ArealOpenAI` as `max_total_tokens`.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
