### PR TITLE
feat: use subprocess to fork colocated workers

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -630,6 +630,14 @@ class SchedulingStrategy:
     target: str | None = field(
         default=None, metadata={"help": "The target role to be colocated with"}
     )
+    fork: bool = field(
+        default=True,
+        metadata={
+            "help": "When True with colocation, the target worker spawns a new "
+            "process on the same node/GPUs instead of sharing its process. "
+            "Provides process isolation while sharing GPU resources."
+        },
+    )
 
 
 @dataclass

--- a/areal/api/scheduler_api.py
+++ b/areal/api/scheduler_api.py
@@ -36,7 +36,6 @@ class Job:
     replicas: int = 0
     tasks: list[SchedulingSpec] = field(default_factory=list)
     scheduling_strategy: SchedulingStrategy = field(default_factory=SchedulingStrategy)
-    shared_placement_group: bool = False
 
 
 class Scheduler(abc.ABC):

--- a/areal/scheduler/ray.py
+++ b/areal/scheduler/ray.py
@@ -165,13 +165,14 @@ class RayScheduler(Scheduler):
         if device == "CPU":
             return res
 
+        # Use 0.9 GPUs to allow forked workers
         if device == "GPU":
-            res["num_gpus"] = float(gpu)
+            res["num_gpus"] = float(gpu) * 0.9
             return res
 
         return {
             "num_cpus": cpu,
-            "resources": {device: float(gpu)},
+            "resources": {device: float(gpu) * 0.9},
             "memory": mem * 1024**3,
         }
 
@@ -236,27 +237,25 @@ class RayScheduler(Scheduler):
         )
 
     def _create_ray_workers(
-        self, role: str, schedulings: list[SchedulingSpec], shared_placement_group: bool
+        self, role: str, schedulings: list[SchedulingSpec]
     ) -> tuple[list[RayWorkerInfo], list[str]]:
+        """Create Ray workers with individual placement groups per worker.
+
+        Each worker gets its own placement group with exclusive GPU access.
+        This ensures proper GPU isolation and supports forked workers sharing
+        the same PG/GPU.
+        """
         worker_info_list: list[RayWorkerInfo] = []
         worker_ids: list[str] = []
 
