### PR TITLE
docs: update CLI reference examples to use train.py

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -9,13 +9,13 @@ can be specified in YAML configuration files or overridden via command line argu
 Configuration files are specified using the `--config` parameter:
 
 ```bash
-python -m areal.infra.launcher --config path/to/config.yaml
+python3 train.py --config path/to/config.yaml
 ```
 
 You can override specific parameters from the command line:
 
 ```bash
-python -m areal.infra.launcher --config path/to/config.yaml actor.lr=1e-4 seed=42
+python3 train.py --config path/to/config.yaml actor.lr=1e-4 seed=42
 ```
 
 For detailed examples, see the experiment configurations in the `examples/` directory.

--- a/docs/generate_cli_docs.py
+++ b/docs/generate_cli_docs.py
@@ -302,13 +302,13 @@ This page provides a comprehensive reference for all configuration parameters av
 Configuration files are specified using the `--config` parameter:
 
 ```bash
-python -m areal.infra.launcher --config path/to/config.yaml
+python3 train.py --config path/to/config.yaml
 ```
 
 You can override specific parameters from the command line:
 
 ```bash
-python -m areal.infra.launcher --config path/to/config.yaml actor.lr=1e-4 seed=42
+python3 train.py --config path/to/config.yaml actor.lr=1e-4 seed=42
 ```
 
 For detailed examples, see the experiment configurations in the `examples/` directory.


### PR DESCRIPTION
## Description

Update CLI reference documentation to use the correct command for running training.
Replace outdated `python -m areal.infra.launcher` examples with `python3 train.py`,
which is the current recommended way to launch training jobs.

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #(issue)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [x] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

This updates both the generated CLI reference and the generator script to ensure
consistency across documentation.

Files changed:
- `docs/cli_reference.md`: Update command examples
- `docs/generate_cli_docs.py`: Update generator template