### PR TITLE
fix(archon): enable torch.compile for attention_norm/ffn_norm

### DIFF
--- a/areal/experimental/models/archon/qwen3/infra/parallelize.py
+++ b/areal/experimental/models/archon/qwen3/infra/parallelize.py
@@ -575,14 +575,6 @@ def _apply_compile(model: Compilable, ep_enabled: bool = False) -> None:
                                 moe_submod, backend="inductor", fullgraph=True
                             ),
                         )
-                elif attr_name == "attention_norm" or attr_name == "ffn_norm":
-                    # NOTE: attention_norm/ffn_norm may use SequenceParallel
-                    # which has issues with torch.compile + Inductor
-                    # SequenceParallel has async redistribute which breaks
-                    # the graph by introducing async tensors in forward
-                    # while the backward expects local tensors.
-                    # NOTE: Upgrading PyTorch may resolve this in the future.
-                    continue
                 else:
                     setattr(
                         inner_block,


### PR DESCRIPTION
## Description

Remove the skip logic that prevented torch.compile from being applied to attention_norm and ffn_norm layers. The original workaround was for SequenceParallel + Inductor compatibility issues that have since been resolved in newer PyTorch versions.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

This change enables torch.compile optimization for attention_norm and ffn_norm layers which were previously skipped due to SequenceParallel + Inductor compatibility issues. These issues have been resolved in newer PyTorch versions.

Files changed:
- `areal/experimental/models/archon/qwen3/infra/parallelize.py:575`: Remove skip logic for norm layers