### PR TITLE
fix(agents): Filter out max_turns from kwargs before API calls

### DIFF
--- a/areal/workflow/anthropic/math_agent.py
+++ b/areal/workflow/anthropic/math_agent.py
@@ -18,6 +18,7 @@ class MathAgent:
         # Store kwargs for client.messages.create call
         self.kwargs = kwargs.copy()
         self.kwargs.pop("max_completion_tokens", None)
+        self.kwargs.pop("max_turns", None)
 
     async def run(self, data: dict, **extra_kwargs) -> float:
         """Run the agent on a single problem.

--- a/areal/workflow/openai/math_agent.py
+++ b/areal/workflow/openai/math_agent.py
@@ -24,6 +24,7 @@ class MathAgent:
     def __init__(self, **kwargs):
         self.kwargs = kwargs.copy()
         self.kwargs.pop("max_tokens", None)
+        self.kwargs.pop("max_turns", None)
 
     async def run(self, data: dict, **extra_kwargs):
         http_client = extra_kwargs.get("http_client", None)
@@ -119,6 +120,7 @@ class MathToolAgent:
     def __init__(self, **kwargs):
         self.kwargs = kwargs.copy()
         self.kwargs.pop("max_tokens", None)
+        self.kwargs.pop("max_turns", None)
 
     async def run(self, data: dict, **extra_kwargs):
         http_client = extra_kwargs.get("http_client", None)


### PR DESCRIPTION
## Description

The `max_turns` parameter was being passed through to API calls in agent workflows, but neither OpenAI nor Anthropic APIs accept this parameter. This caused errors when using agents with `max_turns` configuration.

This fix filters out `max_turns` from kwargs before making API calls in:
- `areal/workflow/anthropic/math_agent.py` - MathAgent class
- `areal/workflow/openai/math_agent.py` - MathAgent and MathToolAgent classes

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

N/A

---

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in [GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!