### PR TITLE
feat: add ignore_eos and skip_special_tokens generation params

### DIFF
--- a/areal/engine/sglang_remote.py
+++ b/areal/engine/sglang_remote.py
@@ -50,6 +50,8 @@ class SGLangBackend:
             "max_new_tokens": gconfig.max_new_tokens,
             "temperature": 0.0 if gconfig.greedy else gconfig.temperature,
             "stop_token_ids": stop_token_ids,
+            "ignore_eos": gconfig.ignore_eos,
+            "skip_special_tokens": gconfig.skip_special_tokens,
             "frequency_penalty": gconfig.frequency_penalty,
         }
         if stop:

--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -45,6 +45,8 @@ class VLLMBackend:
             "max_tokens": gconfig.max_new_tokens,
             "temperature": 0.0 if gconfig.greedy else gconfig.temperature,
             "stop_token_ids": stop_token_ids,
+            "ignore_eos": gconfig.ignore_eos,
+            "skip_special_tokens": gconfig.skip_special_tokens,
             "return_tokens_as_token_ids": True,
             "logprobs": 0,
             "use_beam_search": gconfig.use_beam_search,

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -457,21 +457,23 @@ Core configuration for model training, including optimization and backend settin
 
 Controls text generation behavior for rollout.
 
-| Parameter           | Type                   | Default      | Description                                                                                                                           |
-| ------------------- | ---------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `n_samples`         | integer                | `1`          | Number of sequences to generate per prompt.                                                                                           |
-| `max_new_tokens`    | integer                | `16384`      | Maximum number of tokens to generate.                                                                                                 |
-| `min_new_tokens`    | integer                | `0`          | Minimum number of tokens to generate.                                                                                                 |
-| `max_tokens`        | integer                | `65536`      | Maximum number of tokens including prompt and generated tokens.                                                                       |
-| `greedy`            | boolean                | `False`      | Whether to use greedy decoding (max probability).                                                                                     |
-| `top_p`             | float                  | `1.0`        | Nucleus sampling probability threshold (0.0, 1.0\].                                                                                   |
-| `top_k`             | integer                | `100000000`  | Number of highest probability tokens to consider.                                                                                     |
-| `temperature`       | float                  | `1.0`        | Sampling temperature. Higher values increase diversity.                                                                               |
-| `stop_token_ids`    | list of integer        | **Required** | Stop generation when encountering these token IDs.                                                                                    |
-| `stop`              | list of string \| None | `None`       | One or multiple stop words. Generation will stop if one of these words is sampled.                                                    |
-| `frequency_penalty` | float                  | `0.0`        | Penalizes tokens based on their frequency in generation so far. Must be between -2 and 2 where negative numbers encourage repetition. |
-| `lora_name`         | string                 | `""`         | Lora name to be used for this generation.                                                                                             |
-| `use_beam_search`   | boolean                | `False`      | Enable beam search in the vLLM engine. When enabled, sampling parameters like temperature, top-p, and top-k are auto ignored.         |
+| Parameter             | Type                   | Default      | Description                                                                                                                           |
+| --------------------- | ---------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `n_samples`           | integer                | `1`          | Number of sequences to generate per prompt.                                                                                           |
+| `max_new_tokens`      | integer                | `16384`      | Maximum number of tokens to generate.                                                                                                 |
+| `min_new_tokens`      | integer                | `0`          | Minimum number of tokens to generate.                                                                                                 |
+| `max_tokens`          | integer                | `65536`      | Maximum number of tokens including prompt and generated tokens.                                                                       |
+| `greedy`              | boolean                | `False`      | Whether to use greedy decoding (max probability).                                                                                     |
+| `top_p`               | float                  | `1.0`        | Nucleus sampling probability threshold (0.0, 1.0\].                                                                                   |
+| `top_k`               | integer                | `100000000`  | Number of highest probability tokens to consider.                                                                                     |
+| `temperature`         | float                  | `1.0`        | Sampling temperature. Higher values increase diversity.                                                                               |
+| `stop_token_ids`      | list of integer        | **Required** | Stop generation when encountering these token IDs.                                                                                    |
+| `ignore_eos`          | boolean                | `False`      | Do not stop generation when EOS is encountered.                                                                                       |
+| `skip_special_tokens` | boolean                | `True`       | Skip special tokens when decoding/displaying outputs.                                                                                 |
+| `stop`                | list of string \| None | `None`       | One or multiple stop words. Generation will stop if one of these words is sampled.                                                    |
+| `frequency_penalty`   | float                  | `0.0`        | Penalizes tokens based on their frequency in generation so far. Must be between -2 and 2 where negative numbers encourage repetition. |
+| `lora_name`           | string                 | `""`         | Lora name to be used for this generation.                                                                                             |
+| `use_beam_search`     | boolean                | `False`      | Enable beam search in the vLLM engine. When enabled, sampling parameters like temperature, top-p, and top-k are auto ignored.         |
 
 (section-inference-engine)=
 


### PR DESCRIPTION
## Description

Introduces new configuration options for controlling generation behavior: `ignore_eos` to prevent stopping at end-of-sequence tokens and `skip_special_tokens` to filter them from the output. These parameters are now propagated to the SGLang and VLLM remote backends but excluded from OpenAI API calls where they are not supported.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #223 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
