### PR TITLE
feat(utils): add network filesystem validation for shared paths

### DIFF
--- a/areal/scheduler/local.py
+++ b/areal/scheduler/local.py
@@ -37,6 +37,7 @@ from areal.scheduler.exceptions import (
 from areal.scheduler.rpc.serialization import deserialize_value, serialize_value
 from areal.utils import logging, name_resolve, names
 from areal.utils.concurrent import run_async_task
+from areal.utils.fs import validate_shared_path
 from areal.utils.http import get_default_connector
 from areal.utils.launcher import (
     get_env_vars,
@@ -120,6 +121,14 @@ class LocalScheduler(Scheduler):
         )
         if exp_config is not None:
             self.name_resolve_config = exp_config.cluster.name_resolve
+
+        if self.fileroot:
+            validate_shared_path(self.fileroot, "cluster.fileroot")
+        if self.name_resolve_config.type == "nfs":
+            validate_shared_path(
+                self.name_resolve_config.nfs_record_root,
+                "name_resolve.nfs_record_root",
+            )
 
         # Reconfigure name_resolve and clear old entries
         if self.experiment_name and self.trial_name:

--- a/areal/scheduler/slurm.py
+++ b/areal/scheduler/slurm.py
@@ -33,6 +33,7 @@ from areal.scheduler.exceptions import (
 from areal.scheduler.rpc.serialization import deserialize_value, serialize_value
 from areal.utils import logging, name_resolve, names
 from areal.utils.concurrent import run_async_task
+from areal.utils.fs import validate_shared_path
 from areal.utils.http import get_default_connector
 from areal.utils.launcher import (
     JobState,
@@ -110,6 +111,14 @@ class SlurmScheduler(Scheduler):
         )
         if exp_config is not None:
             self.name_resolve_config = exp_config.cluster.name_resolve
+
+        if self.fileroot:
+            validate_shared_path(self.fileroot, "cluster.fileroot")
+        if self.name_resolve_config.type == "nfs":
+            validate_shared_path(
+                self.name_resolve_config.nfs_record_root,
+                "name_resolve.nfs_record_root",
+            )
 
         # Reconfigure name_resolve and clear old entries
         if self.experiment_name and self.trial_name:

--- a/areal/utils/fs.py
+++ b/areal/utils/fs.py
@@ -1,9 +1,110 @@
 import getpass
 import os
 
+import psutil
+
+from areal.utils.logging import getLogger
+
+logger = getLogger("FileSystemUtils")
+
+# Keywords to match in fstype or device path (case-insensitive substring match)
+NETWORK_FS_KEYWORDS = {
+    # Standard network filesystems
+    "nfs",
+    "lustre",
+    "gpfs",
+    "mmfs",
+    "beegfs",
+    "pvfs",
+    "orangefs",
+    "ceph",
+    "glusterfs",
+    "afs",
+    "cifs",
+    "smb",
+    "rbd",
+    "9p",
+    # Cloud providers
+    "alinas",  # Alibaba Cloud NAS/CPFS
+    "cpfs",  # Alibaba Cloud CPFS
+    "vepfs",  # Volcano Engine (ByteDance) PFS
+    "goosefs",  # Tencent Cloud GooseFS
+    "chdfs",  # Tencent Cloud HDFS
+    "obsfs",  # Huawei Cloud OBS
+    "gcsfuse",  # Google Cloud Storage FUSE
+    "efs",  # AWS Elastic File System
+    "blobfuse",  # Azure Blob FUSE
+    "s3fs",  # S3-compatible storage FUSE
+    "fsx",  # AWS FSx
+    # Distributed filesystems
+    "juicefs",
+    "alluxio",
+    "seaweedfs",
+    "hdfs",
+    "moosefs",
+    "lizardfs",
+    "xtreemfs",
+    "sshfs",
+}
+
 
 def get_user_tmp():
     user = getpass.getuser()
     user_tmp = os.path.join("/home", user, ".cache", "areal")
     os.makedirs(user_tmp, exist_ok=True)
     return user_tmp
+
+
+def validate_shared_path(path: str, name: str = "path", warn_nfs: bool = True) -> None:
+    """
+    Validate that a path exists for shared/distributed access.
+
+    Args:
+        path: Path to validate.
+        name: Descriptive name for the path (used in messages).
+        warn_nfs: If True, warn when not on network filesystem.
+
+    Raises:
+        FileNotFoundError: If the path does not exist.
+    """
+    if not path:
+        return
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"{name} '{path}' does not exist.")
+
+    if not warn_nfs:
+        return
+
+    # Check if path is on network filesystem
+    real_path = os.path.realpath(path)
+    partitions = psutil.disk_partitions(all=True)
+
+    # Find the best matching mountpoint (longest prefix match)
+    best_match = None
+    best_match_len = 0
+
+    for partition in partitions:
+        mountpoint = partition.mountpoint
+        if real_path.startswith(mountpoint) and len(mountpoint) > best_match_len:
+            best_match = partition
+            best_match_len = len(mountpoint)
+
+    is_network = False
+    if best_match:
+        fstype = best_match.fstype.lower()
+        device = best_match.device.lower()
+        combined = fstype + device
+
+        is_network = (
+            any(kw in combined for kw in NETWORK_FS_KEYWORDS)
+            or (":" in device and not device.startswith("/dev"))
+            or device.startswith("//")
+        )
+
+    if not is_network:
+        logger.warning(
+            f"{name} '{path}' is not on a network filesystem. "
+            "This may cause issues in distributed training where all nodes "
+            "need access to the same files. Consider using NFS, Lustre, or "
+            "other shared storage."
+        )

--- a/areal/utils/launcher.py
+++ b/areal/utils/launcher.py
@@ -8,6 +8,7 @@ import time
 
 from areal.api.alloc_mode import AllocationMode, AllocationType
 from areal.utils import logging, name_resolve, names
+from areal.utils.fs import validate_shared_path
 
 logger = logging.getLogger("LauncherUtils")
 
@@ -225,6 +226,13 @@ def validate_config_for_launcher(config):
                 "You should use a yaml config for RL rather than SFT, or "
                 "remove the inference part from `allocation_mode`."
             )
+
+    validate_shared_path(config.cluster.fileroot, "cluster.fileroot")
+    if config.cluster.name_resolve.type == "nfs":
+        validate_shared_path(
+            config.cluster.name_resolve.nfs_record_root,
+            "name_resolve.nfs_record_root",
+        )
 
 
 def validate_config_for_distributed_launcher(config):


### PR DESCRIPTION
## Description

Distributed training requires shared storage paths (fileroot, nfs_record_root) to be accessible from all nodes. Add validation to detect non-network filesystems early and warn users.

Key changes:
- Add validate_shared_path() to detect network filesystems
- Support major cloud providers (Alibaba, AWS, GCP, Azure, etc.)
- Validate paths in LocalScheduler, SlurmScheduler, and launcher

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [x] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Key changes:
- Add `validate_shared_path()` in `areal/utils/fs.py` to detect network filesystems
- Support major network FS types: NFS, Lustre, GPFS, BeeGFS, Ceph, GlusterFS, etc.
- Support cloud providers: Alibaba Cloud (NAS/CPFS), AWS (EFS/FSx), GCP, Azure, etc.
- Validate `cluster.fileroot` and `name_resolve.nfs_record_root` in schedulers and launcher

Files changed:
- `areal/utils/fs.py`: Add `validate_shared_path()` function with network FS detection
- `areal/scheduler/local.py`: Add validation in LocalScheduler
- `areal/scheduler/slurm.py`: Add validation in SlurmScheduler
- `areal/utils/launcher.py`: Add validation in config validation