-        if shared_placement_group:
-            # Train-style: one shared PG with summed/split bundles across nodes
-            sum_cpu, sum_gpu, sum_mem = self._sum_resource_spec(schedulings)
-            bundles = self._create_bundle_list_gpu(sum_cpu, sum_gpu, sum_mem)
-            shared_pg = self._create_placement_group(role, bundles)
-            placement_groups = [shared_pg] * len(schedulings)
-            bundle_indices: list[int | None] = [None] * len(schedulings)
-        else:
-            # Rollout-style: one PG per worker
-            placement_groups = []
-            bundle_indices = []
-            for spec in schedulings:
-                bundles = [self._bundle_spec(spec.cpu, spec.gpu, spec.mem)]
-                pg = self._create_placement_group(role, bundles)
-                placement_groups.append(pg)
-                bundle_indices.append(0)
+        # Create one PG per worker with explicit bundle_index=0
+        placement_groups = []
+        bundle_indices: list[int] = []
+        for spec in schedulings:
+            bundles = [self._bundle_spec(spec.cpu, spec.gpu, spec.mem)]
+            pg = self._create_placement_group(role, bundles)
+            placement_groups.append(pg)
+            bundle_indices.append(0)  # Always use bundle_index=0
 
         master_ip, master_port = get_placement_group_master_ip_and_port(
             placement_groups[0], placement_group_bundle_index=0
@@ -269,13 +268,12 @@ class RayScheduler(Scheduler):
             env = self._build_env_vars(spec)
             options = self._actor_resource_spec(spec.cpu, spec.gpu, spec.mem)
 
-            # Build scheduling strategy with optional bundle index
+            # Build scheduling strategy with explicit bundle index
             strategy_kwargs: dict[str, Any] = {
                 "placement_group": pg,
                 "placement_group_capture_child_tasks": True,
+                "placement_group_bundle_index": bundle_idx,  # Always 0
             }
-            if bundle_idx is not None:
-                strategy_kwargs["placement_group_bundle_index"] = bundle_idx
 
             actor = RayRPCServer.options(
                 **options,
@@ -303,6 +301,145 @@ class RayScheduler(Scheduler):
             worker_ids.append(worker_id)
 
         return worker_info_list, worker_ids
+
+    def _create_forked_workers(
+        self,
+        role: str,
+        target_role: str,
+        target_workers: list[RayWorkerInfo],
+        schedulings,
+    ) -> list[str]:
+        """Create forked workers on same placement groups as target workers.
+
+        Since each target worker has its own PG with bundle_index=0, forked workers
+        share the exact same GPU by using the same PG and bundle_index=0.
+
+        Main workers use num_gpus=0.9, leaving 0.1 for forked workers.
+        Using num_gpus=0.01 allows up to 10 forked workers per target if needed.
+
+        Parameters
+        ----------
+        role : str
+            Role name for the forked workers
+        target_role : str
+            Target role to fork from
+        target_workers : list[RayWorkerInfo]
+            List of target worker infos to fork from
+        schedulings : list[SchedulingSpec]
+            Scheduling specs for the forked workers
+
+        Returns
+        -------
+        list[str]
+            List of forked worker IDs
+        """
+        worker_info_list: list[RayWorkerInfo] = []
+        worker_ids: list[str] = []
+
+        for idx, (target_wi, spec) in enumerate(zip(target_workers, schedulings)):
+            worker_id = f"{role}/{idx}"
+
+            # Reuse placement group from target worker
+            pg = target_wi.placement_group
+            bundle_idx = target_wi.bundle_index  # Should always be 0 now
+
+            # Build scheduling strategy for same placement group
+            strategy_kwargs: dict[str, Any] = {
+                "placement_group": pg,
+                "placement_group_capture_child_tasks": True,
+                "placement_group_bundle_index": bundle_idx,  # Same as target (0)
+            }
+
+            # Use 0.01 GPU to share with target worker (which uses 0.9)
+            # This allows multiple forked workers per target if needed
+            device = ray_resource_type()
+            additional_options = {}
+            if spec.gpu > 0:
+                if device == "GPU":
+                    additional_options = dict(num_gpus=0.01)
+                else:
+                    additional_options = {"resources": {device: 0.01}}
+            actor = RayRPCServer.options(
+                **additional_options,
+                num_cpus=0,  # Minimal CPU allocation for forked actor
+                name=worker_id,
+                runtime_env=RuntimeEnv(env_vars=target_wi.env_vars),
+                scheduling_strategy=PlacementGroupSchedulingStrategy(**strategy_kwargs),
+            ).remote()
+
+            # Build Worker object with same IP/ports as target
+            worker_ports = ray.get(
+                target_wi.actor.alloc_ports.remote(
+                    count=len(target_wi.worker.worker_ports)
+                )
+            )
+
+            worker = Worker(
+                id=worker_id,
+                ip=target_wi.worker.ip,
+                worker_ports=worker_ports,
+                engine_ports=[],
+            )
+
+            wi = RayWorkerInfo(
+                worker=worker,
+                actor=actor,
+                role=role,
+                placement_group=pg,  # Same PG as target
+                bundle_index=bundle_idx,
+                created_at=time.time(),
+                env_vars=target_wi.env_vars.copy(),
+            )
+            worker_info_list.append(wi)
+            worker_ids.append(worker_id)
+
+        # Register forked workers
+        self._workers[role] = worker_info_list
+        for wi in worker_info_list:
+            self._worker_info_by_id[wi.worker.id] = wi
+
+        # Ping forked workers to ensure they're ready
+        self._ping_workers(role, self.startup_timeout)
+
+        # Configure if exp_config available
+        if self.exp_config is not None:
+            for rank, wi in enumerate(worker_info_list):
+                try:
+                    wi.actor.configure.remote(self.exp_config, wi.role, rank)
+                except Exception as e:
+                    logger.error(
+                        f"Configure failed on forked worker {wi.worker.id}: {e}",
+                        exc_info=True,
+                    )
+                    self._cleanup_forked_workers(worker_info_list)
+                    raise WorkerCreationError(
+                        role, "Forked worker configuration failed", str(e)
+                    )
+
+        logger.info(
+            f"Role '{role}' forked from '{target_role}': "
+            f"created {len(worker_ids)} new actors on same placement groups"
+        )
+
+        return worker_ids
+
+    def _cleanup_forked_workers(self, workers: list[RayWorkerInfo]):
+        """Clean up forked workers without removing placement groups.
+
+        Unlike _cleanup_workers, this doesn't remove placement groups since
+        forked workers share placement groups with target workers.
+        """
+        for wi in workers:
+            actor = wi.actor
+            try:
+                actor.destroy.remote()
+            except Exception:
+                logger.warning(
+                    f"Could not destroy forked actor {actor}, force killing actor"
+                )
+                ray.kill(actor, no_restart=True)
+            # Remove from worker_info_by_id
+            self._worker_info_by_id.pop(wi.worker.id, None)
 
     def create_workers(self, job: Job, *args, **kwargs) -> list[str]:
         """
@@ -373,6 +510,15 @@ class RayScheduler(Scheduler):
                     f"({num_workers} != {len(target_workers)})",
                 )
 
+            # Check if fork mode is enabled
+            if strategy.fork:
+                # Fork mode: spawn new actors on same placement groups
+                worker_ids = self._create_forked_workers(
+                    role, colocate_role, target_workers, schedulings
+                )
+                self._colocated_roles[role] = colocate_role
+                return worker_ids
+
             # Reuse existing workers - no new actors spawned
             worker_ids = [w.worker.id for w in target_workers]
             self._colocated_roles[role] = colocate_role
@@ -386,9 +532,7 @@ class RayScheduler(Scheduler):
         if strategy_type != SchedulingStrategyType.separation:
             raise ValueError(f"Unknown scheduling strategy type: {strategy_type}")
         # Non-colocated: spawn new worker actors
-        worker_info_list, worker_ids = self._create_ray_workers(
-            role, schedulings, job.shared_placement_group
-        )
+        worker_info_list, worker_ids = self._create_ray_workers(role, schedulings)
 
         self._workers[role].extend(worker_info_list)
 
@@ -413,8 +557,14 @@ class RayScheduler(Scheduler):
         return worker_ids
 
     def get_workers(self, role: str, timeout: float | None = None) -> list[Worker]:
-        # Check if this is a colocated role - delegate to target role
+        # Check if this is a colocated role
         if role in self._colocated_roles:
+            # If forked role (has its own workers), use those
+            if role in self._workers:
+                worker_info_list = self._workers[role]
+                self._ping_workers(role, timeout)
+                return [wi.worker for wi in worker_info_list]
+            # Otherwise delegate to target role
             target_role = self._colocated_roles[role]
             return self.get_workers(target_role, timeout)
 
@@ -447,9 +597,20 @@ class RayScheduler(Scheduler):
                 self.delete_workers(r)
             return
 
-        # Handle colocated role: just remove the mapping, don't kill actors
+        # Handle colocated role
         if role in self._colocated_roles:
-            logger.info(f"Removing colocated role '{role}' mapping")
+            # Check if this is a forked role (has its own workers)
+            if role in self._workers:
+                # Forked role: clean up the spawned actors (but not placement groups)
+                workers = self._workers[role]
+                logger.info(
+                    f"Cleaning up {len(workers)} forked actors for role '{role}'"
+                )
+                self._cleanup_forked_workers(workers)
+                del self._workers[role]
+            else:
+                logger.info(f"Removing colocated role '{role}' mapping")
+            # Remove colocated mapping
             del self._colocated_roles[role]
             return
 

--- a/areal/scheduler/rpc/rtensor.py
+++ b/areal/scheduler/rpc/rtensor.py
@@ -13,6 +13,7 @@ import orjson
 import ray
 import torch
 
+from areal.utils.concurrent import run_async_task
 from areal.utils.datapack import ffd_allocate, flat2d
 
 
@@ -98,7 +99,7 @@ class HttpTensorBackend:
                     ]
                 )
 
-        return asyncio.run(_fetch_all())
+        return run_async_task(_fetch_all)
 
     async def _fetch_tensor(
         self, session: aiohttp.ClientSession, shard_id: str, node_addr: str

--- a/areal/tests/test_data_redistribution.py
+++ b/areal/tests/test_data_redistribution.py
@@ -1,5 +1,6 @@
 import pickle
 import subprocess
+import sys
 
 import pytest
 import torch
@@ -31,8 +32,7 @@ def assert_tensor_container_close(x1, x2):
 @pytest.mark.skipif(is_in_ci(), reason="CI machine will crash with all_gather_object")
 @pytest.mark.multi_gpu
 @pytest.mark.parametrize("world_size", [2, 4, 8])
-@pytest.mark.parametrize("granularity", [1, 2, 4])
-def test_redistribute(world_size, granularity, tmp_path):
+def test_redistribute(world_size, tmp_path):
     if current_platform.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs")
     port = find_free_ports(1)[0]
@@ -46,11 +46,11 @@ def test_redistribute(world_size, granularity, tmp_path):
                 f"--master_port={port}",
                 "areal/tests/torchrun/redistribute.py",
                 f"--dump-path={str(tmp_path)}",
-                f"--granularity={granularity}",
             ],
             check=True,
-            capture_output=True,
             text=True,
+            stderr=sys.stdout,
+            stdout=sys.stdout,
         )
     except subprocess.CalledProcessError as e:
         pytest.fail(f"Test failed with error: {e.stderr}")

--- a/areal/tests/test_local_scheduler.py
+++ b/areal/tests/test_local_scheduler.py
@@ -167,23 +167,21 @@ class TestLocalSchedulerInitialization:
 
     def test_init_without_gpu_devices_uses_cuda_visible_devices(self, tmp_path):
         """Should detect GPUs from CUDA_VISIBLE_DEVICES environment variable."""
-        with patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1,3"}):
+        # We need to patch the current_platform module-level attribute used in local.py
+        # by patching the import in the local module directly
+        mock_platform = Mock()
+        mock_platform.device_control_env_var = "CUDA_VISIBLE_DEVICES"
+
+        with (
+            patch("areal.scheduler.local.current_platform", mock_platform),
+            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1,3"}),
+        ):
             scheduler = LocalScheduler(
                 log_dir=str(tmp_path),
                 experiment_name="test_exp",
                 trial_name="test_trial",
             )
             assert scheduler.gpu_devices == [0, 1, 3]
-
-    def test_init_with_invalid_cuda_visible_devices(self, tmp_path):
-        """Should fall back to default [0] when CUDA_VISIBLE_DEVICES is invalid."""
-        with patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "invalid,gpu,ids"}):
-            scheduler = LocalScheduler(
-                log_dir=str(tmp_path),
-                experiment_name="test_exp",
-                trial_name="test_trial",
-            )
-            assert scheduler.gpu_devices == [0]
 
     def test_init_creates_log_directory(self, tmp_path):
         """Should create log directory if it doesn't exist."""
@@ -571,47 +569,52 @@ class TestWorkerCreation:
         mock_proc.poll.return_value = None
         mock_popen.return_value = mock_proc
 
-        scheduler = LocalScheduler(
-            gpu_devices=[0],
-            log_dir=str(tmp_path),
-            experiment_name="test_exp",
-            trial_name="test_trial",
-        )
+        # Mock the platform to use CUDA_VISIBLE_DEVICES
+        mock_platform = Mock()
+        mock_platform.device_control_env_var = "CUDA_VISIBLE_DEVICES"
 
-        job = Job(
-            replicas=1,
-            role="envtest",
-            tasks=[
-                SchedulingSpec(
-                    cpu=1,
-                    mem=1024,
-                    gpu=1,
-                    port_count=2,
-                    env_vars={"CUSTOM_VAR": "custom_value", "ANOTHER_VAR": "123"},
-                    cmd="python -m areal.scheduler.rpc.rpc_server",
-                )
-            ],
-        )
-        with patch.object(scheduler, "_configure_worker", return_value=None):
-            worker_ids = scheduler.create_workers(job)
+        with patch("areal.scheduler.local.current_platform", mock_platform):
+            scheduler = LocalScheduler(
+                gpu_devices=[0],
+                log_dir=str(tmp_path),
+                experiment_name="test_exp",
+                trial_name="test_trial",
+            )
 
-        assert len(worker_ids) == 1
+            job = Job(
+                replicas=1,
+                role="envtest",
+                tasks=[
+                    SchedulingSpec(
+                        cpu=1,
+                        mem=1024,
+                        gpu=1,
+                        port_count=2,
+                        env_vars={"CUSTOM_VAR": "custom_value", "ANOTHER_VAR": "123"},
+                        cmd="python -m areal.scheduler.rpc.rpc_server",
+                    )
+                ],
+            )
+            with patch.object(scheduler, "_configure_worker", return_value=None):
+                worker_ids = scheduler.create_workers(job)
 
-        # Verify environment variables were passed
-        # Environment variables are encoded into the shell command string, not passed as env parameter
-        popen_call = mock_popen.call_args
-        cmd_str = popen_call[0][0]
-        assert isinstance(cmd_str, str), f"Expected string, got {type(cmd_str)}"
-        # Verify custom environment variables are in the command string
-        assert "CUSTOM_VAR=custom_value" in cmd_str
-        assert "ANOTHER_VAR=123" in cmd_str
-        # Verify CUDA_VISIBLE_DEVICES is set correctly
-        assert "CUDA_VISIBLE_DEVICES=0" in cmd_str
-        # Verify shell=True is used since cmd is a string
-        assert popen_call[1]["shell"] is True
+            assert len(worker_ids) == 1
 
-        # Clean up workers while mock is still active
-        scheduler.delete_workers(None)
+            # Verify environment variables were passed
+            # Environment variables are encoded into the shell command string, not passed as env parameter
+            popen_call = mock_popen.call_args
+            cmd_str = popen_call[0][0]
+            assert isinstance(cmd_str, str), f"Expected string, got {type(cmd_str)}"
+            # Verify custom environment variables are in the command string
+            assert "CUSTOM_VAR=custom_value" in cmd_str
+            assert "ANOTHER_VAR=123" in cmd_str
+            # Verify CUDA_VISIBLE_DEVICES is set correctly
+            assert "CUDA_VISIBLE_DEVICES=0" in cmd_str
+            # Verify shell=True is used since cmd is a string
+            assert popen_call[1]["shell"] is True
+
+            # Clean up workers while mock is still active
+            scheduler.delete_workers(None)
 
     @patch("areal.scheduler.local.gethostip")
     @patch("areal.scheduler.local.subprocess.Popen")
@@ -659,7 +662,7 @@ class TestWorkerCreation:
         assert actor_ids == ["actor/0", "actor/1"]
         initial_popen_count = mock_popen.call_count
 
-        # Create colocated workers (critics) - should NOT spawn new processes
+        # Create colocated workers (critics) with fork=False - should NOT spawn new processes
         critic_job = Job(
             replicas=2,
             role="critic",
@@ -673,7 +676,7 @@ class TestWorkerCreation:
                 )
             ],
             scheduling_strategy=SchedulingStrategy(
-                type=SchedulingStrategyType.colocation, target="actor"
+                type=SchedulingStrategyType.colocation, target="actor", fork=False
             ),
         )
         critic_ids = scheduler.create_workers(critic_job)
