### PR TITLE
fix: update tree_attn function name to patch_bridge_for_tree_training

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -58,7 +58,7 @@ from areal.models.tree_attn.functional import (
     gather_packed_tree_logprobs_entropy,
     merge_packed_tree_results,
 )
-from areal.models.tree_attn.module import BLOCK_SIZE, patch_bridge_for_tree_attn
+from areal.models.tree_attn.module import BLOCK_SIZE, patch_bridge_for_tree_training
 from areal.models.tree_attn.tree import build_packed_tree_batch
 from areal.platforms import current_platform
 from areal.utils import logging, name_resolve, names, perf_tracer, stats_tracker
@@ -227,7 +227,7 @@ class MegatronEngine(TrainEngine):
 
         self.tokenizer = load_hf_tokenizer(self.config.path)
 
-        with patch_bridge_for_tree_attn(self.enable_tree_training):
+        with patch_bridge_for_tree_training(self.enable_tree_training):
             self.bridge = mbridge.AutoBridge.from_pretrained(self.config.path)
             self.bridge.dtype = self.dtype
             # Set gradient checkpointing options


### PR DESCRIPTION
## Description

This pull request updates the way tree attention training is enabled in the `megatron_engine.py` module. The main change is to use the new `patch_bridge_for_tree_training` function instead of the previous `patch_bridge_for_tree_attn` function, which likely reflects a refactor or improvement in the tree training code.

**Tree Attention Training Refactor:**

* Replaced all usage of `patch_bridge_for_tree_attn` with the new `patch_bridge_for_tree_training` function in both the import statement and in the `initialize` method, improving clarity and potentially aligning with updated tree training logic. [[1]](diffhunk://#diff-ee2b0a343ccdab3736c77b01d789277175cb3861e2416ebcaeeffa038c126ce3L61-R61) [[2]](diffhunk://#diff-ee2b0a343ccdab3736c77b01d789277175cb3861e2416ebcaeeffa038c126ce3L230-R230)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
