### PR TITLE
feat(archon): use meta device + DCP for memory-efficient model init

### DIFF
--- a/areal/experimental/models/archon/base.py
+++ b/areal/experimental/models/archon/base.py
@@ -117,13 +117,6 @@ class BaseStateDictAdapter(ABC):
 class BaseArchonModel(nn.Module, ABC):
     """Base class for Archon models."""
 
-    model_args: BaseModelArgs
-    layers: nn.ModuleDict
-    tok_embeddings: nn.Embedding | None
-    norm: nn.Module | None
-    output: nn.Linear | None
-    score: nn.Linear | None
-
     @abstractmethod
     def forward(
         self,
@@ -134,7 +127,14 @@ class BaseArchonModel(nn.Module, ABC):
     ) -> torch.Tensor: ...
 
     @abstractmethod
-    def init_weights(self, buffer_device: torch.device | None = None) -> None: ...
+    def init_weights(self) -> None:
+        """Initialize model parameters."""
+        ...
+
+    @abstractmethod
+    def init_buffers(self, buffer_device: torch.device | str) -> None:
+        """Initialize model buffers (e.g., rope_cache)."""
+        ...
 
 
 __all__ = [

--- a/areal/tests/experimental/archon/test_moe.py
+++ b/areal/tests/experimental/archon/test_moe.py
@@ -40,7 +40,8 @@ class TestMoEBasic:
         moe_args = MoEArgs(num_experts=4, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(batch_size, seq_len, dim, device="cuda")
         out = moe(x)
@@ -56,7 +57,8 @@ class TestMoEBasic:
         moe_args = MoEArgs(num_experts=4, top_k=1, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(batch_size, seq_len, dim, device="cuda")
         out = moe(x)
@@ -77,7 +79,8 @@ class TestMoEConfigurations:
         moe_args = MoEArgs(num_experts=4, top_k=1, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -91,7 +94,8 @@ class TestMoEConfigurations:
         moe_args = MoEArgs(num_experts=8, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -105,7 +109,8 @@ class TestMoEConfigurations:
         moe_args = MoEArgs(num_experts=64, top_k=8, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -125,7 +130,8 @@ class TestMoESharedExperts:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         assert moe.shared_experts is not None
 
@@ -143,7 +149,8 @@ class TestMoESharedExperts:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         assert moe.shared_experts is None
 
@@ -168,7 +175,8 @@ class TestMoEScoreApplication:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -187,7 +195,8 @@ class TestMoEScoreApplication:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
         out = moe(x)
@@ -207,7 +216,8 @@ class TestMoELoadBalancing:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         # Initially zero
         assert torch.all(moe.tokens_per_expert == 0)
@@ -231,6 +241,7 @@ class TestMoELoadBalancing:
             num_experts=4, top_k=2, load_balance_coeff=1e-3, use_grouped_mm=False
         )
         moe = MoE(moe_args, dim, hidden_dim).cuda()
+        moe.init_buffers(buffer_device=torch.device("cuda"))
         assert moe.expert_bias is not None
 
         # Without load balancing
@@ -238,6 +249,7 @@ class TestMoELoadBalancing:
             num_experts=4, top_k=2, load_balance_coeff=None, use_grouped_mm=False
         )
         moe = MoE(moe_args, dim, hidden_dim).cuda()
+        moe.init_buffers(buffer_device=torch.device("cuda"))
         assert moe.expert_bias is None
 
 
@@ -251,7 +263,8 @@ class TestMoEGradients:
         moe_args = MoEArgs(num_experts=4, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda", requires_grad=True)
         out = moe(x)
@@ -276,7 +289,8 @@ class TestMoEGradients:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         # Use enough tokens so each expert gets some
         x = torch.randn(1, num_experts * 4, dim, device="cuda", requires_grad=True)
@@ -307,7 +321,8 @@ class TestMoEIntegration:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(1, 16, dim, device="cuda")
         out = moe(x)
@@ -323,7 +338,8 @@ class TestMoEIntegration:
         )
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(2, 8, dim, device="cuda")
 
@@ -343,7 +359,8 @@ class TestMoEIntegration:
         moe_args = MoEArgs(num_experts=4, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(1, 16, dim, device="cuda")
         out = moe(x)
@@ -357,7 +374,8 @@ class TestMoEIntegration:
         moe_args = MoEArgs(num_experts=4, top_k=2, use_grouped_mm=False)
 
         moe = MoE(moe_args, dim, hidden_dim).cuda()
-        moe.init_weights(init_std=0.02, buffer_device=torch.device("cuda"))
+        moe.init_weights(init_std=0.02)
+        moe.init_buffers(buffer_device=torch.device("cuda"))
 
         x = torch.randn(1, 1, dim, device="cuda")
         out = moe(x)

--- a/areal/tests/experimental/archon/test_qwen3_model_moe.py
+++ b/areal/tests/experimental/archon/test_qwen3_model_moe.py
@@ -200,7 +200,8 @@ class TestTransformerBlockMoE:
     def test_dense_block_forward(self, dense_args):
         """Test forward pass for dense TransformerBlock."""
         block = TransformerBlock(layer_id=0, model_args=dense_args)
-        block.init_weights(torch.device("cpu"))
+        block.init_weights()
+        block.init_buffers(buffer_device=torch.device("cpu"))
 
         bs, seq_len = 2, 8
         x = torch.randn(bs, seq_len, dense_args.dim)
@@ -237,7 +238,8 @@ class TestTransformerBlockMoE:
     def test_moe_block_forward(self, moe_args):
         """Test forward pass for MoE TransformerBlock."""
         block = TransformerBlock(layer_id=0, model_args=moe_args).cuda()
-        block.init_weights(torch.device("cuda"))
+        block.init_weights()
+        block.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 2, 8
         x = torch.randn(bs, seq_len, moe_args.dim, device="cuda")
@@ -280,7 +282,8 @@ class TestTransformerBlockMoE:
     def test_moe_block_gradient_flow(self, moe_args):
         """Test gradient flow through MoE TransformerBlock."""
         block = TransformerBlock(layer_id=0, model_args=moe_args).cuda()
-        block.init_weights(torch.device("cuda"))
+        block.init_weights()
+        block.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 2, 8
         x = torch.randn(bs, seq_len, moe_args.dim, device="cuda", requires_grad=True)
@@ -381,6 +384,7 @@ class TestQwen3ModelMoE:
         """Test forward pass for dense model."""
         model = Qwen3Model(dense_model_args)
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cpu"))
 
         bs, seq_len = 2, 16
         tokens = torch.randint(0, dense_model_args.vocab_size, (bs, seq_len))
@@ -403,6 +407,7 @@ class TestQwen3ModelMoE:
         """Test forward pass for full MoE model."""
         model = Qwen3Model(moe_model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 2, 16
         tokens = torch.randint(
@@ -427,6 +432,7 @@ class TestQwen3ModelMoE:
         """Test forward pass for mixed MoE/dense model."""
         model = Qwen3Model(mixed_model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 2, 16
         tokens = torch.randint(
@@ -480,6 +486,7 @@ class TestQwen3ModelMoE:
         """Test gradient flow through MoE model."""
         model = Qwen3Model(moe_model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 2, 16
         tokens = torch.randint(
@@ -516,6 +523,7 @@ class TestQwen3ModelMoE:
         """Test gradient flow through mixed MoE/dense model."""
         model = Qwen3Model(mixed_model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 2, 16
         tokens = torch.randint(
@@ -550,6 +558,7 @@ class TestQwen3ModelMoE:
         """Test MoE model with explicit positions."""
         model = Qwen3Model(moe_model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 2, 16
         tokens = torch.randint(
@@ -591,6 +600,7 @@ class TestQwen3ModelMoE:
         )
         model = Qwen3Model(model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 2, 16
         tokens = torch.randint(0, model_args.vocab_size, (bs, seq_len), device="cuda")
@@ -640,6 +650,7 @@ class TestQwen3MoEConfigurations:
 
         model = Qwen3Model(model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 1, 16
         tokens = torch.randint(0, model_args.vocab_size, (bs, seq_len), device="cuda")
@@ -683,6 +694,7 @@ class TestQwen3MoEConfigurations:
 
         model = Qwen3Model(model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 2, 8
         tokens = torch.randint(0, model_args.vocab_size, (bs, seq_len), device="cuda")
@@ -726,6 +738,7 @@ class TestQwen3MoEConfigurations:
 
         model = Qwen3Model(model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
         model.eval()
 
         bs = 1
@@ -766,6 +779,7 @@ class TestQwen3MoEConfigurations:
 
         model = Qwen3Model(model_args).cuda()
         model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cuda"))
 
         bs, seq_len = 1, 32
         tokens = torch.randint(0, model_args.vocab_size, (bs, seq_len), device="cuda")

--- a/areal/tests/experimental/archon/test_state_dict_adapter.py
+++ b/areal/tests/experimental/archon/test_state_dict_adapter.py
@@ -449,7 +449,8 @@ class TestMoEWeightLoadingRoundtrip:
 
         # Create and initialize model
         model1 = Qwen3Model(moe_model_args)
-        model1.init_weights(device)
+        model1.init_weights()
+        model1.init_buffers(buffer_device=device)
         model1.to(device)
 
         # Create adapter
@@ -464,6 +465,7 @@ class TestMoEWeightLoadingRoundtrip:
         # that doesn't exist in HF models (it's initialized to zeros)
         roundtrip_archon_state = adapter.from_hf(hf_state)
         model2 = Qwen3Model(moe_model_args)
+        model2.init_buffers(buffer_device=device)
         model2.load_state_dict(roundtrip_archon_state, strict=False)
         model2.to(device)
 
@@ -493,7 +495,8 @@ class TestMoEWeightLoadingRoundtrip:
         from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
 
         model = Qwen3Model(moe_model_args)
-        model.init_weights(torch.device("cpu"))
+        model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cpu"))
 
         archon_state = model.state_dict()
         adapter = Qwen3StateDictAdapter(moe_adapter_config)
@@ -519,7 +522,8 @@ class TestMoEWeightLoadingRoundtrip:
         from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
 
         model = Qwen3Model(moe_model_args)
-        model.init_weights(torch.device("cpu"))
+        model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cpu"))
 
         archon_state = model.state_dict()
         adapter = Qwen3StateDictAdapter(moe_adapter_config)
@@ -553,7 +557,8 @@ class TestMoEWeightLoadingRoundtrip:
         # - layer 2: dense (FFN)
         # - layer 3: MoE
         model = Qwen3Model(moe_model_args)
-        model.init_weights(torch.device("cpu"))
+        model.init_weights()
+        model.init_buffers(buffer_device=torch.device("cpu"))
 
         # Verify layer structure
         assert model.layers["0"].moe is None

--- a/areal/tests/experimental/archon/test_weight_sync.py
+++ b/areal/tests/experimental/archon/test_weight_sync.py
@@ -96,7 +96,8 @@ def small_dense_model(small_dense_model_args):
     from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
 
     model = Qwen3Model(small_dense_model_args)
-    model.init_weights(torch.device("cpu"))
+    model.init_weights()
+    model.init_buffers(buffer_device=torch.device("cpu"))
     return model
 
 
@@ -106,7 +107,8 @@ def small_moe_model(small_moe_model_args):
     from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
 
     model = Qwen3Model(small_moe_model_args)
-    model.init_weights(torch.device("cpu"))
+    model.init_weights()
+    model.init_buffers(buffer_device=torch.device("cpu"))
     return model
 
 

--- a/areal/tests/experimental/archon/torchrun/dist_utils.py
+++ b/areal/tests/experimental/archon/torchrun/dist_utils.py
@@ -96,7 +96,8 @@ def create_golden_model(
     """Create non-parallelized model for comparison."""
     torch.manual_seed(seed)
     model = Qwen3Model(model_args)
-    model.init_weights(device)
+    model.init_weights()
+    model.init_buffers(buffer_device=device)
     model = model.to(device)
     return model
 

--- a/areal/tests/experimental/archon/torchrun/run_ep_tests.py
+++ b/areal/tests/experimental/archon/torchrun/run_ep_tests.py
@@ -131,7 +131,8 @@ def create_ep_model(
     """Create and parallelize model with given parallel dims."""
     torch.manual_seed(seed)
     model = Qwen3Model(model_args)
-    model.init_weights(device)
+    model.init_weights()
+    model.init_buffers(buffer_device=device)
     model = model.to(device)
 
     parallelize_qwen3(
@@ -318,7 +319,8 @@ def test_weight_sync(
 
     torch.manual_seed(42)
     model = Qwen3Model(model_args)
-    model.init_weights(device)
+    model.init_weights()
+    model.init_buffers(buffer_device=device)
     model = model.to(device)
     original_state = {k: v.clone() for k, v in model.state_dict().items()}
 
@@ -375,7 +377,8 @@ def test_weight_sync(
 
     torch.manual_seed(42)
     model_new = Qwen3Model(model_args)
-    model_new.init_weights(device)
+    model_new.init_weights()
+    model_new.init_buffers(buffer_device=device)
     model_new = model_new.to(device)
 
     loadable_state = {}
@@ -453,7 +456,8 @@ def test_state_dict_update(output: str | None = None) -> bool:
 
     torch.manual_seed(99)
     model_new = Qwen3Model(model_args)
-    model_new.init_weights(device)
+    model_new.init_weights()
+    model_new.init_buffers(buffer_device=device)
     model_new = model_new.to(device)
 
     loadable_state = {}

--- a/areal/tests/experimental/archon/torchrun/run_qwen3_parallelize.py
+++ b/areal/tests/experimental/archon/torchrun/run_qwen3_parallelize.py
@@ -103,7 +103,8 @@ def create_and_parallelize_model(
     """Create model, initialize weights, and apply parallelization."""
     torch.manual_seed(seed)
     model = Qwen3Model(model_args)
-    model.init_weights(device)
+    model.init_weights()
+    model.init_buffers(buffer_device=device)
     model = model.to(device)
 
     parallelize_qwen3(


### PR DESCRIPTION
## Description

Optimize Archon engine initialization to use meta device + FSDP + DCP loading pattern, reducing peak memory from N × model_size to ~1/N × model_size per rank.

Changes:
- Create model structure on meta device (no memory allocation)
- Apply FSDP/TP/EP parallelization to meta device model
- Materialize tensors with to_empty() after FSDP
- Load weights via DCP (each rank reads only its shard)
- Add init_buffers() to BaseArchonModel for buffer-only initialization
- Separate init_weights() (parameters) from init_buffers() (rope_cache)

## Related Issue

Fixes #857 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
