### PR TITLE
fix: add port retry logic to handle TOCTOU race in launch_server

### DIFF
--- a/areal/utils/network.py
+++ b/areal/utils/network.py
@@ -44,6 +44,12 @@ def find_free_ports(
     """
     Find multiple free ports within a specified range.
 
+    .. warning::
+        TOCTOU Race Condition: There is an inherent race between checking if a
+        port is free and actually binding to it. The port may become occupied
+        by another process between the check and use. Callers should implement
+        retry logic if they cannot tolerate bind failures.
+
     Args:
         count: Number of free ports to find
         port_range: Tuple of (min_port, max_port) to search within
@@ -102,6 +108,8 @@ def find_free_ports(
 def is_port_free(port: int) -> bool:
     """
     Check if a port is free by attempting to bind to it.
+
+    Note: Subject to the same TOCTOU race condition as :func:`find_free_ports`.
 
     Args:
         port: Port number to check


### PR DESCRIPTION
## Description

The find_free_ports function has an inherent TOCTOU (Time-of-Check- Time-of-Use) race condition where a port may become occupied between the availability check and actual binding. This caused intermittent server launch failures in CI when multiple workers started concurrently.

Changes:
- Add retry loop in RemoteInfEngine.launch_server with max_port_retries parameter (default 5)
- Exclude previously failed ports from subsequent attempts
- Only retry when server process dies quickly (likely port conflict), not on general timeouts
- Document TOCTOU race condition in find_free_ports and is_port_free

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fix the CI issue: [fix: prevent fake PID killing in LocalScheduler tests](https://github.com/inclusionAI/AReaL/actions/runs/20787001715/job/59699645022?pr=810)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
