### PR TITLE
fix: prevent fake PID killing in LocalScheduler tests

### DIFF
--- a/areal/tests/test_local_scheduler.py
+++ b/areal/tests/test_local_scheduler.py
@@ -391,6 +391,9 @@ class TestWorkerCreation:
             # Verify default spec was used
             assert mock_popen.call_count == 2
 
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
+
     @patch("areal.scheduler.local.gethostip")
     @patch("areal.scheduler.local.subprocess.Popen")
     @patch("areal.scheduler.local.find_free_ports")
@@ -439,6 +442,9 @@ class TestWorkerCreation:
         # All workers should use the same spec
         for worker_info in scheduler._workers["actor"]:
             assert len(worker_info.worker.worker_ports) == 3
+
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
 
     @patch("areal.scheduler.local.gethostip")
     @patch("areal.scheduler.local.subprocess.Popen")
@@ -493,6 +499,9 @@ class TestWorkerCreation:
         assert len(scheduler._workers["critic"][0].worker.worker_ports) == 1
         assert len(scheduler._workers["critic"][1].worker.worker_ports) == 2
 
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
+
     @patch("areal.scheduler.local.gethostip")
     @patch("areal.scheduler.local.subprocess.Popen")
     @patch("areal.scheduler.local.find_free_ports")
@@ -543,6 +552,9 @@ class TestWorkerCreation:
         assert popen_call[1]["shell"] is True
         # Verify that subprocess.Popen was called
         mock_popen.assert_called_once()
+
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
 
     @patch("areal.scheduler.local.gethostip")
     @patch("areal.scheduler.local.subprocess.Popen")
@@ -597,6 +609,9 @@ class TestWorkerCreation:
         assert "CUDA_VISIBLE_DEVICES=0" in cmd_str
         # Verify shell=True is used since cmd is a string
         assert popen_call[1]["shell"] is True
+
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
 
     @patch("areal.scheduler.local.gethostip")
     @patch("areal.scheduler.local.subprocess.Popen")
@@ -673,6 +688,9 @@ class TestWorkerCreation:
         assert "critic" in scheduler._colocated_roles
         assert scheduler._colocated_roles["critic"] == "actor"
 
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
+
     def test_create_workers_duplicate_role_error(self, tmp_path):
         """Should raise WorkerCreationError when attempting to create workers for existing role."""
         scheduler = LocalScheduler(
@@ -704,6 +722,9 @@ class TestWorkerCreation:
 
             assert "Worker group already exists" in str(exc_info.value)
             assert exc_info.value.worker_key == "test"
+
+            # Clean up workers while mock is still active
+            scheduler.delete_workers(None)
 
     def test_create_workers_zero_replicas_error(self, tmp_path):
         """Should raise WorkerCreationError when replicas is 0."""
@@ -1786,6 +1807,9 @@ class TestEdgeCases:
             "worker/4",
         ]
 
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
+
     def test_empty_workers_dict_operations(self, tmp_path):
         """Should handle operations on empty workers dictionary gracefully."""
         scheduler = LocalScheduler(
@@ -1883,6 +1907,9 @@ class TestColocationBehavior:
         assert len(workers) == 1
         assert workers[0].id == "actor/0"
 
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
+
     @patch("areal.scheduler.local.gethostip")
     @patch("areal.scheduler.local.subprocess.Popen")
     @patch("areal.scheduler.local.find_free_ports")
@@ -1937,6 +1964,9 @@ class TestColocationBehavior:
         assert "actor" in scheduler._workers
         assert len(scheduler._workers["actor"]) == 1
 
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
+
     @patch("areal.scheduler.local.gethostip")
     @patch("areal.scheduler.local.subprocess.Popen")
     @patch("areal.scheduler.local.find_free_ports")
@@ -1979,6 +2009,9 @@ class TestColocationBehavior:
             scheduler.create_workers(ref_job)
 
         assert "replica count" in str(exc_info.value).lower()
+
+        # Clean up workers while mock is still active
+        scheduler.delete_workers(None)
 
     @patch("areal.scheduler.local.gethostip")
     @patch("areal.scheduler.local.subprocess.Popen")


### PR DESCRIPTION
## Description

Tests using mock `subprocess.Popen` create fake PIDs (e.g., 1000, 1234). When `LocalScheduler.__del__` runs after the mock context exits, it would call the real `kill_process_tree` on these PIDs, potentially terminating actual system processes and causing CI failures.

Add explicit scheduler.delete_workers(None) calls at the end of 11 affected tests to clean up workers while the mock is still active, ensuring `__del__` finds no workers to kill.

## Related Issue

Fix the CI "Sending SIGTERM to process 1000" issue in [feat(archon): add torch.compile support and profiling tools](https://github.com/inclusionAI/AReaL/actions/runs/20779635643/job/59673989232?pr=807).

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
