### PR TITLE
fix(config): Fix openclaw config typo and increase max_tokens_per_mb

### DIFF
--- a/examples/openclaw/config.yaml
+++ b/examples/openclaw/config.yaml
@@ -4,7 +4,7 @@ trial_name: trial0
 seed: 1
 enable_offload: false
 total_train_epochs: 10
-total_trian_steps: 100
+total_train_steps: 100
 tokenizer_path: ${actor.path}
 
 cluster:
@@ -56,7 +56,7 @@ actor:
   gradient_checkpointing: true
   dtype: bfloat16
   mb_spec:
-    max_tokens_per_mb: 10240
+    max_tokens_per_mb: 15360
   optimizer:
     type: adam
     lr: 1.70e-5


### PR DESCRIPTION
## Description

Fix openclaw example config with two corrections:
- Fix typo: `total_trian_steps` -> `total_train_steps`
- Increase `max_tokens_per_mb` from 10240 to 15360 for better training throughput

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Changed file: `examples/openclaw/config.yaml`

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!