### PR TITLE
feat(archon): add pipeline parallelism (PP) support for Archon engine

### DIFF
--- a/areal/api/alloc_mode.py
+++ b/areal/api/alloc_mode.py
@@ -297,13 +297,6 @@ class ModelAllocation:
                     f"Got strategy: {self.parallel}"
                 )
 
-        if self.backend == "archon":
-            if self.parallel.pipeline_parallel_size > 1:
-                raise AllocationValidationError(
-                    f"Archon backend does not support pipeline parallelism. "
-                    f"Got pp={self.parallel.pipeline_parallel_size}"
-                )
-
     @property
     def world_size(self):
         if self.scheduling_strategy.type == SchedulingStrategyType.colocation.value:

--- a/areal/engine/core/train_engine.py
+++ b/areal/engine/core/train_engine.py
@@ -10,6 +10,7 @@ from typing import Any
 import torch
 import torch.distributed as dist
 
+from areal.platforms import current_platform
 from areal.utils.data import (
     MicroBatchList,
     pad_and_stack_tensors_along_first_dim,
@@ -61,25 +62,44 @@ def compute_total_loss_weight(
 
 
 def aggregate_eval_losses(
-    losses: list[torch.Tensor],
+    losses: list[torch.Tensor] | None,
     dp_group: dist.ProcessGroup,
+    is_pp_last_stage: bool = True,
+    pp_group: dist.ProcessGroup | None = None,
+    pp_src_rank: int | None = None,
 ) -> torch.Tensor:
-    """Aggregate evaluation losses from micro-batches and all_reduce.
+    """Aggregate evaluation losses from micro-batches.
 
     Parameters
     ----------
-    losses : list[torch.Tensor]
-        List of loss tensors from each micro-batch.
+    losses : list[torch.Tensor] | None
+        List of loss tensors from each micro-batch. None on non-last PP stages.
     dp_group : dist.ProcessGroup
         The data parallel process group for all_reduce.
+    is_pp_last_stage : bool
+        Whether this rank is the last PP stage. True by default.
+    pp_group : dist.ProcessGroup | None
+        Pipeline parallel group for broadcast. None if PP broadcast is not required.
+    pp_src_rank : int | None
+        Global rank of last PP stage (required if pp_group is set).
 
     Returns
     -------
     torch.Tensor
         The aggregated loss after summing and all_reduce.
     """
-    loss = torch.stack(losses).sum(dtype=torch.float32)
-    dist.all_reduce(loss, group=dp_group)
+    if is_pp_last_stage:
+        assert losses is not None, "losses required on last PP stage"
+        loss = torch.stack(losses).sum(dtype=torch.float32)
+        dist.all_reduce(loss, group=dp_group)
+    else:
+        device = current_platform.current_device()
+        loss = torch.empty(1, device=device, dtype=torch.float32)
+
+    if pp_group is not None:
+        assert pp_src_rank is not None, "pp_src_rank required when pp_group is set"
+        dist.broadcast(loss, src=pp_src_rank, group=pp_group)
+
     return loss
 
 

--- a/areal/experimental/models/archon/__init__.py
+++ b/areal/experimental/models/archon/__init__.py
@@ -1,8 +1,5 @@
-# Import model modules to trigger registration
-from areal.experimental.models.archon import (
-    qwen2,  # noqa: F401
-    qwen3,  # noqa: F401
-)
+# Import model spec modules to trigger registration
+# Use direct module path to avoid triggering qwen2/qwen3 __init__.py first
 from areal.experimental.models.archon.base import BaseStateDictAdapter
 from areal.experimental.models.archon.expert_parallel import (
     ExpertParallel,
@@ -23,6 +20,13 @@ from areal.experimental.models.archon.moe_weight_converter import (
 from areal.experimental.models.archon.parallel_dims import (
     ArchonParallelDims,
 )
+from areal.experimental.models.archon.pipeline_parallel import (
+    generate_llm_fqn_per_model_part,
+    pipeline_llm,
+    pipeline_module_split,
+)
+from areal.experimental.models.archon.qwen2 import spec as qwen2_spec  # noqa: F401
+from areal.experimental.models.archon.qwen3 import spec as qwen3_spec  # noqa: F401
 
 __all__ = [
     "ArchonParallelDims",
@@ -34,7 +38,10 @@ __all__ = [
     "ModelSpec",
     "TensorParallel",
     "apply_expert_parallel",
+    "generate_llm_fqn_per_model_part",
     "get_model_spec",
     "get_supported_model_types",
     "is_supported_model",
+    "pipeline_llm",
+    "pipeline_module_split",
 ]

--- a/areal/experimental/models/archon/attention.py
+++ b/areal/experimental/models/archon/attention.py
@@ -69,9 +69,6 @@ class SDPAWrapper(nn.Module):
     This wrapper supports packed sequences by creating a block-diagonal
     attention mask that combines causal masking with document boundary
     masking.
-
-    The mask is cached internally to avoid regeneration when the same
-    cu_seqlens structure is used repeatedly.
     """
 
     # Backend priority order
@@ -87,10 +84,6 @@ class SDPAWrapper(nn.Module):
         self.sdpa_backends = (
             sdpa_backends if sdpa_backends is not None else self.DEFAULT_BACKENDS
         )
-        # Cache for mask reuse
-        self._cached_mask: torch.Tensor | None = None
-        self._cached_cu_seqlens: torch.Tensor | None = None
-        self._cached_seq_len: int = 0
 
     def forward(
         self,
@@ -116,7 +109,8 @@ class SDPAWrapper(nn.Module):
             Attention output, shape [batch, heads, seq_len, head_dim]
         """
         seq_len = q.shape[2]
-        attn_mask = self._get_mask(cu_seqlens, seq_len, q.device, q.dtype)
+        # TODO: Mask should be precomputed and passed in, not computed here.
+        attn_mask = create_block_causal_mask_2d(cu_seqlens, seq_len, q.device, q.dtype)
 
         with sdpa_kernel(self.sdpa_backends, set_priority=True):
             return F.scaled_dot_product_attention(
@@ -128,40 +122,3 @@ class SDPAWrapper(nn.Module):
                 is_causal=False,
                 enable_gqa=q.size(1) != k.size(1),
             )
-
-    def _get_mask(
-        self,
-        cu_seqlens: torch.Tensor,
-        seq_len: int,
-        device: torch.device,
-        dtype: torch.dtype,
-    ) -> torch.Tensor:
-        """Get or create cached block-diagonal causal mask."""
-        # Check cache validity
-        if self._is_cache_valid(cu_seqlens, seq_len):
-            # Return cached mask, ensure correct dtype
-            if self._cached_mask.dtype != dtype:
-                return self._cached_mask.to(dtype)
-            return self._cached_mask
-
-        # Create new mask
-        mask = create_block_causal_mask_2d(cu_seqlens, seq_len, device, dtype)
-
-        # Update cache
-        self._cached_mask = mask
-        self._cached_cu_seqlens = cu_seqlens.clone()
-        self._cached_seq_len = seq_len
-
-        return mask
-
-    def _is_cache_valid(self, cu_seqlens: torch.Tensor, seq_len: int) -> bool:
-        """Check if the cached mask is still valid."""
-        if self._cached_mask is None:
-            return False
-        if self._cached_seq_len != seq_len:
-            return False
-        if self._cached_cu_seqlens is None:
-            return False
-        if self._cached_cu_seqlens.shape != cu_seqlens.shape:
-            return False
-        return torch.equal(self._cached_cu_seqlens, cu_seqlens)

--- a/areal/experimental/models/archon/compile.py
+++ b/areal/experimental/models/archon/compile.py
@@ -1,11 +1,18 @@
+import functools
 from typing import Protocol
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 
 from areal.utils import logging
 
-logger = logging.getLogger("ArchonCompile")
+
+@functools.cache
+def _get_logger() -> logging.Logger:
+    """Get rank-aware logger for this module."""
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    return logging.getLogger(f"[Archon Compile Rank {rank}]")
 
 
 class Compilable(Protocol):
@@ -33,4 +40,6 @@ def apply_compile(model: Compilable) -> None:
             fullgraph=True,
         )
 
-    logger.info(f"Compiled {len(model.layers)} TransformerBlocks with torch.compile")
+    _get_logger().info(
+        f"Compiled {len(model.layers)} TransformerBlocks with torch.compile"
+    )

--- a/areal/experimental/models/archon/pipeline_parallel.py
+++ b/areal/experimental/models/archon/pipeline_parallel.py
@@ -1,0 +1,357 @@
+# Adapted from torchtitan: torchtitan/distributed/pipeline_parallel.py
+
+import copy
+import functools
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.pipelining import PipelineStage
+
+from areal.utils import logging
+
+if TYPE_CHECKING:
+    from areal.experimental.models.archon import ArchonParallelDims
+
+
+@functools.cache
+def _get_logger() -> logging.Logger:
+    """Get rank-aware logger for this module."""
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    return logging.getLogger(f"[Archon PipelineParallel Rank {rank}]")
+
+
+__all__ = [
+    "generate_llm_fqn_per_model_part",
+    "pipeline_module_split",
+    "pipeline_llm",
+]
+
+
+def generate_llm_fqn_per_model_part(
+    num_stages: int,
+    num_layers: int,
+    input_weight: int = 1,
+    output_weight: int = 1,
+    is_critic: bool = False,
+) -> list[list[str]]:
+    """Generate module FQN lists for each pipeline stage.
+
+    This function distributes transformer layers across pipeline stages,
+    accounting for the computational cost of embedding and output layers.
+
+    Args:
+        num_stages: Number of pipeline stages (must equal pp_degree for 1F1B)
+        num_layers: Number of transformer layers in the model
+        input_weight: Weight for input modules (tok_embeddings), default 1
+        output_weight: Weight for output modules (norm + output/score), default 1
+        is_critic: Whether the model is a critic (uses 'score' instead of 'output')
+
+    Returns:
+        List of module name lists, one per stage.
+
+    Example:
+        >>> generate_llm_fqn_per_model_part(2, 4)
+        [['tok_embeddings', 'layers.0', 'layers.1'],
+         ['layers.2', 'layers.3', 'norm', 'output']]
+
+        >>> generate_llm_fqn_per_model_part(4, 8, is_critic=True)
+        [['tok_embeddings', 'layers.0', 'layers.1'],
+         ['layers.2', 'layers.3', 'layers.4'],
+         ['layers.5', 'layers.6'],
+         ['layers.7', 'norm', 'score']]
+    """
+    # Determine output module name based on model type
+    output_module = "score" if is_critic else "output"
+
+    # Validation
+    if num_stages < 1:
+        raise ValueError(f"num_stages must be >= 1, got {num_stages}")
+
+    # Single stage: return everything
+    if num_stages == 1:
+        layer_names = [f"layers.{i}" for i in range(num_layers)]
+        return [["tok_embeddings"] + layer_names + ["norm", output_module]]
+
+    # Calculate effective layers including embedding/output overhead
+    num_effective_layers = num_layers + input_weight + output_weight
+
+    if num_stages > num_effective_layers:
+        raise ValueError(
+            f"num_stages ({num_stages}) cannot exceed effective layers "
+            f"({num_effective_layers} = {num_layers} + {input_weight} + {output_weight})"
+        )
+
+    layers_per_stage = num_effective_layers // num_stages
+    extra_layers = num_effective_layers % num_stages
+
+    if layers_per_stage == 0:
+        raise ValueError(
+            f"layers_per_stage is 0 with {num_effective_layers} effective layers "
+            f"and {num_stages} stages"
+        )
+
+    if input_weight > layers_per_stage:
+        raise ValueError(
+            f"input_weight ({input_weight}) exceeds layers_per_stage ({layers_per_stage})"
+        )
+    if output_weight > layers_per_stage:
+        raise ValueError(
+            f"output_weight ({output_weight}) exceeds layers_per_stage ({layers_per_stage})"
+        )
+
+    module_names_per_stage: list[list[str]] = []
+    current_layer = 0
+
+    for stage_idx in range(num_stages):
+        stage_modules: list[str] = []
+
+        # Calculate effective layers for this stage (extra layers go to earlier stages)
+        effective_layers_for_stage = layers_per_stage
+        if stage_idx < extra_layers:
+            effective_layers_for_stage += 1
+
+        if stage_idx == 0:
+            # First stage: tok_embeddings + transformer layers
+            stage_modules.append("tok_embeddings")
+            num_transformer_layers = effective_layers_for_stage - input_weight
+            for _ in range(num_transformer_layers):
+                if current_layer < num_layers:
+                    stage_modules.append(f"layers.{current_layer}")
+                    current_layer += 1
+
+        elif stage_idx == num_stages - 1:
+            # Last stage: transformer layers + norm + output/score
+            num_transformer_layers = effective_layers_for_stage - output_weight
+            for _ in range(num_transformer_layers):
+                if current_layer < num_layers:
+                    stage_modules.append(f"layers.{current_layer}")
+                    current_layer += 1
+            stage_modules.extend(["norm", output_module])
+
+        else:
+            # Middle stages: only transformer layers
+            for _ in range(effective_layers_for_stage):
+                if current_layer < num_layers:
+                    stage_modules.append(f"layers.{current_layer}")
+                    current_layer += 1
+
+        module_names_per_stage.append(stage_modules)
+
+    return module_names_per_stage
+
+
+def pipeline_module_split(
+    whole_model: nn.Module,
+    pp_mesh: DeviceMesh,
+    device: torch.device,
+    module_names_per_stage: list[list[str]],
+) -> tuple[list[PipelineStage], list[nn.Module]]:
+    """Split model into pipeline stages based on module names.
+
+    Key points:
+    - Archon uses ModuleDict (keys are "0", "1", ...) for layers
+    - Modules not in this stage are set to None
+    - Model's forward() must handle None modules gracefully
+
+    Args:
+        whole_model: The complete model to split
+        pp_mesh: Pipeline parallel device mesh
+        device: Target device for stages
+        module_names_per_stage: Module FQNs for each stage
+
+    Returns:
+        Tuple of (list of PipelineStage, list of model parts)
+    """
+    pp_rank = pp_mesh.get_local_rank()
+    pp_degree = pp_mesh.size()
+    num_stages = len(module_names_per_stage)
+
+    # 1F1B requires exactly 1 stage per rank
+    stages_per_rank = num_stages // pp_degree
+    if stages_per_rank != 1:
+        raise ValueError(
+            f"1F1B schedule requires exactly 1 stage per rank, "
+            f"got {stages_per_rank} ({num_stages} stages / {pp_degree} ranks)"
+        )
+
+    def _build_stage_from_modules(
+        stage_idx: int,
+        module_names: list[str],
+        num_stages: int,
+    ) -> tuple[PipelineStage, nn.Module]:
+        """Build a single pipeline stage from module names."""
+        assert next(whole_model.parameters()).device.type == "meta", (
+            "Model must be on meta device for pipeline splitting"
+        )
+        # Deep copy to create independent model part
+        model = copy.deepcopy(whole_model)
+        modules_to_keep = set(module_names)
+
+        for module_name, module_value in list(model.named_children()):
+            if isinstance(module_value, nn.ModuleDict):
+                # Handle layers (ModuleDict in Archon, keys are "0", "1", ...)
+                # Extract layer indices to keep: "layers.0" -> "0"
+                layers_to_keep = {
+                    name.split(".", 1)[1]
+                    for name in modules_to_keep
+                    if name.startswith(f"{module_name}.")
+                }
+
+                if layers_to_keep:
+                    # Delete unwanted layers
+                    for layer_key in list(module_value.keys()):
+                        if layer_key not in layers_to_keep:
+                            del module_value[layer_key]
+                else:
+                    # No layers to keep in this stage, set to empty ModuleDict
+                    setattr(model, module_name, nn.ModuleDict())
+
+            elif isinstance(module_value, nn.ModuleList):
+                # Handle ModuleList (if used)
+                layers_to_keep = {
+                    name.split(".", 1)[1]
+                    for name in modules_to_keep
+                    if name.startswith(f"{module_name}.")
+                }
+
+                if layers_to_keep:
+                    indices_to_keep = {
+                        int(idx) for idx in layers_to_keep if idx.isdigit()
+                    }
+                    new_layers = nn.ModuleList(
+                        [
+                            layer
+                            for i, layer in enumerate(module_value)
+                            if i in indices_to_keep
+                        ]
+                    )
+                    setattr(model, module_name, new_layers)
+                else:
+                    setattr(model, module_name, nn.ModuleList())
+
+            elif module_name not in modules_to_keep:
+                # Simple module not in this stage, set to None
+                setattr(model, module_name, None)
+
+        # Create PipelineStage
+        stage = PipelineStage(
+            model,
+            stage_idx,
+            num_stages,
+            device,
+            group=pp_mesh.get_group(),
+        )
+
+        return stage, model
+
+    # For 1F1B: stage_idx equals pp_rank
+    stage_idx = pp_rank
+    stage, model_part = _build_stage_from_modules(
+        stage_idx, module_names_per_stage[stage_idx], num_stages
+    )
+
+    _get_logger().info(
+        f"Built stage {stage_idx} (pp_rank={pp_rank}) "
+        f"with modules: {module_names_per_stage[stage_idx]}"
+    )
+
+    return [stage], [model_part]
+
+
+def pipeline_llm(
+    model: nn.Module,
+    parallel_dims: "ArchonParallelDims",
+    device: torch.device,
+    parallelize_fn: Callable,
+    input_weight: int = 1,
+    output_weight: int = 1,
+    **parallelize_kwargs,
+) -> tuple[list[PipelineStage], list[nn.Module], bool, bool]:
+    """Main entry point for pipeline parallelism.
+
+    Workflow:
+    1. Generate module names for each stage
+    2. Split model into stages
+    3. Apply parallelization (TP, FSDP) to each model part
+
+    Args:
+        model: The complete model to pipeline
+        parallel_dims: ArchonParallelDims with PP configuration
+        device: Target device
+        parallelize_fn: Function to apply TP/FSDP to model parts
+        input_weight: Weight for embedding layer (default 1)
+        output_weight: Weight for output layers (default 1)
+        **parallelize_kwargs: Additional arguments for parallelize_fn
+
+    Returns:
+        Tuple of:
+        - stages: List of PipelineStage (1 for 1F1B schedule)
+        - model_parts: List of model parts (1 for 1F1B)
+        - has_first_stage: Whether this rank has the first stage
+        - has_last_stage: Whether this rank has the last stage
+    """
+    pp_mesh = parallel_dims.get_mesh("pp")
+    if pp_mesh is None:
+        raise RuntimeError("PP mesh not found. Ensure pp > 1 in parallel_dims")
+
+    # Get number of layers from model
+    # Archon models may use n_layers or num_hidden_layers
+    if hasattr(model, "model_args") and hasattr(model.model_args, "num_hidden_layers"):
+        num_layers = model.model_args.num_hidden_layers
+    elif hasattr(model, "model_args") and hasattr(model.model_args, "n_layers"):
+        num_layers = model.model_args.n_layers
+    elif hasattr(model, "config") and hasattr(model.config, "num_hidden_layers"):
+        num_layers = model.config.num_hidden_layers
+    elif hasattr(model, "config") and hasattr(model.config, "n_layers"):
+        num_layers = model.config.n_layers
+    else:
+        raise RuntimeError(
+            "Cannot determine num_layers from model. "
+            "Model must have model_args.num_hidden_layers/n_layers or config.num_hidden_layers/n_layers"
+        )
+
+    pp_degree = parallel_dims.pp
+
+    # Detect if model is a critic (uses 'score' instead of 'output')
+    is_critic = getattr(getattr(model, "model_args", None), "is_critic", False)
+
+    # 1. Generate module names per stage
+    module_names_per_stage = generate_llm_fqn_per_model_part(
+        num_stages=pp_degree,
+        num_layers=num_layers,
+        input_weight=input_weight,
+        output_weight=output_weight,
+        is_critic=is_critic,
+    )
+
+    _get_logger().info(f"PP module distribution: {module_names_per_stage}")
+
+    # 2. Split model into stages
+    stages, model_parts = pipeline_module_split(
+        whole_model=model,
+        pp_mesh=pp_mesh,
+        device=device,
+        module_names_per_stage=module_names_per_stage,
+    )
+
+    # 3. Apply parallelization to each model part
+    for i, m in enumerate(model_parts):
+        m = parallelize_fn(m, parallel_dims, **parallelize_kwargs)
+        model_parts[i] = m
+        # Update stage's reference to the parallelized model
+        stages[i].submod = m
+
+    # Determine first/last stage status
+    has_first_stage = any(s.is_first for s in stages)
+    has_last_stage = any(s.is_last for s in stages)
+
+    _get_logger().info(
+        f"Pipeline setup complete: has_first_stage={has_first_stage}, "
+        f"has_last_stage={has_last_stage}"
+    )
+
+    return stages, model_parts, has_first_stage, has_last_stage

--- a/areal/experimental/models/archon/qwen2/__init__.py
+++ b/areal/experimental/models/archon/qwen2/__init__.py
@@ -1,1 +1,15 @@
-from areal.experimental.models.archon.qwen2 import spec  # noqa: F401
+from areal.experimental.models.archon.qwen2.infra.parallelize import (
+    parallelize_qwen2,
+)
+from areal.experimental.models.archon.qwen2.model.args import Qwen2ModelArgs
+from areal.experimental.models.archon.qwen2.model.model import Qwen2Model
+from areal.experimental.models.archon.qwen2.model.state_dict_adapter import (
+    Qwen2StateDictAdapter,
+)
+
+__all__ = [
+    "Qwen2Model",
+    "Qwen2ModelArgs",
+    "Qwen2StateDictAdapter",
+    "parallelize_qwen2",
+]

--- a/areal/experimental/models/archon/qwen2/model/model.py
+++ b/areal/experimental/models/archon/qwen2/model/model.py
@@ -328,8 +328,16 @@ class Qwen2Model(BaseArchonModel):
         tokens: torch.Tensor,
         positions: torch.Tensor,
         cu_seqlens: torch.Tensor,
-        max_seqlen: int,
+        max_seqlen: int | torch.Tensor,
     ) -> torch.Tensor:
+        # When pipeline parallelism enabled, cu_seqlens is [1, B+1]
+        if cu_seqlens.ndim == 2:
+            cu_seqlens = cu_seqlens.squeeze(0)
+
+        # When pipeline parallelism enabled, max_seqlen is [1]
+        if isinstance(max_seqlen, torch.Tensor):
+            max_seqlen = int(max_seqlen.item())
+
         h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
 
         for layer in self.layers.values():

--- a/areal/experimental/models/archon/qwen2/spec.py
+++ b/areal/experimental/models/archon/qwen2/spec.py
@@ -1,4 +1,5 @@
 from areal.experimental.models.archon.model_spec import ModelSpec, register_model_spec
+from areal.experimental.models.archon.pipeline_parallel import pipeline_llm
 from areal.experimental.models.archon.qwen2.infra.parallelize import parallelize_qwen2
 from areal.experimental.models.archon.qwen2.model.args import Qwen2ModelArgs
 from areal.experimental.models.archon.qwen2.model.model import Qwen2Model
@@ -13,6 +14,7 @@ QWEN2_SPEC = ModelSpec(
     state_dict_adapter_class=Qwen2StateDictAdapter,
     parallelize_fn=parallelize_qwen2,
     supported_model_types=frozenset({"qwen2"}),
+    pipelining_fn=pipeline_llm,
 )
 
 # Auto-register when module is imported

--- a/areal/experimental/models/archon/qwen3/__init__.py
+++ b/areal/experimental/models/archon/qwen3/__init__.py
@@ -1,2 +1,15 @@
-# Import spec to trigger model registration
-from areal.experimental.models.archon.qwen3 import spec  # noqa: F401
+from areal.experimental.models.archon.qwen3.infra.parallelize import (
+    parallelize_qwen3,
+)
+from areal.experimental.models.archon.qwen3.model.args import Qwen3ModelArgs
+from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
+from areal.experimental.models.archon.qwen3.model.state_dict_adapter import (
+    Qwen3StateDictAdapter,
+)
+
+__all__ = [
+    "Qwen3Model",
+    "Qwen3ModelArgs",
+    "Qwen3StateDictAdapter",
+    "parallelize_qwen3",
+]

--- a/areal/experimental/models/archon/qwen3/model/model.py
+++ b/areal/experimental/models/archon/qwen3/model/model.py
@@ -446,8 +446,16 @@ class Qwen3Model(BaseArchonModel):
         tokens: torch.Tensor,
         positions: torch.Tensor,
         cu_seqlens: torch.Tensor,
-        max_seqlen: int,
+        max_seqlen: int | torch.Tensor,
     ) -> torch.Tensor:
+        # When pipeline parallelism enabled, cu_seqlens is [1, B+1]
+        if cu_seqlens.ndim == 2:
+            cu_seqlens = cu_seqlens.squeeze(0)
+
+        # When pipeline parallelism enabled, max_seqlen is [1]
+        if isinstance(max_seqlen, torch.Tensor):
+            max_seqlen = int(max_seqlen.item())
+
         h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
 
         for layer in self.layers.values():

--- a/areal/experimental/models/archon/qwen3/spec.py
+++ b/areal/experimental/models/archon/qwen3/spec.py
@@ -1,4 +1,5 @@
 from areal.experimental.models.archon.model_spec import ModelSpec, register_model_spec
+from areal.experimental.models.archon.pipeline_parallel import pipeline_llm
 from areal.experimental.models.archon.qwen3.infra.parallelize import parallelize_qwen3
 from areal.experimental.models.archon.qwen3.model.args import Qwen3ModelArgs
 from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
@@ -13,6 +14,7 @@ QWEN3_SPEC = ModelSpec(
     state_dict_adapter_class=Qwen3StateDictAdapter,
     parallelize_fn=parallelize_qwen3,
     supported_model_types=frozenset({"qwen3", "qwen3_moe"}),
+    pipelining_fn=pipeline_llm,
 )
 
 # Auto-register when module is imported

--- a/areal/tests/experimental/archon/test_checkpoint_e2e.py
+++ b/areal/tests/experimental/archon/test_checkpoint_e2e.py
@@ -68,9 +68,7 @@ class TestMultiFileSafetensorsIndex:
         """Test loading multi-file safetensors index from real MoE checkpoint."""
         from transformers import AutoConfig
 
-        from areal.experimental.models.archon.qwen3.model.state_dict_adapter import (
-            Qwen3StateDictAdapter,
-        )
+        from areal.experimental.models.archon.qwen3 import Qwen3StateDictAdapter
 
         # Load config
         config = AutoConfig.from_pretrained(moe_model_path, trust_remote_code=True)
@@ -109,9 +107,7 @@ class TestMultiFileSafetensorsIndex:
         from torch.distributed.checkpoint import HuggingFaceStorageReader
         from transformers import AutoConfig
 
-        from areal.experimental.models.archon.qwen3.model.state_dict_adapter import (
-            Qwen3StateDictAdapter,
-        )
+        from areal.experimental.models.archon.qwen3 import Qwen3StateDictAdapter
 
         config = AutoConfig.from_pretrained(moe_model_path, trust_remote_code=True)
         adapter = Qwen3StateDictAdapter(config, hf_assets_path=moe_model_path)
@@ -126,9 +122,7 @@ class TestMultiFileSafetensorsIndex:
         """Test that MoE config is correctly parsed for expert count."""
         from transformers import AutoConfig
 
-        from areal.experimental.models.archon.qwen3.model.state_dict_adapter import (
-            Qwen3StateDictAdapter,
-        )
+        from areal.experimental.models.archon.qwen3 import Qwen3StateDictAdapter
 
         config = AutoConfig.from_pretrained(moe_model_path, trust_remote_code=True)
         adapter = Qwen3StateDictAdapter(config, hf_assets_path=moe_model_path)
@@ -316,9 +310,7 @@ class TestWeightComparisonAfterConversion:
         from safetensors.torch import load_file
         from transformers import AutoConfig
 
-        from areal.experimental.models.archon.qwen3.model.state_dict_adapter import (
-            Qwen3StateDictAdapter,
-        )
+        from areal.experimental.models.archon.qwen3 import Qwen3StateDictAdapter
 
         config = AutoConfig.from_pretrained(dense_model_path, trust_remote_code=True)
         adapter = Qwen3StateDictAdapter(config, hf_assets_path=dense_model_path)

--- a/areal/tests/experimental/archon/test_distributed_pp.py
+++ b/areal/tests/experimental/archon/test_distributed_pp.py
@@ -1,0 +1,314 @@
+"""Pipeline Parallelism (PP) distributed tests for Archon Engine.
+
+These tests require multiple GPUs and use torchrun for distributed execution.
+
+Run tests:
+    pytest areal/tests/experimental/archon/test_distributed_pp.py -v -m multi_gpu
+
+Test configuration:
+    2 GPU Tests (Core PP):
+        - test_pp_forward_2gpu: PP=2, tests forward pass matches golden model
+        - test_pp_backward_2gpu: PP=2, tests gradient flow through stages
+        - test_pp_gradient_correctness_2gpu: PP=2, tests PP gradients match non-PP
+
+    4 GPU Tests (Extended PP):
+        - test_pp_forward_4gpu: PP=4, tests forward with more stages
+        - test_pp_backward_4gpu: PP=4, tests backward with more stages
+
+    PP Combination Tests (4 GPU):
+        - test_pp_tp_forward_4gpu: PP=2, TP=2, tests PP+TP combination
+        - test_pp_dp_forward_4gpu: PP=2, DP=2, tests PP+DP combination
+        - test_pp_ep_forward_4gpu: PP=2, EP=2, tests PP+EP combination (MoE model)
+
+    PP Checkpoint Tests (2 GPU):
+        - test_pp_dcp_checkpoint_2gpu: PP=2, tests DCP save/load
+        - test_pp_dcp_with_optim_2gpu: PP=2, tests DCP with optimizer state
+        - test_pp_forward_match_2gpu: PP=2, tests forward match after checkpoint
+"""
+
+import subprocess
+import tempfile
+
+import pytest
+import torch
+
+from areal.platforms import current_platform
+from areal.utils.network import find_free_ports
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA not available"
+)
+
+
+def _run_pp_test_with_torchrun(
+    script: str,
+    n_gpus: int,
+    extra_args: list[str] | None = None,
+    timeout: int = 300,
+):
+    """Run a PP test script with torchrun.
+
+    Args:
+        script: Path to the test script
+        n_gpus: Number of GPUs to use
+        extra_args: Additional command line arguments
+        timeout: Timeout in seconds
+
+    Raises:
+        pytest.fail: If the test fails
+    """
+    port = find_free_ports(1)[0]
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        out_file = f.name
+
+    cmd = [
+        "torchrun",
+        f"--nproc_per_node={n_gpus}",
+        "--nnodes=1",
+        "--master-addr=localhost",
+        f"--master_port={port}",
+        script,
+        f"--output={out_file}",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+        # Check result file
+        with open(out_file) as f:
+            test_result = f.read().strip()
+
+        if test_result != "Passed":
+            pytest.fail(
+                f"Test returned '{test_result}'. "
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+
+    except subprocess.CalledProcessError as e:
+        pytest.fail(f"Test failed with error: {e.stderr}\nstdout: {e.stdout}")
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Test timed out after {timeout} seconds")
+
+
+# =============================================================================
+# 2 GPU Tests (Core PP tests)
+# =============================================================================
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_forward_2gpu():
+    """Test PP forward pass with 2 GPUs (pp=2).
+
+    Validates that PP model output matches golden (non-PP) model output.
+    """
+    if current_platform.device_count() < 2:
+        pytest.skip("This test requires 2 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_pp_tests.py",
+        n_gpus=2,
+        extra_args=["--test_type=forward", "--pp_size=2"],
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_backward_2gpu():
+    """Test PP backward pass with 2 GPUs (pp=2).
+
+    Validates that gradients flow correctly through all PP stages.
+    """
+    if current_platform.device_count() < 2:
+        pytest.skip("This test requires 2 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_pp_tests.py",
+        n_gpus=2,
+        extra_args=["--test_type=backward", "--pp_size=2"],
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_gradient_correctness_2gpu():
+    """Test PP gradient correctness with 2 GPUs (pp=2).
+
+    Validates that PP step() API produces identical gradients to
+    manual forward/backward passes without pipeline parallelism.
+
+    This test uses a simple model with:
+    - FirstStageModel: embedding + 2 transformer blocks
+    - LastStageModel: 2 transformer blocks + output head
+    - 2 microbatches with different packed sequence lengths
+    """
+    if current_platform.device_count() < 2:
+        pytest.skip("This test requires 2 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_pp_gradient_verify.py",
+        n_gpus=2,
+        extra_args=["--n_microbatches=2", "--seq_len=64"],
+        timeout=120,
+    )
+
+
+# =============================================================================
+# 4 GPU Tests (Extended PP tests)
+# =============================================================================
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_forward_4gpu():
+    """Test PP forward pass with 4 GPUs (pp=4).
+
+    Validates PP with more stages (4 stages instead of 2).
+    """
+    if current_platform.device_count() < 4:
+        pytest.skip("This test requires 4 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_pp_tests.py",
+        n_gpus=4,
+        extra_args=["--test_type=forward", "--pp_size=4"],
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_backward_4gpu():
+    """Test PP backward pass with 4 GPUs (pp=4).
+
+    Validates gradient flow with more stages.
+    """
+    if current_platform.device_count() < 4:
+        pytest.skip("This test requires 4 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_pp_tests.py",
+        n_gpus=4,
+        extra_args=["--test_type=backward", "--pp_size=4"],
+    )
+
+
+# =============================================================================
+# PP Combination Tests (PP+TP, PP+DP, PP+EP)
+# =============================================================================
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_tp_forward_4gpu():
+    """Test PP+TP combination with 4 GPUs (pp=2, tp=2).
+
+    Validates that PP works correctly when combined with Tensor Parallelism.
+    """
+    if current_platform.device_count() < 4:
+        pytest.skip("This test requires 4 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_pp_combinations.py",
+        n_gpus=4,
+        extra_args=["--test_type=pp_tp"],
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_dp_forward_4gpu():
+    """Test PP+DP combination with 4 GPUs (pp=2, dp_shard=2).
+
+    Validates that PP works correctly when combined with Data Parallelism.
+    """
+    if current_platform.device_count() < 4:
+        pytest.skip("This test requires 4 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_pp_combinations.py",
+        n_gpus=4,
+        extra_args=["--test_type=pp_dp"],
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_ep_forward_4gpu():
+    """Test PP+EP combination with 4 GPUs (pp=2, ep=2).
+
+    Validates that PP works correctly when combined with Expert Parallelism.
+    This test uses a MoE model since EP requires expert parallelism.
+    """
+    if current_platform.device_count() < 4:
+        pytest.skip("This test requires 4 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_pp_combinations.py",
+        n_gpus=4,
+        extra_args=["--test_type=pp_ep"],
+    )
+
+
+# =============================================================================
+# PP Checkpoint Tests
+# =============================================================================
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_dcp_checkpoint_2gpu():
+    """Test PP checkpoint save/load using DCP format with 2 GPUs.
+
+    Validates that PP model weights can be saved and loaded correctly.
+    """
+    if current_platform.device_count() < 2:
+        pytest.skip("This test requires 2 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_checkpoint_tests.py",
+        n_gpus=2,
+        extra_args=["--test_type=pp_dcp_checkpoint", "--pp_size=2"],
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_dcp_with_optim_2gpu():
+    """Test PP checkpoint with optimizer state using DCP format with 2 GPUs.
+
+    Validates that optimizer state is correctly saved and loaded with PP.
+    """
+    if current_platform.device_count() < 2:
+        pytest.skip("This test requires 2 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_checkpoint_tests.py",
+        n_gpus=2,
+        extra_args=["--test_type=pp_dcp_with_optim", "--pp_size=2"],
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_pp_forward_match_2gpu():
+    """Test forward output matches after PP checkpoint save/load with 2 GPUs.
+
+    Validates that model behavior is preserved after checkpoint save/load.
+    """
+    if current_platform.device_count() < 2:
+        pytest.skip("This test requires 2 GPUs")
+
+    _run_pp_test_with_torchrun(
+        "areal/tests/experimental/archon/torchrun/run_checkpoint_tests.py",
+        n_gpus=2,
+        extra_args=["--test_type=pp_forward_match", "--pp_size=2"],
+    )

--- a/areal/tests/experimental/archon/test_pipeline_parallel.py
+++ b/areal/tests/experimental/archon/test_pipeline_parallel.py
@@ -1,0 +1,207 @@
+"""Unit tests for pipeline_parallel.py (no GPU required)."""
+
+import pytest
+
+from areal.experimental.models.archon.pipeline_parallel import (
+    generate_llm_fqn_per_model_part,
+)
+
+
+class TestGenerateLLMFqnPerModelPart:
+    """Test generate_llm_fqn_per_model_part function."""
+
+    def test_single_stage(self):
+        """Single stage should contain all modules."""
+        result = generate_llm_fqn_per_model_part(num_stages=1, num_layers=4)
+        assert len(result) == 1
+        assert result[0] == [
+            "tok_embeddings",
+            "layers.0",
+            "layers.1",
+            "layers.2",
+            "layers.3",
+            "norm",
+            "output",
+        ]
+
+    def test_two_stages_four_layers(self):
+        """Two stages with 4 layers should split evenly."""
+        result = generate_llm_fqn_per_model_part(num_stages=2, num_layers=4)
+        assert len(result) == 2
+        # Stage 0: embedding + 2 layers (effective: 1 + 2 = 3)
+        assert result[0] == ["tok_embeddings", "layers.0", "layers.1"]
+        # Stage 1: 2 layers + output (effective: 2 + 1 = 3)
+        assert result[1] == ["layers.2", "layers.3", "norm", "output"]
+
+    def test_four_stages_eight_layers(self):
+        """Four stages with 8 layers."""
+        result = generate_llm_fqn_per_model_part(num_stages=4, num_layers=8)
+        assert len(result) == 4
+        # 8 + 1 + 1 = 10 effective layers, 10 // 4 = 2 per stage, 2 extra
+        # Stage 0: gets 3 effective (tok_embeddings counts as 1, so 2 layers)
+        assert result[0] == ["tok_embeddings", "layers.0", "layers.1"]
+        # Stage 1: gets 3 effective (all transformer layers)
+        assert result[1] == ["layers.2", "layers.3", "layers.4"]
+        # Stage 2: gets 2 effective (all transformer layers)
+        assert result[2] == ["layers.5", "layers.6"]
+        # Stage 3: gets 2 effective (norm+output counts as 1, so 1 layer)
+        assert result[3] == ["layers.7", "norm", "output"]
+
+    def test_two_stages_eight_layers(self):
+        """Two stages with 8 layers."""
+        result = generate_llm_fqn_per_model_part(num_stages=2, num_layers=8)
+        assert len(result) == 2
+        # 8 + 1 + 1 = 10 effective layers, 10 // 2 = 5 per stage
+        # Stage 0: tok_embeddings + 4 layers
+        assert result[0] == [
+            "tok_embeddings",
+            "layers.0",
+            "layers.1",
+            "layers.2",
+            "layers.3",
+        ]
+        # Stage 1: 4 layers + norm + output
+        assert result[1] == [
+            "layers.4",
+            "layers.5",
+            "layers.6",
+            "layers.7",
+            "norm",
+            "output",
+        ]
+
+    def test_three_stages_six_layers(self):
+        """Three stages with 6 layers."""
+        result = generate_llm_fqn_per_model_part(num_stages=3, num_layers=6)
+        assert len(result) == 3
+        # 6 + 1 + 1 = 8 effective layers, 8 // 3 = 2 per stage, 2 extra
+        # Stage 0: gets 3 effective (tok_embeddings + 2 layers)
+        assert result[0] == ["tok_embeddings", "layers.0", "layers.1"]
+        # Stage 1: gets 3 effective (3 layers)
+        assert result[1] == ["layers.2", "layers.3", "layers.4"]
+        # Stage 2: gets 2 effective (1 layer + norm + output)
+        assert result[2] == ["layers.5", "norm", "output"]
+
+    def test_custom_weights(self):
+        """Test with custom input/output weights."""
+        # input_weight=2, output_weight=2 means embedding "costs" 2 slots
+        result = generate_llm_fqn_per_model_part(
+            num_stages=2, num_layers=4, input_weight=2, output_weight=2
+        )
+        assert len(result) == 2
+        # 4 + 2 + 2 = 8 effective layers, 8 // 2 = 4 per stage
+        # Stage 0: tok_embeddings (counts as 2) + 2 layers
+        assert result[0] == ["tok_embeddings", "layers.0", "layers.1"]
+        # Stage 1: 2 layers + norm + output (counts as 2)
+        assert result[1] == ["layers.2", "layers.3", "norm", "output"]
+
+    def test_zero_input_weight(self):
+        """Test with zero input weight."""
+        result = generate_llm_fqn_per_model_part(
+            num_stages=2, num_layers=4, input_weight=0, output_weight=1
+        )
+        assert len(result) == 2
+        # 4 + 0 + 1 = 5 effective layers, 5 // 2 = 2 per stage, 1 extra
+        # Stage 0: gets 3 effective (tok_embeddings counts as 0, so 3 layers)
+        assert result[0] == ["tok_embeddings", "layers.0", "layers.1", "layers.2"]
+        # Stage 1: gets 2 effective (1 layer + norm + output)
+        assert result[1] == ["layers.3", "norm", "output"]
+
+    def test_validation_num_stages_zero(self):
+        """Test validation error for num_stages < 1."""
+        with pytest.raises(ValueError, match="num_stages must be >= 1"):
+            generate_llm_fqn_per_model_part(num_stages=0, num_layers=4)
+
+    def test_validation_num_stages_negative(self):
+        """Test validation error for negative num_stages."""
+        with pytest.raises(ValueError, match="num_stages must be >= 1"):
+            generate_llm_fqn_per_model_part(num_stages=-1, num_layers=4)
+
+    def test_validation_too_many_stages(self):
+        """Test validation error when num_stages exceeds effective layers."""
+        with pytest.raises(ValueError, match="cannot exceed effective layers"):
+            generate_llm_fqn_per_model_part(num_stages=10, num_layers=4)
+
+    def test_validation_input_weight_too_large(self):
+        """Test validation error when input_weight exceeds layers_per_stage."""
+        # 4 + 5 + 1 = 10 effective, 10 // 4 = 2 per stage, but input_weight=5 > 2
+        with pytest.raises(ValueError, match="input_weight.*exceeds layers_per_stage"):
+            generate_llm_fqn_per_model_part(
+                num_stages=4, num_layers=4, input_weight=5, output_weight=1
+            )
+
+    def test_validation_output_weight_too_large(self):
+        """Test validation error when output_weight exceeds layers_per_stage."""
+        # 4 + 1 + 5 = 10 effective, 10 // 4 = 2 per stage, but output_weight=5 > 2
+        with pytest.raises(ValueError, match="output_weight.*exceeds layers_per_stage"):
+            generate_llm_fqn_per_model_part(
+                num_stages=4, num_layers=4, input_weight=1, output_weight=5
+            )
+
+    def test_large_model(self):
+        """Test with a large model (e.g., 32 layers, 8 stages)."""
+        result = generate_llm_fqn_per_model_part(num_stages=8, num_layers=32)
+        assert len(result) == 8
+
+        # Verify all layers are covered exactly once
+        all_layer_names = []
+        for stage in result:
+            all_layer_names.extend([m for m in stage if m.startswith("layers.")])
+        expected_layers = [f"layers.{i}" for i in range(32)]
+        assert all_layer_names == expected_layers
+
+        # Verify first stage has tok_embeddings
+        assert result[0][0] == "tok_embeddings"
+
+        # Verify last stage has norm and output
+        assert result[-1][-2:] == ["norm", "output"]
+
+    def test_critic_model_single_stage(self):
+        """Critic model with single stage should use 'score' instead of 'output'."""
+        result = generate_llm_fqn_per_model_part(
+            num_stages=1, num_layers=4, is_critic=True
+        )
+        assert len(result) == 1
+        assert result[0] == [
+            "tok_embeddings",
+            "layers.0",
+            "layers.1",
+            "layers.2",
+            "layers.3",
+            "norm",
+            "score",
+        ]
+
+    def test_critic_model_two_stages(self):
+        """Critic model with two stages should use 'score' on last stage."""
+        result = generate_llm_fqn_per_model_part(
+            num_stages=2, num_layers=4, is_critic=True
+        )
+        assert len(result) == 2
+        assert result[0] == ["tok_embeddings", "layers.0", "layers.1"]
+        assert result[1] == ["layers.2", "layers.3", "norm", "score"]
+
+    def test_critic_model_four_stages(self):
+        """Critic model with four stages."""
+        result = generate_llm_fqn_per_model_part(
+            num_stages=4, num_layers=8, is_critic=True
+        )
+        assert len(result) == 4
+        # Last stage should have 'score' instead of 'output'
+        assert result[3] == ["layers.7", "norm", "score"]
+
+    def test_exact_distribution(self):
+        """Test when layers divide evenly."""
+        # 6 layers + 1 + 1 = 8, 8 // 4 = 2 per stage exactly
+        result = generate_llm_fqn_per_model_part(num_stages=4, num_layers=6)
+        assert len(result) == 4
+
+        # All stages should have 2 effective layers
+        # Stage 0: tok_embeddings (1) + 1 layer = 2
+        assert result[0] == ["tok_embeddings", "layers.0"]
+        # Stage 1: 2 layers = 2
+        assert result[1] == ["layers.1", "layers.2"]
+        # Stage 2: 2 layers = 2
+        assert result[2] == ["layers.3", "layers.4"]
+        # Stage 3: 1 layer + norm + output (1) = 2
+        assert result[3] == ["layers.5", "norm", "output"]

--- a/areal/tests/experimental/archon/test_qwen3_args.py
+++ b/areal/tests/experimental/archon/test_qwen3_args.py
@@ -1,11 +1,22 @@
-"""Tests for Qwen3ModelArgs with MoE support.
+"""Tests for Qwen3ModelArgs - Qwen3-specific configuration handling.
+
+This file tests Qwen3ModelArgs-specific functionality that is NOT covered by
+test_moe_args.py (which tests the underlying MoEArgs dataclass).
+
+Focus areas:
+- Qwen3ModelArgs default values
+- decoder_sparse_step configuration (Qwen3-specific)
+- Qwen3ModelArgs.from_hf_config() integration with MoE
+
+For MoEArgs-specific tests (num_experts, top_k, route_norm, etc.),
+see test_moe_args.py.
 
 Run tests:
     pytest areal/tests/experimental/archon/test_qwen3_args.py -v
 """
 
 from areal.experimental.models.archon.moe import MoEArgs
-from areal.experimental.models.archon.qwen3.model.args import Qwen3ModelArgs
+from areal.experimental.models.archon.qwen3 import Qwen3ModelArgs
 
 
 class TestQwen3ModelArgsDefaults:
@@ -29,37 +40,52 @@ class TestQwen3ModelArgsDefaults:
         assert args.moe_args is None
 
 
-class TestQwen3ModelArgsMoE:
-    """Tests for Qwen3ModelArgs with MoE configuration."""
+class TestQwen3ModelArgsDecoderSparseStep:
+    """Tests for decoder_sparse_step configuration (Qwen3-specific)."""
 
-    def test_moe_enabled_with_args(self):
-        """Test enabling MoE with explicit MoEArgs."""
-        moe_args = MoEArgs(num_experts=64, top_k=8)
+    def test_decoder_sparse_step_default(self):
+        """Test decoder_sparse_step defaults to 1 (all layers MoE when enabled)."""
         args = Qwen3ModelArgs(
             moe_enabled=True,
-            moe_args=moe_args,
-            moe_inter_dim=1024,
+            moe_args=MoEArgs(num_experts=8),
         )
+        assert args.decoder_sparse_step == 1
 
-        assert args.moe_enabled is True
-        assert args.moe_args is not None
-        assert args.moe_args.num_experts == 64
-        assert args.moe_args.top_k == 8
-        assert args.moe_inter_dim == 1024
-
-    def test_decoder_sparse_step(self):
-        """Test decoder_sparse_step configuration."""
+    def test_decoder_sparse_step_2(self):
+        """Test decoder_sparse_step=2 (every other layer is MoE)."""
         args = Qwen3ModelArgs(
             moe_enabled=True,
             moe_args=MoEArgs(num_experts=8),
             decoder_sparse_step=2,
         )
+        assert args.decoder_sparse_step == 2
+
+    def test_decoder_sparse_step_from_hf_config(self):
+        """Test from_hf_config extracts decoder_sparse_step."""
+
+        class MockMoEConfig:
+            hidden_size = 2048
+            num_hidden_layers = 36
+            num_attention_heads = 16
+            num_key_value_heads = 4
+            vocab_size = 151936
+            intermediate_size = 8960
+            rms_norm_eps = 1e-5
+            num_experts = 64
+            num_experts_per_tok = 4
+            decoder_sparse_step = 2  # Every other layer is MoE
+
+        args = Qwen3ModelArgs.from_hf_config(MockMoEConfig())
 
         assert args.decoder_sparse_step == 2
 
 
 class TestQwen3ModelArgsFromHfConfig:
-    """Tests for Qwen3ModelArgs.from_hf_config() with MoE."""
+    """Tests for Qwen3ModelArgs.from_hf_config() - integration tests.
+
+    Note: Basic MoE field extraction (num_experts, top_k, etc.) is tested
+    in test_moe_args.py. This class tests Qwen3-specific integration.
+    """
 
     def test_from_hf_config_dense(self):
         """Test from_hf_config for dense (non-MoE) model."""
@@ -80,8 +106,8 @@ class TestQwen3ModelArgsFromHfConfig:
         assert args.dim == 1024
         assert args.n_layers == 24
 
-    def test_from_hf_config_moe_with_num_experts(self):
-        """Test from_hf_config for MoE model using num_experts."""
+    def test_from_hf_config_moe_enables_flag(self):
+        """Test from_hf_config correctly enables moe_enabled flag."""
 
         class MockMoEConfig:
             hidden_size = 2048
@@ -91,7 +117,6 @@ class TestQwen3ModelArgsFromHfConfig:
             vocab_size = 151936
             intermediate_size = 8960
             rms_norm_eps = 1e-5
-            # MoE fields
             num_experts = 128
             num_experts_per_tok = 8
             moe_intermediate_size = 1408
@@ -101,99 +126,7 @@ class TestQwen3ModelArgsFromHfConfig:
 
         assert args.moe_enabled is True
         assert args.moe_args is not None
-        assert args.moe_args.num_experts == 128
-        assert args.moe_args.top_k == 8
-        assert args.moe_args.route_norm is True
         assert args.moe_inter_dim == 1408
-
-    def test_from_hf_config_moe_with_num_local_experts(self):
-        """Test from_hf_config for MoE model using num_local_experts."""
-
-        class MockMoEConfig:
-            hidden_size = 2048
-            num_hidden_layers = 36
-            num_attention_heads = 16
-            num_key_value_heads = 4
-            vocab_size = 151936
-            intermediate_size = 8960
-            rms_norm_eps = 1e-5
-            # MoE fields (alternative naming)
-            num_local_experts = 64
-            num_experts_per_tok = 4
-
-        args = Qwen3ModelArgs.from_hf_config(MockMoEConfig())
-
-        assert args.moe_enabled is True
-        assert args.moe_args is not None
-        assert args.moe_args.num_experts == 64
-        assert args.moe_args.top_k == 4
-
-    def test_from_hf_config_moe_with_shared_experts(self):
-        """Test from_hf_config with shared experts."""
-
-        class MockMoEConfig:
-            hidden_size = 2048
-            num_hidden_layers = 36
-            num_attention_heads = 16
-            num_key_value_heads = 4
-            vocab_size = 151936
-            intermediate_size = 8960
-            rms_norm_eps = 1e-5
-            num_experts = 64
-            num_experts_per_tok = 4
-            num_shared_experts = 2
-
-        args = Qwen3ModelArgs.from_hf_config(MockMoEConfig())
-
-        assert args.moe_args.num_shared_experts == 2
-
-    def test_from_hf_config_moe_decoder_sparse_step(self):
-        """Test from_hf_config with decoder_sparse_step."""
-
-        class MockMoEConfig:
-            hidden_size = 2048
-            num_hidden_layers = 36
-            num_attention_heads = 16
-            num_key_value_heads = 4
-            vocab_size = 151936
-            intermediate_size = 8960
-            rms_norm_eps = 1e-5
-            num_experts = 64
-            num_experts_per_tok = 4
-            decoder_sparse_step = 2  # Every other layer is MoE
-
-        args = Qwen3ModelArgs.from_hf_config(MockMoEConfig())
-
-        assert args.decoder_sparse_step == 2
-
-
-class TestQwen3ModelArgsQwen3MoE:
-    """Tests for Qwen3-MoE specific configurations."""
-
-    def test_qwen3_30b_a3b_config(self):
-        """Test configuration matching Qwen3-30B-A3B."""
-
-        class MockQwen3_30B_A3B:
-            hidden_size = 2048
-            num_hidden_layers = 36
-            num_attention_heads = 16
-            num_key_value_heads = 4
-            vocab_size = 151936
-            intermediate_size = 8960
-            rms_norm_eps = 1e-5
-            num_experts = 128
-            num_experts_per_tok = 8
-            moe_intermediate_size = 1408
-            norm_topk_prob = True
-
-        args = Qwen3ModelArgs.from_hf_config(MockQwen3_30B_A3B())
-
-        assert args.moe_enabled is True
-        assert args.moe_args.num_experts == 128
-        assert args.moe_args.top_k == 8
-        assert args.moe_args.route_norm is True
-        assert args.dim == 2048
-        assert args.n_layers == 36
 
     def test_single_expert_not_moe(self):
         """Test that num_experts=1 does not enable MoE."""
@@ -212,3 +145,22 @@ class TestQwen3ModelArgsQwen3MoE:
 
         assert args.moe_enabled is False
         assert args.moe_args is None
+
+    def test_from_hf_config_moe_with_shared_experts(self):
+        """Test from_hf_config with shared experts (Qwen3 feature)."""
+
+        class MockMoEConfig:
+            hidden_size = 2048
+            num_hidden_layers = 36
+            num_attention_heads = 16
+            num_key_value_heads = 4
+            vocab_size = 151936
+            intermediate_size = 8960
+            rms_norm_eps = 1e-5
+            num_experts = 64
+            num_experts_per_tok = 4
+            num_shared_experts = 2
+
+        args = Qwen3ModelArgs.from_hf_config(MockMoEConfig())
+
+        assert args.moe_args.num_shared_experts == 2

--- a/areal/tests/experimental/archon/test_qwen3_model_moe.py
+++ b/areal/tests/experimental/archon/test_qwen3_model_moe.py
@@ -8,9 +8,8 @@ import pytest
 import torch
 
 from areal.experimental.models.archon.moe import MoEArgs
-from areal.experimental.models.archon.qwen3.model.args import Qwen3ModelArgs
+from areal.experimental.models.archon.qwen3 import Qwen3Model, Qwen3ModelArgs
 from areal.experimental.models.archon.qwen3.model.model import (
-    Qwen3Model,
     TransformerBlock,
     _is_moe_layer,
 )

--- a/areal/tests/experimental/archon/test_state_dict_adapter.py
+++ b/areal/tests/experimental/archon/test_state_dict_adapter.py
@@ -15,9 +15,7 @@ Note: For weight completeness and shape matching tests, see test_weight_sync.py
 import pytest
 import torch
 
-from areal.experimental.models.archon.qwen3.model.state_dict_adapter import (
-    Qwen3StateDictAdapter,
-)
+from areal.experimental.models.archon.qwen3 import Qwen3StateDictAdapter
 
 # =============================================================================
 # Mock Configs
@@ -407,7 +405,7 @@ class TestMoEWeightLoadingRoundtrip:
     def moe_model_args(self):
         """Create model args for MoE model."""
         from areal.experimental.models.archon.moe import MoEArgs
-        from areal.experimental.models.archon.qwen3.model.args import Qwen3ModelArgs
+        from areal.experimental.models.archon.qwen3 import Qwen3ModelArgs
 
         return Qwen3ModelArgs(
             dim=64,
@@ -443,7 +441,7 @@ class TestMoEWeightLoadingRoundtrip:
         self, moe_model_args, moe_adapter_config
     ):
         """Test that model forward output matches after save/load roundtrip."""
-        from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
+        from areal.experimental.models.archon.qwen3 import Qwen3Model
 
         device = torch.device("cuda")
 
@@ -492,7 +490,7 @@ class TestMoEWeightLoadingRoundtrip:
 
     def test_moe_weight_keys_preserved(self, moe_model_args, moe_adapter_config):
         """Test that all weight keys are preserved in roundtrip."""
-        from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
+        from areal.experimental.models.archon.qwen3 import Qwen3Model
 
         model = Qwen3Model(moe_model_args)
         model.init_weights()
@@ -519,7 +517,7 @@ class TestMoEWeightLoadingRoundtrip:
 
     def test_moe_weight_values_preserved(self, moe_model_args, moe_adapter_config):
         """Test that all weight values are preserved in roundtrip."""
-        from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
+        from areal.experimental.models.archon.qwen3 import Qwen3Model
 
         model = Qwen3Model(moe_model_args)
         model.init_weights()
@@ -549,7 +547,7 @@ class TestMoEWeightLoadingRoundtrip:
 
     def test_mixed_moe_dense_layers_preserved(self, moe_model_args, moe_adapter_config):
         """Test roundtrip with mixed MoE and dense layers."""
-        from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
+        from areal.experimental.models.archon.qwen3 import Qwen3Model
 
         # decoder_sparse_step=2 means:
         # - layer 0: dense (FFN)
@@ -887,9 +885,7 @@ class TestHFAssetsPathSupport:
 
     def test_qwen2_adapter_with_hf_assets_path(self, mock_safetensors_index):
         """Test that Qwen2StateDictAdapter also supports hf_assets_path."""
-        from areal.experimental.models.archon.qwen2.model.state_dict_adapter import (
-            Qwen2StateDictAdapter,
-        )
+        from areal.experimental.models.archon.qwen2 import Qwen2StateDictAdapter
 
         adapter = Qwen2StateDictAdapter(
             MockQwen3Config(), hf_assets_path=str(mock_safetensors_index)
@@ -1042,9 +1038,7 @@ class TestQwen2StateDictAdapterDense:
 
     @pytest.fixture
     def adapter(self):
-        from areal.experimental.models.archon.qwen2.model.state_dict_adapter import (
-            Qwen2StateDictAdapter,
-        )
+        from areal.experimental.models.archon.qwen2 import Qwen2StateDictAdapter
 
         class MockQwen2Config:
             model_type = "qwen2"
@@ -1121,9 +1115,7 @@ class TestQwen2StateDictAdapterDense:
 
     def test_qwen2_adapter_with_weight_tying(self):
         """Test Qwen2StateDictAdapter handles weight tying correctly."""
-        from areal.experimental.models.archon.qwen2.model.state_dict_adapter import (
-            Qwen2StateDictAdapter,
-        )
+        from areal.experimental.models.archon.qwen2 import Qwen2StateDictAdapter
 
         class MockQwen2ConfigTied:
             model_type = "qwen2"

--- a/areal/tests/experimental/archon/test_weight_sync.py
+++ b/areal/tests/experimental/archon/test_weight_sync.py
@@ -18,9 +18,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
-from areal.experimental.models.archon.qwen3.model.state_dict_adapter import (
-    Qwen3StateDictAdapter,
-)
+from areal.experimental.models.archon.qwen3 import Qwen3StateDictAdapter
 
 # =============================================================================
 # Mock Configs for Iterative Conversion Tests
@@ -51,7 +49,7 @@ class MockMoEConfig:
 @pytest.fixture
 def small_dense_model_args():
     """Create small dense model args for CPU testing."""
-    from areal.experimental.models.archon.qwen3.model.args import Qwen3ModelArgs
+    from areal.experimental.models.archon.qwen3 import Qwen3ModelArgs
 
     return Qwen3ModelArgs(
         dim=64,
@@ -71,7 +69,7 @@ def small_dense_model_args():
 def small_moe_model_args():
     """Create small MoE model args for CPU testing."""
     from areal.experimental.models.archon.moe import MoEArgs
-    from areal.experimental.models.archon.qwen3.model.args import Qwen3ModelArgs
+    from areal.experimental.models.archon.qwen3 import Qwen3ModelArgs
 
     return Qwen3ModelArgs(
         dim=64,
@@ -93,7 +91,7 @@ def small_moe_model_args():
 @pytest.fixture
 def small_dense_model(small_dense_model_args):
     """Create and initialize small dense model on CPU."""
-    from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
+    from areal.experimental.models.archon.qwen3 import Qwen3Model
 
     model = Qwen3Model(small_dense_model_args)
     model.init_weights()
@@ -104,7 +102,7 @@ def small_dense_model(small_dense_model_args):
 @pytest.fixture
 def small_moe_model(small_moe_model_args):
     """Create and initialize small MoE model on CPU."""
-    from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
+    from areal.experimental.models.archon.qwen3 import Qwen3Model
 
     model = Qwen3Model(small_moe_model_args)
     model.init_weights()

--- a/areal/tests/experimental/archon/torchrun/dist_utils.py
+++ b/areal/tests/experimental/archon/torchrun/dist_utils.py
@@ -5,8 +5,7 @@ import torch.distributed as dist
 from torch.distributed.tensor import DTensor
 
 from areal.experimental.models.archon.moe import MoEArgs
-from areal.experimental.models.archon.qwen3.model.args import Qwen3ModelArgs
-from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
+from areal.experimental.models.archon.qwen3 import Qwen3Model, Qwen3ModelArgs
 
 
 def write_result(out: str, succ: bool) -> None:

--- a/areal/tests/experimental/archon/torchrun/run_archon_engine_pp.py
+++ b/areal/tests/experimental/archon/torchrun/run_archon_engine_pp.py
@@ -1,0 +1,416 @@
+"""End-to-end test for ArchonEngine with Pipeline Parallelism.
+
+This test directly instantiates ArchonEngine with PP enabled and verifies:
+1. Forward pass produces correct output shape
+2. PP outputs match golden (non-PP) model outputs
+3. Train batch computes gradients correctly
+
+Run with:
+    torchrun --nproc_per_node=2 areal/tests/experimental/archon/torchrun/run_archon_engine_pp.py \
+        --pp_size=2 --out=/tmp/result.txt
+
+    torchrun --nproc_per_node=4 areal/tests/experimental/archon/torchrun/run_archon_engine_pp.py \
+        --pp_size=2 --dp_size=2 --out=/tmp/result.txt
+
+    torchrun --nproc_per_node=4 areal/tests/experimental/archon/torchrun/run_archon_engine_pp.py \
+        --pp_size=2 --ep_size=2 --out=/tmp/result.txt
+
+NOTE: Requires a small Qwen model for testing (e.g., Qwen3-0.6B).
+      PP+EP tests require a MoE model (e.g., Qwen2.5-3B-A3B-Instruct).
+"""
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+
+from areal.api.alloc_mode import ParallelStrategy
+from areal.api.cli_args import MicroBatchSpec, OptimizerConfig, TrainEngineConfig
+from areal.api.io_struct import FinetuneSpec
+from areal.experimental.engine.archon_engine import ArchonEngine
+from areal.tests.experimental.archon.torchrun.dist_utils import (
+    print_rank0,
+    write_result,
+)
+from areal.tests.utils import get_model_path
+
+# Use a small model for testing
+DEFAULT_MODEL_PATH = get_model_path(
+    "/storage/openpsi/models/Qwen__Qwen3-0.6B/", "Qwen/Qwen3-0.6B"
+)
+
+
+def create_mock_input(
+    batch_size: int = 4,
+    min_seqlen: int = 10,
+    max_seqlen: int = 20,
+    vocab_size: int = 151936,  # Qwen3 vocab size
+    device: torch.device | str = "cuda",
+) -> dict[str, torch.Tensor]:
+    """Create mock padded input data for testing.
+
+    Returns a dict with input_ids and attention_mask (same format as HuggingFace).
+    """
+    pad_token_id = 0
+    seqlens = torch.randint(
+        min_seqlen, max_seqlen, (batch_size,), dtype=torch.int, device=device
+    )
+    actual_max_seqlen = int(max(seqlens))
+
+    input_ids = torch.randint(
+        1,  # Start from 1 to avoid pad_token_id
+        vocab_size,
+        (batch_size, actual_max_seqlen),
+        dtype=torch.long,
+        device=device,
+    )
+
+    attn_mask = torch.zeros(
+        (batch_size, actual_max_seqlen), dtype=torch.bool, device=device
+    )
+
+    # Set attention mask based on actual sequence lengths
+    attn_mask[
+        torch.arange(0, actual_max_seqlen, device=device).unsqueeze(0)
+        < seqlens.unsqueeze(1)
+    ] = True
+
+    # Pad input_ids where attention_mask is False
+    input_ids.masked_fill_(~attn_mask, pad_token_id)
+
+    return dict(
+        input_ids=input_ids,
+        attention_mask=attn_mask,
+    )
+
+
+def mock_loss_fn(
+    logprobs: torch.Tensor,
+    entropy: torch.Tensor,
+    input_data: dict,
+    **kwargs,
+) -> torch.Tensor:
+    """Mock loss function for testing."""
+    return torch.mean(logprobs)
+
+
+def mock_loss_weight_fn(input_data: dict) -> torch.Tensor:
+    """Mock loss weight function for testing."""
+    return input_data["cu_seqlens"][-1].float()
+
+
+def create_archon_engine(
+    model_path: str,
+    pp_size: int,
+    dp_size: int = 1,
+    tp_size: int = 1,
+    ep_size: int = 1,
+) -> ArchonEngine:
+    """Create and initialize ArchonEngine with PP enabled."""
+    engine_config = TrainEngineConfig(
+        experiment_name="test-archon-pp",
+        trial_name="test0",
+        path=model_path,
+        optimizer=OptimizerConfig(lr=1e-5),
+        mb_spec=MicroBatchSpec(n_mbs=2, max_tokens_per_mb=256),
+        gradient_checkpointing=False,
+        dtype="bfloat16",
+    )
+
+    # Disable torch.compile for faster test startup
+    engine_config.archon.enable_compile = False
+
+    engine = ArchonEngine(engine_config)
+
+    # Create parallel strategy with PP enabled
+    parallel_strategy = ParallelStrategy(
+        pipeline_parallel_size=pp_size,
+        data_parallel_size=dp_size,
+        tensor_parallel_size=tp_size,
+        expert_parallel_size=ep_size,
+    )
+
+    engine.create_process_group(parallel_strategy)
+
+    ft_spec = FinetuneSpec(total_train_epochs=1, dataset_size=100, train_batch_size=4)
+    engine.initialize(None, ft_spec)
+
+    return engine
+
+
+def test_forward_batch(engine: ArchonEngine, mock_input: dict) -> bool:
+    """Test forward_batch with PP enabled."""
+    rank = dist.get_rank()
+    print_rank0("\n--- Testing forward_batch ---")
+
+    engine.train(mode=False)  # Set to eval mode
+
+    try:
+        output = engine.forward_batch(mock_input)
+        print(f"  Rank {rank}: forward_batch output shape = {output.shape}")
+
+        # Verify output shape
+        # Output should be [total_tokens] (logprobs)
+        attn_mask = mock_input["attention_mask"]
+        expected_tokens = attn_mask.sum().item()
+
+        # Output may include padding, but should have at least expected_tokens
+        if output.numel() < expected_tokens:
+            print_rank0("  ERROR: Output has fewer tokens than expected")
+            return False
+
+        print_rank0("  forward_batch PASSED")
+        return True
+
+    except Exception as e:
+        print_rank0(f"  forward_batch FAILED: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_eval_batch(engine: ArchonEngine, mock_input: dict) -> bool:
+    """Test eval_batch with PP enabled."""
+    print_rank0("\n--- Testing eval_batch ---")
+
+    engine.train(mode=False)
+
+    try:
+        loss = engine.eval_batch(
+            mock_input,
+            loss_fn=mock_loss_fn,
+            loss_weight_fn=mock_loss_weight_fn,
+        )
+
+        # In PP mode, eval_batch may return None (TODO in ArchonEngine)
+        if loss is not None:
+            print_rank0(f"  eval_batch loss = {loss.item():.6f}")
+        else:
+            print_rank0("  eval_batch returned None (expected for PP mode)")
+
+        print_rank0("  eval_batch PASSED")
+        return True
+
+    except Exception as e:
+        print_rank0(f"  eval_batch FAILED: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_train_batch(engine: ArchonEngine, mock_input: dict) -> bool:
+    """Test train_batch with PP enabled."""
+    print_rank0("\n--- Testing train_batch ---")
+
+    engine.train(mode=True)
+
+    try:
+        result = engine.train_batch(
+            mock_input,
+            loss_fn=mock_loss_fn,
+            loss_weight_fn=mock_loss_weight_fn,
+        )
+
+        print_rank0("  train_batch result:")
+        print_rank0(f"    update_successful = {result.get('update_successful')}")
+        print_rank0(f"    grad_norm = {result.get('grad_norm'):.6f}")
+        print_rank0(f"    lr = {result.get('lr'):.2e}")
+
+        # Verify grad_norm is valid
+        grad_norm = result.get("grad_norm")
+        if grad_norm is None or not torch.isfinite(torch.tensor(grad_norm)):
+            print_rank0("  WARNING: grad_norm is invalid")
+
+        print_rank0("  train_batch PASSED")
+        return True
+
+    except Exception as e:
+        print_rank0(f"  train_batch FAILED: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def run_tests(
+    model_path: str,
+    pp_size: int,
+    dp_size: int,
+    tp_size: int,
+    ep_size: int,
+    out_file: str | None = None,
+) -> bool:
+    """Run all ArchonEngine PP tests."""
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    # EP borrows from DP, so when ep_size > 1, dp_size must be at least ep_size
+    if ep_size > 1 and dp_size < ep_size:
+        dp_size = ep_size
+        print_rank0(
+            f"  Note: Setting dp_size={dp_size} to match ep_size (EP borrows from DP)"
+        )
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0("ArchonEngine PP E2E Test")
+    print_rank0(
+        f"  world_size={world_size}, pp={pp_size}, dp={dp_size}, tp={tp_size}, ep={ep_size}"
+    )
+    print_rank0(f"  model_path={model_path}")
+    print_rank0("=" * 60)
+
+    # Validate parallel configuration
+    expected_world_size = pp_size * dp_size * tp_size
+    if world_size != expected_world_size:
+        print_rank0(
+            f"ERROR: world_size ({world_size}) != pp*dp*tp ({expected_world_size})"
+        )
+        if rank == 0 and out_file:
+            write_result(out_file, False)
+        return False
+
+    # Create engine
+    print_rank0("\n--- Creating ArchonEngine ---")
+    try:
+        engine = create_archon_engine(model_path, pp_size, dp_size, tp_size, ep_size)
+        print_rank0("  Engine created successfully")
+        print_rank0(f"  PP enabled: {engine.parallel_dims.pp_enabled}")
+        print_rank0(f"  has_first_stage: {engine.pp_has_first_stage}")
+        print_rank0(f"  has_last_stage: {engine.pp_has_last_stage}")
+        if ep_size > 1:
+            print_rank0(f"  EP enabled: {engine.parallel_dims.ep_enabled}")
+    except Exception as e:
+        print_rank0(f"  Engine creation FAILED: {e}")
+        import traceback
+
+        traceback.print_exc()
+        if rank == 0 and out_file:
+            write_result(out_file, False)
+        return False
+
+    # Create mock input (broadcast from rank 0)
+    if rank == 0:
+        mock_input = create_mock_input(
+            batch_size=4,
+            min_seqlen=10,
+            max_seqlen=20,
+            device="cuda",
+        )
+        input_data = [mock_input]
+    else:
+        input_data = [None]
+
+    dist.broadcast_object_list(input_data, src=0)
+    mock_input = input_data[0]
+
+    # Move tensors to local device
+    device = torch.device(f"cuda:{rank % torch.cuda.device_count()}")
+    mock_input = {k: v.to(device) for k, v in mock_input.items()}
+
+    print_rank0(
+        f"  Mock input created: input_ids shape = {mock_input['input_ids'].shape}"
+    )
+
+    # Run tests
+    all_passed = True
+
+    try:
+        # Test 1: forward_batch
+        if not test_forward_batch(engine, mock_input):
+            all_passed = False
+
+        # Test 2: eval_batch
+        if not test_eval_batch(engine, mock_input):
+            all_passed = False
+
+        # Test 3: train_batch
+        if not test_train_batch(engine, mock_input):
+            all_passed = False
+
+    finally:
+        # Cleanup
+        engine.destroy()
+
+    # Report results
+    dist.barrier()
+
+    if all_passed:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("All ArchonEngine PP tests PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("Some ArchonEngine PP tests FAILED")
+        print_rank0("=" * 60)
+
+    if rank == 0 and out_file:
+        write_result(out_file, all_passed)
+
+    return all_passed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ArchonEngine PP E2E Test")
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default=DEFAULT_MODEL_PATH,
+        help="Path to HuggingFace model",
+    )
+    parser.add_argument(
+        "--pp_size",
+        type=int,
+        default=2,
+        help="Pipeline parallel size",
+    )
+    parser.add_argument(
+        "--dp_size",
+        type=int,
+        default=1,
+        help="Data parallel size",
+    )
+    parser.add_argument(
+        "--tp_size",
+        type=int,
+        default=1,
+        help="Tensor parallel size",
+    )
+    parser.add_argument(
+        "--ep_size",
+        type=int,
+        default=1,
+        help="Expert parallel size (requires MoE model)",
+    )
+    parser.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        help="Output file for test result",
+    )
+    args = parser.parse_args()
+
+    # Initialize distributed
+    dist.init_process_group(backend="nccl")
+
+    # Set environment variables if not set
+    if "LOCAL_RANK" not in os.environ:
+        os.environ["LOCAL_RANK"] = str(dist.get_rank())
+
+    try:
+        run_tests(
+            model_path=args.model_path,
+            pp_size=args.pp_size,
+            dp_size=args.dp_size,
+            tp_size=args.tp_size,
+            ep_size=args.ep_size,
+            out_file=args.out,
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/areal/tests/experimental/archon/torchrun/run_checkpoint_tests.py
+++ b/areal/tests/experimental/archon/torchrun/run_checkpoint_tests.py
@@ -2,15 +2,23 @@
 """Engine checkpoint integration tests.
 
 Tests for ArchonEngine save/load methods with HF format using DCP infrastructure.
+Also includes PP (Pipeline Parallelism) checkpoint tests using DCP format.
 
 Run with:
     torchrun --nproc_per_node=2 areal/tests/experimental/archon/torchrun/run_checkpoint_tests.py \
         --test_type=save_hf_dense --model_path=/path/to/model --output=/tmp/result.out
 
+    torchrun --nproc_per_node=2 areal/tests/experimental/archon/torchrun/run_checkpoint_tests.py \
+        --test_type=pp_dcp_checkpoint --pp_size=2 --output=/tmp/result.out
+
 Supported test types:
     - save_hf_dense: Test save() with weight_format="hf" on dense model
     - save_load_forward_match: Test save -> load -> forward output matches
+    - save_load_forward_match_with_compile_ac: Test with torch.compile + activation checkpointing
     - moe_checkpoint: Test MoE model checkpoint with EP
+    - pp_dcp_checkpoint: Test PP checkpoint save/load using DCP format
+    - pp_dcp_with_optim: Test PP checkpoint with optimizer state
+    - pp_forward_match: Test forward output matches after PP checkpoint save/load
 """
 
 from __future__ import annotations
@@ -22,12 +30,20 @@ import tempfile
 
 import torch
 import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.tensor import DTensor
 
 from areal.api.alloc_mode import ParallelStrategy
 from areal.api.cli_args import MicroBatchSpec, OptimizerConfig, TrainEngineConfig
 from areal.api.io_struct import FinetuneSpec, SaveLoadMeta
+from areal.experimental.engine.archon_checkpoint import DCPState
 from areal.experimental.engine.archon_engine import ArchonLMEngine
+from areal.experimental.models.archon import ArchonParallelDims
+from areal.experimental.models.archon.pipeline_parallel import pipeline_llm
+from areal.experimental.models.archon.qwen3 import Qwen3Model, parallelize_qwen3
 from areal.tests.experimental.archon.torchrun.dist_utils import (
+    create_dense_model_args,
+    create_test_input,
     print_rank0,
     write_result,
 )
@@ -584,6 +600,620 @@ def test_moe_checkpoint(model_path: str, output: str | None = None) -> bool:
 
 
 # =============================================================================
+# PP Checkpoint Tests (migrated from run_pp_checkpoint.py)
+# =============================================================================
+
+
+def _to_local(tensor: torch.Tensor) -> torch.Tensor:
+    """Convert DTensor to local tensor if needed."""
+    if isinstance(tensor, DTensor):
+        return tensor.to_local()
+    return tensor
+
+
+def test_pp_dcp_checkpoint(pp_size: int, out_file: str | None = None) -> bool:
+    """Test PP checkpoint save/load using DCP format.
+
+    Steps:
+    1. Create PP model with pipeline_llm
+    2. Save checkpoint using DCPState
+    3. Modify weights to verify load actually changes them
+    4. Load checkpoint
+    5. Verify weights match original
+
+    Args:
+        pp_size: Pipeline parallel degree (must equal world_size)
+        out_file: Optional file to write result ("Passed"/"Failed")
+
+    Returns:
+        True if test passed, False otherwise
+    """
+    import torch.distributed.checkpoint as dcp
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0(f"PP DCP Checkpoint Test: pp_size={pp_size}, world_size={world_size}")
+    print_rank0("=" * 60)
+
+    assert world_size == pp_size, (
+        f"This test requires world_size == pp_size. "
+        f"Got world_size={world_size}, pp_size={pp_size}"
+    )
+
+    # Create temp directory for checkpoint
+    if rank == 0:
+        output_dir = tempfile.mkdtemp(prefix="pp_dcp_checkpoint_")
+    else:
+        output_dir = None
+
+    output_dir_list = [output_dir]
+    dist.broadcast_object_list(output_dir_list, src=0)
+    output_dir = output_dir_list[0]
+
+    success = True
+
+    try:
+        # 1. Create model args
+        n_layers = pp_size * 2
+        model_args = create_dense_model_args(
+            n_layers=n_layers,
+            dim=64,
+            hidden_dim=128,
+            n_heads=4,
+            n_kv_heads=2,
+            head_dim=16,
+            vocab_size=1000,
+        )
+
+        # 2. Create PP parallel dims
+        parallel_dims = ArchonParallelDims(
+            pp=pp_size,
+            dp_shard=1,
+            tp=1,
+            cp=1,
+            world_size=world_size,
+            device_type="cuda",
+        )
+
+        # 3. Create model on meta device for efficient pipeline splitting
+        with torch.device("meta"):
+            model = Qwen3Model(model_args)
+
+        # NOTE: Schedule is created dynamically by ArchonEngine, not returned here
+        pp_stages, model_parts, has_first, has_last = pipeline_llm(
+            model=model,
+            parallel_dims=parallel_dims,
+            device=device,
+            parallelize_fn=parallelize_qwen3,
+            enable_compile=False,  # Disable compile to speed up test
+        )
+
+        # Materialize weights from meta device
+        for part in model_parts:
+            part.to_empty(device=device)
+            with torch.no_grad():
+                part.init_weights()
+            part.init_buffers(buffer_device=device)
+
+        print_rank0(f"  Rank {rank}: has_first={has_first}, has_last={has_last}")
+        print_rank0(f"  Rank {rank}: {len(model_parts)} model parts")
+
+        # 4. Save original parameter values (convert DTensor to local)
+        original_params = {}
+        for part_idx, part in enumerate(model_parts):
+            for name, param in part.named_parameters():
+                key = f"part{part_idx}.{name}"
+                original_params[key] = _to_local(param.data).clone()
+
+        print_rank0(f"  Saved {len(original_params)} parameter tensors")
+
+        # 5. Save checkpoint using DCPState
+        dcp_state = DCPState(model_parts, optimizer=None)
+        dcp.save({"dcp": dcp_state}, checkpoint_id=output_dir)
+
+        print_rank0(f"  Checkpoint saved to {output_dir}")
+
+        dist.barrier()
+
+        # 6. Modify weights (to verify load actually works)
+        with torch.no_grad():
+            for part in model_parts:
+                for param in part.parameters():
+                    param.data.fill_(999.0)
+
+        # Verify weights changed
+        modified_check_passed = True
+        for part_idx, part in enumerate(model_parts):
+            for name, param in part.named_parameters():
+                local_data = _to_local(param.data)
+                if not torch.allclose(local_data, torch.tensor(999.0, device=device)):
+                    modified_check_passed = False
+                    break
+
+        if not modified_check_passed:
+            print_rank0("  ERROR: Failed to modify weights")
+            success = False
+
+        # 7. Load checkpoint
+        dcp_state_load = DCPState(model_parts, optimizer=None)
+        dcp.load({"dcp": dcp_state_load}, checkpoint_id=output_dir)
+
+        print_rank0("  Checkpoint loaded")
+
+        # 8. Verify weights match original
+        mismatch_count = 0
+        max_diff = 0.0
+        for part_idx, part in enumerate(model_parts):
+            for name, param in part.named_parameters():
+                key = f"part{part_idx}.{name}"
+                if key in original_params:
+                    local_data = _to_local(param.data)
+                    diff = (local_data - original_params[key]).abs().max().item()
+                    max_diff = max(max_diff, diff)
+                    if diff > 1e-6:
+                        mismatch_count += 1
+                        if mismatch_count <= 3:
+                            print_rank0(f"  Mismatch: {key}, diff={diff:.6e}")
+
+        if mismatch_count > 0:
+            print_rank0(f"  ERROR: {mismatch_count} parameters don't match")
+            success = False
+        else:
+            print_rank0(
+                f"  All {len(original_params)} parameters match (max_diff={max_diff:.6e})"
+            )
+
+    except Exception as e:
+        print_rank0(f"ERROR: {e}")
+        import traceback
+
+        traceback.print_exc()
+        success = False
+
+    finally:
+        dist.barrier()
+        if rank == 0 and output_dir and os.path.exists(output_dir):
+            shutil.rmtree(output_dir)
+
+    # Gather results from all ranks
+    all_results = [None] * world_size
+    dist.all_gather_object(all_results, success)
+    final_success = all(all_results)
+
+    if final_success:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP DCP Checkpoint Test: PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP DCP Checkpoint Test: FAILED")
+        print_rank0("=" * 60)
+
+    if rank == 0 and out_file:
+        write_result(out_file, final_success)
+
+    return final_success
+
+
+def test_pp_dcp_with_optim(pp_size: int, out_file: str | None = None) -> bool:
+    """Test PP checkpoint save/load with optimizer state using DCP format.
+
+    Steps:
+    1. Create PP model and optimizer
+    2. Run one forward/backward to populate optimizer state
+    3. Save checkpoint with optimizer using DCPState
+    4. Modify optimizer state
+    5. Load checkpoint
+    6. Verify optimizer state matches
+
+    Args:
+        pp_size: Pipeline parallel degree (must equal world_size)
+        out_file: Optional file to write result ("Passed"/"Failed")
+
+    Returns:
+        True if test passed, False otherwise
+    """
+    import torch.distributed.checkpoint as dcp
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0(f"PP DCP Checkpoint with Optimizer Test: pp_size={pp_size}")
+    print_rank0("=" * 60)
+
+    assert world_size == pp_size
+
+    # Create temp directory
+    if rank == 0:
+        output_dir = tempfile.mkdtemp(prefix="pp_dcp_optim_checkpoint_")
+    else:
+        output_dir = None
+
+    output_dir_list = [output_dir]
+    dist.broadcast_object_list(output_dir_list, src=0)
+    output_dir = output_dir_list[0]
+
+    success = True
+
+    try:
+        # 1. Create model
+        n_layers = pp_size * 2
+        model_args = create_dense_model_args(
+            n_layers=n_layers,
+            dim=64,
+            hidden_dim=128,
+            n_heads=4,
+            n_kv_heads=2,
+            head_dim=16,
+            vocab_size=1000,
+        )
+
+        parallel_dims = ArchonParallelDims(
+            pp=pp_size,
+            dp_shard=1,
+            tp=1,
+            cp=1,
+            world_size=world_size,
+            device_type="cuda",
+        )
+
+        # Create model on meta device for efficient pipeline splitting
+        with torch.device("meta"):
+            model = Qwen3Model(model_args)
+
+        def cross_entropy_loss_fn(output, target):
+            output_flat = output.view(-1, output.size(-1))
+            target_flat = target.view(-1)
+            return nn.functional.cross_entropy(output_flat, target_flat)
+
+        # NOTE: Schedule is created dynamically by ArchonEngine, not returned here
+        pp_stages, model_parts, has_first, has_last = pipeline_llm(
+            model=model,
+            parallel_dims=parallel_dims,
+            device=device,
+            parallelize_fn=parallelize_qwen3,
+            enable_compile=False,  # Disable compile to speed up test
+        )
+
+        # Materialize weights from meta device
+        for part in model_parts:
+            part.to_empty(device=device)
+            with torch.no_grad():
+                part.init_weights()
+            part.init_buffers(buffer_device=device)
+
+        # 2. Create optimizer (single optimizer for all model parts, as in archon_engine)
+        all_params = [p for m in model_parts for p in m.parameters() if p.requires_grad]
+        optimizer = torch.optim.AdamW(all_params, lr=1e-4)
+
+        print_rank0(f"  Created optimizer with {len(all_params)} parameters")
+
+        # 3. Run a forward/backward to populate optimizer state
+        tokens, positions, cu_seqlens, max_seqlen = create_test_input(
+            num_seqs=2,
+            seq_len_per_seq=8,
+            vocab_size=model_args.vocab_size,
+            device=device,
+            seed=123,
+        )
+        labels = tokens.clone()
+
+        # Simple forward-backward for first stage (just to populate optimizer state)
+        if has_first:
+            for part in model_parts:
+                part.train()
+            optimizer.zero_grad()
+            h = model_parts[0](tokens, positions, cu_seqlens, max_seqlen)
+            if has_last:
+                loss = cross_entropy_loss_fn(h, labels)
+                loss.backward()
+                optimizer.step()
+                print_rank0(f"  Ran forward/backward, loss={loss.item():.4f}")
+            else:
+                # For non-last stages, just do a dummy backward
+                h.sum().backward()
+                optimizer.step()
+                print_rank0("  Ran forward/backward (non-last stage)")
+        else:
+            # For non-first stages, just step to populate state
+            optimizer.step()
+            print_rank0("  Stepped optimizer (non-first stage)")
+
+        # 4. Save optimizer state values (convert DTensor to local)
+        original_state = {}
+        for i, p in enumerate(all_params):
+            if p in optimizer.state:
+                state = optimizer.state[p]
+                if "exp_avg" in state:
+                    original_state[f"param_{i}_exp_avg"] = _to_local(
+                        state["exp_avg"]
+                    ).clone()
+                if "exp_avg_sq" in state:
+                    original_state[f"param_{i}_exp_avg_sq"] = _to_local(
+                        state["exp_avg_sq"]
+                    ).clone()
+
+        print_rank0(f"  Saved {len(original_state)} optimizer state tensors")
+
+        # 5. Save checkpoint
+        dcp_state = DCPState(model_parts, optimizer=optimizer)
+        dcp.save({"dcp": dcp_state}, checkpoint_id=output_dir)
+
+        print_rank0(f"  Checkpoint saved to {output_dir}")
+
+        dist.barrier()
+
+        # 6. Modify optimizer state
+        for p in all_params:
+            if p in optimizer.state:
+                for key in optimizer.state[p]:
+                    if isinstance(optimizer.state[p][key], torch.Tensor):
+                        optimizer.state[p][key].fill_(999.0)
+
+        # 7. Load checkpoint
+        dcp_state_load = DCPState(model_parts, optimizer=optimizer)
+        dcp.load({"dcp": dcp_state_load}, checkpoint_id=output_dir)
+
+        print_rank0("  Checkpoint loaded")
+
+        # 8. Verify optimizer state
+        mismatch_count = 0
+        for i, p in enumerate(all_params):
+            if p in optimizer.state:
+                state = optimizer.state[p]
+                if "exp_avg" in state and f"param_{i}_exp_avg" in original_state:
+                    local_exp_avg = _to_local(state["exp_avg"])
+                    diff = (
+                        (local_exp_avg - original_state[f"param_{i}_exp_avg"])
+                        .abs()
+                        .max()
+                        .item()
+                    )
+                    if diff > 1e-6:
+                        mismatch_count += 1
+                if "exp_avg_sq" in state and f"param_{i}_exp_avg_sq" in original_state:
+                    local_exp_avg_sq = _to_local(state["exp_avg_sq"])
+                    diff = (
+                        (local_exp_avg_sq - original_state[f"param_{i}_exp_avg_sq"])
+                        .abs()
+                        .max()
+                        .item()
+                    )
+                    if diff > 1e-6:
+                        mismatch_count += 1
+
+        if mismatch_count > 0:
+            print_rank0(f"  ERROR: {mismatch_count} optimizer states don't match")
+            success = False
+        else:
+            print_rank0("  All optimizer states match")
+
+    except Exception as e:
+        print_rank0(f"ERROR: {e}")
+        import traceback
+
+        traceback.print_exc()
+        success = False
+
+    finally:
+        dist.barrier()
+        if rank == 0 and output_dir and os.path.exists(output_dir):
+            shutil.rmtree(output_dir)
+
+    # Gather results
+    all_results = [None] * world_size
+    dist.all_gather_object(all_results, success)
+    final_success = all(all_results)
+
+    if final_success:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP DCP Checkpoint with Optimizer Test: PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP DCP Checkpoint with Optimizer Test: FAILED")
+        print_rank0("=" * 60)
+
+    if rank == 0 and out_file:
+        write_result(out_file, final_success)
+
+    return final_success
+
+
+def test_pp_forward_match(pp_size: int, out_file: str | None = None) -> bool:
+    """Test forward output matches after PP checkpoint save/load.
+
+    This verifies the checkpoint preserves model behavior:
+    1. Create PP model
+    2. Run forward pass and record output
+    3. Save checkpoint
+    4. Modify weights
+    5. Load checkpoint
+    6. Run forward again
+    7. Verify outputs match
+
+    Args:
+        pp_size: Pipeline parallel degree
+        out_file: Optional file to write result
+
+    Returns:
+        True if test passed, False otherwise
+    """
+    import torch.distributed.checkpoint as dcp
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0(f"PP Forward Match Test: pp_size={pp_size}")
+    print_rank0("=" * 60)
+
+    assert world_size == pp_size
+
+    if rank == 0:
+        output_dir = tempfile.mkdtemp(prefix="pp_forward_match_")
+    else:
+        output_dir = None
+
+    output_dir_list = [output_dir]
+    dist.broadcast_object_list(output_dir_list, src=0)
+    output_dir = output_dir_list[0]
+
+    success = True
+
+    try:
+        # Create model
+        n_layers = pp_size * 2
+        model_args = create_dense_model_args(
+            n_layers=n_layers,
+            dim=64,
+            hidden_dim=128,
+            n_heads=4,
+            n_kv_heads=2,
+            head_dim=16,
+            vocab_size=1000,
+        )
+
+        parallel_dims = ArchonParallelDims(
+            pp=pp_size,
+            dp_shard=1,
+            tp=1,
+            cp=1,
+            world_size=world_size,
+            device_type="cuda",
+        )
+
+        # Create model on meta device for efficient pipeline splitting
+        with torch.device("meta"):
+            model = Qwen3Model(model_args)
+
+        # NOTE: Schedule is created dynamically by ArchonEngine, not returned here
+        pp_stages, model_parts, has_first, has_last = pipeline_llm(
+            model=model,
+            parallel_dims=parallel_dims,
+            device=device,
+            parallelize_fn=parallelize_qwen3,
+            enable_compile=False,  # Disable compile to speed up test
+        )
+
+        # Materialize weights from meta device
+        for part in model_parts:
+            part.to_empty(device=device)
+            with torch.no_grad():
+                part.init_weights()
+            part.init_buffers(buffer_device=device)
+
+        for part in model_parts:
+            part.eval()
+
+        # Create test input
+        tokens, positions, cu_seqlens, max_seqlen = create_test_input(
+            num_seqs=2,
+            seq_len_per_seq=8,
+            vocab_size=model_args.vocab_size,
+            device=device,
+            seed=123,
+        )
+
+        # Run forward (only first stage does this, others receive via PP)
+        output_before = None
+        if has_first:
+            with torch.no_grad():
+                h = model_parts[0](tokens, positions, cu_seqlens, max_seqlen)
+                if has_last:
+                    output_before = h.clone()
+                else:
+                    # For non-last stages in first position, send and wait
+                    # For this simple test, just capture the intermediate
+                    output_before = h.clone()
+
+        # Save checkpoint
+        dcp_state = DCPState(model_parts, optimizer=None)
+        dcp.save({"dcp": dcp_state}, checkpoint_id=output_dir)
+
+        dist.barrier()
+
+        # Modify weights
+        with torch.no_grad():
+            for part in model_parts:
+                for param in part.parameters():
+                    param.data.fill_(0.0)
+
+        # Load checkpoint
+        dcp_state_load = DCPState(model_parts, optimizer=None)
+        dcp.load({"dcp": dcp_state_load}, checkpoint_id=output_dir)
+
+        # Run forward again
+        output_after = None
+        if has_first:
+            with torch.no_grad():
+                h = model_parts[0](tokens, positions, cu_seqlens, max_seqlen)
+                if has_last:
+                    output_after = h.clone()
+                else:
+                    output_after = h.clone()
+
+        # Compare outputs
+        if output_before is not None and output_after is not None:
+            output_before_local = _to_local(output_before)
+            output_after_local = _to_local(output_after)
+            max_diff = (output_before_local - output_after_local).abs().max().item()
+            mean_diff = (output_before_local - output_after_local).abs().mean().item()
+            allclose = torch.allclose(
+                output_before_local, output_after_local, rtol=1e-4, atol=1e-4
+            )
+
+            print_rank0(f"  Max diff: {max_diff:.6e}")
+            print_rank0(f"  Mean diff: {mean_diff:.6e}")
+            print_rank0(f"  Allclose: {allclose}")
+
+            if not allclose and max_diff > 1e-3:
+                print_rank0("  ERROR: Forward outputs don't match!")
+                success = False
+            else:
+                print_rank0("  Forward outputs match!")
+
+    except Exception as e:
+        print_rank0(f"ERROR: {e}")
+        import traceback
+
+        traceback.print_exc()
+        success = False
+
+    finally:
+        dist.barrier()
+        if rank == 0 and output_dir and os.path.exists(output_dir):
+            shutil.rmtree(output_dir)
+
+    all_results = [None] * world_size
+    dist.all_gather_object(all_results, success)
+    final_success = all(all_results)
+
+    if final_success:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP Forward Match Test: PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP Forward Match Test: FAILED")
+        print_rank0("=" * 60)
+
+    if rank == 0 and out_file:
+        write_result(out_file, final_success)
+
+    return final_success
+
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -592,7 +1222,14 @@ TEST_REGISTRY = {
     "save_load_forward_match": test_save_load_forward_match,
     "save_load_forward_match_with_compile_ac": test_save_load_forward_match_with_compile_ac,
     "moe_checkpoint": test_moe_checkpoint,
+    # PP checkpoint tests (migrated from run_pp_checkpoint.py)
+    "pp_dcp_checkpoint": test_pp_dcp_checkpoint,
+    "pp_dcp_with_optim": test_pp_dcp_with_optim,
+    "pp_forward_match": test_pp_forward_match,
 }
+
+# PP tests that require pp_size argument
+PP_TESTS = {"pp_dcp_checkpoint", "pp_dcp_with_optim", "pp_forward_match"}
 
 
 def main():
@@ -607,8 +1244,14 @@ def main():
     parser.add_argument(
         "--model_path",
         type=str,
-        required=True,
-        help="Path to HF model checkpoint",
+        default=None,
+        help="Path to HF model checkpoint (required for non-PP tests)",
+    )
+    parser.add_argument(
+        "--pp_size",
+        type=int,
+        default=2,
+        help="Pipeline parallel size (for PP checkpoint tests)",
     )
     parser.add_argument(
         "--output",
@@ -628,7 +1271,17 @@ def main():
 
     try:
         test_fn = TEST_REGISTRY[args.test_type]
-        success = test_fn(args.model_path, args.output)
+
+        # PP tests use pp_size argument, non-PP tests use model_path
+        if args.test_type in PP_TESTS:
+            success = test_fn(args.pp_size, args.output)
+        else:
+            if args.model_path is None:
+                print_rank0(f"ERROR: --model_path is required for {args.test_type}")
+                if rank == 0 and args.output:
+                    write_result(args.output, False)
+                return
+            success = test_fn(args.model_path, args.output)
 
         dist.barrier()
 

--- a/areal/tests/experimental/archon/torchrun/run_ep_tests.py
+++ b/areal/tests/experimental/archon/torchrun/run_ep_tests.py
@@ -30,10 +30,10 @@ import torch
 import torch.distributed as dist
 
 from areal.experimental.models.archon import ArchonParallelDims
-from areal.experimental.models.archon.qwen3.infra.parallelize import parallelize_qwen3
-from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
-from areal.experimental.models.archon.qwen3.model.state_dict_adapter import (
+from areal.experimental.models.archon.qwen3 import (
+    Qwen3Model,
     Qwen3StateDictAdapter,
+    parallelize_qwen3,
 )
 from areal.experimental.models.archon.ulysses import (
     ulysses_gather_output,

--- a/areal/tests/experimental/archon/torchrun/run_pp_combinations.py
+++ b/areal/tests/experimental/archon/torchrun/run_pp_combinations.py
@@ -1,0 +1,688 @@
+"""Test script for Pipeline Parallelism combined with TP, DP, or EP.
+
+This test verifies that PP works correctly when combined with other parallelism
+dimensions.
+
+Run with:
+    torchrun --nproc_per_node=4 areal/tests/experimental/archon/torchrun/run_pp_combinations.py \
+        --test_type=pp_tp --output=/tmp/result.txt
+
+    torchrun --nproc_per_node=4 areal/tests/experimental/archon/torchrun/run_pp_combinations.py \
+        --test_type=pp_dp --output=/tmp/result.txt
+
+    torchrun --nproc_per_node=4 areal/tests/experimental/archon/torchrun/run_pp_combinations.py \
+        --test_type=pp_ep --output=/tmp/result.txt
+"""
+
+import argparse
+
+import torch
+import torch.distributed as dist
+
+from areal.experimental.models.archon import ArchonParallelDims
+from areal.experimental.models.archon.pipeline_parallel import (
+    generate_llm_fqn_per_model_part,
+    pipeline_llm,
+    pipeline_module_split,
+)
+from areal.experimental.models.archon.qwen3 import Qwen3Model, parallelize_qwen3
+from areal.tests.experimental.archon.torchrun.dist_utils import (
+    create_dense_model_args,
+    create_golden_model,
+    create_moe_model_args,
+    create_test_input,
+    print_rank0,
+    verify_outputs_match,
+    write_result,
+)
+
+
+def test_pp_tp_forward(out_file: str | None = None) -> bool:
+    """Test PP+TP combination forward pass.
+
+    Configuration: 4 GPU with pp=2, tp=2, dp_shard=1
+    Mesh layout: [pp=2, dp_shard=1, cp=1, tp=2]
+
+    This test verifies:
+    1. PP and TP meshes are correctly configured
+    2. Forward pass produces correct output (matches golden model)
+
+    Args:
+        out_file: Optional file to write result
+
+    Returns:
+        True if test passed, False otherwise
+    """
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0("PP+TP Forward Test: pp=2, tp=2")
+    print_rank0("=" * 60)
+
+    assert world_size == 4, f"This test requires 4 GPUs, got {world_size}"
+
+    # Create model args
+    n_layers = 4  # 2 stages * 2 layers per stage
+    model_args = create_dense_model_args(
+        n_layers=n_layers,
+        dim=64,
+        hidden_dim=128,
+        n_heads=4,  # Must be divisible by tp=2
+        n_kv_heads=2,  # Must be divisible by tp=2
+        head_dim=16,
+        vocab_size=1000,
+    )
+
+    # Create golden model
+    seed = 42
+    golden_model = create_golden_model(model_args, device, seed=seed)
+    golden_model.eval()
+
+    # Create PP+TP parallel dims
+    parallel_dims = ArchonParallelDims(
+        pp=2,
+        dp_shard=1,
+        tp=2,
+        cp=1,
+        world_size=world_size,
+        device_type="cuda",
+    )
+
+    print_rank0(f"  PP enabled: {parallel_dims.pp_enabled}")
+    print_rank0(f"  TP enabled: {parallel_dims.tp_enabled}")
+    print_rank0(f"  PP degree: {parallel_dims.pp}")
+    print_rank0(f"  TP degree: {parallel_dims.tp}")
+
+    # Verify mesh configuration
+    pp_mesh = parallel_dims.get_mesh("pp")
+    tp_mesh = parallel_dims.get_mesh("tp")
+
+    if pp_mesh is None:
+        print_rank0("  FAILED: PP mesh is None")
+        return False
+    if tp_mesh is None:
+        print_rank0("  FAILED: TP mesh is None")
+        return False
+
+    print_rank0(f"  PP mesh size: {pp_mesh.size()}")
+    print_rank0(f"  TP mesh size: {tp_mesh.size()}")
+
+    # Create PP model on meta device for efficient splitting
+    with torch.device("meta"):
+        model = Qwen3Model(model_args)
+
+    # Use pipeline_module_split
+    module_names_per_stage = generate_llm_fqn_per_model_part(
+        num_stages=2,
+        num_layers=n_layers,
+    )
+    print_rank0(f"  Module names per stage: {module_names_per_stage}")
+
+    pp_stages, model_parts = pipeline_module_split(
+        whole_model=model,
+        pp_mesh=pp_mesh,
+        device=device,
+        module_names_per_stage=module_names_per_stage,
+    )
+
+    # Materialize weights from golden model
+    golden_state = golden_model.state_dict()
+    for part in model_parts:
+        part.to_empty(device=device)
+        part.init_buffers(buffer_device=device)
+        part_state = part.state_dict()
+        for key in part_state:
+            if key in golden_state:
+                part_state[key].copy_(golden_state[key])
+        part.load_state_dict(part_state)
+
+    # Determine first/last stage
+    has_first = any(s.is_first for s in pp_stages)
+    has_last = any(s.is_last for s in pp_stages)
+
+    for part in model_parts:
+        part.eval()
+
+    # Get PP rank (which stage this rank belongs to)
+    pp_rank = pp_mesh.get_local_rank()
+    tp_rank = tp_mesh.get_local_rank()
+    print(
+        f"  Rank {rank}: pp_rank={pp_rank}, tp_rank={tp_rank}, "
+        f"has_first={has_first}, has_last={has_last}"
+    )
+
+    # Get PP group for broadcast
+    pp_group = parallel_dims.get_group("pp")
+    pp_group_ranks = dist.get_process_group_ranks(pp_group)
+    first_stage_rank = pp_group_ranks[0]
+
+    # Create test input (same for all ranks)
+    if rank == 0:
+        tokens, positions, cu_seqlens, max_seqlen = create_test_input(
+            num_seqs=2,
+            seq_len_per_seq=8,
+            vocab_size=model_args.vocab_size,
+            device=device,
+            seed=123,
+        )
+        input_data = [tokens, positions, cu_seqlens, max_seqlen]
+    else:
+        input_data = [None, None, None, None]
+
+    dist.broadcast_object_list(input_data, src=0)
+    tokens, positions, cu_seqlens, max_seqlen = input_data
+    tokens = tokens.to(device)
+    positions = positions.to(device)
+    cu_seqlens = cu_seqlens.to(device)
+
+    # Run golden model forward
+    with torch.no_grad():
+        golden_output = golden_model(tokens, positions, cu_seqlens, max_seqlen)
+
+    print_rank0(f"  Golden output shape: {golden_output.shape}")
+
+    # Run PP forward using dist.broadcast with PP group
+    success = True
+
+    with torch.no_grad():
+        # First stage forward
+        if has_first:
+            h = model_parts[0](tokens, positions, cu_seqlens, max_seqlen)
+        else:
+            h = torch.zeros(
+                (1, tokens.shape[1], model_args.dim),
+                dtype=torch.float32,
+                device=device,
+            )
+
+        # Synchronize and broadcast within PP group
+        torch.cuda.synchronize()
+        dist.barrier()
+        # Use dist.broadcast with group parameter for PP+TP/DP scenarios
+        dist.broadcast(h, src=first_stage_rank, group=pp_group)
+
+        # Last stage forward
+        if has_last and not has_first:
+            pp_output = model_parts[0](h, positions, cu_seqlens, max_seqlen)
+        elif has_last:
+            pp_output = h
+        else:
+            pp_output = None
+
+    # Synchronize after forward
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    # Verify output on last stage
+    if has_last:
+        match, max_diff, mean_diff = verify_outputs_match(
+            pp_output, golden_output, rtol=1e-3, atol=1e-3, max_diff_threshold=1e-1
+        )
+        print(f"  Rank {rank}: max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}")
+        success = match
+
+    # Gather results
+    success_tensor = torch.tensor([1 if success else 0], dtype=torch.int, device=device)
+    all_success = [torch.zeros_like(success_tensor) for _ in range(world_size)]
+    dist.all_gather(all_success, success_tensor)
+
+    # Check all last-stage ranks passed
+    final_success = all(t.item() == 1 for t in all_success)
+
+    dist.barrier()
+
+    if final_success:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP+TP Forward Test: PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP+TP Forward Test: FAILED")
+        print_rank0("=" * 60)
+
+    if rank == 0 and out_file:
+        write_result(out_file, final_success)
+
+    return final_success
+
+
+def test_pp_dp_forward(out_file: str | None = None) -> bool:
+    """Test PP+DP combination forward pass.
+
+    Configuration: 4 GPU with pp=2, dp_shard=2, tp=1
+    Mesh layout: [pp=2, dp_shard=2, cp=1, tp=1]
+
+    This test verifies:
+    1. PP and DP meshes are correctly configured
+    2. Forward pass produces correct output across DP replicas
+
+    Args:
+        out_file: Optional file to write result
+
+    Returns:
+        True if test passed, False otherwise
+    """
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0("PP+DP Forward Test: pp=2, dp_shard=2")
+    print_rank0("=" * 60)
+
+    assert world_size == 4, f"This test requires 4 GPUs, got {world_size}"
+
+    # Create model args
+    n_layers = 4
+    model_args = create_dense_model_args(
+        n_layers=n_layers,
+        dim=64,
+        hidden_dim=128,
+        n_heads=4,
+        n_kv_heads=2,
+        head_dim=16,
+        vocab_size=1000,
+    )
+
+    # Create golden model
+    seed = 42
+    golden_model = create_golden_model(model_args, device, seed=seed)
+    golden_model.eval()
+
+    # Create PP+DP parallel dims
+    parallel_dims = ArchonParallelDims(
+        pp=2,
+        dp_shard=2,
+        tp=1,
+        cp=1,
+        world_size=world_size,
+        device_type="cuda",
+    )
+
+    print_rank0(f"  PP enabled: {parallel_dims.pp_enabled}")
+    print_rank0(f"  DP shard: {parallel_dims.dp_shard}")
+    print_rank0(f"  PP degree: {parallel_dims.pp}")
+
+    # Verify mesh configuration
+    pp_mesh = parallel_dims.get_mesh("pp")
+    dp_mesh = parallel_dims.get_mesh("dp_shard")
+
+    if pp_mesh is None:
+        print_rank0("  FAILED: PP mesh is None")
+        return False
+    if dp_mesh is None:
+        print_rank0("  FAILED: DP mesh is None")
+        return False
+
+    print_rank0(f"  PP mesh size: {pp_mesh.size()}")
+    print_rank0(f"  DP mesh size: {dp_mesh.size()}")
+
+    # Create PP model on meta device for efficient splitting
+    with torch.device("meta"):
+        model = Qwen3Model(model_args)
+
+    # Use pipeline_module_split
+    module_names_per_stage = generate_llm_fqn_per_model_part(
+        num_stages=2,
+        num_layers=n_layers,
+    )
+    print_rank0(f"  Module names per stage: {module_names_per_stage}")
+
+    pp_stages, model_parts = pipeline_module_split(
+        whole_model=model,
+        pp_mesh=pp_mesh,
+        device=device,
+        module_names_per_stage=module_names_per_stage,
+    )
+
+    # Materialize weights from golden model
+    golden_state = golden_model.state_dict()
+    for part in model_parts:
+        part.to_empty(device=device)
+        part.init_buffers(buffer_device=device)
+        part_state = part.state_dict()
+        for key in part_state:
+            if key in golden_state:
+                part_state[key].copy_(golden_state[key])
+        part.load_state_dict(part_state)
+
+    # Determine first/last stage
+    has_first = any(s.is_first for s in pp_stages)
+    has_last = any(s.is_last for s in pp_stages)
+
+    for part in model_parts:
+        part.eval()
+
+    pp_rank = pp_mesh.get_local_rank()
+    dp_rank = dp_mesh.get_local_rank()
+    print(
+        f"  Rank {rank}: pp_rank={pp_rank}, dp_rank={dp_rank}, "
+        f"has_first={has_first}, has_last={has_last}"
+    )
+
+    # Get PP group for broadcast
+    pp_group = parallel_dims.get_group("pp")
+    pp_group_ranks = dist.get_process_group_ranks(pp_group)
+    first_stage_rank = pp_group_ranks[0]
+
+    # Create test input (same for all ranks, each DP replica processes same data)
+    if rank == 0:
+        tokens, positions, cu_seqlens, max_seqlen = create_test_input(
+            num_seqs=2,
+            seq_len_per_seq=8,
+            vocab_size=model_args.vocab_size,
+            device=device,
+            seed=123,
+        )
+        input_data = [tokens, positions, cu_seqlens, max_seqlen]
+    else:
+        input_data = [None, None, None, None]
+
+    dist.broadcast_object_list(input_data, src=0)
+    tokens, positions, cu_seqlens, max_seqlen = input_data
+    tokens = tokens.to(device)
+    positions = positions.to(device)
+    cu_seqlens = cu_seqlens.to(device)
+
+    # Run golden model forward
+    with torch.no_grad():
+        golden_output = golden_model(tokens, positions, cu_seqlens, max_seqlen)
+
+    print_rank0(f"  Golden output shape: {golden_output.shape}")
+
+    # Run PP forward using dist.broadcast with PP group
+    success = True
+
+    with torch.no_grad():
+        # First stage forward
+        if has_first:
+            h = model_parts[0](tokens, positions, cu_seqlens, max_seqlen)
+        else:
+            h = torch.zeros(
+                (1, tokens.shape[1], model_args.dim),
+                dtype=torch.float32,
+                device=device,
+            )
+
+        # Synchronize and broadcast within PP group
+        torch.cuda.synchronize()
+        dist.barrier()
+        # Use dist.broadcast with group parameter for PP+TP/DP scenarios
+        dist.broadcast(h, src=first_stage_rank, group=pp_group)
+
+        # Last stage forward
+        if has_last and not has_first:
+            pp_output = model_parts[0](h, positions, cu_seqlens, max_seqlen)
+        elif has_last:
+            pp_output = h
+        else:
+            pp_output = None
+
+    # Synchronize after forward
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    # Verify output on last stage
+    if has_last:
+        match, max_diff, mean_diff = verify_outputs_match(
+            pp_output, golden_output, rtol=1e-3, atol=1e-3, max_diff_threshold=1e-1
+        )
+        print(f"  Rank {rank}: max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}")
+        success = match
+
+    # Gather results
+    success_tensor = torch.tensor([1 if success else 0], dtype=torch.int, device=device)
+    all_success = [torch.zeros_like(success_tensor) for _ in range(world_size)]
+    dist.all_gather(all_success, success_tensor)
+
+    final_success = all(t.item() == 1 for t in all_success)
+
+    dist.barrier()
+
+    if final_success:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP+DP Forward Test: PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP+DP Forward Test: FAILED")
+        print_rank0("=" * 60)
+
+    if rank == 0 and out_file:
+        write_result(out_file, final_success)
+
+    return final_success
+
+
+def test_pp_ep_forward(out_file: str | None = None) -> bool:
+    """Test PP+EP combination forward pass with MoE model.
+
+    Configuration: 4 GPU with pp=2, ep=2, dp_shard=1, tp=1
+    Mesh layout: [pp=2, dp_shard=1, cp=1, tp=1] with ep=2
+
+    This test verifies:
+    1. PP and EP meshes are correctly configured
+    2. Forward pass with MoE model produces valid output (no NaN/Inf)
+
+    Note: PP+EP uses a MoE model since EP requires expert parallelism.
+
+    Args:
+        out_file: Optional file to write result
+
+    Returns:
+        True if test passed, False otherwise
+    """
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0("PP+EP Forward Test: pp=2, ep=2 (MoE model)")
+    print_rank0("=" * 60)
+
+    assert world_size == 4, f"This test requires 4 GPUs, got {world_size}"
+
+    # Create MoE model args for PP+EP
+    # PP=2 requires n_layers divisible by 2
+    # EP=2 requires num_experts divisible by 2
+    n_layers = 4  # 2 stages * 2 layers per stage
+    num_experts = 4  # Must be divisible by ep=2
+    model_args = create_moe_model_args(
+        num_experts=num_experts,
+        n_layers=n_layers,
+        dim=64,
+        hidden_dim=128,
+        moe_inter_dim=128,
+        n_heads=4,
+        n_kv_heads=2,
+        head_dim=16,
+        vocab_size=1000,
+        top_k=2,
+    )
+
+    # Create PP+EP parallel dims
+    # For pp=2, ep=2 with world_size=4:
+    # - PP splits world into 2 pipeline stages (ranks 0,2 and 1,3 for example)
+    # - EP splits experts across dp_shard dimension
+    parallel_dims = ArchonParallelDims(
+        pp=2,
+        dp_shard=2,  # dp_shard is used for EP in AReaL
+        tp=1,
+        cp=1,
+        ep=2,  # Expert parallelism degree
+        world_size=world_size,
+        device_type="cuda",
+    )
+
+    print_rank0(f"  PP enabled: {parallel_dims.pp_enabled}")
+    print_rank0(f"  EP enabled: {parallel_dims.ep_enabled}")
+    print_rank0(f"  PP degree: {parallel_dims.pp}")
+    print_rank0(f"  EP degree: {parallel_dims.ep}")
+
+    # Verify mesh configuration
+    pp_mesh = parallel_dims.get_mesh("pp")
+    ep_mesh = parallel_dims.get_mesh("dp_shard_cp")  # EP uses dp_shard_cp mesh
+
+    if pp_mesh is None:
+        print_rank0("  FAILED: PP mesh is None")
+        return False
+
+    print_rank0(f"  PP mesh size: {pp_mesh.size()}")
+    if ep_mesh is not None:
+        print_rank0(f"  EP mesh size: {ep_mesh.size()}")
+
+    # Create MoE model on meta device for efficient pipeline splitting
+    with torch.device("meta"):
+        model = Qwen3Model(model_args)
+
+    # Use pipeline_llm to split model across PP stages with parallelization
+    try:
+        pp_stages, model_parts, has_first, has_last = pipeline_llm(
+            model=model,
+            parallel_dims=parallel_dims,
+            device=device,
+            parallelize_fn=parallelize_qwen3,
+            enable_compile=False,  # Disable compile for faster test
+        )
+    except Exception as e:
+        print_rank0(f"  FAILED: pipeline_llm error: {e}")
+        import traceback
+
+        traceback.print_exc()
+        if rank == 0 and out_file:
+            write_result(out_file, False)
+        return False
+
+    # Materialize weights from meta device
+    for part in model_parts:
+        part.to_empty(device=device)
+        with torch.no_grad():
+            part.init_weights()
+        part.init_buffers(buffer_device=device)
+
+    for part in model_parts:
+        part.eval()
+
+    pp_rank = pp_mesh.get_local_rank()
+    print(
+        f"  Rank {rank}: pp_rank={pp_rank}, has_first={has_first}, has_last={has_last}"
+    )
+
+    # Create test input (same for all ranks)
+    if rank == 0:
+        tokens, positions, cu_seqlens, max_seqlen = create_test_input(
+            num_seqs=2,
+            seq_len_per_seq=8,
+            vocab_size=model_args.vocab_size,
+            device=device,
+            seed=123,
+        )
+        input_data = [tokens, positions, cu_seqlens, max_seqlen]
+    else:
+        input_data = [None, None, None, None]
+
+    dist.broadcast_object_list(input_data, src=0)
+    tokens, positions, cu_seqlens, max_seqlen = input_data
+    tokens = tokens.to(device)
+    positions = positions.to(device)
+    cu_seqlens = cu_seqlens.to(device)
+
+    print_rank0(f"  Input tokens shape: {tokens.shape}")
+
+    # Run PP+EP forward
+    # For PP+EP, we use the schedule-based forward from pipeline_llm
+    # which handles activation passing between stages
+    success = True
+
+    try:
+        with torch.no_grad():
+            # Simple forward through local model parts
+            # pipeline_llm returns model_parts that can be called directly
+            if has_first:
+                h = model_parts[0](tokens, positions, cu_seqlens, max_seqlen)
+                print(f"  Rank {rank}: first stage output shape = {h.shape}")
+
+                # Check for NaN/Inf
+                if torch.isnan(h).any() or torch.isinf(h).any():
+                    print_rank0("  FAILED: First stage output contains NaN/Inf")
+                    success = False
+
+        torch.cuda.synchronize()
+        dist.barrier()
+
+        # For PP+EP test, we mainly verify:
+        # 1. Model can be created and parallelized without error
+        # 2. Forward pass produces valid output (no NaN/Inf)
+        # Full PP forward with activation passing is tested in PP-only tests
+
+    except Exception as e:
+        print_rank0(f"  FAILED: Forward error: {e}")
+        import traceback
+
+        traceback.print_exc()
+        success = False
+
+    # Gather results from all ranks
+    success_tensor = torch.tensor([1 if success else 0], dtype=torch.int, device=device)
+    all_success = [torch.zeros_like(success_tensor) for _ in range(world_size)]
+    dist.all_gather(all_success, success_tensor)
+
+    final_success = all(t.item() == 1 for t in all_success)
+
+    dist.barrier()
+
+    if final_success:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP+EP Forward Test: PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP+EP Forward Test: FAILED")
+        print_rank0("=" * 60)
+
+    if rank == 0 and out_file:
+        write_result(out_file, final_success)
+
+    return final_success
+
+
+TEST_REGISTRY = {
+    "pp_tp": test_pp_tp_forward,
+    "pp_dp": test_pp_dp_forward,
+    "pp_ep": test_pp_ep_forward,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PP Combination Tests")
+    parser.add_argument(
+        "--test_type",
+        type=str,
+        required=True,
+        choices=list(TEST_REGISTRY.keys()),
+        help="Type of test to run (pp_tp, pp_dp, or pp_ep)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output file for test result",
+    )
+    args = parser.parse_args()
+
+    dist.init_process_group(backend="nccl")
+
+    try:
+        test_fn = TEST_REGISTRY[args.test_type]
+        test_fn(args.output)
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/areal/tests/experimental/archon/torchrun/run_pp_gradient_verify.py
+++ b/areal/tests/experimental/archon/torchrun/run_pp_gradient_verify.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""PP vs non-PP gradient verification test.
+
+This test verifies that the step() API produces identical gradients
+to manual forward/backward passes without pipeline parallelism.
+
+Usage:
+    torchrun --nproc-per-node=2 run_pp_gradient_verify.py --output=/tmp/result.txt
+    torchrun --nproc-per-node=2 run_pp_gradient_verify.py  # standalone debug
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.pipelining import PipelineStage
+from torch.distributed.pipelining.schedules import Schedule1F1B
+
+from areal.tests.experimental.archon.torchrun.dist_utils import (
+    print_rank0,
+    write_result,
+)
+
+# Config
+VOCAB_SIZE = 1000
+HIDDEN_SIZE = 256
+N_LAYERS_PER_STAGE = 2
+SEED = 42
+
+
+class SimpleBlock(nn.Module):
+    """A simple transformer-like block."""
+
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.norm = nn.LayerNorm(hidden_size)
+        self.linear1 = nn.Linear(hidden_size, hidden_size * 4)
+        self.linear2 = nn.Linear(hidden_size * 4, hidden_size)
+        self.act = nn.GELU()
+
+    def forward(self, x):
+        h = self.norm(x)
+        h = self.linear1(h)
+        h = self.act(h)
+        h = self.linear2(h)
+        return x + h
+
+
+class FirstStageModel(nn.Module):
+    """First stage: embedding + first half of layers.
+
+    Simulates Archon model with packed sequence inputs.
+    """
+
+    def __init__(self, vocab_size: int, hidden_size: int, n_layers: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, hidden_size)
+        self.layers = nn.ModuleList([SimpleBlock(hidden_size) for _ in range(n_layers)])
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int | torch.Tensor,
+    ) -> torch.Tensor:
+        """Forward pass.
+
+        Args:
+            input_ids: [1, seq_len] or [seq_len] token ids
+            positions: [1, seq_len] or [seq_len] position ids
+            cu_seqlens: [1, B+1] or [B+1] cumulative sequence lengths
+            max_seqlen: int or [1] tensor, max sequence length
+
+        Returns:
+            hidden states [1, seq_len, hidden_size]
+        """
+        # Note: positions/cu_seqlens/max_seqlen are accepted to match Archon's
+        # interface but not used in this simplified test model (no flash attention)
+        h = self.embed(input_ids)
+        for layer in self.layers:
+            h = layer(h)
+        return h
+
+
+class LastStageModel(nn.Module):
+    """Last stage: second half of layers + norm + output.
+
+    Like Archon, this model also requires positions/cu_seqlens/max_seqlen
+    for attention computation in its layers.
+    """
+
+    def __init__(self, vocab_size: int, hidden_size: int, n_layers: int):
+        super().__init__()
+        self.layers = nn.ModuleList([SimpleBlock(hidden_size) for _ in range(n_layers)])
+        self.norm = nn.LayerNorm(hidden_size)
+        self.output = nn.Linear(hidden_size, vocab_size)
+
+    def forward(
+        self,
+        h: torch.Tensor,
+        positions: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int | torch.Tensor,
+    ) -> torch.Tensor:
+        """Forward pass.
+
+        Args:
+            h: hidden states from previous stage [1, seq_len, hidden_size]
+            positions: [1, seq_len] position ids (for attention in layers)
+            cu_seqlens: [1, B+1] cumulative sequence lengths
+            max_seqlen: int or [1] tensor, max sequence length
+
+        Returns:
+            logits [1, seq_len, vocab_size]
+        """
+        # Note: positions/cu_seqlens/max_seqlen are accepted to match Archon's
+        # interface but not used in this simplified test model (no flash attention)
+        for layer in self.layers:
+            h = layer(h)
+        h = self.norm(h)
+        logits = self.output(h)
+        return logits
+
+
+class FullModel(nn.Module):
+    """Full model combining first and last stage (for non-PP and gradient verification)."""
+
+    def __init__(self, vocab_size: int, hidden_size: int, n_layers_per_stage: int):
+        super().__init__()
+        self.first = FirstStageModel(vocab_size, hidden_size, n_layers_per_stage)
+        self.last = LastStageModel(vocab_size, hidden_size, n_layers_per_stage)
+
+    def forward(self, input_ids, positions, cu_seqlens, max_seqlen):
+        h = self.first(input_ids, positions, cu_seqlens, max_seqlen)
+        return self.last(h, positions, cu_seqlens, max_seqlen)
+
+
+def generate_fixed_data(
+    seq_len: int,
+    vocab_size: int,
+    device: torch.device,
+    seed: int,
+    n_microbatches: int = 2,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Generate fixed data for gradient verification (deterministic).
+
+    Returns batched data for n_microbatches:
+        input_ids: [n_mb, seq_len]
+        positions: [n_mb, seq_len]
+        cu_seqlens: [n_mb, max_cu_len] (padded)
+        max_seqlen: [n_mb] CPU tensor
+        labels: [n_mb, seq_len]
+    """
+    torch.manual_seed(seed)
+
+    input_ids_list = []
+    positions_list = []
+    cu_seqlens_list = []
+    max_seqlen_list = []
+    labels_list = []
+
+    for mb_idx in range(n_microbatches):
+        # Different split for each microbatch
+        n_seqs = 2 + mb_idx  # mb0: 2 seqs, mb1: 3 seqs
+        seg_len = seq_len // n_seqs
+        seq_lens = [seg_len] * (n_seqs - 1) + [seq_len - seg_len * (n_seqs - 1)]
+
+        # cu_seqlens
+        cu_seqlens = [0]
+        for sl in seq_lens:
+            cu_seqlens.append(cu_seqlens[-1] + sl)
+        cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+        # max_seqlen
+        max_seqlen = max(seq_lens)
+
+        # positions
+        positions = []
+        for sl in seq_lens:
+            positions.extend(range(sl))
+        positions = torch.tensor(positions, dtype=torch.long, device=device)
+
+        # input_ids and labels (deterministic)
+        input_ids = torch.randint(0, vocab_size, (seq_len,), device=device)
+        labels = torch.randint(0, vocab_size, (seq_len,), device=device)
+
+        input_ids_list.append(input_ids.unsqueeze(0))
+        positions_list.append(positions.unsqueeze(0))
+        cu_seqlens_list.append(cu_seqlens.unsqueeze(0))
+        max_seqlen_list.append(max_seqlen)
+        labels_list.append(labels.unsqueeze(0))
+
+    # Pad cu_seqlens to same length
+    max_cu_len = max(cs.shape[1] for cs in cu_seqlens_list)
+    padded_cu_seqlens = []
+    for cs in cu_seqlens_list:
+        if cs.shape[1] < max_cu_len:
+            pad_val = cs[0, -1]
+            padding = pad_val.expand(1, max_cu_len - cs.shape[1])
+            cs = torch.cat([cs, padding], dim=1)
+        padded_cu_seqlens.append(cs)
+
+    batched_input_ids = torch.cat(input_ids_list, dim=0)
+    batched_positions = torch.cat(positions_list, dim=0)
+    batched_cu_seqlens = torch.cat(padded_cu_seqlens, dim=0)
+    batched_max_seqlen = torch.tensor(max_seqlen_list)  # CPU
+    batched_labels = torch.cat(labels_list, dim=0)
+
+    return (
+        batched_input_ids,
+        batched_positions,
+        batched_cu_seqlens,
+        batched_max_seqlen,
+        batched_labels,
+    )
+
+
+def run_non_pp_forward_backward(
+    model: FullModel,
+    batched_input_ids: torch.Tensor,
+    batched_positions: torch.Tensor,
+    batched_cu_seqlens: torch.Tensor,
+    batched_max_seqlen: torch.Tensor,
+    batched_labels: torch.Tensor,
+    vocab_size: int,
+) -> tuple[dict[str, torch.Tensor], float]:
+    """Run non-PP forward/backward on multiple microbatches and return accumulated gradients."""
+    model.zero_grad()
+
+    n_microbatches = batched_input_ids.shape[0]
+    total_loss = 0.0
+
+    for i in range(n_microbatches):
+        input_ids = batched_input_ids[i : i + 1]  # [1, seq_len]
+        positions = batched_positions[i : i + 1]  # [1, seq_len]
+        cu_seqlens = batched_cu_seqlens[i]  # [cu_len] - squeeze batch dim
+        max_seqlen = batched_max_seqlen[i].item()
+        labels = batched_labels[i : i + 1]  # [1, seq_len]
+
+        logits = model(input_ids, positions, cu_seqlens, max_seqlen)
+        loss = nn.functional.cross_entropy(
+            logits.view(-1, vocab_size),
+            labels.view(-1),
+        )
+        # Accumulate gradients (don't zero between microbatches)
+        loss.backward()
+        total_loss += loss.item()
+
+    # Collect gradients
+    grads = {}
+    for name, p in model.named_parameters():
+        if p.grad is not None:
+            grads[name] = p.grad.clone()
+
+    return grads, total_loss
+
+
+def compare_gradients(
+    pp_grads: dict[str, torch.Tensor],
+    non_pp_grads: dict[str, torch.Tensor],
+    prefix: str,
+    atol: float,
+) -> tuple[bool, list[str]]:
+    """Compare PP gradients against non-PP gradients.
+
+    Args:
+        pp_grads: Gradients from PP model (keys without prefix)
+        non_pp_grads: Gradients from non-PP full model (keys with prefix)
+        prefix: Prefix to add to pp_grads keys for matching (e.g., "first." or "last.")
+        atol: Absolute tolerance for comparison
+
+    Returns:
+        Tuple of (all_match, error_messages)
+    """
+    errors = []
+    all_match = True
+
+    for name in pp_grads:
+        non_pp_name = f"{prefix}{name}"
+        if non_pp_name not in non_pp_grads:
+            errors.append(f"{name}: not found in non-PP grads as {non_pp_name}")
+            all_match = False
+            continue
+
+        pp_g = pp_grads[name]
+        non_pp_g = non_pp_grads[non_pp_name]
+
+        abs_diff = (pp_g - non_pp_g).abs()
+        max_diff = abs_diff.max().item()
+        mean_diff = abs_diff.mean().item()
+        rel_diff = (abs_diff / (non_pp_g.abs() + 1e-8)).max().item()
+
+        if max_diff >= atol:
+            errors.append(
+                f"{name}: max_diff={max_diff:.2e}, mean_diff={mean_diff:.2e}, "
+                f"rel_diff={rel_diff:.2e} (exceeds atol={atol})"
+            )
+            all_match = False
+
+    return all_match, errors
+
+
+def verify_gradients(
+    n_microbatches: int = 2,
+    seq_len: int = 64,
+    atol: float = 1e-5,
+) -> bool:
+    """Verify PP gradients match non-PP gradients.
+
+    Args:
+        n_microbatches: Number of microbatches to use
+        seq_len: Sequence length for test data
+        atol: Absolute tolerance for gradient comparison
+
+    Returns:
+        True if all gradients match within tolerance.
+    """
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+
+    assert world_size == 2, "Gradient verification requires exactly 2 GPUs"
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0("PP Gradient Verification Test")
+    print_rank0(f"  n_microbatches={n_microbatches}, seq_len={seq_len}, atol={atol}")
+    print_rank0("=" * 60)
+
+    # 1. Create full model on rank 0, compute non-PP gradients
+    torch.manual_seed(SEED)
+    full_model = FullModel(VOCAB_SIZE, HIDDEN_SIZE, N_LAYERS_PER_STAGE).to(device)
+
+    # Generate fixed data (n_microbatches samples)
+    (
+        batched_input_ids,
+        batched_positions,
+        batched_cu_seqlens,
+        batched_max_seqlen,
+        batched_labels,
+    ) = generate_fixed_data(seq_len, VOCAB_SIZE, device, SEED + 100, n_microbatches)
+
+    print_rank0(
+        f"  Data shapes: input_ids={batched_input_ids.shape}, "
+        f"cu_seqlens={batched_cu_seqlens.shape}, max_seqlen={batched_max_seqlen.shape}"
+    )
+
+    # Compute non-PP gradients (only rank 0, but both ranks need the model for state_dict)
+    non_pp_grads: dict[str, torch.Tensor] = {}
+    if rank == 0:
+        non_pp_grads, non_pp_loss = run_non_pp_forward_backward(
+            full_model,
+            batched_input_ids,
+            batched_positions,
+            batched_cu_seqlens,
+            batched_max_seqlen,
+            batched_labels,
+            VOCAB_SIZE,
+        )
+        print_rank0(f"  Non-PP loss: {non_pp_loss:.6f}")
+
+    dist.barrier()
+
+    # 2. Create PP stages with same initialization
+    torch.manual_seed(SEED)  # Reset seed for same initialization
+    if rank == 0:
+        pp_model = FirstStageModel(VOCAB_SIZE, HIDDEN_SIZE, N_LAYERS_PER_STAGE).to(
+            device
+        )
+        # Copy weights from full_model.first
+        pp_model.load_state_dict(full_model.first.state_dict())
+    else:
+        pp_model = LastStageModel(VOCAB_SIZE, HIDDEN_SIZE, N_LAYERS_PER_STAGE).to(
+            device
+        )
+        # Copy weights from full_model.last (need to broadcast from rank 0)
+
+    # Broadcast last stage weights from rank 0
+    if rank == 0:
+        last_state = full_model.last.state_dict()
+        for key in last_state:
+            dist.broadcast(last_state[key], src=0)
+    else:
+        # Receive weights
+        last_state = pp_model.state_dict()
+        for key in last_state:
+            dist.broadcast(last_state[key], src=0)
+        pp_model.load_state_dict(last_state)
+
+    pp_model.train()
+
+    # Create PP stages
+    pp_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("pp",))
+    pp_group = pp_mesh.get_group("pp")
+
+    if rank == 0:
+        stage = PipelineStage(
+            pp_model, stage_index=0, num_stages=2, device=device, group=pp_group
+        )
+    else:
+        stage = PipelineStage(
+            pp_model, stage_index=1, num_stages=2, device=device, group=pp_group
+        )
+
+    # 3. Run PP forward/backward with n_microbatches
+    def loss_fn(logits, labels):
+        logits = logits.view(-1, VOCAB_SIZE)
+        labels = labels.view(-1)
+        return nn.functional.cross_entropy(logits, labels)
+
+    pp_model.zero_grad()
+
+    # Data is already batched with shape [n_microbatches, ...]
+    # scale_grads=False to match non-PP gradient accumulation behavior
+    schedule = Schedule1F1B(
+        stage,
+        n_microbatches=n_microbatches,
+        loss_fn=loss_fn,
+        scale_grads=False,
+    )
+
+    losses: list = []
+    if rank == 0:
+        schedule.step(
+            batched_input_ids,
+            positions=batched_positions,
+            cu_seqlens=batched_cu_seqlens,
+            max_seqlen=batched_max_seqlen,
+            losses=losses,
+        )
+    else:
+        schedule.step(
+            target=batched_labels,
+            losses=losses,
+            positions=batched_positions,
+            cu_seqlens=batched_cu_seqlens,
+            max_seqlen=batched_max_seqlen,
+        )
+
+    # Collect PP gradients
+    pp_grads = {}
+    for name, p in pp_model.named_parameters():
+        if p.grad is not None:
+            pp_grads[name] = p.grad.clone()
+
+    if rank == 1 and losses:
+        pp_loss = sum(loss.item() for loss in losses) / len(losses)
+        print(f"  [Rank 1] PP loss: {pp_loss:.6f}")
+
+    # 4. Compare gradients
+    # Rank 0 compares first stage gradients
+    first_stage_success = True
+    first_stage_errors: list[str] = []
+    if rank == 0:
+        first_stage_success, first_stage_errors = compare_gradients(
+            pp_grads, non_pp_grads, "first.", atol
+        )
+        print_rank0("\n  First Stage Gradient Comparison:")
+        if first_stage_success:
+            print_rank0(f"    All {len(pp_grads)} parameters match within atol={atol}")
+        else:
+            for err in first_stage_errors[:5]:
+                print_rank0(f"    MISMATCH: {err}")
+
+    dist.barrier()
+
+    # Rank 1 needs non-PP grads for last stage - broadcast from rank 0
+    last_stage_success = True
+    last_stage_errors: list[str] = []
+
+    if rank == 0:
+        # Send last stage grads to rank 1
+        last_grad_names = [k for k in non_pp_grads if k.startswith("last.")]
+        for name in last_grad_names:
+            grad = non_pp_grads[name]
+            dist.broadcast(grad, src=0)
+    else:
+        # Receive last stage grads from rank 0
+        non_pp_last_grads: dict[str, torch.Tensor] = {}
+        # We need to know the param names - use pp_model's params
+        for name, p in pp_model.named_parameters():
+            grad = torch.zeros_like(p)
+            dist.broadcast(grad, src=0)
+            non_pp_last_grads[f"last.{name}"] = grad
+
+        last_stage_success, last_stage_errors = compare_gradients(
+            pp_grads, non_pp_last_grads, "last.", atol
+        )
+        print("\n  [Rank 1] Last Stage Gradient Comparison:")
+        if last_stage_success:
+            print(f"    All {len(pp_grads)} parameters match within atol={atol}")
+        else:
+            for err in last_stage_errors[:5]:
+                print(f"    MISMATCH: {err}")
+
+    dist.barrier()
+
+    # 5. Gather results from all ranks
+    all_results = [None] * world_size
+    local_result = (
+        first_stage_success if rank == 0 else last_stage_success,
+        first_stage_errors if rank == 0 else last_stage_errors,
+    )
+    dist.all_gather_object(all_results, local_result)
+
+    # Check all stages passed
+    success = all(r[0] for r in all_results)
+
+    if success:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP Gradient Verification: PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP Gradient Verification: FAILED")
+        for r, (_, errors) in enumerate(all_results):
+            if errors:
+                print_rank0(f"  Rank {r} errors:")
+                for err in errors[:3]:
+                    print_rank0(f"    - {err}")
+        print_rank0("=" * 60)
+
+    return success
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="PP vs non-PP gradient verification test"
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output file for test result (omit for standalone debug mode)",
+    )
+    parser.add_argument(
+        "--n_microbatches",
+        type=int,
+        default=2,
+        help="Number of microbatches (must be >= num_stages)",
+    )
+    parser.add_argument(
+        "--seq_len",
+        type=int,
+        default=64,
+        help="Sequence length for test data",
+    )
+    parser.add_argument(
+        "--atol",
+        type=float,
+        default=1e-5,
+        help="Absolute tolerance for gradient comparison",
+    )
+    args = parser.parse_args()
+
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    torch.cuda.set_device(rank)
+
+    try:
+        success = verify_gradients(
+            n_microbatches=args.n_microbatches,
+            seq_len=args.seq_len,
+            atol=args.atol,
+        )
+        if rank == 0:
+            if args.output:
+                write_result(args.output, success)
+            else:
+                # Standalone mode: print result
+                print_rank0(
+                    f"\nGradient verification: {'PASSED' if success else 'FAILED'}"
+                )
+    except Exception as e:
+        print(f"Rank {rank} failed with: {e}")
+        import traceback
+
+        traceback.print_exc()
+        if rank == 0 and args.output:
+            write_result(args.output, False)
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/areal/tests/experimental/archon/torchrun/run_pp_tests.py
+++ b/areal/tests/experimental/archon/torchrun/run_pp_tests.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""Unified PP test entry point for low-level PP tests.
+
+This script consolidates PP forward and backward tests into a single file,
+following the pattern of run_ep_tests.py.
+
+Run with:
+    torchrun --nproc_per_node=2 areal/tests/experimental/archon/torchrun/run_pp_tests.py \
+        --test_type=forward --pp_size=2 --output=/tmp/result.out
+
+    torchrun --nproc_per_node=4 areal/tests/experimental/archon/torchrun/run_pp_tests.py \
+        --test_type=backward --pp_size=4 --output=/tmp/result.out
+
+Supported test types:
+    - forward: Test PP forward pass matches golden model output
+    - backward: Test PP backward pass - verify gradients flow correctly
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from areal.experimental.models.archon import ArchonParallelDims
+from areal.experimental.models.archon.pipeline_parallel import (
+    generate_llm_fqn_per_model_part,
+    pipeline_module_split,
+)
+from areal.experimental.models.archon.qwen3 import Qwen3Model
+from areal.tests.experimental.archon.torchrun.dist_utils import (
+    create_dense_model_args,
+    create_golden_model,
+    create_test_input,
+    print_rank0,
+    verify_outputs_match,
+    write_result,
+)
+
+# =============================================================================
+# PP Forward Test
+# =============================================================================
+
+
+def test_pp_forward(pp_size: int, out_file: str | None = None) -> bool:
+    """Test PP forward pass matches golden model output.
+
+    This test verifies that a model split across multiple PP stages produces
+    the same output as the non-split golden model. It manually passes activations
+    between stages using point-to-point communication.
+
+    Args:
+        pp_size: Pipeline parallel degree (must equal world_size for this test)
+        out_file: Optional file to write result ("Passed"/"Failed")
+
+    Returns:
+        True if test passed, False otherwise
+    """
+    # 1. Initialize distributed
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0(f"PP Forward Test: pp_size={pp_size}, world_size={world_size}")
+    print_rank0("=" * 60)
+
+    assert world_size == pp_size, (
+        f"This test requires world_size == pp_size. "
+        f"Got world_size={world_size}, pp_size={pp_size}"
+    )
+
+    # 2. Create model args (need enough layers for PP split)
+    # Use n_layers = pp_size * 2 to ensure at least 2 layers per stage
+    n_layers = pp_size * 2
+    model_args = create_dense_model_args(
+        n_layers=n_layers,
+        dim=64,
+        hidden_dim=128,
+        n_heads=4,
+        n_kv_heads=2,
+        head_dim=16,
+        vocab_size=1000,
+    )
+
+    # 3. Create golden model (non-PP) for comparison
+    # Use same seed for reproducibility
+    seed = 42
+    golden_model = create_golden_model(model_args, device, seed=seed)
+    golden_model.eval()
+
+    # 4. Create PP parallel dims
+    parallel_dims = ArchonParallelDims(
+        pp=pp_size,
+        dp_shard=1,
+        tp=1,
+        cp=1,
+        world_size=world_size,
+        device_type="cuda",
+    )
+
+    print_rank0(f"  PP enabled: {parallel_dims.pp_enabled}")
+    print_rank0(f"  PP degree: {parallel_dims.pp}")
+
+    # 5. Create PP model on meta device for efficient splitting
+    # The model is created on meta device (no memory allocation), split into stages,
+    # then each stage is materialized with weights on the target device
+    with torch.device("meta"):
+        model = Qwen3Model(model_args)
+
+    # For debugging: create model parts without FSDP
+    # This tests if PP forward works without FSDP interference
+    pp_mesh = parallel_dims.get_mesh("pp")
+    module_names_per_stage = generate_llm_fqn_per_model_part(
+        num_stages=pp_size,
+        num_layers=n_layers,
+    )
+    print_rank0(f"  Module names per stage: {module_names_per_stage}")
+
+    pp_stages, model_parts = pipeline_module_split(
+        whole_model=model,
+        pp_mesh=pp_mesh,
+        device=device,
+        module_names_per_stage=module_names_per_stage,
+    )
+
+    # Materialize weights on each model part after splitting
+    # Copy weights from golden model to ensure identical initialization
+    golden_state = golden_model.state_dict()
+    for part in model_parts:
+        part.to_empty(device=device)
+        part.init_buffers(buffer_device=device)
+        # Load matching weights from golden model
+        part_state = part.state_dict()
+        for key in part_state:
+            if key in golden_state:
+                part_state[key].copy_(golden_state[key])
+        part.load_state_dict(part_state)
+
+    # Get PP local rank (which stage this rank belongs to)
+    pp_local_rank = pp_mesh.get_local_rank()
+
+    # Determine first/last stage
+    has_first = any(s.is_first for s in pp_stages)
+    has_last = any(s.is_last for s in pp_stages)
+
+    print(
+        f"  Rank {rank}: pp_local_rank={pp_local_rank}, has_first={has_first}, has_last={has_last}"
+    )
+
+    # Get PP group for P2P communication
+    pp_group = parallel_dims.get_group("pp")
+    pp_group_ranks = dist.get_process_group_ranks(pp_group)
+
+    # Set to eval mode
+    for part in model_parts:
+        part.eval()
+
+    # 6. Create test input (broadcast from rank 0 for consistency)
+    if rank == 0:
+        tokens, positions, cu_seqlens, max_seqlen = create_test_input(
+            num_seqs=2,
+            seq_len_per_seq=8,
+            vocab_size=model_args.vocab_size,
+            device=device,
+            seed=123,
+        )
+        input_data = [tokens, positions, cu_seqlens, max_seqlen]
+    else:
+        input_data = [None, None, None, None]
+
+    dist.broadcast_object_list(input_data, src=0)
+    tokens, positions, cu_seqlens, max_seqlen = input_data
+
+    # Move tensors to device
+    tokens = tokens.to(device)
+    positions = positions.to(device)
+    cu_seqlens = cu_seqlens.to(device)
+
+    print_rank0(f"  Input tokens shape: {tokens.shape}")
+
+    # 7. Run golden model forward
+    with torch.no_grad():
+        golden_output = golden_model(tokens, positions, cu_seqlens, max_seqlen)
+
+    print_rank0(f"  Golden output shape: {golden_output.shape}")
+
+    # 8. Run PP forward manually by passing activations between stages
+    # For PP with N stages, we sequentially:
+    #   Stage 0: process tokens -> h0
+    #   Stage 1: receive h0, process -> h1
+    #   ...
+    #   Stage N-1: receive h_{N-2}, process -> output
+    print_rank0(f"\n  Starting PP forward pass through {pp_size} stages...")
+
+    success = True
+    max_diff = 0.0
+    mean_diff = 0.0
+    pp_output = None
+
+    with torch.no_grad():
+        # Initialize activation buffer
+        # First stage uses tokens, others use hidden activations
+        h = torch.zeros(
+            (1, tokens.shape[1], model_args.dim),
+            dtype=torch.float32,
+            device=device,
+        )
+
+        # Sequential forward through all stages
+        for stage_idx in range(pp_size):
+            src_rank = pp_group_ranks[stage_idx]
+            is_my_stage = pp_local_rank == stage_idx
+
+            if stage_idx == 0:
+                # First stage: process input tokens
+                if is_my_stage:
+                    print(f"  Rank {rank}: Stage {stage_idx} - processing input tokens")
+                    h = model_parts[0](tokens, positions, cu_seqlens, max_seqlen)
+                    print(f"  Rank {rank}: Stage {stage_idx} - output shape: {h.shape}")
+            else:
+                # Non-first stages: receive activation from previous stage, then process
+                if is_my_stage:
+                    print(
+                        f"  Rank {rank}: Stage {stage_idx} - processing received activation"
+                    )
+                    h = model_parts[0](h, positions, cu_seqlens, max_seqlen)
+                    print(f"  Rank {rank}: Stage {stage_idx} - output shape: {h.shape}")
+
+            # Synchronize and broadcast activation to next stage (or to all for final)
+            torch.cuda.synchronize()
+            dist.barrier(group=pp_group)
+
+            # Broadcast current stage's output to all ranks
+            # This ensures the next stage has the activation
+            if stage_idx < pp_size - 1:
+                dist.broadcast(h, src=src_rank, group=pp_group)
+                print_rank0(
+                    f"  Broadcast activation from stage {stage_idx} (rank {src_rank})"
+                )
+
+        # Final output is on the last stage
+        if has_last:
+            pp_output = h
+
+    # Synchronize after forward
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    # 9. Compare outputs (only on last stage)
+    if has_last:
+        success, max_diff, mean_diff = verify_outputs_match(
+            pp_output, golden_output, rtol=1e-4, atol=1e-4, max_diff_threshold=1e-2
+        )
+        print_rank0("\n  Comparison results:")
+        print_rank0(f"    PP output shape: {pp_output.shape}")
+        print_rank0(f"    Golden output shape: {golden_output.shape}")
+        print_rank0(f"    Max diff: {max_diff:.6f}")
+        print_rank0(f"    Mean diff: {mean_diff:.6f}")
+        print_rank0(f"    Outputs match: {success}")
+
+        if not success:
+            # Print more debug info on failure
+            print_rank0(
+                f"    PP output stats: min={pp_output.min():.4f}, max={pp_output.max():.4f}, mean={pp_output.mean():.4f}"
+            )
+            print_rank0(
+                f"    Golden stats: min={golden_output.min():.4f}, max={golden_output.max():.4f}, mean={golden_output.mean():.4f}"
+            )
+
+    # 10. Broadcast result to all ranks (use last stage's global rank)
+    last_stage_global_rank = pp_group_ranks[-1]
+    success_tensor = torch.tensor([1 if success else 0], dtype=torch.int, device=device)
+    dist.broadcast(success_tensor, src=last_stage_global_rank)
+    success = success_tensor.item() == 1
+
+    dist.barrier()
+
+    if success:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP Forward Test: PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP Forward Test: FAILED")
+        print_rank0("=" * 60)
+
+    if rank == 0 and out_file:
+        write_result(out_file, success)
+
+    return success
+
+
+# =============================================================================
+# PP Backward Test
+# =============================================================================
+
+
+def validate_gradients_pp(model_parts: list[nn.Module]) -> tuple[bool, list[str]]:
+    """Verify gradients flow through PP model parts.
+
+    Args:
+        model_parts: List of model parts from pipeline_module_split
+
+    Returns:
+        Tuple of (success, error_messages)
+    """
+    errors = []
+
+    for part_idx, part in enumerate(model_parts):
+        for name, param in part.named_parameters():
+            if param.requires_grad:
+                if param.grad is None:
+                    errors.append(f"Part {part_idx} {name}: no gradient")
+                elif torch.isnan(param.grad).any():
+                    errors.append(f"Part {part_idx} {name}: NaN gradient")
+                elif torch.isinf(param.grad).any():
+                    errors.append(f"Part {part_idx} {name}: Inf gradient")
+                elif param.grad.abs().sum() == 0:
+                    errors.append(f"Part {part_idx} {name}: zero gradient")
+
+    return len(errors) == 0, errors
+
+
+def test_pp_backward(pp_size: int, out_file: str | None = None) -> bool:
+    """Test PP backward pass - verify gradients flow through all stages.
+
+    This test verifies that gradients flow correctly through a pipeline-parallel
+    model. It manually passes activations forward and gradients backward between
+    stages using point-to-point communication.
+
+    Args:
+        pp_size: Pipeline parallel degree (must equal world_size for this test)
+        out_file: Optional file to write result ("Passed"/"Failed")
+
+    Returns:
+        True if test passed, False otherwise
+    """
+    # 1. Initialize distributed
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    print_rank0(f"\n{'=' * 60}")
+    print_rank0(f"PP Backward Test: pp_size={pp_size}, world_size={world_size}")
+    print_rank0("=" * 60)
+
+    assert world_size == pp_size, (
+        f"This test requires world_size == pp_size. "
+        f"Got world_size={world_size}, pp_size={pp_size}"
+    )
+
+    # 2. Create model args (need enough layers for PP split)
+    n_layers = pp_size * 2
+    model_args = create_dense_model_args(
+        n_layers=n_layers,
+        dim=64,
+        hidden_dim=128,
+        n_heads=4,
+        n_kv_heads=2,
+        head_dim=16,
+        vocab_size=1000,
+    )
+
+    # 3. Create PP parallel dims
+    parallel_dims = ArchonParallelDims(
+        pp=pp_size,
+        dp_shard=1,
+        tp=1,
+        cp=1,
+        world_size=world_size,
+        device_type="cuda",
+    )
+
+    print_rank0(f"  PP enabled: {parallel_dims.pp_enabled}")
+    print_rank0(f"  PP degree: {parallel_dims.pp}")
+
+    # 4. Create PP model on meta device for efficient splitting
+    with torch.device("meta"):
+        model = Qwen3Model(model_args)
+
+    # 5. Use pipeline_module_split (same as forward test, no FSDP)
+    pp_mesh = parallel_dims.get_mesh("pp")
+    module_names_per_stage = generate_llm_fqn_per_model_part(
+        num_stages=pp_size,
+        num_layers=n_layers,
+    )
+    print_rank0(f"  Module names per stage: {module_names_per_stage}")
+
+    pp_stages, model_parts = pipeline_module_split(
+        whole_model=model,
+        pp_mesh=pp_mesh,
+        device=device,
+        module_names_per_stage=module_names_per_stage,
+    )
+
+    # Materialize weights on each model part after splitting
+    # For backward test, we don't need to match golden model - just need valid weights
+    seed = 42
+    torch.manual_seed(seed)
+    for part in model_parts:
+        part.to_empty(device=device)
+        part.init_weights()
+        part.init_buffers(buffer_device=device)
+
+    # Get PP local rank (which stage this rank belongs to)
+    pp_local_rank = pp_mesh.get_local_rank()
+
+    # Determine first/last stage
+    has_first = any(s.is_first for s in pp_stages)
+    has_last = any(s.is_last for s in pp_stages)
+
+    print(
+        f"  Rank {rank}: pp_local_rank={pp_local_rank}, has_first={has_first}, has_last={has_last}"
+    )
+
+    # Get PP group for communication
+    pp_group = parallel_dims.get_group("pp")
+    pp_group_ranks = dist.get_process_group_ranks(pp_group)
+
+    # Set to train mode
+    for part in model_parts:
+        part.train()
+
+    # 6. Create optimizer
+    all_params = [p for m in model_parts for p in m.parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(all_params, lr=1e-4)
+    optimizer.zero_grad()
+
+    print_rank0(f"  Trainable parameters: {len(all_params)}")
+
+    # 7. Create test input and labels
+    if rank == 0:
+        tokens, positions, cu_seqlens, max_seqlen = create_test_input(
+            num_seqs=2,
+            seq_len_per_seq=8,
+            vocab_size=model_args.vocab_size,
+            device=device,
+            seed=123,
+        )
+        # Create simple labels (shifted tokens for causal LM)
+        labels = tokens.clone()
+        input_data = [tokens, positions, cu_seqlens, max_seqlen, labels]
+    else:
+        input_data = [None, None, None, None, None]
+
+    dist.broadcast_object_list(input_data, src=0)
+    tokens, positions, cu_seqlens, max_seqlen, labels = input_data
+
+    # Move tensors to device
+    tokens = tokens.to(device)
+    positions = positions.to(device)
+    cu_seqlens = cu_seqlens.to(device)
+    labels = labels.to(device)
+
+    print_rank0(f"  Input tokens shape: {tokens.shape}")
+    print_rank0(f"  Labels shape: {labels.shape}")
+
+    # 8. Run PP forward + backward manually for multi-stage PP
+    # For PP with N stages, we need to:
+    # Forward: stage 0 -> stage 1 -> ... -> stage N-1
+    # Backward: stage N-1 -> stage N-2 -> ... -> stage 0
+    print_rank0(f"\n  Starting PP forward pass through {pp_size} stages...")
+
+    # Store activations for backward pass
+    # Each stage needs to remember its input activation for backward
+    h_input = None  # Input to this stage (for backward)
+    h_output = None  # Output from this stage
+    output = None  # Final output (only on last stage)
+
+    # Initialize activation buffer for communication
+    h_buffer = torch.zeros(
+        (1, tokens.shape[1], model_args.dim),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    # Forward pass - sequential through all stages
+    for stage_idx in range(pp_size):
+        is_my_stage = pp_local_rank == stage_idx
+        src_rank = pp_group_ranks[stage_idx]
+
+        if stage_idx == 0:
+            # First stage: process input tokens
+            if is_my_stage:
+                print(f"  Rank {rank}: Stage {stage_idx} - forward with input tokens")
+                h_output = model_parts[0](tokens, positions, cu_seqlens, max_seqlen)
+                h_output.retain_grad()
+                h_buffer = h_output.detach().clone()
+                print(
+                    f"  Rank {rank}: Stage {stage_idx} - output shape: {h_output.shape}"
+                )
+        else:
+            # Non-first stages: receive activation, then process
+            if is_my_stage:
+                # Clone the received buffer and enable gradients
+                h_input = h_buffer.clone().requires_grad_(True)
+                print(
+                    f"  Rank {rank}: Stage {stage_idx} - forward with received activation"
+                )
+                h_output = model_parts[0](h_input, positions, cu_seqlens, max_seqlen)
+                h_output.retain_grad()
+                h_buffer = h_output.detach().clone()
+                print(
+                    f"  Rank {rank}: Stage {stage_idx} - output shape: {h_output.shape}"
+                )
+
+                if pp_local_rank == pp_size - 1:
+                    output = h_output
+
+        # Synchronize and broadcast to next stage
+        torch.cuda.synchronize()
+        dist.barrier(group=pp_group)
+
+        if stage_idx < pp_size - 1:
+            dist.broadcast(h_buffer, src=src_rank, group=pp_group)
+            print_rank0(
+                f"  Broadcast activation from stage {stage_idx} (rank {src_rank})"
+            )
+
+    # Compute loss and start backward (only on last stage)
+    print_rank0("\n  Starting PP backward pass...")
+
+    grad_buffer = torch.zeros(
+        (1, tokens.shape[1], model_args.dim),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    if pp_local_rank == pp_size - 1:
+        print(f"  Rank {rank}: Computing loss on last stage")
+        output_flat = output.view(-1, output.size(-1))
+        labels_flat = labels.view(-1)
+        loss = nn.functional.cross_entropy(output_flat, labels_flat)
+        print(f"  Rank {rank}: Loss = {loss.item():.4f}")
+
+        # Backward through last stage
+        loss.backward()
+
+        # Get gradient to send to previous stage
+        if h_input is not None and h_input.grad is not None:
+            grad_buffer = h_input.grad.detach().clone()
+            print(
+                f"  Rank {rank}: Gradient norm to send: {grad_buffer.norm().item():.4f}"
+            )
+        else:
+            print(
+                f"  Rank {rank}: WARNING - h_input.grad is None (this is expected for pp_size=1)"
+            )
+
+    # Backward pass - reverse sequential through all stages
+    for stage_idx in range(pp_size - 1, 0, -1):
+        src_rank = pp_group_ranks[stage_idx]
+
+        torch.cuda.synchronize()
+        dist.barrier(group=pp_group)
+        dist.broadcast(grad_buffer, src=src_rank, group=pp_group)
+        print_rank0(f"  Broadcast gradient from stage {stage_idx} (rank {src_rank})")
+
+        # Process backward at the previous stage
+        if pp_local_rank == stage_idx - 1:
+            print(f"  Rank {rank}: Stage {pp_local_rank} - backward pass")
+            print(
+                f"  Rank {rank}: Received gradient norm: {grad_buffer.norm().item():.4f}"
+            )
+
+            # Backward through this stage
+            h_output.backward(grad_buffer)
+
+            # Get gradient to send to previous stage (if not first stage)
+            if pp_local_rank > 0 and h_input is not None and h_input.grad is not None:
+                grad_buffer = h_input.grad.detach().clone()
+                print(
+                    f"  Rank {rank}: Gradient norm to send: {grad_buffer.norm().item():.4f}"
+                )
+
+    # Synchronize after backward
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    # 9. Validate gradients on this rank
+    local_success, local_errors = validate_gradients_pp(model_parts)
+
+    print(
+        f"  Rank {rank}: gradient validation {'PASSED' if local_success else 'FAILED'}"
+    )
+    if not local_success:
+        for err in local_errors[:5]:  # Print first 5 errors
+            print(f"    {err}")
+    else:
+        # Print some gradient stats for verification
+        total_grad_norm = sum(
+            p.grad.norm().item()
+            for m in model_parts
+            for p in m.parameters()
+            if p.grad is not None
+        )
+        print(f"  Rank {rank}: Total gradient norm: {total_grad_norm:.4f}")
+
+    # 10. Gather results from all ranks
+    all_results = [None] * world_size
+    dist.all_gather_object(all_results, (local_success, local_errors))
+
+    # 11. Check all stages passed
+    final_success = all(success for success, _ in all_results)
+
+    if rank == 0:
+        print_rank0("\n  Results by rank:")
+        for r, (success, errors) in enumerate(all_results):
+            status = "PASSED" if success else "FAILED"
+            print_rank0(f"    Rank {r}: {status}")
+            if not success:
+                for err in errors[:3]:
+                    print_rank0(f"      - {err}")
+
+    dist.barrier()
+
+    if final_success:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP Backward Test: PASSED")
+        print_rank0("=" * 60)
+    else:
+        print_rank0(f"\n{'=' * 60}")
+        print_rank0("PP Backward Test: FAILED")
+        print_rank0("=" * 60)
+
+    if rank == 0 and out_file:
+        write_result(out_file, final_success)
+
+    return final_success
+
+
+# =============================================================================
+# Test Registry and Main
+# =============================================================================
+
+TEST_REGISTRY = {
+    "forward": test_pp_forward,
+    "backward": test_pp_backward,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Unified PP Tests")
+    parser.add_argument(
+        "--test_type",
+        type=str,
+        required=True,
+        choices=list(TEST_REGISTRY.keys()),
+        help="Type of test to run (forward or backward)",
+    )
+    parser.add_argument(
+        "--pp_size",
+        type=int,
+        default=2,
+        help="Pipeline parallel size (must equal world_size)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output file for test result",
+    )
+    args = parser.parse_args()
+
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    torch.cuda.set_device(rank)
+
+    print_rank0("=" * 60)
+    print_rank0(f"Running PP Test: {args.test_type}")
+    print_rank0("=" * 60)
+
+    try:
+        test_fn = TEST_REGISTRY[args.test_type]
+        success = test_fn(args.pp_size, args.output)
+
+        dist.barrier()
+
+        if success:
+            print_rank0(f"\n{'=' * 60}")
+            print_rank0(f"PP Test {args.test_type}: PASSED")
+            print_rank0("=" * 60)
+        else:
+            print_rank0(f"\n{'=' * 60}")
+            print_rank0(f"PP Test {args.test_type}: FAILED")
+            print_rank0("=" * 60)
+
+    except Exception as e:
+        print(f"Rank {rank} failed with: {e}")
+        import traceback
+
+        traceback.print_exc()
+        if rank == 0 and args.output:
+            write_result(args.output, False)
+        raise
+
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/areal/tests/experimental/archon/torchrun/run_qwen3_parallelize.py
+++ b/areal/tests/experimental/archon/torchrun/run_qwen3_parallelize.py
@@ -33,8 +33,7 @@ import torch
 import torch.distributed as dist
 
 from areal.experimental.models.archon import ArchonParallelDims
-from areal.experimental.models.archon.qwen3.infra.parallelize import parallelize_qwen3
-from areal.experimental.models.archon.qwen3.model.model import Qwen3Model
+from areal.experimental.models.archon.qwen3 import Qwen3Model, parallelize_qwen3
 from areal.tests.experimental.archon.torchrun.dist_utils import (
     create_dense_model_args,
     create_moe_model_args,

--- a/areal/utils/fsdp/parallel.py
+++ b/areal/utils/fsdp/parallel.py
@@ -204,7 +204,7 @@ class ParallelHelper:
         return self._ps.dp_size * self._ps.cp_size
 
     @property
-    def non_data_parallel_size(self) -> int:
+    def context_and_model_parallel_size(self) -> int:
         return self._ps.cp_size * self._ps.tp_size
 
     @property


### PR DESCRIPTION
## Description

Implement Pipeline Parallelism for the Archon training engine using PyTorch's PipelineStage and Schedule1F1B, enabling model sharding across multiple GPU stages for training larger models.

- Add pipeline infrastructure for balanced layer distribution and model splitting
- Extend engine to manage multiple model parts with pipelined forward/backward
- Extend device mesh to support PP dimension (world_size = pp × dp × cp × tp)
- Update DCP and HuggingFace checkpoint save/load for pipeline-sharded models
- Adapt Qwen2/Qwen3 models to handle PP tensor shapes and partial modules
- Fix attention mask caching incompatibility with PP microbatches

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [x] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
