### PR TITLE
refactor(archon): cleanup parallel dims and FSDP config for pipeline parallelism

### DIFF
--- a/areal/experimental/engine/archon_engine.py
+++ b/areal/experimental/engine/archon_engine.py
@@ -251,7 +251,7 @@ class ArchonEngine(TrainEngine):
             reduce_dtype=torch.float32,
             loss_parallel=True,
             cpu_offload=self.config.archon.offload_params,
-            reshard_after_forward=True,
+            reshard_after_forward_policy="default",
             ac_config=ac_config,
             enable_compile=enable_compile,
         )

--- a/areal/experimental/models/archon/model_spec.py
+++ b/areal/experimental/models/archon/model_spec.py
@@ -41,7 +41,7 @@ class ParallelizeFn(Protocol):
         reduce_dtype: torch.dtype = torch.float32,
         loss_parallel: bool = True,
         cpu_offload: bool = False,
-        reshard_after_forward: bool = True,
+        reshard_after_forward_policy: str = "default",
         ac_config: ActivationCheckpointConfig | None = None,
         enable_compile: bool = True,
     ) -> nn.Module: ...

--- a/areal/experimental/models/archon/moe/moe.py
+++ b/areal/experimental/models/archon/moe/moe.py
@@ -214,22 +214,21 @@ class MoE(nn.Module):
 
         return out.view(bs, slen, dim)
 
-    def init_weights(self, init_std: float, buffer_device: torch.device | None = None):
+    def init_weights(self, init_std: float, buffer_device: torch.device):
         """Initialize weights.
 
         Args:
             init_std: Standard deviation for output projections.
             buffer_device: Device for buffers.
         """
-        self.router.init_weights(init_std=0.02)
-        self.experts.init_weights(init_std=init_std)
+        self.experts.init_weights(init_std)
+        self.router.init_weights(init_std)
 
         if self.shared_experts is not None:
-            self.shared_experts.init_weights(init_std=init_std)
+            self.shared_experts.init_weights(init_std)
 
         # Reset buffers
-        device = buffer_device or self.tokens_per_expert.device
-        with torch.device(device):
+        with torch.device(buffer_device):
             self.tokens_per_expert = torch.zeros(self.num_experts, dtype=torch.float32)
             if self.load_balance_coeff is not None:
                 self.expert_bias = torch.zeros(self.num_experts, dtype=torch.float32)

--- a/areal/experimental/models/archon/qwen3/model/model.py
+++ b/areal/experimental/models/archon/qwen3/model/model.py
@@ -341,7 +341,7 @@ class TransformerBlock(nn.Module):
             norm.reset_parameters()
         self.attention.init_weights(self.weight_init_std)
         if self.moe_enabled:
-            self.moe.init_weights(self.weight_init_std)
+            self.moe.init_weights(self.weight_init_std, buffer_device)
         else:
             self.feed_forward.init_weights(self.weight_init_std)
 

--- a/areal/tests/experimental/archon/test_moe.py
+++ b/areal/tests/experimental/archon/test_moe.py
@@ -40,7 +40,7 @@ class TestMoEBasic:
         moe_args = MoEArgs(num_experts=4, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(batch_size, seq_len, dim, device="cuda")
         out = moe(x)
@@ -56,7 +56,7 @@ class TestMoEBasic:
         moe_args = MoEArgs(num_experts=4, top_k=1, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(batch_size, seq_len, dim, device="cuda")
         out = moe(x)
@@ -77,7 +77,7 @@ class TestMoEConfigurations:
         moe_args = MoEArgs(num_experts=4, top_k=1, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -91,7 +91,7 @@ class TestMoEConfigurations:
         moe_args = MoEArgs(num_experts=8, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -105,7 +105,7 @@ class TestMoEConfigurations:
         moe_args = MoEArgs(num_experts=64, top_k=8, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -125,7 +125,7 @@ class TestMoESharedExperts:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         assert moe.shared_experts is not None
 
@@ -143,7 +143,7 @@ class TestMoESharedExperts:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         assert moe.shared_experts is None
 
@@ -168,7 +168,7 @@ class TestMoEScoreApplication:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -187,7 +187,7 @@ class TestMoEScoreApplication:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -207,7 +207,7 @@ class TestMoELoadBalancing:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         # Initially zero
         assert torch.all(moe.tokens_per_expert == 0)
@@ -253,7 +253,7 @@ class TestMoEGradients:
         moe_args = MoEArgs(num_experts=4, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda", requires_grad=True)
         out = moe(x)
@@ -280,7 +280,7 @@ class TestMoEGradients:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         # Use enough tokens so each expert gets some
         x = torch.randn(1, num_experts * 4, dim, device="cuda", requires_grad=True)
@@ -311,7 +311,7 @@ class TestMoEIntegration:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(1, 16, dim, device="cuda")
         out = moe(x)
@@ -327,7 +327,7 @@ class TestMoEIntegration:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
 
@@ -347,7 +347,7 @@ class TestMoEIntegration:
         moe_args = MoEArgs(num_experts=4, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(1, 16, dim, device="cuda")
         out = moe(x)
@@ -361,7 +361,7 @@ class TestMoEIntegration:
         moe_args = MoEArgs(num_experts=4, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02)
+        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
 
         x = torch.randn(1, 1, dim, device="cuda")
         out = moe(x)

--- a/areal/tests/experimental/archon/torchrun/run_ep_tests.py
+++ b/areal/tests/experimental/archon/torchrun/run_ep_tests.py
@@ -160,7 +160,7 @@ def create_ep_model(
         reduce_dtype=torch.float32,
         loss_parallel=False,
         cpu_offload=False,
-        reshard_after_forward=True,
+        reshard_after_forward_policy="default",
         ac_config=None,
         enable_compile=False,
     )
@@ -406,7 +406,7 @@ def test_weight_sync(
         reduce_dtype=torch.float32,
         loss_parallel=False,
         cpu_offload=False,
-        reshard_after_forward=True,
+        reshard_after_forward_policy="default",
         ac_config=None,
         enable_compile=False,
     )

--- a/areal/tests/experimental/archon/torchrun/run_qwen3_parallelize.py
+++ b/areal/tests/experimental/archon/torchrun/run_qwen3_parallelize.py
@@ -113,7 +113,7 @@ def create_and_parallelize_model(
         reduce_dtype=torch.float32,
         loss_parallel=True,
         cpu_offload=False,
-        reshard_after_forward=True,
+        reshard_after_forward_policy="default",
         ac_config=None,
         enable_compile=enable_compile,
     )


### PR DESCRIPTION
## Description

Prepare archon infrastructure for pipeline parallelism (PP) support:

- Add pp dimension to ArchonParallelDims with pp_enabled property
- Add dp_replicate placeholder for future HSDP support
- Replace reshard_after_forward bool with reshard_after_forward_policy string ("default"/"always"/"never") to handle PP-specific resharding
- Fix MoE init_weights to require buffer_device (remove optional None)
- Add shard_placement_fn for MoE experts when dp_mod_ep * ep > num_experts
- Improve comments for FSDP resharding optimization on final layers

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
