### PR TITLE
 Fix: Implement get_device_stats() for train_controller

### DIFF
--- a/areal/controller/train_controller.py
+++ b/areal/controller/train_controller.py
@@ -487,6 +487,9 @@ class TrainController:
             self._init_weight_update_from_distributed(meta)
             self.weight_update_group_initialized = True
 
+    def get_device_stats(self):
+        return self._custom_function_call("get_device_stats")
+
     def prepare_batch(
         self,
         dataloader: StatefulDataLoader,


### PR DESCRIPTION
## Description

This PR adds a missing `get_device_stats` method to `TrainController`.  
The absence of this method caused an `AttributeError` in the single-controller
PPO workflow when `PPOActorController` attempted to access device runtime
statistics during training.

## Related Issue

Fixes #761

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

The fix forwards `get_device_stats` calls from `TrainController` to the
underlying training engines via RPC, matching the expectations of
`PPOActorController` and existing training workflows.

