### PR TITLE
Enhance host IP detection in areal.utils.network

### DIFF
--- a/areal/utils/network.py
+++ b/areal/utils/network.py
@@ -7,6 +7,22 @@ def gethostname():
 
 
 def gethostip(probe_host: str = "8.8.8.8", probe_port: int = 80) -> str:
+    """
+    Find the local IPv4 address for outbound route to `probe_host:probe_port` (typically
+    a LAN/private IP). Use hostname resolution first; if it fails or returns loopback (127.*),
+    fall back to a UDP connect.
+
+    Args:
+        probe_host: Remote IPv4 address used to trigger route selection, default to Google
+                    Public DNS IP.
+        probe_port: Remote port used for the UDP probe.
+
+    Returns:
+        The selected local IPv4 address as a string
+
+    Raises:
+        RuntimeError: If no suitable IPv4 address can be determined
+    """
     try:
         ip = socket.gethostbyname(socket.gethostname())
         if ip and not ip.startswith("127."):


### PR DESCRIPTION
## Description

In some Ascend NPU nodes, the host IP cannot be detected reliably using `socket.gethostbyname(socket.gethostname())`: either a `socket.gaierror` would be raised, or it might resolve the host IP to `127.0.0.1`, which hinders multi-node training. This PR enhances the IP detection mechanism by additionally probing through UDP in case the `gethostbyname()` call fails.

## Related Issue

https://github.com/inclusionAI/AReaL/issues/777

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
