### PR TITLE
fix(proxy): use unique role names for proxy workers to fix rollout dump version=0 bug

### DIFF
--- a/areal/infra/controller/rollout_controller.py
+++ b/areal/infra/controller/rollout_controller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import shutil
 import threading
+import traceback
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
@@ -122,7 +123,15 @@ class RolloutController:
         This avoids collisions when multiple controllers (e.g., rollout and
         eval-rollout) each fork proxy workers into the same scheduler.
         """
+        if not hasattr(self, "_worker_role"):
+            raise RuntimeError(
+                "Cannot access _proxy_role before initialize() is called"
+            )
         return f"proxy-{self._worker_role}"
+
+    def _proxy_engine_name(self, rank: int) -> str:
+        """Generate engine name for a proxy worker rank."""
+        return f"{self._proxy_role}/{rank}"
 
     def _engine_name(self, rank: int) -> str:
         """Generate engine name for a worker rank.
@@ -287,22 +296,24 @@ class RolloutController:
         if hasattr(self, "_worker_role"):
             try:
                 self.scheduler.delete_workers(role=self._worker_role)
+                self.workers.clear()
                 logger.info("Workers deleted")
-            except Exception as e:
-                logger.error(f"Error deleting workers: {e}")
+            except Exception:
+                logger.error(f"Error deleting workers: {traceback.format_exc()}")
 
         # Delete proxy workers if initialized
         if self._proxy_started:
             try:
                 self.scheduler.delete_workers(role=self._proxy_role)
+                self.proxy_workers.clear()
+                self.proxy_addrs.clear()
+                self._proxy_started = False
                 logger.info("Proxy workers deleted")
-            except Exception as e:
-                logger.error(f"Error deleting proxy workers: {e}")
-            self.proxy_workers.clear()
-            self.proxy_addrs.clear()
-            self._proxy_started = False
+            except Exception:
+                logger.error(f"Error deleting proxy workers: {traceback.format_exc()}")
 
-        self.workers.clear()
+        with self._futures_lock:
+            self._pending_futures.clear()
 
     def start_proxy(self) -> None:
         """Initialize proxy workers for AgentWorkflow support.
@@ -354,7 +365,7 @@ class RolloutController:
 
         init_tasks = []
         for rank, (worker, server_info) in enumerate(
-            zip(self.proxy_workers, self.server_infos)
+            zip(self.proxy_workers, self.server_infos, strict=True)
         ):
             init_tasks.append(
                 self.scheduler.async_call_engine(
@@ -526,10 +537,6 @@ class RolloutController:
 
     def _proxy_collective_rpc(self, method: str, *args, **kwargs) -> list[Any]:
         return run_async_task(self._proxy_collective_rpc_async, method, *args, **kwargs)
-
-    def _proxy_engine_name(self, rank: int) -> str:
-        """Generate engine name for a proxy worker rank."""
-        return f"{self._proxy_role}/{rank}"
 
     async def _proxy_collective_rpc_async(
         self, method: str, *args, **kwargs

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -761,9 +761,10 @@ class RemoteInfEngine(InferenceEngine):
             )
 
             # Assert response is JSON dict (not text/binary from error pages)
-            assert isinstance(result, dict), (
-                f"Expected JSON dict response, got {type(result).__name__}"
-            )
+            if not isinstance(result, dict):
+                raise ValueError(
+                    f"Expected JSON dict response, got {type(result).__name__}"
+                )
 
             # Parse response using backend
             gen_result = self.backend.parse_generation_response(result)
@@ -772,8 +773,9 @@ class RemoteInfEngine(InferenceEngine):
             # Update accumulated outputs
             accumulated_output_tokens.extend(gen_result.output_tokens)
             accumulated_output_logprobs.extend(gen_result.output_logprobs)
-            cur_ver = self.get_version()
-            accumulated_versions.extend([cur_ver] * len(gen_result.output_tokens))
+            accumulated_versions.extend(
+                [self.get_version()] * len(gen_result.output_tokens)
+            )
 
             # Update request for next iteration
             req.input_ids += gen_result.output_tokens


### PR DESCRIPTION
## Description
When both rollout and eval-rollout controllers call start_proxy(), they both used the hardcoded role name "proxy" for fork_workers(). The second call overwrote _workers["proxy"] in the scheduler, causing set_version to be sent to eval-rollout's proxy workers instead of rollout's proxies. This left rollout proxy engines permanently at version 0.

Fix by introducing _proxy_role property that returns "proxy-{worker_role}" (e.g., "proxy-rollout", "proxy-eval-rollout"), ensuring each controller's proxy workers have a unique role name in the scheduler. Also removes debug logging from the version investigation.