### PR TITLE
refactor(data): simplify pad_mb_list alignment parameters

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1386,8 +1386,7 @@ class MegatronEngine(TrainEngine):
             mb_list,
             pad_value=0.0,
             pad_to_maximum=self.config.pad_to_maximum,
-            align_sequences=True,
-            align_to_multiple_of=align_to_multiple_of,
+            seq_align_to=align_to_multiple_of,
         )
         self.logger.info(
             f"#microbatch: {len(mb_list.group_lens)}, microbatch #tokens: {mb_list.group_lens}, "


### PR DESCRIPTION
## Description

Replace `align_sequences: bool` + `align_to_multiple_of: int | None` with a single `seq_align_to: int | None` parameter. None means no alignment, making the API cleaner and removing redundant validation.

## Related Issue

Resolve [a review comment](https://github.com/inclusionAI/AReaL/pull/817#discussion_r2678442851)

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
