### PR TITLE
fix: remove duplicate setup in gsm8k_rl

### DIFF
--- a/examples/math/gsm8k_rl.py
+++ b/examples/math/gsm8k_rl.py
@@ -10,18 +10,11 @@ def main(args):
     config, _ = load_expr_config(args, GRPOConfig)
     tokenizer = load_hf_tokenizer(config.tokenizer_path)
 
-    train_dataset = get_custom_dataset("train", config.train_dataset, tokenizer)
-    valid_dataset = get_custom_dataset("test", config.valid_dataset, tokenizer)
-
-    workflow_kwargs = dict(
-        reward_fn="areal.reward.gsm8k.gsm8k_reward_fn",
-        gconfig=config.gconfig,
-        tokenizer=config.tokenizer_path,
-        enable_thinking=False,
+    train_dataset = get_custom_dataset(
+        split="train",
+        dataset_config=config.train_dataset,
+        tokenizer=tokenizer,
     )
-    eval_workflow_kwargs = workflow_kwargs.copy()
-    eval_workflow_kwargs["gconfig"] = config.gconfig.new(temperature=0.6)
-
     valid_dataset = get_custom_dataset(
         split="test",
         dataset_config=config.valid_dataset,


### PR DESCRIPTION
## Description

This PR removes duplicated `valid_dataset` loading and duplicated `workflow_kwargs` / `eval_workflow_kwargs` construction in `examples/math/gsm8k_rl.py`. As a commonly referenced entry-point for code walkthroughs, keeping this example clean improves readability and consistency (aligned with `gsm8k_sft.py`). The duplicated blocks were redundant because later definitions overwrote earlier ones, so this is **no functional change**.


## Related Issue

N/A


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

N/A

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
