### PR TITLE
fix: update multi-turn math test configuration

### DIFF
--- a/areal/tests/test_examples.py
+++ b/areal/tests/test_examples.py
@@ -424,12 +424,11 @@ def test_multi_turn_math(tmp_path_factory):
             "actor.mb_spec.max_tokens_per_mb=1024",
             "train_dataset.batch_size=16",
             f"train_dataset.path={dataset_path}",
+            f"valid_dataset.path={dataset_path}",
             "cluster.n_gpus_per_node=2",
             f"cluster.fileroot={str(experiments_path)}",
             f"cluster.name_resolve.nfs_record_root={str(name_resolve_path)}",
             f"actor.path={model_path}",
-            "n_trajs=1",
-            "max_turns=2",
         )
     )
     assert success, "Multi-turn Math example failed"


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `test_multi_turn_math` test case to improve dataset configuration and simplify test parameters.

- Test configuration improvements:
  * The validation dataset path is now explicitly set to match the training dataset path in the test arguments, ensuring both datasets are correctly configured.
  * The `n_trajs` and `max_turns` parameters have been removed from the test arguments, likely to use default values or to simplify the test setup.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [x] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
