### PR TITLE
feat(archon): enable PP > 1 for RL training with XCCL weight sync

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1198,6 +1198,8 @@ class MegatronEngine(TrainEngine):
         if self.is_pipeline_parallel_head():
             assert meta.alloc_mode is not None
 
+            self.engine_lock.acquire()
+
             fut = self.rollout_engine.init_weights_update_group(meta)
 
             self.logger.info(
@@ -1215,6 +1217,8 @@ class MegatronEngine(TrainEngine):
             )
 
             fut.result()
+
+            self.engine_lock.release()
 
     @trace_perf("megatron_engine.update_weights_from_distributed", category="comm")
     def _update_weights_from_distributed(self, meta: WeightUpdateMeta) -> None:


### PR DESCRIPTION
## Description

Enable pipeline parallelism (PP > 1) to work correctly with RL training by fixing data broadcast and weight synchronization issues.

Key changes:
- Replace cp_tp mesh with pp_cp_tp mesh to include PP in context_and_model_parallel_group
- Add per-PP-stage weight update groups for XCCL weight sync
- Add DistributedLock to serialize NCCL group initialization
- Add PP + weight_tying validation (unsupported combination)
- Fix MegatronEngine missing engine_lock in init

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)
