### PR TITLE
feat(archon): enable TP + AC + compile compatibility with _WaitAsyncWrapper

### DIFF
--- a/areal/tests/experimental/archon/test_activation_checkpoint.py
+++ b/areal/tests/experimental/archon/test_activation_checkpoint.py
@@ -1,0 +1,338 @@
+"""Unit tests for Archon activation checkpointing.
+
+Tests cover:
+1. _wait_async_tensor helper function
+2. _WaitAsyncWrapper module wrapper
+3. ActivationCheckpointConfig validation
+4. apply_activation_checkpointing with all modes
+
+Run tests:
+    pytest areal/tests/experimental/archon/test_activation_checkpoint.py -v
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from areal.experimental.models.archon.activation_checkpoint import (
+    ActivationCheckpointConfig,
+    _wait_async_tensor,
+    _WaitAsyncWrapper,
+    apply_activation_checkpointing,
+)
+
+# =============================================================================
+# _wait_async_tensor Tests
+# =============================================================================
+
+
+class TestWaitAsyncTensor:
+    """Test _wait_async_tensor helper function."""
+
+    def test_regular_tensor_passthrough(self):
+        """Regular tensor should pass through unchanged."""
+        x = torch.randn(2, 3)
+        result = _wait_async_tensor(x)
+        assert result is x
+
+    def test_none_passthrough(self):
+        """None should pass through unchanged."""
+        result = _wait_async_tensor(None)
+        assert result is None
+
+    def test_non_tensor_passthrough(self):
+        """Non-tensor objects should pass through unchanged."""
+        x = [1, 2, 3]
+        result = _wait_async_tensor(x)
+        assert result is x
+
+    def test_int_passthrough(self):
+        """Integer should pass through unchanged."""
+        result = _wait_async_tensor(42)
+        assert result == 42
+
+    def test_string_passthrough(self):
+        """String should pass through unchanged."""
+        result = _wait_async_tensor("test")
+        assert result == "test"
+
+
+# =============================================================================
+# _WaitAsyncWrapper Tests
+# =============================================================================
+
+
+class TestWaitAsyncWrapper:
+    """Test _WaitAsyncWrapper module."""
+
+    def test_wrapper_forwards_to_module(self):
+        """Wrapper should forward calls to inner module."""
+        inner = nn.Linear(4, 2)
+        wrapper = _WaitAsyncWrapper(inner)
+
+        x = torch.randn(3, 4)
+        expected = inner(x)
+        result = wrapper(x)
+
+        assert torch.allclose(result, expected)
+
+    def test_wrapper_handles_kwargs(self):
+        """Wrapper should handle keyword arguments."""
+
+        class DummyModule(nn.Module):
+            def forward(self, x, scale=1.0):
+                return x * scale
+
+        inner = DummyModule()
+        wrapper = _WaitAsyncWrapper(inner)
+
+        x = torch.randn(2, 2)
+        result = wrapper(x, scale=2.0)
+        expected = x * 2.0
+
+        assert torch.allclose(result, expected)
+
+    def test_wrapper_handles_multiple_args(self):
+        """Wrapper should handle multiple positional arguments."""
+
+        class MultiArgModule(nn.Module):
+            def forward(self, a, b, c):
+                return a + b + c
+
+        inner = MultiArgModule()
+        wrapper = _WaitAsyncWrapper(inner)
+
+        a, b, c = torch.randn(2), torch.randn(2), torch.randn(2)
+        result = wrapper(a, b, c)
+        expected = a + b + c
+
+        assert torch.allclose(result, expected)
+
+    def test_wrapper_preserves_module_parameters(self):
+        """Wrapper should preserve inner module's parameters."""
+        inner = nn.Linear(4, 2)
+        wrapper = _WaitAsyncWrapper(inner)
+
+        # Parameters should be accessible
+        params = list(wrapper.parameters())
+        inner_params = list(inner.parameters())
+        assert len(params) == len(inner_params)
+
+        for p, ip in zip(params, inner_params):
+            assert p is ip
+
+    def test_wrapper_preserves_training_mode(self):
+        """Wrapper should forward training mode to inner module."""
+        inner = nn.Linear(4, 2)
+        wrapper = _WaitAsyncWrapper(inner)
+
+        wrapper.train()
+        assert inner.training is True
+
+        wrapper.eval()
+        assert inner.training is False
+
+
+# =============================================================================
+# ActivationCheckpointConfig Tests
+# =============================================================================
+
+
+class TestActivationCheckpointConfig:
+    """Test ActivationCheckpointConfig validation."""
+
+    def test_default_config(self):
+        """Default config should have mode='none'."""
+        config = ActivationCheckpointConfig()
+        assert config.mode == "none"
+        assert config.selective_ac_option == "1"
+        assert config.preserve_rng_state is False
+
+    def test_full_mode(self):
+        """Full mode should be valid."""
+        config = ActivationCheckpointConfig(mode="full")
+        assert config.mode == "full"
+
+    def test_selective_mode_with_integer(self):
+        """Selective mode with integer option should be valid."""
+        config = ActivationCheckpointConfig(mode="selective", selective_ac_option="2")
+        assert config.mode == "selective"
+        assert config.selective_ac_option == "2"
+
+    def test_selective_mode_with_op(self):
+        """Selective mode with 'op' option should be valid."""
+        config = ActivationCheckpointConfig(mode="selective", selective_ac_option="op")
+        assert config.selective_ac_option == "op"
+
+    def test_preserve_rng_state(self):
+        """preserve_rng_state should be configurable."""
+        config = ActivationCheckpointConfig(mode="full", preserve_rng_state=True)
+        assert config.preserve_rng_state is True
+
+    def test_invalid_mode_raises(self):
+        """Invalid mode should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid AC mode"):
+            ActivationCheckpointConfig(mode="invalid")
+
+    def test_invalid_selective_option_raises(self):
+        """Invalid selective_ac_option should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid selective_ac_option"):
+            ActivationCheckpointConfig(mode="selective", selective_ac_option="bad")
+
+    def test_zero_selective_option_raises(self):
+        """selective_ac_option='0' should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid selective_ac_option"):
+            ActivationCheckpointConfig(mode="selective", selective_ac_option="0")
+
+    def test_selective_option_not_validated_for_non_selective_mode(self):
+        """selective_ac_option should not be validated for non-selective modes."""
+        # Should not raise even with invalid selective_ac_option
+        config = ActivationCheckpointConfig(mode="full", selective_ac_option="bad")
+        assert config.mode == "full"
+
+
+# =============================================================================
+# apply_activation_checkpointing Tests
+# =============================================================================
+
+
+class DummyBlock(nn.Module):
+    """Dummy transformer block for testing."""
+
+    def __init__(self, dim=8):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class DummyModel(nn.Module):
+    """Dummy model with layers attribute for testing."""
+
+    def __init__(self, num_layers=4, dim=8):
+        super().__init__()
+        self.layers = nn.ModuleDict(
+            {str(i): DummyBlock(dim) for i in range(num_layers)}
+        )
+
+    def forward(self, x):
+        for layer in self.layers.values():
+            x = layer(x)
+        return x
+
+
+class TestApplyActivationCheckpointing:
+    """Test apply_activation_checkpointing function."""
+
+    def test_none_mode_no_wrapping(self):
+        """None mode should not wrap any layers."""
+        model = DummyModel(num_layers=3)
+        config = ActivationCheckpointConfig(mode="none")
+        apply_activation_checkpointing(model, config)
+
+        for layer in model.layers.values():
+            assert isinstance(layer, DummyBlock)
+            assert not isinstance(layer, _WaitAsyncWrapper)
+
+    def test_full_mode_wraps_all_layers(self):
+        """Full mode should wrap all layers with _WaitAsyncWrapper."""
+        model = DummyModel(num_layers=3)
+        config = ActivationCheckpointConfig(mode="full")
+        apply_activation_checkpointing(model, config)
+
+        for layer in model.layers.values():
+            assert isinstance(layer, _WaitAsyncWrapper)
+
+    def test_selective_mode_wraps_every_n_layers(self):
+        """Selective mode should wrap every Nth layer."""
+        model = DummyModel(num_layers=4)
+        config = ActivationCheckpointConfig(mode="selective", selective_ac_option="2")
+        apply_activation_checkpointing(model, config)
+
+        # With ac_freq=2, the 2nd and 4th layers are checkpointed.
+        # This corresponds to layers with index 1 and 3.
+        assert not isinstance(model.layers["0"], _WaitAsyncWrapper)
+        assert isinstance(model.layers["1"], _WaitAsyncWrapper)
+        assert not isinstance(model.layers["2"], _WaitAsyncWrapper)
+        assert isinstance(model.layers["3"], _WaitAsyncWrapper)
+
+    def test_selective_mode_every_layer(self):
+        """Selective mode with option '1' should wrap every layer."""
+        model = DummyModel(num_layers=3)
+        config = ActivationCheckpointConfig(mode="selective", selective_ac_option="1")
+        apply_activation_checkpointing(model, config)
+
+        for layer in model.layers.values():
+            assert isinstance(layer, _WaitAsyncWrapper)
+
+    def test_selective_op_mode_wraps_all_layers(self):
+        """Selective op mode should wrap all layers."""
+        model = DummyModel(num_layers=3)
+        config = ActivationCheckpointConfig(mode="selective", selective_ac_option="op")
+        apply_activation_checkpointing(model, config)
+
+        for layer in model.layers.values():
+            assert isinstance(layer, _WaitAsyncWrapper)
+
+    def test_model_without_layers_raises(self):
+        """Model without layers attribute should raise ValueError."""
+        model = nn.Linear(4, 2)
+        config = ActivationCheckpointConfig(mode="full")
+        with pytest.raises(ValueError, match="must have a 'layers' attribute"):
+            apply_activation_checkpointing(model, config)
+
+    def test_wrapped_model_forward_works(self):
+        """Wrapped model should still produce correct forward output."""
+        model = DummyModel(num_layers=3, dim=4)
+
+        # Get reference output before wrapping
+        x = torch.randn(2, 4)
+        with torch.no_grad():
+            ref_output = model(x.clone())
+
+        # Apply AC and verify output matches
+        config = ActivationCheckpointConfig(mode="full")
+        apply_activation_checkpointing(model, config)
+
+        with torch.no_grad():
+            wrapped_output = model(x.clone())
+
+        assert torch.allclose(ref_output, wrapped_output)
+
+    def test_wrapped_model_backward_works(self):
+        """Wrapped model should support backward pass."""
+        model = DummyModel(num_layers=3, dim=4)
+        config = ActivationCheckpointConfig(mode="full")
+        apply_activation_checkpointing(model, config)
+
+        x = torch.randn(2, 4, requires_grad=True)
+        output = model(x)
+        loss = output.sum()
+
+        # Should not raise
+        loss.backward()
+
+        # Gradients should exist
+        assert x.grad is not None
+        for param in model.parameters():
+            assert param.grad is not None
+
+    def test_multiple_models_independent(self):
+        """Multiple models should be wrapped independently."""
+        model1 = DummyModel(num_layers=4)
+        model2 = DummyModel(num_layers=4)
+
+        config1 = ActivationCheckpointConfig(mode="selective", selective_ac_option="2")
+        config2 = ActivationCheckpointConfig(mode="full")
+
+        apply_activation_checkpointing(model1, config1)
+        apply_activation_checkpointing(model2, config2)
+
+        # model1: selective, every 2nd layer
+        assert not isinstance(model1.layers["0"], _WaitAsyncWrapper)
+        assert isinstance(model1.layers["1"], _WaitAsyncWrapper)
+
+        # model2: all layers wrapped
+        for layer in model2.layers.values():
+            assert isinstance(layer, _WaitAsyncWrapper)

--- a/areal/tests/experimental/archon/torchrun/run_tp_ac_compile.py
+++ b/areal/tests/experimental/archon/torchrun/run_tp_ac_compile.py
@@ -1,0 +1,271 @@
+"""Test TP + AC + torch.compile compatibility.
+
+This test verifies that _WaitAsyncWrapper prevents dynamo recompilation
+when AsyncCollectiveTensor flows between checkpointed transformer blocks.
+
+Run with torchrun (requires at least 2 GPUs for TP=2):
+    torchrun --nproc_per_node=2 areal/tests/experimental/archon/torchrun/run_tp_ac_compile.py
+
+This test would have raised ValueError before the fix due to the incompatible
+combination of TP + AC + compile. After the fix with _WaitAsyncWrapper,
+this combination should work without dynamo recompilation warnings.
+"""
+
+import argparse
+import os
+import warnings
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from areal.api.alloc_mode import ParallelStrategy
+from areal.api.cli_args import (
+    ArchonEngineConfig,
+    MicroBatchSpec,
+    TrainEngineConfig,
+)
+from areal.api.io_struct import FinetuneSpec
+from areal.experimental.engine.archon_engine import ArchonEngine
+from areal.platforms import current_platform
+from areal.tests.utils import get_model_path
+from areal.utils.data import tensor_container_to
+
+MODEL_PATHS = {
+    "qwen3": get_model_path(
+        "/storage/openpsi/models/Qwen__Qwen3-0.6B/", "Qwen/Qwen3-0.6B"
+    ),
+}
+
+
+def setup_distributed_environment():
+    """Set up distributed environment for torchrun."""
+    if dist.is_initialized():
+        return
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    master_addr = os.environ.get("MASTER_ADDR", "localhost")
+    master_port = os.environ.get("MASTER_PORT", "29500")
+
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://{master_addr}:{master_port}",
+        world_size=world_size,
+        rank=rank,
+    )
+    current_platform.set_device(rank)
+
+
+def mock_input(
+    device: torch.device,
+    batch_size: int = 4,
+    min_seqlen: int = 4,
+    max_seqlen: int = 16,
+) -> dict[str, Any]:
+    """Create mock padded input data for testing."""
+    pad_token_id = 0
+    seqlens = torch.randint(
+        min_seqlen, max_seqlen, (batch_size,), dtype=torch.int, device=device
+    )
+    max_len = int(max(seqlens))
+    input_ids = torch.randint(
+        10000, 50000, (batch_size, max_len), dtype=torch.long, device=device
+    )
+    attn_mask = torch.zeros((batch_size, max_len), dtype=torch.bool, device=device)
+
+    attn_mask[
+        torch.arange(0, max_len, device=device).unsqueeze(0) < seqlens.unsqueeze(1)
+    ] = 1
+    input_ids.masked_fill_(~attn_mask, pad_token_id)
+
+    return dict(
+        input_ids=input_ids,
+        attention_mask=attn_mask,
+    )
+
+
+def make_engine_with_tp_ac_compile(
+    model_type: str, mb_spec: MicroBatchSpec, tp_size: int
+):
+    """Create and initialize a ArchonEngine with TP + AC + compile.
+
+    This combination would have raised ValueError before the fix.
+    """
+    # Enable gradient_checkpointing (AC) and compile
+    archon_config = ArchonEngineConfig(
+        enable_compile=True,
+        recompute_granularity="full",  # full AC
+    )
+
+    config = TrainEngineConfig(
+        experiment_name="test_tp_ac_compile",
+        trial_name="test",
+        path=MODEL_PATHS[model_type],
+        mb_spec=mb_spec,
+        optimizer=None,  # No optimizer needed for forward-only test
+        gradient_checkpointing=True,  # Enable AC
+        archon=archon_config,
+    )
+    print(f"config = {config}")
+
+    ft_spec = FinetuneSpec(total_train_epochs=1, dataset_size=128, train_batch_size=8)
+
+    engine = ArchonEngine(config)
+
+    # Create parallel strategy with TP
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    dp_size = world_size // tp_size
+    parallel_strategy = ParallelStrategy(
+        data_parallel_size=dp_size,
+        tensor_parallel_size=tp_size,
+    )
+
+    engine.create_process_group(parallel_strategy=parallel_strategy)
+    engine.initialize(addr=None, ft_spec=ft_spec)
+    return engine
+
+
+def test_tp_ac_compile_compatibility(model_type: str, tp_size: int):
+    """Test TP + AC + compile compatibility.
+
+    This test verifies:
+    1. The combination of TP + AC + compile no longer raises ValueError
+    2. No dynamo recompilation warnings are triggered during forward passes
+    3. The model produces valid outputs
+    """
+    setup_distributed_environment()
+
+    torch.manual_seed(42)
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    dp_size = world_size // tp_size
+
+    print(
+        f"[Rank {rank}] Testing TP + AC + compile compatibility with "
+        f"world_size={world_size}, dp={dp_size}, tp={tp_size}"
+    )
+
+    if world_size < tp_size:
+        print(f"[Rank {rank}] Skipping test: world_size < tp_size")
+        return
+
+    batch_size = 4
+    mb_spec = MicroBatchSpec(n_mbs=2)
+
+    # Capture warnings during engine creation and forward passes
+    recompile_warnings = []
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        # Create engine with TP + AC + compile
+        # This would have raised ValueError before the fix
+        engine = make_engine_with_tp_ac_compile(model_type, mb_spec, tp_size)
+
+        # Verify configuration
+        assert engine.parallel_dims.tp_enabled, "TP should be enabled"
+        assert engine.parallel_dims.tp == tp_size, f"Expected tp={tp_size}"
+        print(
+            f"[Rank {rank}] Engine initialized with "
+            f"tp={engine.parallel_dims.tp}, dp={engine.parallel_dims.dp_shard}, "
+            f"AC=enabled, compile=enabled"
+        )
+
+        # Create input
+        if rank == 0:
+            full_input = mock_input(
+                device=torch.device(f"{current_platform.device_type}:0"),
+                batch_size=batch_size,
+                max_seqlen=16,
+            )
+            full_input_list = [full_input]
+        else:
+            full_input_list = [None]
+
+        if dist.is_initialized():
+            dist.broadcast_object_list(full_input_list, src=0, group=dist.group.WORLD)
+
+        full_input = full_input_list[0]
+        full_input = tensor_container_to(
+            full_input, torch.device(f"{current_platform.device_type}:{rank}")
+        )
+
+        # Run multiple forward passes to trigger potential recompilation
+        engine.eval()
+        num_iterations = 5
+        for i in range(num_iterations):
+            logprobs = engine.forward_batch(
+                input_=full_input,
+                aggregate_fn=lambda xs: torch.cat(xs, dim=0),
+            )
+            if i == 0:
+                print(f"[Rank {rank}] First forward pass completed")
+                print(f"[Rank {rank}] Output logprobs shape: {logprobs.shape}")
+
+        print(f"[Rank {rank}] Completed {num_iterations} forward passes")
+
+        # Check for recompilation warnings
+        for warning in w:
+            msg = str(warning.message)
+            if "recompile_limit" in msg or "AsyncCollectiveTensor" in msg:
+                recompile_warnings.append(msg)
+                print(f"[Rank {rank}] Warning: {msg[:200]}...")
+
+    # Report results
+    if recompile_warnings:
+        print(
+            f"[Rank {rank}] FAILED: Got {len(recompile_warnings)} "
+            f"recompilation warnings"
+        )
+        # Cleanup before failing
+        engine.destroy()
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        raise AssertionError(
+            f"Got {len(recompile_warnings)} recompilation warnings. "
+            f"First warning: {recompile_warnings[0][:200]}..."
+        )
+
+    # Verify output shape
+    assert logprobs.shape[0] == batch_size, (
+        f"Expected batch_size={batch_size}, got {logprobs.shape[0]}"
+    )
+
+    # Verify outputs are valid (not NaN/Inf)
+    assert not torch.isnan(logprobs).any(), "Output contains NaN"
+    assert not torch.isinf(logprobs).any(), "Output contains Inf"
+
+    print(f"[Rank {rank}] PASSED: No recompilation warnings with TP + AC + compile")
+    print(f"[Rank {rank}] Sample logprobs (first 5): {logprobs[0, :5]}")
+
+    # Cleanup
+    engine.destroy()
+
+    if dist.is_initialized():
+        dist.barrier()
+        print(f"[Rank {rank}] All ranks completed successfully")
+        dist.destroy_process_group()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test TP + AC + compile compatibility")
+    parser.add_argument(
+        "--model_type",
+        type=str,
+        choices=["qwen3"],
+        default="qwen3",
+        help="Type of model to test",
+    )
+    parser.add_argument(
+        "--tp_size",
+        type=int,
+        default=2,
+        help="Tensor Parallel size (must divide world_size)",
+    )
+    args = parser.parse_args()
+    test_tp_ac_compile_compatibility(args.model_type, args.tp_size)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

- Add _WaitAsyncWrapper to wait AsyncCollectiveTensor before checkpoint region,
  resolving dynamo recompilation issue when combining TP, AC, and torch.compile
- Replace ValueError with info log for TP + AC + compile combination
- Add custom varlen_attn op to op-level SAC save list for proper checkpointing
- Import varlen_attention in activation_checkpoint to ensure op registration
- Add unit tests for activation checkpointing and distributed TP+AC+compile test
## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [x] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
