### PR TITLE
docs(openclaw): Replace hardcoded admin key with placeholder in README

### DIFF
--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -116,7 +116,7 @@ Example output:
 
   ℹ  To start the next episode with the same key:
 
-  python start_session.py http://<gateway> --admin-key sk-test123456 --api-key sk-sess-xxxxxxxxxxxx
+  python start_session.py http://<gateway> --admin-key <admin-api-key> --api-key sk-sess-xxxxxxxxxxxx
 
 SESSION_API_KEY=sk-sess-xxxxxxxxxxxx
 SESSION_ID=demo-task-0


### PR DESCRIPTION
## Description

Replace hardcoded `sk-test123456` admin key with `<admin-api-key>` placeholder in the openclaw README example output, consistent with the convention used elsewhere in the document.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with
  `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

N/A

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!