### PR TITLE
fix: change checkpoint cleanup flag to fix update_weights_from_disk in single-controller mode

### DIFF
--- a/areal/controller/train_controller.py
+++ b/areal/controller/train_controller.py
@@ -701,7 +701,7 @@ class TrainController:
             replace=True,
         )
 
-        meta.clear_checkpoint = False
+        meta.clear_checkpoint_after_load = False
         self._run_async_task(self.rollout.update_weights_from_disk(meta))
         shutil.rmtree(meta.path, ignore_errors=True)
 


### PR DESCRIPTION
## Description

Fixes an issue where rollout workers prematurely delete the shared checkpoint directory during disk weight updates.
The root cause was that `train_controller.py` was setting a non-existent field:

```python
meta.clear_checkpoint = False
```

However, the `WeightUpdateMeta` class defines **only**:

```python
clear_checkpoint_after_load: bool = True
```

and does **not** define `clear_checkpoint`.
Because of this mismatch, workers continued using the default (`True`) and deleted the checkpoint directory.
This PR updates the controller to correctly set:

```python
meta.clear_checkpoint_after_load = False
```

so workers no longer delete the shared checkpoint directory.

## Related Issue

Fixes #710

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [ ] Test coverage improvement

## Checklist

* [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
* [x] I have run formatting tools (pre-commit or manual)
* [x] I have run relevant unit tests and they pass
* [ ] I have added tests for new functionality
* [ ] I have updated documentation if needed
* [x] My branch is up to date with main
* [ ] This PR introduces breaking changes
* [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
* [x] No critical issues raised by AI reviewers (`/gemini review`)

## Additional Context

The fix is applied in `train_controller.py`, replacing the incorrect `meta.clear_checkpoint` assignment with the correct `meta.clear_checkpoint_after_load = False`, aligning with the actual fields defined in `WeightUpdateMeta`.