@@ -1890,12 +1893,12 @@ class TestColocationBehavior:
         with patch.object(scheduler, "_configure_worker", return_value=None):
             scheduler.create_workers(actor_job)
 
-        # Create colocated role
+        # Create colocated role with fork=False (reuses existing workers)
         ref_job = Job(
             replicas=1,
             role="ref",
             scheduling_strategy=SchedulingStrategy(
-                type=SchedulingStrategyType.colocation, target="actor"
+                type=SchedulingStrategyType.colocation, target="actor", fork=False
             ),
         )
         scheduler.create_workers(ref_job)
@@ -1937,12 +1940,12 @@ class TestColocationBehavior:
         with patch.object(scheduler, "_configure_worker", return_value=None):
             scheduler.create_workers(actor_job)
 
-        # Create colocated role
+        # Create colocated role with fork=False (reuses existing workers)
         ref_job = Job(
             replicas=1,
             role="ref",
             scheduling_strategy=SchedulingStrategy(
-                type=SchedulingStrategyType.colocation, target="actor"
+                type=SchedulingStrategyType.colocation, target="actor", fork=False
             ),
         )
         scheduler.create_workers(ref_job)
@@ -2040,3 +2043,518 @@ class TestColocationBehavior:
         )
         with pytest.raises(WorkerNotFoundError):
             scheduler.create_workers(ref_job)
