### PR TITLE
fix: use group_size=1 for eval in proxy examples

### DIFF
--- a/examples/experimental/proxy/train.py
+++ b/examples/experimental/proxy/train.py
@@ -166,7 +166,11 @@ def main(args):
 
         def _get_server_and_workflow(rollout: InferenceEngine, is_eval: bool = False):
             name = "train" if not is_eval else "eval"
-            temperature = 0.6 if is_eval else 1.0
+            gconfig = (
+                config.gconfig.new(temperature=0.6, n_samples=1)
+                if is_eval
+                else config.gconfig
+            )
             rollout_stat_scope = "rollout" if not is_eval else "eval-rollout"
             dump_dir = "generated" if not is_eval else "generated-eval"
 
@@ -180,7 +184,7 @@ def main(args):
             server.start(wait_until_ready=True)
             workflow = ProxyWorkflow(
                 proxy_server=server,
-                gconfig=config.gconfig.new(temperature=temperature),
+                gconfig=gconfig,
                 base_url=f"{server.public_addr}/v1",
                 max_concurrent_processes=num_processes // world_size,
                 agent_module_path=config.agent_module_path,

--- a/examples/experimental/proxy/train_sep.py
+++ b/examples/experimental/proxy/train_sep.py
@@ -310,7 +310,11 @@ def main(args):
         ):
             # Prepare proxy server, workflow and agent thread
             name = "train" if not is_eval else "eval"
-            temperature = 0.6 if is_eval else 1.0
+            gconfig = (
+                config.gconfig.new(temperature=0.6, n_samples=1)
+                if is_eval
+                else config.gconfig
+            )
             rollout_stat_scope = "rollout" if not is_eval else "eval-rollout"
             dump_dir = "generated" if not is_eval else "generated-eval"
 
@@ -337,7 +341,7 @@ def main(args):
                 dataset_config=config.train_dataset,
             )
             agent_workflow = GSM8kAgentWorkflow(
-                gconfig=config.gconfig.new(temperature=temperature),
+                gconfig=gconfig,
                 base_url=f"{server.public_addr}/v1",
                 max_concurrent_processes=num_processes // world_size,
                 agent_module_path=config.agent_module_path,


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does -->

Current eval uses the same group size as in training; this PR changes it to 1.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
