### PR TITLE
feat(launcher): auto-set OMP_NUM_THREADS based on cpus_per_task

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -665,7 +665,7 @@ class SchedulingStrategy:
 @dataclass
 class SchedulingSpec:
     cpu: int = field(
-        default=4, metadata={"help": "Number of CPU cores required per GPU"}
+        default=8, metadata={"help": "Number of CPU cores required per GPU"}
     )
     gpu: int = field(
         default=0,

--- a/areal/launcher/local.py
+++ b/areal/launcher/local.py
@@ -26,6 +26,8 @@ from areal.utils.launcher import (
     JobException,
     JobInfo,
     JobState,
+    get_scheduling_spec,
+    get_thread_env_vars,
     validate_config_for_launcher,
     wait_llm_server_addrs,
 )
@@ -325,11 +327,13 @@ def local_main(config, run_id: int = 0):
         )
 
         # Launch inference servers.
-        try:
-            rollout_env_vars = config.rollout.scheduling_spec[0].env_vars
-        except AttributeError:
-            # In case `scheduling_spec` or `env_vars` is missing
-            rollout_env_vars = {}
+        rollout_spec = get_scheduling_spec(config.rollout)
+        rollout_env_vars = rollout_spec.env_vars
+        rollout_cpus_per_task = rollout_spec.cpu
+        thread_env = get_thread_env_vars(
+            cpus_per_task=rollout_cpus_per_task,
+            existing_env_vars=rollout_env_vars,
+        )
         launcher.submit_array(
             job_name="llm_server",
             cmd=server_cmd,
@@ -337,7 +341,7 @@ def local_main(config, run_id: int = 0):
             gpu=alloc_mode.gen.pp_size
             * alloc_mode.gen.tp_size
             * alloc_mode.gen.dp_size,
-            env_vars={**BASE_ENVIRONS, **rollout_env_vars},
+            env_vars={**BASE_ENVIRONS, **thread_env, **rollout_env_vars},
         )
 
         # Get llm server addresses by name resolve
@@ -374,17 +378,20 @@ def local_main(config, run_id: int = 0):
             _env_vars["NCCL_CUMEM_ENABLE"] = "0"
             _env_vars["NCCL_NVLS_ENABLE"] = "0"
         # All experiment configs should have the `actor` field.