+
+
+class TestForkColocationBehavior:
+    """Test fork colocation behavior for spawning new worker processes.
+
+    These tests use real subprocesses and RPC servers to verify fork functionality.
+    """
+
+    @pytest.fixture
+    def rpc_server_process(self, tmp_path):
+        """Start a real RPC server process for testing.
+
+        Returns tuple of (process, host, port).
+        """
+        import socket
+        import subprocess
+
+        host = "127.0.0.1"
+
+        # Try to find a free port and start the server
+        # Retry a few times in case of port collision
+        proc = None
+        port = None
+        last_error = None
+        for _ in range(5):
+            # Find a free port
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", 0))
+                port = s.getsockname()[1]
+
+            # Start RPC server
+            cmd = [
+                "python",
+                "-m",
+                "areal.scheduler.rpc.rpc_server",
+                "--host",
+                host,
+                "--port",
+                str(port),
+                "--experiment-name",
+                "test_fork_exp",
+                "--trial-name",
+                "test_fork_trial",
+                "--role",
+                "actor",
+                "--worker-index",
+                "0",
+                "--fileroot",
+                str(tmp_path),
+            ]
+
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+
+            # Wait for server to be ready
+            deadline = time.time() + 15
+            server_ready = False
+            while time.time() < deadline:
+                try:
+                    resp = requests.get(f"http://{host}:{port}/health", timeout=2)
+                    if resp.status_code == 200:
+                        server_ready = True
+                        break
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ):
+                    pass
+                # Check if process died
+                if proc.poll() is not None:
+                    stdout = proc.stdout.read().decode() if proc.stdout else ""
+                    last_error = (
+                        f"Process died with code {proc.returncode}: {stdout[:500]}"
+                    )
+                    break
+                time.sleep(0.5)
+
+            if server_ready:
+                break
+            else:
+                # Kill the failed process and retry
+                try:
+                    proc.kill()
+                    proc.wait(timeout=2)
+                except Exception:
+                    pass
+                proc = None
+        else:
+            raise RuntimeError(
+                f"RPC server failed to start after 5 attempts on port {port}. "
+                f"Last error: {last_error}"
+            )
+
+        yield proc, host, port
+
+        # Cleanup
+        kill_process_tree(proc.pid, timeout=3, graceful=True)
+
+    def test_fork_endpoint_spawns_new_process(self, rpc_server_process):
+        """Should spawn a new RPC server process when /fork is called."""
+        _, host, port = rpc_server_process
+
+        # Call /fork endpoint
+        response = requests.post(
+            f"http://{host}:{port}/fork",
+            json={"role": "ref", "worker_index": 0},
+            timeout=60,
+        )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["status"] == "success"
+        assert "host" in result
+        assert "port" in result
+        assert "pid" in result
+
+        forked_pid = result["pid"]
+        forked_port = result["port"]
+
+        # Verify new process exists
+        assert psutil.pid_exists(forked_pid)
+
+        # Verify forked server is responsive
+        forked_response = requests.get(
+            f"http://{result['host']}:{forked_port}/health", timeout=5
+        )
+        assert forked_response.status_code == 200
+
+    def test_forked_worker_inherits_environment(self, rpc_server_process):
+        """Forked worker should inherit environment variables from parent."""
+        _, host, port = rpc_server_process
+
+        # Call /fork endpoint
+        response = requests.post(
+            f"http://{host}:{port}/fork",
+            json={"role": "ref", "worker_index": 0},
+            timeout=60,
+        )
+
+        assert response.status_code == 200
+        result = response.json()
+
+        # Verify forked server is alive and accessible
+        forked_response = requests.get(
+            f"http://{result['host']}:{result['port']}/health", timeout=5
+        )
+        assert forked_response.status_code == 200
+
+    def test_create_forked_workers_via_scheduler(self, tmp_path):
+        """LocalScheduler should create forked workers through /fork endpoint."""
+        import socket
+        import subprocess
+
+        # Find two free ports
+        ports = []
+        for _ in range(2):
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", 0))
+                ports.append(s.getsockname()[1])
+
+        host = "127.0.0.1"
+
+        # Start RPC server manually
+        cmd = [
+            "python",
+            "-m",
+            "areal.scheduler.rpc.rpc_server",
+            "--host",
+            host,
+            "--port",
+            str(ports[0]),
+            "--experiment-name",
+            "test_fork_exp",
+            "--trial-name",
+            "test_fork_trial",
+            "--role",
+            "actor",
+            "--worker-index",
+            "0",
+            "--fileroot",
+            str(tmp_path),
+        ]
+
+        server_proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        try:
+            # Wait for server to be ready
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                try:
+                    resp = requests.get(f"http://{host}:{ports[0]}/health", timeout=1)
+                    if resp.status_code == 200:
+                        break
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ):
+                    pass
+                time.sleep(0.2)
+            else:
+                raise RuntimeError("RPC server failed to start")
+
+            # Create scheduler and manually add the worker
+            scheduler = LocalScheduler(
+                gpu_devices=[0],
+                log_dir=str(tmp_path),
+                experiment_name="test_fork_exp",
+                trial_name="test_fork_trial",
+            )
+
+            # Manually register the actor worker (simulating what create_workers does)
+            actor_worker = Worker(
+                id="actor/0",
+                ip=host,
+                worker_ports=[str(ports[0])],
+                engine_ports=[],
+            )
+            actor_worker_info = WorkerInfo(
+                worker=actor_worker,
+                process=server_proc,
+                role="actor",
+                gpu_devices=[0],
+                created_at=time.time(),
+                log_file=str(tmp_path / "actor.log"),
+                env_vars={},
+            )
+            scheduler._workers["actor"] = [actor_worker_info]
+
+            # Now create forked workers using fork=True
+            ref_job = Job(
+                replicas=1,
+                role="ref",
+                scheduling_strategy=SchedulingStrategy(
+                    type=SchedulingStrategyType.colocation, target="actor", fork=True
+                ),
+            )
+
+            worker_ids = scheduler.create_workers(ref_job)
+
+            # Verify forked workers were created
+            assert worker_ids == ["ref/0"]
+            assert "ref" in scheduler._workers
+            assert len(scheduler._workers["ref"]) == 1
+
+            # Verify forked role is tracked in _colocated_roles
+            assert "ref" in scheduler._colocated_roles
+            assert scheduler._colocated_roles["ref"] == "actor"
+
+            # Verify forked worker has process=None (managed by parent)
+            forked_worker = scheduler._workers["ref"][0]
+            assert forked_worker.process is None
+
+            # Verify forked worker is a real, responsive server
+            forked_response = requests.get(
+                f"http://{forked_worker.worker.ip}:{forked_worker.worker.worker_ports[0]}/health",
+                timeout=5,
+            )
+            assert forked_response.status_code == 200
+
+            # Cleanup via scheduler
+            scheduler.delete_workers(None)
+
+        finally:
+            # Ensure cleanup
+            kill_process_tree(server_proc.pid, timeout=3, graceful=True)
+
+    def test_fork_replica_mismatch_raises_error(self, tmp_path):
+        """Should raise error when forked role has different replica count."""
+        import socket
+        import subprocess
+
+        # Find ports for 2 workers
+        ports = []
+        for _ in range(4):  # 2 ports per worker
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", 0))
+                ports.append(s.getsockname()[1])
+
+        host = "127.0.0.1"
+        server_procs = []
+
+        try:
+            # Start 2 RPC servers for actor role
+            for i in range(2):
+                cmd = [
+                    "python",
+                    "-m",
+                    "areal.scheduler.rpc.rpc_server",
+                    "--host",
+                    host,
+                    "--port",
+                    str(ports[i]),
+                    "--experiment-name",
+                    "test_fork_exp",
+                    "--trial-name",
+                    "test_fork_trial",
+                    "--role",
+                    "actor",
+                    "--worker-index",
+                    str(i),
+                    "--fileroot",
+                    str(tmp_path),
+                ]
+
+                proc = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
+                server_procs.append(proc)
+
+            # Wait for servers to be ready
+            for i in range(2):
+                deadline = time.time() + 30
+                while time.time() < deadline:
+                    try:
+                        resp = requests.get(
+                            f"http://{host}:{ports[i]}/health", timeout=1
+                        )
+                        if resp.status_code == 200:
+                            break
+                    except (
+                        requests.exceptions.ConnectionError,
+                        requests.exceptions.Timeout,
+                    ):
+                        pass
+                    time.sleep(0.2)
+                else:
+                    raise RuntimeError(f"RPC server {i} failed to start")
+
+            # Create scheduler and manually add workers
+            scheduler = LocalScheduler(
+                gpu_devices=[0, 1],
+                log_dir=str(tmp_path),
+                experiment_name="test_fork_exp",
+                trial_name="test_fork_trial",
+            )
+
+            # Manually register actor workers
+            scheduler._workers["actor"] = []
+            for i in range(2):
+                actor_worker = Worker(
+                    id=f"actor/{i}",
+                    ip=host,
+                    worker_ports=[str(ports[i])],
+                    engine_ports=[],
+                )
+                actor_worker_info = WorkerInfo(
+                    worker=actor_worker,
+                    process=server_procs[i],
+                    role="actor",
+                    gpu_devices=[i],
+                    created_at=time.time(),
+                    log_file=str(tmp_path / f"actor_{i}.log"),
+                    env_vars={},
+                )
+                scheduler._workers["actor"].append(actor_worker_info)
+
+            # Try to create forked role with different replica count
+            ref_job = Job(
+                replicas=1,  # Mismatch - actor has 2 replicas!
+                role="ref",
+                scheduling_strategy=SchedulingStrategy(
+                    type=SchedulingStrategyType.colocation, target="actor", fork=True
+                ),
+            )
+
+            with pytest.raises(WorkerCreationError) as exc_info:
+                scheduler.create_workers(ref_job)
+
+            assert "replica count" in str(exc_info.value).lower()
+
+        finally:
+            # Cleanup all server processes
+            for proc in server_procs:
+                kill_process_tree(proc.pid, timeout=3, graceful=True)
+
+    def test_fork_target_not_found_raises_error(self, tmp_path):
+        """Should raise error when fork target role doesn't exist."""
+        scheduler = LocalScheduler(
+            gpu_devices=[0],
+            log_dir=str(tmp_path),
+            experiment_name="test_exp",
+            trial_name="test_trial",
+        )
+
+        # Try to create forked role with non-existent target
+        ref_job = Job(
+            replicas=1,
+            role="ref",
+            scheduling_strategy=SchedulingStrategy(
+                type=SchedulingStrategyType.colocation, target="nonexistent", fork=True
+            ),
+        )
+
+        with pytest.raises(WorkerNotFoundError):
+            scheduler.create_workers(ref_job)
+
+    def test_delete_forked_workers_cleans_up_tracking(self, tmp_path):
+        """Should remove forked role from tracking when deleted."""
+        import socket
+        import subprocess
+
+        # Find a free port
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", 0))
+            port = s.getsockname()[1]
+
+        host = "127.0.0.1"
+
+        # Start RPC server
+        cmd = [
+            "python",
+            "-m",
+            "areal.scheduler.rpc.rpc_server",
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--experiment-name",
+            "test_fork_exp",
+            "--trial-name",
+            "test_fork_trial",
+            "--role",
+            "actor",
+            "--worker-index",
+            "0",
+            "--fileroot",
+            str(tmp_path),
+        ]
+
+        server_proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        try:
+            # Wait for server to be ready
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                try:
+                    resp = requests.get(f"http://{host}:{port}/health", timeout=1)
+                    if resp.status_code == 200:
+                        break
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ):
+                    pass
+                time.sleep(0.2)
+            else:
+                raise RuntimeError("RPC server failed to start")
+
+            # Create scheduler and manually add the worker
+            scheduler = LocalScheduler(
+                gpu_devices=[0],
+                log_dir=str(tmp_path),
+                experiment_name="test_fork_exp",
+                trial_name="test_fork_trial",
+            )
+
+            # Manually register the actor worker
+            actor_worker = Worker(
+                id="actor/0",
+                ip=host,
+                worker_ports=[str(port)],
+                engine_ports=[],
+            )
+            actor_worker_info = WorkerInfo(
+                worker=actor_worker,
+                process=server_proc,
+                role="actor",
+                gpu_devices=[0],
+                created_at=time.time(),
+                log_file=str(tmp_path / "actor.log"),
+                env_vars={},
+            )
+            scheduler._workers["actor"] = [actor_worker_info]
+
+            # Create forked workers
+            ref_job = Job(
+                replicas=1,
+                role="ref",
+                scheduling_strategy=SchedulingStrategy(
+                    type=SchedulingStrategyType.colocation, target="actor", fork=True
+                ),
+            )
+
+            scheduler.create_workers(ref_job)
+
+            # Verify forked role exists
+            assert "ref" in scheduler._colocated_roles
+            assert "ref" in scheduler._workers
+
+            # Delete forked role
+            scheduler.delete_workers("ref")
+
+            # Verify forked role is removed
+            assert "ref" not in scheduler._colocated_roles
+            assert "ref" not in scheduler._workers
+
+            # Target role should still exist
+            assert "actor" in scheduler._workers
+
+        finally:
+            # Cleanup
+            kill_process_tree(server_proc.pid, timeout=3, graceful=True)

