### PR TITLE
fix(utils): correct initial log step to start from 0

### DIFF
--- a/areal/utils/stats_logger.py
+++ b/areal/utils/stats_logger.py
@@ -29,7 +29,7 @@ class StatsLogger:
         self.ft_spec = ft_spec
         self.init()
 
-        self._last_commit_step = 0
+        self._last_commit_step = -1
 
     def init(self):
         if dist.is_initialized() and dist.get_rank() != 0:


### PR DESCRIPTION
## Description

Fix the `StatsLogger` initial `_last_commit_step` value from `0` to `-1` so that logging starts correctly from step 0.

Previously, with `_last_commit_step = 0`, the first log would be skipped or incorrectly handled. By initializing it to `-1`, the first commit at step 0 is properly logged.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

N/A

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