-        try:
-            actor_env_vars = config.actor.scheduling_spec[0].env_vars
-        except AttributeError:
-            # in case `scheduling_spec` or `env_vars` is missing
-            actor_env_vars = {}
+        actor_spec = get_scheduling_spec(config.actor)
+        actor_env_vars = actor_spec.env_vars
+        actor_cpus_per_task = actor_spec.cpu
+        thread_env = get_thread_env_vars(
+            cpus_per_task=actor_cpus_per_task,
+            existing_env_vars=actor_env_vars,
+        )
         launcher.submit(
             job_name="trainer",
             cmd=f"torchrun --nnodes 1 --nproc-per-node {nprocs} --master-addr localhost --master-port {find_free_ports(1, (10000, 50000))[0]} {' '.join(sys.argv[1:])}",
             gpu=gpu,
             env_vars={
                 **BASE_ENVIRONS,
+                **thread_env,
                 **actor_env_vars,
                 **_env_vars,
                 **tms_env_vars,

--- a/areal/launcher/ray.py
+++ b/areal/launcher/ray.py
@@ -17,7 +17,6 @@ from areal.api.alloc_mode import AllocationMode, AllocationType
 from areal.api.cli_args import (
     ClusterSpecConfig,
     RecoverConfig,
-    SchedulingSpec,
     SGLangConfig,
     parse_cli_args,
     to_structured_cfg,
@@ -30,6 +29,8 @@ from areal.utils.launcher import (
     BASE_ENVIRONS,
     JobException,
     JobState,
+    get_scheduling_spec,
+    get_thread_env_vars,
     validate_config_for_distributed_launcher,
     wait_llm_server_addrs,
 )
@@ -372,18 +373,10 @@ def ray_main(config, run_id: int = 0):
     allocation_mode = config.allocation_mode
     allocation_mode = AllocationMode.from_str(allocation_mode)
 
-    try:
-        actor_spec = to_structured_cfg(config.actor.scheduling_spec[0], SchedulingSpec)
-    except AttributeError:
-        actor_spec = SchedulingSpec()
+    actor_spec = get_scheduling_spec(config.actor)
 
     if allocation_mode.gen_backend in ("sglang", "vllm"):
-        try:
-            rollout_spec = to_structured_cfg(
-                config.rollout.scheduling_spec[0], SchedulingSpec
-            )
-        except AttributeError:
-            rollout_spec = SchedulingSpec()
+        rollout_spec = get_scheduling_spec(config.rollout)
 
     if not is_recover_run:
         metadata_file = save_experiment_metadata(
@@ -446,7 +439,14 @@ def ray_main(config, run_id: int = 0):
 
             return env_vars
 
-        # launch a task to start all sglang servers in one node
+        # Launch a task to start all sglang servers in one node.
+        # Use full-node CPU allocation for llm_server since one Ray task manages
+        # all GPUs on a node. Thread env vars are set per-node (not per-GPU).
+        sglang_cpus_per_task = rollout_spec.cpu * n_gpus_per_node
+        thread_env = get_thread_env_vars(
+            cpus_per_task=sglang_cpus_per_task,
+            existing_env_vars=rollout_spec.env_vars,
+        )
         launcher.submit_array(
             job_name="llm_server",
             file_path=sglang_entry_point,
@@ -455,9 +455,9 @@ def ray_main(config, run_id: int = 0):
             nodes=n_sglang_nodes,
             list_args=sglang_args_list,
             gpus_per_task=n_gpus_per_node,
-            cpus_per_task=rollout_spec.cpu * n_gpus_per_node,
+            cpus_per_task=sglang_cpus_per_task,
             mem_per_task=rollout_spec.mem * 1024 * n_gpus_per_node,
-            env_vars={**BASE_ENVIRONS, **rollout_spec.env_vars},
+            env_vars={**BASE_ENVIRONS, **thread_env, **rollout_spec.env_vars},
             env_hook=(
                 partial(sglang_env_hook, n_sglang_nodes, node_group_size)
                 if cross_nodes
@@ -491,6 +491,11 @@ def ray_main(config, run_id: int = 0):
         vllm_entry_point = str(
             pathlib.Path(__file__).resolve().parent.joinpath("vllm_server.py")
         )
+        vllm_cpus_per_task = rollout_spec.cpu * vllm_tp_size
+        thread_env = get_thread_env_vars(
+            cpus_per_task=vllm_cpus_per_task,
+            existing_env_vars=rollout_spec.env_vars,
+        )
         launcher.submit_array(
             job_name="llm_server",
             file_path=vllm_entry_point,
@@ -499,9 +504,9 @@ def ray_main(config, run_id: int = 0):
             nodes=n_vllm_nodes,
             list_args=vllm_args_list,
             gpus_per_task=vllm_tp_size,
-            cpus_per_task=rollout_spec.cpu * vllm_tp_size,
+            cpus_per_task=vllm_cpus_per_task,
             mem_per_task=rollout_spec.mem * 1024 * vllm_tp_size,
-            env_vars={**BASE_ENVIRONS, **rollout_spec.env_vars},
+            env_vars={**BASE_ENVIRONS, **thread_env, **rollout_spec.env_vars},
         )
         # Get vllm server addresses via name_resolve
         try:
@@ -570,6 +575,13 @@ def ray_main(config, run_id: int = 0):
             _env_vars["NCCL_CUMEM_ENABLE"] = "0"
             _env_vars["NCCL_NVLS_ENABLE"] = "0"
 
+        # Use per-GPU CPU count for thread env vars since Ray spawns individual
+        # tasks per GPU, each inheriting these env vars. This differs from
+        # llm_server which uses full-node allocation.
+        thread_env = get_thread_env_vars(
+            cpus_per_task=actor_spec.cpu,
+            existing_env_vars=actor_spec.env_vars,
+        )
         launcher.submit_array(
             job_name="trainer",
             file_path=trainer_entry_point,
@@ -582,6 +594,7 @@ def ray_main(config, run_id: int = 0):
             mem_per_task=actor_spec.mem * 1024,
             env_vars={
                 **BASE_ENVIRONS,
+                **thread_env,
                 **actor_spec.env_vars,
                 **_env_vars,
                 **tms_env_vars,

--- a/areal/launcher/sglang_server.py
+++ b/areal/launcher/sglang_server.py
@@ -19,16 +19,26 @@ from areal.api.cli_args import (
 )
 from areal.platforms import current_platform
 from areal.utils import logging, name_resolve, names
-from areal.utils.launcher import TRITON_CACHE_PATH, apply_sglang_patch
+from areal.utils.launcher import (
+    TRITON_CACHE_PATH,
+    apply_sglang_patch,
+    get_scheduling_spec,
+)
 from areal.utils.network import find_free_ports, gethostip
 from areal.utils.proc import kill_process_tree
 
 logger = logging.getLogger("SGLangWrapper")
 
 
-def launch_server_cmd(command: list[str]) -> subprocess.Popen:
+def launch_server_cmd(
+    command: list[str], custom_env: dict[str, str] | None = None
+) -> subprocess.Popen:
     """
     Launch inference server in a new process and return its process handle.
+
+    Args:
+        command: The command to execute.
+        custom_env: Custom environment variables to set for the subprocess.
     """
     # Replace newline continuations and split the command string.
     logger.info(f"Launch command: {' '.join(command)}")
@@ -37,6 +47,10 @@ def launch_server_cmd(command: list[str]) -> subprocess.Popen:
     triton_cache_path = _env.get("TRITON_CACHE_PATH", TRITON_CACHE_PATH)
     unique_triton_cache_path = os.path.join(triton_cache_path, str(uuid.uuid4()))
     _env["TRITON_CACHE_PATH"] = unique_triton_cache_path
+
+    if custom_env is not None:
+        _env.update(custom_env)
+
     return subprocess.Popen(
         command,
         env=_env,
@@ -77,6 +91,7 @@ class SGLangServerWrapper:
         sglang_config: SGLangConfig,
         allocation_mode: AllocationMode,
         n_gpus_per_node: int,
+        cpu_per_gpu: int | None = None,
     ):
         self.experiment_name = experiment_name
         self.trial_name = trial_name
@@ -84,6 +99,7 @@ class SGLangServerWrapper:
         self.allocation_mode = allocation_mode
         self.server_processes = []  # List to store multiple server processes
         self.n_gpus_per_node = n_gpus_per_node
+        self.cpu_per_gpu = cpu_per_gpu
 
         if self.config.enable_fast_load or self.config.enable_multithread_load:
             apply_sglang_patch()
@@ -208,12 +224,16 @@ def launch_sglang_server(argv):
     allocation_mode = AllocationMode.from_str(allocation_mode)
     assert allocation_mode.gen_backend == "sglang"
 
+    # Get CPU per GPU from rollout scheduling spec
+    rollout_spec = get_scheduling_spec(config.rollout)
+
     sglang_server = SGLangServerWrapper(
         config.experiment_name,
         config.trial_name,
         config.sglang,
         allocation_mode,
         n_gpus_per_node=config.cluster.n_gpus_per_node,
+        cpu_per_gpu=rollout_spec.cpu,
     )
     sglang_server.run()
 

--- a/areal/scheduler/local.py
+++ b/areal/scheduler/local.py
@@ -40,6 +40,7 @@ from areal.utils.concurrent import run_async_task
 from areal.utils.http import get_default_connector
 from areal.utils.launcher import (
     get_env_vars,
+    get_thread_env_vars,
 )
 from areal.utils.network import find_free_ports, gethostip
 from areal.utils.proc import kill_process_tree, run_with_streaming_logs
@@ -623,6 +624,12 @@ class LocalScheduler(Scheduler):
                 env[current_platform.device_control_env_var] = ",".join(
                     map(str, gpu_devices)
                 )
+
+                thread_env = get_thread_env_vars(
+                    cpus_per_task=scheduling.cpu,
+                    existing_env_vars=scheduling.env_vars,
+                )
+                env.update(thread_env)
 
                 if scheduling.env_vars:
                     env.update(scheduling.env_vars)

--- a/areal/scheduler/ray.py
+++ b/areal/scheduler/ray.py
@@ -31,7 +31,7 @@ from areal.scheduler.exceptions import (
 )
 from areal.scheduler.rpc.ray_rpc_server import RayRPCServer
 from areal.utils import logging
-from areal.utils.launcher import get_env_vars
+from areal.utils.launcher import get_env_vars, get_thread_env_vars
 from areal.utils.ray import get_placement_group_master_ip_and_port
 
 logger = logging.getLogger("RayScheduler")
@@ -235,10 +235,16 @@ class RayScheduler(Scheduler):
         additional_envs_str = None
         if spec.env_vars:
             additional_envs_str = ",".join(f"{k}={v}" for k, v in spec.env_vars.items())
-        return get_env_vars(
+        env = get_env_vars(
             self.exp_config.cluster.cluster_name if self.exp_config else "",
             additional_envs_str,
         )
+        thread_env = get_thread_env_vars(
+            cpus_per_task=spec.cpu,
+            existing_env_vars=spec.env_vars,
+        )
+        env.update(thread_env)
+        return env
 
     def _create_ray_workers(
         self, role: str, schedulings: list[SchedulingSpec]

--- a/areal/scheduler/slurm.py
+++ b/areal/scheduler/slurm.py
@@ -37,6 +37,7 @@ from areal.utils.http import get_default_connector
 from areal.utils.launcher import (
     JobState,
     get_env_vars,
+    get_thread_env_vars,
 )
 from areal.utils.offload import get_tms_env_vars
 from areal.utils.proc import build_streaming_log_cmd
@@ -405,6 +406,11 @@ class SlurmScheduler(Scheduler):
             if self.enable_tms_offload:
                 sch.env_vars.update(get_tms_env_vars())
             sch.env_vars.update(get_env_vars(self.cluster_name))
+            thread_env = get_thread_env_vars(
+                cpus_per_task=sch.cpu,
+                existing_env_vars=sch.env_vars,
+            )
+            sch.env_vars.update(thread_env)
 
         if len(schedulings) == 1:
             # Expand single spec to all workers

--- a/areal/utils/launcher.py
+++ b/areal/utils/launcher.py
@@ -41,6 +41,85 @@ BASE_ENVIRONS = {
     "PYTHONPATH": PYTHONPATH,
 }
 
+# Thread control environment variables for OpenMP/MKL/etc.
+THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+
+# Default thread count when cpus_per_task cannot be determined
+THREAD_NUM_DEFAULT_WHEN_UNKNOWN = 8
+
+
+def get_thread_env_vars(
+    cpus_per_task: int | None = None,
+    existing_env_vars: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Get thread control environment variables.
+
+    Priority (from highest to lowest):
+    1. existing_env_vars settings (user-configured via SchedulingSpec.env_vars)
+    2. os.environ settings (user pre-set in script/shell)
+    3. cpus_per_task dynamically computed value
+    4. THREAD_NUM_DEFAULT_WHEN_UNKNOWN fallback value
+
+    Args:
+        cpus_per_task: Number of CPU cores allocated per task.
+        existing_env_vars: Existing environment variable dict (e.g., SchedulingSpec.env_vars)
+
+    Returns:
+        Thread environment variable dict
+    """
+    if existing_env_vars is None:
+        existing_env_vars = {}
+
+    # Determine thread count
+    if cpus_per_task is not None and cpus_per_task > 0:
+        num_threads = cpus_per_task
+    else:
+        num_threads = THREAD_NUM_DEFAULT_WHEN_UNKNOWN
+
+    thread_env = {}
+    for var in THREAD_ENV_VARS:
+        # Priority: existing_env_vars > os.environ > computed value
+        if var in existing_env_vars:
+            thread_env[var] = existing_env_vars[var]
+        elif var in os.environ:
+            thread_env[var] = os.environ[var]
+        else:
+            thread_env[var] = str(num_threads)
+
+    # Log auto-set variables
+    newly_set = [
+        v for v in THREAD_ENV_VARS if v not in existing_env_vars and v not in os.environ
+    ]
+    if newly_set:
+        logger.info(
+            f"Auto-setting thread env vars to {num_threads}: {', '.join(newly_set)}"
+        )
+
+    return thread_env
+
+
+def get_scheduling_spec(config_part):
+    """Safely retrieve SchedulingSpec from config.
+
+    Args:
+        config_part: Config object (e.g., config.actor or config.rollout)
+
+    Returns:
+        SchedulingSpec instance (default if not configured)
+    """
+    from areal.api.cli_args import SchedulingSpec, to_structured_cfg
+
+    try:
+        return to_structured_cfg(config_part.scheduling_spec[0], SchedulingSpec)
+    except AttributeError:
+        return SchedulingSpec()
+
 
 def get_env_vars(
     cluster_name: str, additional_env_vars: str | None = None

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -936,7 +936,7 @@ Configuration class: SchedulingSpec
 
 | Parameter              | Type                   | Default                                      | Description                                                                                                                    |
 | ---------------------- | ---------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `cpu`                  | integer                | `4`                                          | Number of CPU cores required per GPU                                                                                           |
+| `cpu`                  | integer                | `8`                                          | Number of CPU cores required per GPU                                                                                           |
 | `gpu`                  | integer                | `0`                                          | Number of GPU units required. Used only when allocating pods.                                                                  |
 | `mem`                  | integer                | `32`                                         | Amount of memory (GB) required per GPU                                                                                         |
 | `port_count`           | integer                | `2`                                          | Number of ports to expose                                                                                                      |

--- a/examples/alignment/hhrlhf_rw.yaml
+++ b/examples/alignment/hhrlhf_rw.yaml
@@ -41,7 +41,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/camel/config.yaml
+++ b/examples/camel/config.yaml
@@ -79,7 +79,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/countdown/train_config.yaml
+++ b/examples/countdown/train_config.yaml
@@ -80,7 +80,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/experimental/prox_approx/gsm8k_grpo_prox_approx.yaml
+++ b/examples/experimental/prox_approx/gsm8k_grpo_prox_approx.yaml
@@ -81,7 +81,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/experimental/prox_approx/gsm8k_grpo_prox_approx_eval.yaml
+++ b/examples/experimental/prox_approx/gsm8k_grpo_prox_approx_eval.yaml
@@ -81,7 +81,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/lora/gsm8k_grpo_lora.yaml
+++ b/examples/lora/gsm8k_grpo_lora.yaml
@@ -87,7 +87,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/lora/gsm8k_grpo_lora_vllm.yaml
+++ b/examples/lora/gsm8k_grpo_lora_vllm.yaml
@@ -91,7 +91,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
 

--- a/examples/math/boba_grpo.yaml
+++ b/examples/math/boba_grpo.yaml
@@ -80,7 +80,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars:

--- a/examples/math/gsm8k_dapo_dynamic_bs.yaml
+++ b/examples/math/gsm8k_dapo_dynamic_bs.yaml
@@ -85,7 +85,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_drgrpo.yaml
+++ b/examples/math/gsm8k_drgrpo.yaml
@@ -79,7 +79,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_grpo.yaml
+++ b/examples/math/gsm8k_grpo.yaml
@@ -81,7 +81,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_grpo_lora.yaml
+++ b/examples/math/gsm8k_grpo_lora.yaml
@@ -87,7 +87,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_grpo_megatron.yaml
+++ b/examples/math/gsm8k_grpo_megatron.yaml
@@ -80,7 +80,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_grpo_npu.yaml
+++ b/examples/math/gsm8k_grpo_npu.yaml
@@ -81,7 +81,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars:

--- a/examples/math/gsm8k_gspo.yaml
+++ b/examples/math/gsm8k_gspo.yaml
@@ -82,7 +82,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_liteppo.yaml
+++ b/examples/math/gsm8k_liteppo.yaml
@@ -79,7 +79,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_m2po.yaml
+++ b/examples/math/gsm8k_m2po.yaml
@@ -81,7 +81,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_ppo.yaml
+++ b/examples/math/gsm8k_ppo.yaml
@@ -76,7 +76,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_ppo_megatron.yaml
+++ b/examples/math/gsm8k_ppo_megatron.yaml
@@ -76,7 +76,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_reinforce.yaml
+++ b/examples/math/gsm8k_reinforce.yaml
@@ -77,7 +77,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_reinforce_baseline.yaml
+++ b/examples/math/gsm8k_reinforce_baseline.yaml
@@ -81,7 +81,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_rloo.yaml
+++ b/examples/math/gsm8k_rloo.yaml
@@ -81,7 +81,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_sapo.yaml
+++ b/examples/math/gsm8k_sapo.yaml
@@ -85,7 +85,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/math/gsm8k_sft.yaml
+++ b/examples/math/gsm8k_sft.yaml
@@ -41,7 +41,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/multi_turn_math/gsm8k_grpo_mt.yaml
+++ b/examples/multi_turn_math/gsm8k_grpo_mt.yaml
@@ -84,7 +84,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/openai_agents/config.yaml
+++ b/examples/openai_agents/config.yaml
@@ -79,7 +79,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/search_agent/local_1.5b_example.yaml
+++ b/examples/search_agent/local_1.5b_example.yaml
@@ -94,7 +94,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/search_agent/tongyi_deepresearch/config.yaml
+++ b/examples/search_agent/tongyi_deepresearch/config.yaml
@@ -82,7 +82,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/skypilot/gsm8k_grpo_ray.yaml
+++ b/examples/skypilot/gsm8k_grpo_ray.yaml
@@ -77,7 +77,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/tir/tir_math_config.yaml
+++ b/examples/tir/tir_math_config.yaml
@@ -74,7 +74,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/vlm/clevr_count_70k_grpo.yaml
+++ b/examples/vlm/clevr_count_70k_grpo.yaml
@@ -80,7 +80,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/vlm/clevr_count_70k_sft.yaml
+++ b/examples/vlm/clevr_count_70k_sft.yaml
@@ -38,7 +38,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/vlm/geometry3k_grpo.yaml
+++ b/examples/vlm/geometry3k_grpo.yaml
@@ -80,7 +80,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}

--- a/examples/vlm_npu/geometry3k_grpo.yaml
+++ b/examples/vlm_npu/geometry3k_grpo.yaml
@@ -80,7 +80,6 @@ actor:
     - task_type: worker
       port_count: 2
       gpu: 1
-      cpu: 4
       mem: 32
       cmd: python3 -m areal.scheduler.rpc.rpc_server
       env_vars: {}


### PR DESCRIPTION
## Description

Dynamically compute thread control environment variables (OMP_NUM_THREADS, MKL_NUM_THREADS, etc.) based on allocated CPU cores to prevent thread explosion in multi-process training scenarios.

Changes:
- Add get_thread_env_vars() function in launcher utils
- Update SchedulingSpec.cpu default from 4 to 8
- Apply thread env vars in Local, Ray, and Slurm launchers
- Support user override via SchedulingSpec.env_vars or os.environ

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