--- a/areal/tests/test_ray_scheduler.py
+++ b/areal/tests/test_ray_scheduler.py
@@ -1,10 +1,11 @@
 import asyncio
+import time
 from unittest.mock import Mock, patch
 
 import pytest
 from ray.util.state import summarize_actors
 
-from areal.api.cli_args import BaseExperimentConfig
+from areal.api.cli_args import BaseExperimentConfig, SchedulingStrategy
 from areal.api.scheduler_api import Job, SchedulingSpec, Worker
 from areal.scheduler.ray import RayScheduler, RayWorkerInfo, ray_resource_type
 
@@ -47,13 +48,18 @@ class TestWorkerCreationAndDeletion:
                     gpu=1,
                 ),
             ],
-            shared_placement_group=True,
         )
 
         # create workers
         worker_ids = scheduler.create_workers(job)
         assert len(worker_ids) == 2
         assert len(scheduler._workers["train"]) == 2
+
+        # Verify each worker has its own placement group with bundle_index=0
+        pgs = [wi.placement_group for wi in scheduler._workers["train"]]
+        assert pgs[0] != pgs[1], "Each worker should have its own placement group"
+        for wi in scheduler._workers["train"]:
+            assert wi.bundle_index == 0, "bundle_index should always be 0"
 
         actor_summary = summarize_actors()
 
@@ -170,3 +176,214 @@ class TestUtilityFunctions:
         assert len(bundle_list) == 2
         for bundle in bundle_list:
             assert bundle[ray_resource_type()] <= _num_gpu_per_node
+
+
+class TestForkColocation:
+    """Tests for fork-based colocation in RayScheduler."""
+
+    def test_fork_creates_workers_on_same_placement_group(self):
+        """Test that forked workers are created on the same placement group."""
+        config = BaseExperimentConfig()
+
+        scheduler = RayScheduler(startup_timeout=60.0, exp_config=config)
+
+        # First create target workers (each gets its own PG with bundle_index=0)
+        actor_job = Job(
+            replicas=2,
+            role="actor",
+            tasks=[
+                SchedulingSpec(cpu=1, mem=1, gpu=1),
+                SchedulingSpec(cpu=1, mem=1, gpu=1),
+            ],
+        )
+
+        # Create actor workers
+        actor_worker_ids = scheduler.create_workers(actor_job)
+        assert len(actor_worker_ids) == 2
+        assert len(scheduler._workers["actor"]) == 2
+
+        # Create forked ref workers
+        ref_job = Job(
+            replicas=2,
+            role="ref",
+            tasks=[SchedulingSpec(cpu=1, mem=1, gpu=1)],
+            scheduling_strategy=SchedulingStrategy(
+                type="colocation", target="actor", fork=True
+            ),
+        )
+
+        ref_worker_ids = scheduler.create_workers(ref_job)
+
+        # Verify forked workers were created
+        assert len(ref_worker_ids) == 2
+        assert "ref" in scheduler._workers
+        assert len(scheduler._workers["ref"]) == 2
+
+        # Verify forked workers use same placement groups
+        for i in range(2):
+            actor_pg = scheduler._workers["actor"][i].placement_group
+            ref_pg = scheduler._workers["ref"][i].placement_group
+            assert actor_pg == ref_pg, "Forked worker should use same placement group"
+            # Verify both have bundle_index=0
+            assert scheduler._workers["actor"][i].bundle_index == 0
+            assert scheduler._workers["ref"][i].bundle_index == 0
+
+        # Verify ref role is tracked as colocated
+        assert "ref" in scheduler._colocated_roles
+        assert scheduler._colocated_roles["ref"] == "actor"
+
+        # Verify actors summary shows 4 actors (2 actor + 2 ref)
+        actor_summary = summarize_actors()
+        assert (
+            actor_summary["cluster"]["summary"]["RayRPCServer"]["state_counts"]["ALIVE"]
+            == 4
+        )
+
+        # Clean up
+        scheduler.delete_workers()
+
+    def test_fork_get_workers_returns_forked_workers(self):
+        """Test that get_workers returns forked workers directly."""
+        config = BaseExperimentConfig()
+        scheduler = RayScheduler(startup_timeout=60.0, exp_config=config)
+
+        # Create target workers
+        actor_job = Job(
+            replicas=2,
+            role="actor",
+            tasks=[SchedulingSpec(cpu=1, mem=1, gpu=1)],
+        )
+        scheduler.create_workers(actor_job)
+
+        # Create forked workers
+        ref_job = Job(
+            replicas=2,
+            role="ref",
+            tasks=[SchedulingSpec(cpu=1, mem=1, gpu=1)],
+            scheduling_strategy=SchedulingStrategy(
+                type="colocation", target="actor", fork=True
+            ),
+        )
+        scheduler.create_workers(ref_job)
+
+        # Get workers for ref role should return ref workers, not actor workers
+        ref_workers = scheduler.get_workers("ref")
+        assert len(ref_workers) == 2
+        assert all(w.id.startswith("ref/") for w in ref_workers)
+
+        # Clean up
+        scheduler.delete_workers()
+
+    def test_fork_delete_cleans_up_forked_actors(self):
+        """Test that deleting forked role cleans up its actors."""
+        config = BaseExperimentConfig()
+        scheduler = RayScheduler(startup_timeout=60.0, exp_config=config)
+
+        # Create target workers
+        actor_job = Job(
+            replicas=2,
+            role="actor",
+            tasks=[SchedulingSpec(cpu=1, mem=1, gpu=1)],
+        )
+        scheduler.create_workers(actor_job)
+
+        # Create forked workers
+        ref_job = Job(
+            replicas=2,
+            role="ref",
+            tasks=[SchedulingSpec(cpu=1, mem=1, gpu=1)],
+            scheduling_strategy=SchedulingStrategy(
+                type="colocation", target="actor", fork=True
+            ),
+        )
+        scheduler.create_workers(ref_job)
+
+        # Verify we have 4 actors total
+        actor_summary = summarize_actors()
+        assert (
+            actor_summary["cluster"]["summary"]["RayRPCServer"]["state_counts"]["ALIVE"]
+            == 4
+        )
+
+        # Delete only the ref role
+        scheduler.delete_workers("ref")
+
+        # Verify ref role is cleaned up
+        assert "ref" not in scheduler._workers
+        assert "ref" not in scheduler._colocated_roles
+
+        # Verify actor workers still exist
+        assert "actor" in scheduler._workers
+        assert len(scheduler._workers["actor"]) == 2
+
+        # Verify only 2 actors remain alive
+        # Wait for actors to be terminated (actor.destroy.remote() is async)
+
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            actor_summary = summarize_actors()
+            alive_count = (
+                actor_summary["cluster"]["summary"]
+                .get("RayRPCServer", {})
+                .get("state_counts", {})
+                .get("ALIVE", 0)
+            )
+            if alive_count == 2:
+                break
+            time.sleep(1)
+
+        actor_summary = summarize_actors()
+        assert (
+            actor_summary["cluster"]["summary"]["RayRPCServer"]["state_counts"]["ALIVE"]
+            == 2
+        )
+
+        # Clean up
+        scheduler.delete_workers()
+
+    def test_non_fork_colocation_reuses_workers(self):
+        """Test that non-fork colocation reuses target workers."""
+        config = BaseExperimentConfig()
+        scheduler = RayScheduler(startup_timeout=60.0, exp_config=config)
+
+        # Create target workers
+        actor_job = Job(
+            replicas=2,
+            role="actor",
+            tasks=[SchedulingSpec(cpu=1, mem=1, gpu=1)],
+        )
+        scheduler.create_workers(actor_job)
+
+        # Create colocated workers without fork
+        ref_job = Job(
+            replicas=2,
+            role="ref",
+            tasks=[SchedulingSpec(cpu=1, mem=1, gpu=1)],
+            scheduling_strategy=SchedulingStrategy(
+                type="colocation", target="actor", fork=False
+            ),
+        )
+        ref_worker_ids = scheduler.create_workers(ref_job)
+
+        # Ref should reuse actor worker IDs
+        assert all(w.startswith("actor/") for w in ref_worker_ids)
+
+        # Ref role should NOT have its own workers
+        assert "ref" not in scheduler._workers
+
+        # But ref should be tracked as colocated
+        assert "ref" in scheduler._colocated_roles
+
+        # get_workers for ref should return actor workers
+        ref_workers = scheduler.get_workers("ref")
+        assert all(w.id.startswith("actor/") for w in ref_workers)
+
+        # Only 2 actors total (no new actors for ref)
+        actor_summary = summarize_actors()
+        assert (
+            actor_summary["cluster"]["summary"]["RayRPCServer"]["state_counts"]["ALIVE"]
+            == 2
+        )
+
+        # Clean up
+        scheduler.delete_workers()

--- a/areal/tests/test_train_controller.py
+++ b/areal/tests/test_train_controller.py
@@ -705,28 +705,6 @@ class TestTrainControllerExportStats:
             assert result[k] == expected_stats[k]
 
 
-class TestTrainControllerAsyncMethods:
-    """Tests for async method handling."""
-
-    def test_run_async_task(self, train_controller):
-        """Test _run_async_task correctly runs async tasks."""
-
-        async def async_task():
-            return 42
-
-        result = train_controller._run_async_task(async_task())
-        assert result == 42
-
-    def test_run_async_task_with_exception(self, train_controller):
-        """Test _run_async_task propagates exceptions."""
-
-        async def failing_task():
-            raise ValueError("Test error")
-
-        with pytest.raises(ValueError, match="Test error"):
-            train_controller._run_async_task(failing_task())
-
-
 class TestTrainControllerDispatchInputs:
     """Tests for input dispatching across DP groups."""
 

--- a/areal/utils/concurrent.py
+++ b/areal/utils/concurrent.py
@@ -1,0 +1,61 @@
+import asyncio
+import atexit
+import concurrent.futures
+import threading
+
+# Lazy-initialized shared executor to reduce thread creation/destruction overhead
+# when run_async_task is called frequently
+_shared_executor: concurrent.futures.ThreadPoolExecutor | None = None
+_executor_lock = threading.Lock()
+
+
+def get_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Get or create the shared thread pool executor.
+
+    This provides a global shared executor for background tasks that need
+    to run in separate threads. The executor is lazily initialized and
+    automatically cleaned up at process exit.
+
+    Returns
+    -------
+    ThreadPoolExecutor
+        A shared thread pool executor with 4 workers.
+    """
+    global _shared_executor
+    if _shared_executor is None:
+        with _executor_lock:
+            if _shared_executor is None:
+                _shared_executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=4, thread_name_prefix="shared_executor"
+                )
+                # Register cleanup on process exit
+                atexit.register(_shutdown_executor)
+    return _shared_executor
+
+
+def _shutdown_executor() -> None:
+    """Shutdown the shared thread pool executor if it exists.
+
+    Called via atexit at process exit, when no other threads should be
+    accessing the executor.
+    """
+    global _shared_executor
+    if _shared_executor is not None:
+        _shared_executor.shutdown(wait=False)
+        _shared_executor = None
+
+
+def run_async_task(func, *args, **kwargs):
+    # Check if we're already in an async context
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None:
+        # Already in async context, use shared executor to avoid overhead
+        future = get_executor().submit(asyncio.run, func(*args, **kwargs))
+        return future.result()
+    else:
+        # Not in async context, use asyncio.run directly
+        return asyncio.run(func(*args, **kwargs))

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -931,10 +931,11 @@ Configuration class: SchedulingSpec
 
 Configuration class: SchedulingStrategy
 
-| Parameter | Type           | Default        | Description                               |
-| --------- | -------------- | -------------- | ----------------------------------------- |
-| `type`    | string         | `"separation"` | - **Choices:** `separation`, `colocation` |
-| `target`  | string \| None | `None`         | The target role to be colocated with      |
+| Parameter | Type           | Default        | Description                                                                                                                                                                     |
+| --------- | -------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`    | string         | `"separation"` | - **Choices:** `separation`, `colocation`                                                                                                                                       |
+| `target`  | string \| None | `None`         | The target role to be colocated with                                                                                                                                            |
+| `fork`    | boolean        | `True`         | When True with colocation, the target worker spawns a new process on the same node/GPUs instead of sharing its process. Provides process isolation while sharing GPU resources. |
 
 (section-session-tracer)=
 

--- a/docs/lite/gsm8k_grpo.md
+++ b/docs/lite/gsm8k_grpo.md
@@ -516,7 +516,7 @@ class DistRolloutCoordinator:
             batch = tensor_container_to(batch, current_platform.current_device())
 
         # Broadcast and redistribute to all data parallel ranks
-        return self._broadcast_and_redistribute_batch(batch, granularity=group_size)
+        return self._broadcast_and_redistribute_batch(batch)
 ```
 
 **Key Design**:

--- a/examples/lora/gsm8k_grpo_lora.py
+++ b/examples/lora/gsm8k_grpo_lora.py
@@ -7,7 +7,7 @@ import torch.distributed as dist
 from areal.api.alloc_mode import AllocationMode
 from areal.api.cli_args import GRPOConfig, load_expr_config
 from areal.api.io_struct import FinetuneSpec, StepInfo, WeightUpdateMeta
-from areal.core.dist_rollout import redistribute
+from areal.core.dist_rollout import redistribute_trajectories
 from areal.dataset import get_custom_dataset
 from areal.engine.fsdp_engine import FSDPPPOActor
 from areal.engine.sglang_remote import RemoteSGLangEngine
@@ -16,8 +16,6 @@ from areal.reward.gsm8k import gsm8k_reward_fn
 from areal.utils import seeding, stats_tracker
 from areal.utils.data import (
     broadcast_tensor_container,
-    concat_padded_tensors,
-    get_batch_size,
     tensor_container_to,
 )
 from areal.utils.dataloader import create_dataloader
@@ -29,17 +27,16 @@ from areal.utils.stats_logger import StatsLogger
 from areal.workflow.rlvr import RLVRWorkflow
 
 
-def bcast_and_split_from_rank0(batch: dict | None, granularity: int) -> dict:
+def bcast_and_split_from_rank0(batch: list) -> dict:
     batch = broadcast_tensor_container(batch, src_rank=0)
-    bs = get_batch_size(batch)
+    bs = len(batch)
     assert bs % dist.get_world_size() == 0
     bs_per_rank = bs // dist.get_world_size()
-    local_batch = []
-    for i in range(dist.get_rank() * bs_per_rank, (dist.get_rank() + 1) * bs_per_rank):
-        local_batch.append({k: v[i : i + 1] for k, v in batch.items()})
-    local_batch = concat_padded_tensors(local_batch)
+    local_batch = batch[
+        dist.get_rank() * bs_per_rank : (dist.get_rank() + 1) * bs_per_rank
+    ]
     # Make the sequences on each rank more balanced.
-    return redistribute(local_batch, granularity=granularity).data
+    return redistribute_trajectories(local_batch).data
 
 
 def main(args):
@@ -173,9 +170,7 @@ def main(args):
                     group_size=config.gconfig.n_samples,
                 )
                 batch = tensor_container_to(batch, actor.device)
-            batch = bcast_and_split_from_rank0(
-                batch, granularity=config.gconfig.n_samples
-            )
+            batch = bcast_and_split_from_rank0(batch)
 
         # Create barrier to synchronize all rollout processes.
         current_platform.synchronize()


### PR DESCRIPTION
## Description

This PR adds an option to create colocated workers via subprocess, instead of hosting them in the same process.

This is primarily because that the python multi-threading performance is too low. If we allocate eval rollout and rollout into the same worker, there will be two threads executing the workflow, leading to congestion.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [x] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
