### PR TITLE
refactor: flatten sub-module imports to use parent package re-exports

### DIFF
--- a/areal/api/__init__.py
+++ b/areal/api/__init__.py
@@ -1,0 +1,66 @@
+__all__ = [
+    "RolloutWorkflow",
+    "AsyncRewardWrapper",
+    "TrainEngine",
+    "InferenceEngine",
+    "Scheduler",
+    "Worker",
+    "Job",
+    "AllocationMode",
+    "AllocationType",
+    "ParallelStrategy",
+    "FSDPParallelStrategy",
+    "MegatronParallelStrategy",
+    "ModelRequest",
+    "ModelResponse",
+    "WeightUpdateMeta",
+    "SaveLoadMeta",
+    "StepInfo",
+    "FinetuneSpec",
+    "ParamSpec",
+    "RolloutStat",
+    "LocalInfServerInfo",
+    "WorkflowLike",
+    "AgentWorkflow",
+]
+
+_LAZY_IMPORTS = {
+    "TrainEngine": "areal.api.engine_api",
+    "InferenceEngine": "areal.api.engine_api",
+    "Scheduler": "areal.api.scheduler_api",
+    "Worker": "areal.api.scheduler_api",
+    "Job": "areal.api.scheduler_api",
+    "AllocationMode": "areal.api.alloc_mode",
+    "AllocationType": "areal.api.alloc_mode",
+    "ParallelStrategy": "areal.api.alloc_mode",
+    "FSDPParallelStrategy": "areal.api.alloc_mode",
+    "MegatronParallelStrategy": "areal.api.alloc_mode",
+    "ModelRequest": "areal.api.io_struct",
+    "ModelResponse": "areal.api.io_struct",
+    "WeightUpdateMeta": "areal.api.io_struct",
+    "SaveLoadMeta": "areal.api.io_struct",
+    "StepInfo": "areal.api.io_struct",
+    "FinetuneSpec": "areal.api.io_struct",
+    "ParamSpec": "areal.api.io_struct",
+    "RolloutStat": "areal.api.io_struct",
+    "LocalInfServerInfo": "areal.api.io_struct",
+    "WorkflowLike": "areal.api.workflow_api",
+    "AgentWorkflow": "areal.api.workflow_api",
+    "AsyncRewardWrapper": "areal.api.reward_api",
+    "RolloutWorkflow": "areal.api.workflow_api",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        val = getattr(module, name)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return list(__all__)

--- a/areal/dataset/__init__.py
+++ b/areal/dataset/__init__.py
@@ -151,3 +151,9 @@ def get_custom_dataset(
         processor=processor,
         **kwargs,
     )
+
+
+__all__ = [
+    "VALID_DATASETS",
+    "get_custom_dataset",
+]

--- a/areal/engine/__init__.py
+++ b/areal/engine/__init__.py
@@ -1,0 +1,42 @@
+__all__ = [
+    "FSDPEngine",
+    "FSDPPPOActor",
+    "FSDPPPOCritic",
+    "FSDPLMEngine",
+    "FSDPRWEngine",
+    "MegatronEngine",
+    "MegatronPPOActor",
+    "MegatronPPOCritic",
+    "MegatronLMEngine",
+    "RemoteSGLangEngine",
+    "RemotevLLMEngine",
+]
+
+_LAZY_IMPORTS = {
+    "FSDPEngine": "areal.engine.fsdp_engine",
+    "FSDPPPOActor": "areal.engine.fsdp_engine",
+    "FSDPPPOCritic": "areal.engine.fsdp_engine",
+    "FSDPLMEngine": "areal.engine.fsdp_engine",
+    "FSDPRWEngine": "areal.engine.fsdp_engine",
+    "MegatronEngine": "areal.engine.megatron_engine",
+    "MegatronPPOActor": "areal.engine.megatron_engine",
+    "MegatronPPOCritic": "areal.engine.megatron_engine",
+    "MegatronLMEngine": "areal.engine.megatron_engine",
+    "RemoteSGLangEngine": "areal.engine.sglang_remote",
+    "RemotevLLMEngine": "areal.engine.vllm_remote",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        val = getattr(module, name)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return list(__all__)

--- a/areal/engine/core/model.py
+++ b/areal/engine/core/model.py
@@ -1,7 +1,7 @@
 import torch
 
+from areal.api import AllocationMode, WeightUpdateMeta
 from areal.api.cli_args import BaseExperimentConfig
-from areal.api.io_struct import AllocationMode, WeightUpdateMeta
 
 VALID_VISION_MODELS = [
     "qwen2_vl",

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -41,17 +41,19 @@ from transformers import (
     get_linear_schedule_with_warmup,
 )
 
-from areal.api.alloc_mode import FSDPParallelStrategy, ParallelStrategy
-from areal.api.cli_args import PerfTracerConfig, TrainEngineConfig
-from areal.api.engine_api import InferenceEngine, TrainEngine
-from areal.api.io_struct import (
-    DeviceRuntimeInfo,
+from areal.api import (
     FinetuneSpec,
+    FSDPParallelStrategy,
+    InferenceEngine,
+    ParallelStrategy,
     ParamSpec,
     SaveLoadMeta,
+    TrainEngine,
     WeightUpdateMeta,
+    WorkflowLike,
 )
-from areal.api.workflow_api import WorkflowLike
+from areal.api.cli_args import PerfTracerConfig, TrainEngineConfig
+from areal.api.io_struct import DeviceRuntimeInfo
 from areal.engine.core import (
     aggregate_eval_losses,
     compute_total_loss_weight,
@@ -123,8 +125,8 @@ from areal.utils.perf_tracer import trace_perf, trace_scope
 from areal.utils.save_load import get_state_dict_from_repo_id_or_path
 
 if TYPE_CHECKING:
+    from areal.api import Scheduler
     from areal.api.cli_args import PPOActorConfig, PPOCriticConfig
-    from areal.api.scheduler_api import Scheduler
 
 
 @dataclasses.dataclass

--- a/areal/engine/fsdp_utils/parallel.py
+++ b/areal/engine/fsdp_utils/parallel.py
@@ -16,7 +16,7 @@ from torch.distributed.tensor.parallel import (
 )
 from transformers import PretrainedConfig
 
-from areal.api.alloc_mode import FSDPParallelStrategy
+from areal.api import FSDPParallelStrategy
 from areal.api.cli_args import FSDPWrapPolicy, TrainEngineConfig
 from areal.engine.core.model import (
     is_gemma3_model,

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -28,21 +28,20 @@ from torch import nn
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import PretrainedConfig
 
-from areal.api.alloc_mode import (
+from areal.api import (
     AllocationMode,
+    FinetuneSpec,
+    InferenceEngine,
     MegatronParallelStrategy,
     ParallelStrategy,
-)
-from areal.api.cli_args import MicroBatchSpec, PerfTracerConfig, TrainEngineConfig
-from areal.api.engine_api import InferenceEngine, TrainEngine
-from areal.api.io_struct import (
-    DeviceRuntimeInfo,
-    FinetuneSpec,
     ParamSpec,
     SaveLoadMeta,
+    TrainEngine,
     WeightUpdateMeta,
+    WorkflowLike,
 )
-from areal.api.workflow_api import WorkflowLike
+from areal.api.cli_args import MicroBatchSpec, PerfTracerConfig, TrainEngineConfig
+from areal.api.io_struct import DeviceRuntimeInfo
 from areal.engine.core import (
     aggregate_eval_losses,
     compute_total_loss_weight,
@@ -105,8 +104,8 @@ from areal.utils.perf_tracer import trace_perf, trace_scope
 from areal.utils.seeding import get_seed
 
 if TYPE_CHECKING:
+    from areal.api import Scheduler
     from areal.api.cli_args import PPOActorConfig, PPOCriticConfig
-    from areal.api.scheduler_api import Scheduler
 
 
 class _MegatronModelList(list):

--- a/areal/engine/megatron_utils/pipeline_parallel.py
+++ b/areal/engine/megatron_utils/pipeline_parallel.py
@@ -6,7 +6,7 @@ from megatron.core.transformer.pipeline_parallel_layer_layout import (
 )
 from transformers import PretrainedConfig
 
-from areal.api.alloc_mode import MegatronParallelStrategy
+from areal.api import MegatronParallelStrategy
 from areal.utils import logging
 
 logger = logging.getLogger("MCoreParallel")

--- a/areal/engine/sglang_remote.py
+++ b/areal/engine/sglang_remote.py
@@ -10,21 +10,23 @@ import numpy as np
 import pybase64
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from areal.api.cli_args import InferenceEngineConfig, PerfTracerConfig, SGLangConfig
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import (
-    HttpGenerationResult,
-    HttpRequest,
+from areal.api import (
+    InferenceEngine,
     LocalInfServerInfo,
     ModelRequest,
     ModelResponse,
     ParamSpec,
+    Scheduler,
     WeightUpdateMeta,
+    WorkflowLike,
+)
+from areal.api.cli_args import InferenceEngineConfig, PerfTracerConfig, SGLangConfig
+from areal.api.io_struct import (
+    HttpGenerationResult,
+    HttpRequest,
     WeightUpdateRequests,
     get_versioned_lora_name,
 )
-from areal.api.scheduler_api import Scheduler
-from areal.api.workflow_api import WorkflowLike
 from areal.infra import RemoteInfEngine, RolloutController, WorkflowExecutor
 from areal.infra.platforms import current_platform
 from areal.infra.utils.launcher import TRITON_CACHE_PATH

--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -8,21 +8,23 @@ from typing import Any
 
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from areal.api.cli_args import InferenceEngineConfig, PerfTracerConfig, vLLMConfig
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import (
-    HttpGenerationResult,
-    HttpRequest,
+from areal.api import (
+    InferenceEngine,
     LocalInfServerInfo,
     ModelRequest,
     ModelResponse,
     ParamSpec,
+    Scheduler,
     WeightUpdateMeta,
+    WorkflowLike,
+)
+from areal.api.cli_args import InferenceEngineConfig, PerfTracerConfig, vLLMConfig
+from areal.api.io_struct import (
+    HttpGenerationResult,
+    HttpRequest,
     WeightUpdateRequests,
     get_versioned_lora_name,
 )
-from areal.api.scheduler_api import Scheduler
-from areal.api.workflow_api import WorkflowLike
 from areal.infra import RemoteInfEngine, RolloutController, WorkflowExecutor
 from areal.infra.platforms import current_platform
 from areal.infra.utils.launcher import TRITON_CACHE_PATH

--- a/areal/experimental/engine/archon_engine.py
+++ b/areal/experimental/engine/archon_engine.py
@@ -24,15 +24,15 @@ from transformers import (
     PreTrainedTokenizerFast,
 )
 
-from areal.api.alloc_mode import ParallelStrategy
-from areal.api.cli_args import MicroBatchSpec
-from areal.api.engine_api import TrainEngine
-from areal.api.io_struct import (
-    DeviceRuntimeInfo,
+from areal.api import (
     FinetuneSpec,
+    ParallelStrategy,
     SaveLoadMeta,
+    TrainEngine,
     WeightUpdateMeta,
 )
+from areal.api.cli_args import MicroBatchSpec
+from areal.api.io_struct import DeviceRuntimeInfo
 from areal.engine.core.distributed import patch_dist_group_timeout
 from areal.engine.core.train_engine import (
     aggregate_eval_losses,
@@ -108,10 +108,8 @@ if TYPE_CHECKING:
     from torch.distributed.pipelining import PipelineStage
     from torchdata.stateful_dataloader import StatefulDataLoader
 
+    from areal.api import InferenceEngine, Scheduler, WorkflowLike
     from areal.api.cli_args import PerfTracerConfig, TrainEngineConfig
-    from areal.api.engine_api import InferenceEngine
-    from areal.api.scheduler_api import Scheduler
-    from areal.api.workflow_api import WorkflowLike
     from areal.experimental.engine.archon_runner import ForwardBackwardRunner
 
 

--- a/areal/experimental/engine/archon_weight_sync.py
+++ b/areal/experimental/engine/archon_weight_sync.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 from torch import nn
 from torch.distributed.tensor import DTensor
 
-from areal.api.io_struct import ParamSpec, WeightUpdateMeta
+from areal.api import ParamSpec, WeightUpdateMeta
 from areal.engine.core.distributed import init_custom_process_group
 from areal.experimental.engine.archon_checkpoint import save_model_to_hf
 from areal.infra.platforms import current_platform
@@ -21,7 +21,7 @@ from areal.utils.network import find_free_ports, gethostip
 from areal.utils.perf_tracer import trace_perf
 
 if TYPE_CHECKING:
-    from areal.api.engine_api import InferenceEngine
+    from areal.api import InferenceEngine
     from areal.experimental.engine.archon_engine import ArchonEngine
 
 

--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -49,8 +49,8 @@ from openai.types.responses.response_usage import (
 from openai.types.responses.tool_param import ToolParam
 from openai.types.shared_params.metadata import Metadata
 
+from areal.api import ModelRequest, ModelResponse
 from areal.api.cli_args import GenerationHyperparameters
-from areal.api.io_struct import ModelRequest, ModelResponse
 from areal.experimental.openai.cache import InteractionCache
 from areal.experimental.openai.tool_call_parser import process_tool_calls
 from areal.experimental.openai.types import InteractionWithTokenLogpReward

--- a/areal/experimental/openai/proxy/proxy_rollout_server.py
+++ b/areal/experimental/openai/proxy/proxy_rollout_server.py
@@ -56,7 +56,7 @@ from .server import (
 )
 
 if TYPE_CHECKING:
-    from areal.api.engine_api import InferenceEngine
+    from areal.api import InferenceEngine
 
 
 logger = getLogger("ProxyRolloutServer")

--- a/areal/experimental/openai/proxy/workflow.py
+++ b/areal/experimental/openai/proxy/workflow.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp
 
-from areal.api.workflow_api import RolloutWorkflow
+from areal.api import RolloutWorkflow
 from areal.infra import workflow_context
 from areal.utils import logging, stats_tracker
 from areal.utils.perf_tracer import session_context, trace_session

--- a/areal/experimental/openai/types.py
+++ b/areal/experimental/openai/types.py
@@ -7,7 +7,7 @@ from openai.types.chat import ChatCompletion
 from openai.types.responses.response import Response
 from openai.types.responses.response_input_param import ResponseInputParam
 
-from areal.api.io_struct import ModelResponse
+from areal.api import ModelResponse
 from areal.utils import logging
 
 logger = logging.getLogger("TokenLogpReward")

--- a/areal/experimental/workflow/multi_turn_v2.py
+++ b/areal/experimental/workflow/multi_turn_v2.py
@@ -4,10 +4,8 @@ from typing import Any
 from transformers import PreTrainedTokenizerFast
 
 from areal import workflow_context
+from areal.api import AsyncRewardWrapper, InferenceEngine, RolloutWorkflow
 from areal.api.cli_args import GenerationHyperparameters
-from areal.api.engine_api import InferenceEngine
-from areal.api.reward_api import AsyncRewardWrapper
-from areal.api.workflow_api import RolloutWorkflow
 from areal.experimental.openai import ArealOpenAI
 from areal.utils import logging, stats_tracker
 

--- a/areal/infra/controller/rollout_callback.py
+++ b/areal/infra/controller/rollout_callback.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import requests
 
-from areal.api.io_struct import ParamSpec, WeightUpdateMeta
+from areal.api import ParamSpec, WeightUpdateMeta
 from areal.infra.rpc.serialization import serialize_value
 from areal.infra.utils.concurrent import get_executor
 from areal.utils import logging

--- a/areal/infra/controller/rollout_controller.py
+++ b/areal/infra/controller/rollout_controller.py
@@ -14,22 +14,25 @@ from flask import Flask, jsonify, request
 from torchdata.stateful_dataloader import StatefulDataLoader
 from werkzeug.serving import make_server
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import (
+    AllocationMode,
+    InferenceEngine,
+    Job,
+    LocalInfServerInfo,
+    ModelRequest,
+    ModelResponse,
+    ParamSpec,
+    RolloutWorkflow,
+    Scheduler,
+    WeightUpdateMeta,
+    Worker,
+    WorkflowLike,
+)
 from areal.api.cli_args import (
     InferenceEngineConfig,
     PerfTracerConfig,
     SchedulingSpec,
 )
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import (
-    LocalInfServerInfo,
-    ModelRequest,
-    ModelResponse,
-    ParamSpec,
-    WeightUpdateMeta,
-)
-from areal.api.scheduler_api import Job, Scheduler, Worker
-from areal.api.workflow_api import RolloutWorkflow, WorkflowLike
 from areal.infra.rpc.serialization import deserialize_value
 from areal.infra.utils.concurrent import run_async_task
 from areal.utils import logging, perf_tracer

--- a/areal/infra/controller/train_controller.py
+++ b/areal/infra/controller/train_controller.py
@@ -4,17 +4,19 @@ from typing import Any
 import torch.distributed as dist
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from areal.api.alloc_mode import ParallelStrategy
-from areal.api.cli_args import PerfTracerConfig, TrainEngineConfig
-from areal.api.engine_api import TrainEngine
-from areal.api.io_struct import (
+from areal.api import (
     AllocationMode,
     FinetuneSpec,
+    Job,
+    ParallelStrategy,
     SaveLoadMeta,
+    Scheduler,
+    TrainEngine,
     WeightUpdateMeta,
+    Worker,
+    WorkflowLike,
 )
-from areal.api.scheduler_api import Job, Scheduler, Worker
-from areal.api.workflow_api import WorkflowLike
+from areal.api.cli_args import PerfTracerConfig, TrainEngineConfig
 from areal.infra.rpc.rtensor import RTensor
 from areal.infra.utils.concurrent import run_async_task
 from areal.utils import logging, stats_tracker

--- a/areal/infra/dist_rollout.py
+++ b/areal/infra/dist_rollout.py
@@ -6,8 +6,7 @@ import torch
 import torch.distributed as dist
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from areal.api.engine_api import InferenceEngine, TrainEngine
-from areal.api.workflow_api import WorkflowLike
+from areal.api import InferenceEngine, TrainEngine, WorkflowLike
 from areal.infra.platforms import current_platform
 from areal.utils.data import (
     all_gather_tensor_container,

--- a/areal/infra/launcher/local.py
+++ b/areal/infra/launcher/local.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 
 import psutil
 
-from areal.api.alloc_mode import AllocationMode, AllocationType
+from areal.api import AllocationMode, AllocationType
 from areal.api.cli_args import (
     ClusterSpecConfig,
     InferenceEngineConfig,

--- a/areal/infra/launcher/ray.py
+++ b/areal/infra/launcher/ray.py
@@ -13,7 +13,7 @@ from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 import areal.utils.logging as logging
-from areal.api.alloc_mode import AllocationMode, AllocationType
+from areal.api import AllocationMode, AllocationType
 from areal.api.cli_args import (
     ClusterSpecConfig,
     InferenceEngineConfig,

--- a/areal/infra/launcher/sglang_server.py
+++ b/areal/infra/launcher/sglang_server.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 
 import requests
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode
 from areal.api.cli_args import (
     ClusterSpecConfig,
     InferenceEngineConfig,

--- a/areal/infra/launcher/slurm.py
+++ b/areal/infra/launcher/slurm.py
@@ -7,7 +7,7 @@ import sys
 import time
 
 import areal.utils.logging as logging
-from areal.api.alloc_mode import AllocationMode, AllocationType
+from areal.api import AllocationMode, AllocationType
 from areal.api.cli_args import (
     ClusterSpecConfig,
     InferenceEngineConfig,

--- a/areal/infra/launcher/vllm_server.py
+++ b/areal/infra/launcher/vllm_server.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 
 import requests
 
+from areal.api import AllocationMode
 from areal.api.cli_args import (
     ClusterSpecConfig,
     InferenceEngineConfig,
@@ -18,7 +19,6 @@ from areal.api.cli_args import (
     to_structured_cfg,
     vLLMConfig,
 )
-from areal.api.io_struct import AllocationMode
 from areal.infra.platforms import current_platform
 from areal.infra.utils.launcher import TRITON_CACHE_PATH, get_scheduling_spec
 from areal.infra.utils.proc import kill_process_tree

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -22,19 +22,22 @@ import torch.distributed as dist
 import uvloop
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from areal.api.cli_args import InferenceEngineConfig, OpenAIProxyConfig
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import (
-    HttpGenerationResult,
-    HttpRequest,
+from areal.api import (
+    InferenceEngine,
     LocalInfServerInfo,
     ModelRequest,
     ModelResponse,
     ParamSpec,
+    RolloutWorkflow,
     WeightUpdateMeta,
+    WorkflowLike,
+)
+from areal.api.cli_args import InferenceEngineConfig, OpenAIProxyConfig
+from areal.api.io_struct import (
+    HttpGenerationResult,
+    HttpRequest,
     WeightUpdateRequests,
 )
-from areal.api.workflow_api import RolloutWorkflow, WorkflowLike
 from areal.infra import workflow_context
 from areal.infra.platforms import current_platform
 from areal.infra.utils.concurrent import get_executor

--- a/areal/infra/rpc/ray_rpc_server.py
+++ b/areal/infra/rpc/ray_rpc_server.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import ray
 
+from areal.api import InferenceEngine, TrainEngine
 from areal.api.cli_args import BaseExperimentConfig
-from areal.api.engine_api import InferenceEngine, TrainEngine
 from areal.infra.rpc.rtensor import RTensor
 from areal.utils import logging, name_resolve, seeding
 from areal.utils.data import (

--- a/areal/infra/rpc/rpc_server.py
+++ b/areal/infra/rpc/rpc_server.py
@@ -18,8 +18,8 @@ import requests
 from flask import Flask, Response, jsonify, request
 from werkzeug.serving import make_server
 
+from areal.api import InferenceEngine, TrainEngine
 from areal.api.cli_args import BaseExperimentConfig, NameResolveConfig
-from areal.api.engine_api import InferenceEngine, TrainEngine
 from areal.infra.platforms import current_platform
 from areal.infra.rpc import rtensor
 from areal.infra.rpc.rtensor import RTensor

--- a/areal/infra/scheduler/local.py
+++ b/areal/infra/scheduler/local.py
@@ -13,12 +13,13 @@ import aiohttp
 import orjson
 import requests
 
+from areal.api import Job, Scheduler, Worker
 from areal.api.cli_args import (
     BaseExperimentConfig,
     NameResolveConfig,
+    SchedulingSpec,
     SchedulingStrategyType,
 )
-from areal.api.scheduler_api import Job, Scheduler, SchedulingSpec, Worker
 from areal.infra.platforms import current_platform
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
 from areal.infra.scheduler.exceptions import (

--- a/areal/infra/scheduler/ray.py
+++ b/areal/infra/scheduler/ray.py
@@ -13,12 +13,12 @@ from ray.util.placement_group import (
 )
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+from areal.api import Job, Scheduler, Worker
 from areal.api.cli_args import (
     BaseExperimentConfig,
     SchedulingSpec,
     SchedulingStrategyType,
 )
-from areal.api.scheduler_api import Job, Scheduler, Worker
 from areal.infra.rpc.ray_rpc_server import RayRPCServer
 from areal.infra.scheduler.exceptions import (
     EngineCallError,

--- a/areal/infra/scheduler/slurm.py
+++ b/areal/infra/scheduler/slurm.py
@@ -12,12 +12,13 @@ import aiohttp
 import orjson
 import requests
 
+from areal.api import Job, Scheduler, Worker
 from areal.api.cli_args import (
     BaseExperimentConfig,
     NameResolveConfig,
+    SchedulingSpec,
     SchedulingStrategyType,
 )
-from areal.api.scheduler_api import Job, Scheduler, SchedulingSpec, Worker
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
 from areal.infra.scheduler.exceptions import (
     EngineCallError,

--- a/areal/infra/staleness_manager.py
+++ b/areal/infra/staleness_manager.py
@@ -7,7 +7,7 @@ and staleness constraints for asynchronous rollout generation in RL training.
 from threading import Lock
 from typing import Protocol
 
-from areal.api.io_struct import RolloutStat
+from areal.api import RolloutStat
 
 
 class VersionProvider(Protocol):

--- a/areal/infra/utils/launcher.py
+++ b/areal/infra/utils/launcher.py
@@ -6,7 +6,7 @@ import pathlib
 import sys
 import time
 
-from areal.api.alloc_mode import AllocationMode, AllocationType
+from areal.api import AllocationMode, AllocationType
 from areal.utils import logging, name_resolve, names
 from areal.utils.fs import validate_shared_path
 

--- a/areal/infra/utils/ray_placement_group.py
+++ b/areal/infra/utils/ray_placement_group.py
@@ -11,7 +11,7 @@ from ray.util.placement_group import (
 )
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-from areal.api.scheduler_api import SchedulingSpec
+from areal.api.cli_args import SchedulingSpec
 from areal.infra.utils.ray import create_resource_spec
 from areal.utils import logging
 

--- a/areal/infra/workflow_executor.py
+++ b/areal/infra/workflow_executor.py
@@ -19,7 +19,7 @@ import aiofiles.os
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from areal.api.cli_args import InferenceEngineConfig
-from areal.api.workflow_api import RolloutWorkflow
+from areal.api import RolloutWorkflow
 from .async_task_runner import (
     AsyncTaskRunner,
     TaskQueueFullError,

--- a/areal/reward/__init__.py
+++ b/areal/reward/__init__.py
@@ -75,3 +75,36 @@ def get_math_verify_worker() -> MathVerifyWorker:
     if _MATH_VERIFY_WORKER is None:
         _MATH_VERIFY_WORKER = MathVerifyWorker()
     return _MATH_VERIFY_WORKER
+
+
+__all__ = [
+    "VALID_REWARD_FN",
+    "get_custom_reward_fn",
+    "MathVerifyWorker",
+    "get_math_verify_worker",
+    "gsm8k_reward_fn",
+    "geometry3k_reward_fn",
+    "clevr_count_70k_reward_fn",
+]
+
+
+_LAZY_IMPORTS = {
+    "gsm8k_reward_fn": "areal.reward.gsm8k",
+    "geometry3k_reward_fn": "areal.reward.geometry3k",
+    "clevr_count_70k_reward_fn": "areal.reward.clevr_count_70k",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        val = getattr(module, name)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return list(__all__)

--- a/areal/reward/geometry3k.py
+++ b/areal/reward/geometry3k.py
@@ -1,7 +1,8 @@
 import re
 
-from areal.reward import get_math_verify_worker
 from areal.utils import logging
+
+from . import get_math_verify_worker
 
 logger = logging.getLogger("Geometry3KReward")
 

--- a/areal/reward/gsm8k.py
+++ b/areal/reward/gsm8k.py
@@ -1,5 +1,6 @@
-from areal.reward import get_math_verify_worker
 from areal.utils import logging
+
+from . import get_math_verify_worker
 
 logger = logging.getLogger("GSM8KReward")
 

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -3,8 +3,8 @@ from typing import Any
 
 import torch
 
+from areal.api import TrainEngine
 from areal.api.cli_args import MicroBatchSpec, PPOActorConfig
-from areal.api.engine_api import TrainEngine
 from areal.infra import TrainController
 from areal.trainer.ppo.stats import infer_token_denominator
 from areal.utils import logging, stats_tracker

--- a/areal/trainer/ppo/critic.py
+++ b/areal/trainer/ppo/critic.py
@@ -3,8 +3,8 @@ from typing import Any
 
 import torch
 
+from areal.api import TrainEngine
 from areal.api.cli_args import MicroBatchSpec, PPOCriticConfig
-from areal.api.engine_api import TrainEngine
 from areal.infra import TrainController
 from areal.trainer.ppo.stats import infer_token_denominator
 from areal.utils import stats_tracker

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -10,7 +10,17 @@ import torch.distributed as dist
 from datasets import Dataset
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import (
+    AllocationMode,
+    FinetuneSpec,
+    InferenceEngine,
+    RolloutWorkflow,
+    SaveLoadMeta,
+    Scheduler,
+    StepInfo,
+    WeightUpdateMeta,
+    WorkflowLike,
+)
 from areal.api.cli_args import (
     InferenceEngineConfig,
     PPOActorConfig,
@@ -23,12 +33,7 @@ from areal.api.cli_args import (
     ValidDatasetConfig,
     vLLMConfig,
 )
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import FinetuneSpec, SaveLoadMeta, StepInfo, WeightUpdateMeta
-from areal.api.scheduler_api import Scheduler
-from areal.api.workflow_api import RolloutWorkflow, WorkflowLike
-from areal.engine.sglang_remote import RemoteSGLangEngine
-from areal.engine.vllm_remote import RemotevLLMEngine
+from areal.engine import RemoteSGLangEngine, RemotevLLMEngine
 from areal.infra import (
     LocalScheduler,
     RayScheduler,
@@ -47,8 +52,12 @@ from areal.utils.saver import Saver
 from areal.utils.stats_logger import StatsLogger
 
 if TYPE_CHECKING:
-    from areal.engine.fsdp_engine import FSDPPPOActor, FSDPPPOCritic
-    from areal.engine.megatron_engine import MegatronPPOActor, MegatronPPOCritic
+    from areal.engine import (
+        FSDPPPOActor,
+        FSDPPPOCritic,
+        MegatronPPOActor,
+        MegatronPPOCritic,
+    )
     from areal.experimental.engine.archon_engine import ArchonPPOActor, ArchonPPOCritic
     from areal.trainer.ppo.actor import PPOActorController
     from areal.trainer.ppo.critic import PPOCriticController
@@ -612,11 +621,11 @@ class PPOTrainer:
         self, actor_config: PPOActorConfig
     ) -> FSDPPPOActor | MegatronPPOActor | ArchonPPOActor | PPOActorController:
         if self.allocation_mode.train_backend == "fsdp":
-            from areal.engine.fsdp_engine import FSDPPPOActor
+            from areal.engine import FSDPPPOActor
 
             actor_cls = FSDPPPOActor
         elif self.allocation_mode.train_backend == "megatron":
-            from areal.engine.megatron_engine import MegatronPPOActor
+            from areal.engine import MegatronPPOActor
 
             actor_cls = MegatronPPOActor
         elif self.allocation_mode.train_backend == "archon":
@@ -638,11 +647,11 @@ class PPOTrainer:
         self, critic_config: PPOCriticConfig
     ) -> FSDPPPOCritic | MegatronPPOCritic | ArchonPPOCritic | PPOCriticController:
         if self.allocation_mode.train_backend == "fsdp":
-            from areal.engine.fsdp_engine import FSDPPPOCritic
+            from areal.engine import FSDPPPOCritic
 
             critic_cls = FSDPPPOCritic
         elif self.allocation_mode.train_backend == "megatron":
-            from areal.engine.megatron_engine import MegatronPPOCritic
+            from areal.engine import MegatronPPOCritic
 
             critic_cls = MegatronPPOCritic
         elif self.allocation_mode.train_backend == "archon":
@@ -664,11 +673,11 @@ class PPOTrainer:
         allocation_mode = AllocationMode.from_str(teacher_config.allocation_mode)
 
         if allocation_mode.train_backend == "fsdp":
-            from areal.engine.fsdp_engine import FSDPPPOActor
+            from areal.engine import FSDPPPOActor
 
             actor_cls = FSDPPPOActor
         elif allocation_mode.train_backend == "megatron":
-            from areal.engine.megatron_engine import MegatronPPOActor
+            from areal.engine import MegatronPPOActor
 
             actor_cls = MegatronPPOActor
         elif allocation_mode.train_backend == "archon":

--- a/areal/trainer/rw/rw_engine.py
+++ b/areal/trainer/rw/rw_engine.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import torch
 
-from areal.api.engine_api import TrainEngine
+from areal.api import TrainEngine
 from areal.infra import TrainController
 from areal.infra.platforms import current_platform
 from areal.utils import logging, stats_tracker

--- a/areal/trainer/sft/lm_engine.py
+++ b/areal/trainer/sft/lm_engine.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import torch
 
-from areal.api.engine_api import TrainEngine
+from areal.api import TrainEngine
 from areal.infra import TrainController
 from areal.utils import stats_tracker
 from areal.utils.perf_tracer import trace_perf

--- a/areal/trainer/sft_trainer.py
+++ b/areal/trainer/sft_trainer.py
@@ -7,15 +7,13 @@ import torch.distributed as dist
 from datasets import Dataset
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec, Scheduler, StepInfo
 from areal.api.cli_args import (
     SFTConfig,
     TrainDatasetConfig,
     TrainEngineConfig,
     ValidDatasetConfig,
 )
-from areal.api.io_struct import FinetuneSpec, StepInfo
-from areal.api.scheduler_api import Scheduler
 from areal.infra import (
     LocalScheduler,
     RayScheduler,
@@ -39,8 +37,7 @@ from areal.utils.saver import Saver
 from areal.utils.stats_logger import StatsLogger
 
 if TYPE_CHECKING:
-    from areal.engine.fsdp_engine import FSDPLMEngine
-    from areal.engine.megatron_engine import MegatronLMEngine
+    from areal.engine import FSDPLMEngine, MegatronLMEngine
     from areal.experimental.engine.archon_engine import ArchonLMEngine
     from areal.trainer.sft.lm_engine import LMController
 
@@ -288,11 +285,11 @@ class SFTTrainer:
         self, actor_config: TrainEngineConfig
     ) -> FSDPLMEngine | MegatronLMEngine | ArchonLMEngine | LMController:
         if self.allocation_mode.train_backend == "fsdp":
-            from areal.engine.fsdp_engine import FSDPLMEngine
+            from areal.engine import FSDPLMEngine
 
             actor_cls = FSDPLMEngine
         elif self.allocation_mode.train_backend == "megatron":
-            from areal.engine.megatron_engine import MegatronLMEngine
+            from areal.engine import MegatronLMEngine
 
             actor_cls = MegatronLMEngine
         elif self.allocation_mode.train_backend == "archon":

--- a/areal/utils/evaluator.py
+++ b/areal/utils/evaluator.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 
+from areal.api import FinetuneSpec
 from areal.api.cli_args import EvaluatorConfig
-from areal.api.io_struct import FinetuneSpec
 from areal.utils import timeutil
 
 

--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -8,9 +8,15 @@ import torch.distributed as dist
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor, PreTrainedTokenizerFast
 
+from areal.api import (
+    FinetuneSpec,
+    InferenceEngine,
+    SaveLoadMeta,
+    StepInfo,
+    TrainEngine,
+    WeightUpdateMeta,
+)
 from areal.api.cli_args import RecoverConfig
-from areal.api.engine_api import InferenceEngine, TrainEngine
-from areal.api.io_struct import FinetuneSpec, SaveLoadMeta, StepInfo, WeightUpdateMeta
 from areal.infra import TrainController
 from areal.utils import logging, timeutil
 from areal.utils.evaluator import Evaluator

--- a/areal/utils/saver.py
+++ b/areal/utils/saver.py
@@ -3,9 +3,8 @@ import os
 
 from transformers import AutoProcessor, PreTrainedTokenizerFast
 
+from areal.api import FinetuneSpec, SaveLoadMeta, TrainEngine
 from areal.api.cli_args import SaverConfig
-from areal.api.engine_api import TrainEngine
-from areal.api.io_struct import FinetuneSpec, SaveLoadMeta
 from areal.infra import TrainController
 from areal.utils import timeutil
 from areal.utils.async_checkpoint import AsyncCheckpointManager, AsyncMode

--- a/areal/utils/stats_logger.py
+++ b/areal/utils/stats_logger.py
@@ -8,8 +8,8 @@ import torch.distributed as dist
 import wandb
 from tensorboardX import SummaryWriter
 
+from areal.api import FinetuneSpec
 from areal.api.cli_args import BaseExperimentConfig, StatsLoggerConfig
-from areal.api.io_struct import FinetuneSpec
 from areal.utils import logging
 from areal.utils.printing import tabulate_stats
 from areal.version import version_info

--- a/areal/utils/testing_utils.py
+++ b/areal/utils/testing_utils.py
@@ -12,8 +12,7 @@ import torch
 from huggingface_hub import snapshot_download
 from transformers import AutoConfig
 
-from areal.api.engine_api import InferenceEngine
-from areal.api.workflow_api import RolloutWorkflow
+from areal.api import InferenceEngine, RolloutWorkflow
 from areal.experimental.models.archon import get_model_spec, is_supported_model
 from areal.experimental.openai.types import InteractionWithTokenLogpReward
 from areal.utils import logging

--- a/areal/workflow/__init__.py
+++ b/areal/workflow/__init__.py
@@ -1,0 +1,26 @@
+__all__ = [
+    "RLVRWorkflow",
+    "MultiTurnWorkflow",
+    "VisionRLVRWorkflow",
+]
+
+_LAZY_IMPORTS = {
+    "RLVRWorkflow": "areal.workflow.rlvr",
+    "MultiTurnWorkflow": "areal.workflow.multi_turn",
+    "VisionRLVRWorkflow": "areal.workflow.vision_rlvr",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        val = getattr(module, name)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return list(__all__)

--- a/areal/workflow/anthropic/claude_math_agent.py
+++ b/areal/workflow/anthropic/claude_math_agent.py
@@ -12,7 +12,7 @@ from claude_agent_sdk import (
 )
 from math_verify import parse, verify
 
-from areal.api.reward_api import AsyncRewardWrapper
+from areal.api import AsyncRewardWrapper
 
 
 def math_reward_fn(completions: str, answer: str) -> float:

--- a/areal/workflow/anthropic/math_agent.py
+++ b/areal/workflow/anthropic/math_agent.py
@@ -1,10 +1,9 @@
 import os
 
+import anthropic
 from math_verify import parse, verify
 
-import anthropic
-
-from areal.api.reward_api import AsyncRewardWrapper
+from areal.api import AsyncRewardWrapper
 
 
 def math_reward_fn(completions: str, answer: str) -> float:

--- a/areal/workflow/langchain/math_agent.py
+++ b/areal/workflow/langchain/math_agent.py
@@ -7,13 +7,12 @@ proxy-based training infrastructure via the AgentWorkflow pattern.
 import math
 import os
 
+from langchain.agents import create_agent
+from langchain.tools import tool
 from langchain_openai import ChatOpenAI
 from math_verify import parse, verify
 
-from langchain.agents import create_agent
-from langchain.tools import tool
-
-from areal.api.reward_api import AsyncRewardWrapper
+from areal.api import AsyncRewardWrapper
 
 
 def math_reward_fn(completions: str, answer: str) -> float:

--- a/areal/workflow/multi_turn.py
+++ b/areal/workflow/multi_turn.py
@@ -6,11 +6,8 @@ import torch
 from transformers import PreTrainedTokenizerFast
 
 from areal import workflow_context
+from areal.api import AsyncRewardWrapper, InferenceEngine, ModelRequest, RolloutWorkflow
 from areal.api.cli_args import GenerationHyperparameters
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import ModelRequest
-from areal.api.reward_api import AsyncRewardWrapper
-from areal.api.workflow_api import RolloutWorkflow
 from areal.utils import logging, stats_tracker
 
 logger = logging.getLogger("MultiTurnWorkflow")

--- a/areal/workflow/openai/math_agent.py
+++ b/areal/workflow/openai/math_agent.py
@@ -13,7 +13,7 @@ from math_verify import parse, verify
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion
 
-from areal.api.reward_api import AsyncRewardWrapper
+from areal.api import AsyncRewardWrapper
 
 
 def math_reward_fn(completions: str, answer: str) -> float:

--- a/areal/workflow/rlvr.py
+++ b/areal/workflow/rlvr.py
@@ -6,11 +6,14 @@ import torch
 from transformers import PreTrainedTokenizerFast
 
 from areal import workflow_context
+from areal.api import (
+    AsyncRewardWrapper,
+    InferenceEngine,
+    ModelRequest,
+    ModelResponse,
+    RolloutWorkflow,
+)
 from areal.api.cli_args import GenerationHyperparameters
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import ModelRequest, ModelResponse
-from areal.api.reward_api import AsyncRewardWrapper
-from areal.api.workflow_api import RolloutWorkflow
 from areal.utils import logging, stats_tracker
 from areal.utils.dynamic_import import import_from_string
 from areal.utils.perf_tracer import (

--- a/areal/workflow/vision_rlvr.py
+++ b/areal/workflow/vision_rlvr.py
@@ -6,10 +6,8 @@ import torch
 from transformers import AutoProcessor, PreTrainedTokenizerFast
 
 from areal import workflow_context
+from areal.api import AsyncRewardWrapper, InferenceEngine, ModelRequest, ModelResponse
 from areal.api.cli_args import GenerationHyperparameters
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import ModelRequest, ModelResponse
-from areal.api.reward_api import AsyncRewardWrapper
 from areal.utils import logging, stats_tracker
 from areal.utils.dynamic_import import import_from_string
 from areal.utils.image import image2base64

--- a/examples/alignment/hhrlhf_rw.py
+++ b/examples/alignment/hhrlhf_rw.py
@@ -4,11 +4,10 @@ import sys
 import torch.distributed as dist
 
 from areal import current_platform
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec, StepInfo
 from areal.api.cli_args import RWConfig, load_expr_config
-from areal.api.io_struct import FinetuneSpec, StepInfo
 from areal.dataset import get_custom_dataset
-from areal.engine.fsdp_engine import FSDPRWEngine
+from areal.engine import FSDPRWEngine
 from areal.utils import seeding, stats_tracker
 from areal.utils.data import (
     broadcast_tensor_container,

--- a/examples/camel/train.py
+++ b/examples/camel/train.py
@@ -4,9 +4,8 @@ from camel.agents import ChatAgent
 from transformers import PreTrainedTokenizerFast
 
 from areal import PPOTrainer, workflow_context
+from areal.api import AsyncRewardWrapper, RolloutWorkflow
 from areal.api.cli_args import GenerationHyperparameters, GRPOConfig, load_expr_config
-from areal.api.reward_api import AsyncRewardWrapper
-from areal.api.workflow_api import RolloutWorkflow
 from areal.dataset import get_custom_dataset
 from areal.experimental.camel.openai_model import AReaLOpenAICompatibleModel
 from areal.experimental.openai import ArealOpenAI

--- a/examples/countdown/train.py
+++ b/examples/countdown/train.py
@@ -8,10 +8,8 @@ from reward_score import compute_score
 from transformers import PreTrainedTokenizerFast
 
 from areal import PPOTrainer, workflow_context
+from areal.api import InferenceEngine, ModelRequest, RolloutWorkflow
 from areal.api.cli_args import GenerationHyperparameters, GRPOConfig, load_expr_config
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import ModelRequest
-from areal.api.workflow_api import RolloutWorkflow
 from areal.utils import logging, stats_tracker
 
 worker_id = uuid.uuid4().hex[:4]

--- a/examples/math/gsm8k_eval.py
+++ b/examples/math/gsm8k_eval.py
@@ -1,10 +1,9 @@
 import sys
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode
 from areal.api.cli_args import GRPOConfig, SGLangConfig, load_expr_config, vLLMConfig
 from areal.dataset import get_custom_dataset
-from areal.engine.sglang_remote import RemoteSGLangEngine
-from areal.engine.vllm_remote import RemotevLLMEngine
+from areal.engine import RemoteSGLangEngine, RemotevLLMEngine
 from areal.infra import LocalScheduler, RayScheduler, SlurmScheduler
 from areal.utils import logging, seeding
 from areal.utils.dataloader import create_dataloader

--- a/examples/multi_turn_math/gsm8k_rl_mt.py
+++ b/examples/multi_turn_math/gsm8k_rl_mt.py
@@ -6,9 +6,8 @@ from openai.types.chat import ChatCompletion
 from transformers import PreTrainedTokenizerFast
 
 from areal import PPOTrainer, workflow_context
+from areal.api import AsyncRewardWrapper, RolloutWorkflow
 from areal.api.cli_args import GenerationHyperparameters, GRPOConfig, load_expr_config
-from areal.api.reward_api import AsyncRewardWrapper
-from areal.api.workflow_api import RolloutWorkflow
 from areal.dataset import get_custom_dataset
 from areal.experimental.openai import ArealOpenAI
 from areal.reward import get_math_verify_worker

--- a/examples/openai_agents/train_agents.py
+++ b/examples/openai_agents/train_agents.py
@@ -6,9 +6,8 @@ from agents import Runner as OpenAIRunner
 from transformers import PreTrainedTokenizerFast
 
 from areal import PPOTrainer, workflow_context
+from areal.api import AsyncRewardWrapper, RolloutWorkflow
 from areal.api.cli_args import GenerationHyperparameters, GRPOConfig, load_expr_config
-from areal.api.reward_api import AsyncRewardWrapper
-from areal.api.workflow_api import RolloutWorkflow
 from areal.dataset import get_custom_dataset
 from areal.experimental.openai import ArealOpenAI
 from areal.utils import stats_tracker

--- a/examples/search_agent/tongyi_deepresearch/train.py
+++ b/examples/search_agent/tongyi_deepresearch/train.py
@@ -9,14 +9,14 @@ from datasets import load_dataset
 from transformers import PreTrainedTokenizerFast
 
 from areal import PPOTrainer, workflow_context
+from areal.api import RolloutWorkflow
 from areal.api.cli_args import (
     GenerationHyperparameters,
     GRPOConfig,
     InferenceEngineConfig,
     load_expr_config,
 )
-from areal.api.workflow_api import RolloutWorkflow
-from areal.engine.sglang_remote import RemoteSGLangEngine
+from areal.engine import RemoteSGLangEngine
 from areal.experimental.openai import ArealOpenAI
 from areal.utils import logging, stats_tracker
 from areal.utils.hf_utils import load_hf_tokenizer

--- a/examples/tir/tir_workflow.py
+++ b/examples/tir/tir_workflow.py
@@ -8,16 +8,19 @@ import torch
 from transformers import PreTrainedTokenizerFast
 
 from areal import workflow_context
+from areal.api import (
+    AsyncRewardWrapper,
+    InferenceEngine,
+    ModelRequest,
+    ModelResponse,
+    RolloutWorkflow,
+)
 from areal.api.cli_args import (
     GenerationHyperparameters,
     GRPOConfig,
     dataclass,
     field,
 )
-from areal.api.engine_api import InferenceEngine
-from areal.api.io_struct import ModelRequest, ModelResponse
-from areal.api.reward_api import AsyncRewardWrapper
-from areal.api.workflow_api import RolloutWorkflow
 from areal.utils import logging, stats_tracker
 
 from prompts import ANSWER, SYSTEM_PROMPT, TORL_PROMPT  # isort: skip

--- a/tests/experimental/archon/torchrun/run_archon_engine_pp.py
+++ b/tests/experimental/archon/torchrun/run_archon_engine_pp.py
@@ -31,9 +31,8 @@ from tests.experimental.archon.torchrun.dist_utils import (
 )
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import ParallelStrategy
+from areal.api import FinetuneSpec, ParallelStrategy
 from areal.api.cli_args import MicroBatchSpec, OptimizerConfig, TrainEngineConfig
-from areal.api.io_struct import FinetuneSpec
 from areal.experimental.engine.archon_engine import ArchonEngine
 
 # Use a small model for testing

--- a/tests/experimental/archon/torchrun/run_checkpoint_tests.py
+++ b/tests/experimental/archon/torchrun/run_checkpoint_tests.py
@@ -40,14 +40,13 @@ from tests.experimental.archon.torchrun.dist_utils import (
     write_result,
 )
 
-from areal.api.alloc_mode import ParallelStrategy
+from areal.api import FinetuneSpec, ParallelStrategy, SaveLoadMeta
 from areal.api.cli_args import (
     ArchonEngineConfig,
     MicroBatchSpec,
     OptimizerConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec, SaveLoadMeta
 from areal.experimental.engine.archon_checkpoint import DCPState
 from areal.experimental.engine.archon_engine import ArchonLMEngine
 from areal.experimental.models.archon import ArchonParallelDims

--- a/tests/experimental/archon/torchrun/run_cp_forward.py
+++ b/tests/experimental/archon/torchrun/run_cp_forward.py
@@ -16,12 +16,11 @@ import torch.distributed as dist
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import ParallelStrategy
+from areal.api import FinetuneSpec, ParallelStrategy
 from areal.api.cli_args import (
     MicroBatchSpec,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec
 from areal.experimental.engine.archon_engine import ArchonEngine
 from areal.infra.platforms import current_platform
 from areal.utils.data import tensor_container_to

--- a/tests/experimental/archon/torchrun/run_forward.py
+++ b/tests/experimental/archon/torchrun/run_forward.py
@@ -16,12 +16,11 @@ import torch.distributed as dist
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import ParallelStrategy
+from areal.api import FinetuneSpec, ParallelStrategy
 from areal.api.cli_args import (
     MicroBatchSpec,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec
 from areal.experimental.engine.archon_engine import ArchonEngine
 from areal.infra.platforms import current_platform
 from areal.utils.data import tensor_container_to

--- a/tests/experimental/archon/torchrun/run_tp_forward.py
+++ b/tests/experimental/archon/torchrun/run_tp_forward.py
@@ -16,12 +16,11 @@ import torch.distributed as dist
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import ParallelStrategy
+from areal.api import FinetuneSpec, ParallelStrategy
 from areal.api.cli_args import (
     MicroBatchSpec,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec
 from areal.experimental.engine.archon_engine import ArchonEngine
 from areal.infra.platforms import current_platform
 from areal.utils.data import tensor_container_to

--- a/tests/experimental/archon/torchrun/run_vs_fsdp.py
+++ b/tests/experimental/archon/torchrun/run_vs_fsdp.py
@@ -17,10 +17,9 @@ from datasets import load_dataset
 from tests.experimental.archon.torchrun.dist_utils import write_result
 from tests.utils import get_dataset_path, get_model_path
 
-from areal.api.alloc_mode import ParallelStrategy
+from areal.api import FinetuneSpec, ParallelStrategy
 from areal.api.cli_args import MicroBatchSpec, OptimizerConfig, TrainEngineConfig
-from areal.api.io_struct import FinetuneSpec
-from areal.engine.fsdp_engine import FSDPLMEngine
+from areal.engine import FSDPLMEngine
 from areal.experimental.engine.archon_engine import ArchonLMEngine
 from areal.infra.platforms import current_platform
 from areal.utils.data import pad_sequences_to_tensors

--- a/tests/experimental/archon/utils.py
+++ b/tests/experimental/archon/utils.py
@@ -11,10 +11,9 @@ import torch.distributed as dist
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM
 
-from areal.api.alloc_mode import ParallelStrategy
+from areal.api import FinetuneSpec, ParallelStrategy
 from areal.api.cli_args import MicroBatchSpec, OptimizerConfig, TrainEngineConfig
-from areal.api.io_struct import FinetuneSpec
-from areal.engine.fsdp_engine import FSDPLMEngine
+from areal.engine import FSDPLMEngine
 from areal.experimental.engine.archon_engine import ArchonLMEngine
 from areal.infra.platforms import current_platform
 from areal.utils.data import pad_sequences_to_tensors

--- a/tests/experimental/openai/test_client.py
+++ b/tests/experimental/openai/test_client.py
@@ -76,7 +76,7 @@ def tokenizer():
 @pytest.fixture
 def openai_client(sglang_server, tokenizer):
     from areal.api.cli_args import InferenceEngineConfig
-    from areal.engine.sglang_remote import RemoteSGLangEngine
+    from areal.engine import RemoteSGLangEngine
 
     config = InferenceEngineConfig(
         experiment_name=EXPR_NAME,

--- a/tests/experimental/openai/test_client_with_tool.py
+++ b/tests/experimental/openai/test_client_with_tool.py
@@ -76,7 +76,7 @@ def tokenizer():
 @pytest.fixture
 def openai_client(sglang_server, tokenizer):
     from areal.api.cli_args import InferenceEngineConfig
-    from areal.engine.sglang_remote import RemoteSGLangEngine
+    from areal.engine import RemoteSGLangEngine
 
     config = InferenceEngineConfig(
         experiment_name=EXPR_NAME,

--- a/tests/experimental/openai/test_concat_prompt.py
+++ b/tests/experimental/openai/test_concat_prompt.py
@@ -10,7 +10,7 @@ from openai.types.chat import ChatCompletionToolParam
 
 from tests.utils import get_model_path
 
-from areal.api.io_struct import ModelResponse
+from areal.api import ModelResponse
 from areal.experimental.openai.client import (
     concat_prompt_token_ids_with_parent,
 )

--- a/tests/experimental/openai/test_proxy_integration.py
+++ b/tests/experimental/openai/test_proxy_integration.py
@@ -11,13 +11,12 @@ import torch
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, LocalInfServerInfo
 from areal.api.cli_args import (
     InferenceEngineConfig,
     SGLangConfig,
 )
-from areal.api.io_struct import LocalInfServerInfo
-from areal.engine.sglang_remote import RemoteSGLangEngine
+from areal.engine import RemoteSGLangEngine
 from areal.infra import RolloutController
 from areal.infra.rpc.rtensor import RTensor
 from areal.infra.scheduler.local import LocalScheduler

--- a/tests/fp8/engine_utils.py
+++ b/tests/fp8/engine_utils.py
@@ -12,16 +12,15 @@ import torch
 import torch.nn.functional as F
 from megatron.core import parallel_state as mpu
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec
 from areal.api.cli_args import (
     FP8EngineConfig,
     MegatronEngineConfig,
     OptimizerConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec
+from areal.engine import MegatronEngine
 from areal.engine.core.train_engine import reorder_and_pad_outputs
-from areal.engine.megatron_engine import MegatronEngine
 from areal.utils import logging
 from areal.utils.data import (
     broadcast_tensor,

--- a/tests/fp8/model_hooks.py
+++ b/tests/fp8/model_hooks.py
@@ -14,8 +14,8 @@ from tests.fp8.engine_utils import (
     print_gemm_profile,
 )
 
+from areal.engine import MegatronEngine
 from areal.engine.core.train_engine import compute_total_loss_weight
-from areal.engine.megatron_engine import MegatronEngine
 from areal.engine.megatron_utils.megatron import get_named_parameters
 from areal.utils import logging
 

--- a/tests/fp8/test_fp8_rmsnorm.py
+++ b/tests/fp8/test_fp8_rmsnorm.py
@@ -22,7 +22,7 @@ from tests.fp8.engine_utils import create_engine
 from tests.fp8.model_hooks import get_model_from_engine
 from tests.utils import get_model_path
 
-from areal.engine.megatron_engine import MegatronEngine
+from areal.engine import MegatronEngine
 from areal.utils import logging
 
 logger = logging.getLogger("FP8 BF16 RMSNorm Test")

--- a/tests/grpo/entrypoint.py
+++ b/tests/grpo/entrypoint.py
@@ -7,10 +7,10 @@ import torch.distributed as dist
 from areal import PPOTrainer
 from areal.api.cli_args import GRPOConfig, load_expr_config
 from areal.dataset import get_custom_dataset
-from areal.reward.gsm8k import gsm8k_reward_fn
+from areal.reward import gsm8k_reward_fn
 from areal.utils import stats_tracker
 from areal.utils.hf_utils import load_hf_tokenizer
-from areal.workflow.rlvr import RLVRWorkflow
+from areal.workflow import RLVRWorkflow
 
 
 class MinimalPPOTrainer(PPOTrainer):

--- a/tests/test_allocation_mode.py
+++ b/tests/test_allocation_mode.py
@@ -1,7 +1,7 @@
 import pytest
 
+from areal.api import AllocationMode
 from areal.api.alloc_mode import (
-    AllocationMode,
     AllocationValidationError,
     InvalidAllocationModeError,
     ModelAllocation,

--- a/tests/test_datapack.py
+++ b/tests/test_datapack.py
@@ -6,9 +6,8 @@ import numpy as np
 import pytest
 import torch
 
+from areal.api import AllocationMode, TrainEngine
 from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
-from areal.api.engine_api import TrainEngine
-from areal.api.io_struct import AllocationMode
 from areal.infra import TrainController
 from areal.infra.rpc.rtensor import RTensor, TensorShardInfo
 from areal.utils.datapack import balanced_greedy_partition, ffd_allocate

--- a/tests/test_fsdp_dcp.py
+++ b/tests/test_fsdp_dcp.py
@@ -2,7 +2,7 @@ import subprocess
 
 import pytest
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 

--- a/tests/test_fsdp_engine_nccl.py
+++ b/tests/test_fsdp_engine_nccl.py
@@ -5,16 +5,14 @@ import torch.distributed as dist
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec, WeightUpdateMeta
 from areal.api.cli_args import (
     InferenceEngineConfig,
     OptimizerConfig,
     SGLangConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec, WeightUpdateMeta
-from areal.engine.fsdp_engine import FSDPEngine
-from areal.engine.sglang_remote import RemoteSGLangEngine
+from areal.engine import FSDPEngine, RemoteSGLangEngine
 from areal.utils import network
 
 EXPR_NAME = "test_fsdp_engine_nccl"

--- a/tests/test_fsdp_memory_efficient_lora.py
+++ b/tests/test_fsdp_memory_efficient_lora.py
@@ -2,7 +2,7 @@ import subprocess
 
 import pytest
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 

--- a/tests/test_inference_engines.py
+++ b/tests/test_inference_engines.py
@@ -7,14 +7,13 @@ import torch.distributed as dist
 
 from tests.utils import get_model_path
 
+from areal.api import RolloutWorkflow, WeightUpdateMeta
 from areal.api.cli_args import (
     GenerationHyperparameters,
     InferenceEngineConfig,
     SGLangConfig,
     vLLMConfig,
 )
-from areal.api.io_struct import WeightUpdateMeta
-from areal.api.workflow_api import RolloutWorkflow
 from areal.utils import network
 from areal.utils.data import concat_padded_tensors, get_batch_size
 from areal.utils.hf_utils import load_hf_tokenizer
@@ -81,12 +80,12 @@ def inference_engine(request):
 
     # Launch remote server and initialize engine
     if backend == "vllm":
-        from areal.engine.vllm_remote import RemotevLLMEngine
+        from areal.engine import RemotevLLMEngine
 
         engine_class = RemotevLLMEngine
         server_args = vllm_args
     else:  # sglang
-        from areal.engine.sglang_remote import RemoteSGLangEngine
+        from areal.engine import RemoteSGLangEngine
 
         engine_class = RemoteSGLangEngine
         server_args = sglang_args
@@ -128,7 +127,7 @@ def inference_engine(request):
 @pytest.mark.ci
 def test_rollout(inference_engine, n_samples):
     """Test engine rollout with different sample sizes."""
-    from areal.workflow.rlvr import RLVRWorkflow
+    from areal.workflow import RLVRWorkflow
 
     config = InferenceEngineConfig(
         experiment_name=inference_engine["expr_name"],
@@ -184,7 +183,7 @@ def test_rollout(inference_engine, n_samples):
 @pytest.mark.ci
 def test_staleness_control(inference_engine, bs, ofp, n_samples):
     """Test engine staleness control mechanism."""
-    from areal.workflow.rlvr import RLVRWorkflow
+    from areal.workflow import RLVRWorkflow
 
     config = InferenceEngineConfig(
         experiment_name=inference_engine["expr_name"],
@@ -248,7 +247,7 @@ def test_staleness_control(inference_engine, bs, ofp, n_samples):
 @pytest.mark.ci
 def test_wait_for_task(inference_engine):
     """Test wait_for_task functionality with real inference engines."""
-    from areal.workflow.rlvr import RLVRWorkflow
+    from areal.workflow import RLVRWorkflow
 
     config = InferenceEngineConfig(
         experiment_name=inference_engine["expr_name"],
@@ -326,9 +325,9 @@ def test_disk_update_weights_from_fsdp_engine(tmp_path_factory, inference_engine
     """Test disk-based weight updates from FSDP engine to inference engine."""
 
     # setup FSDP engine
+    from areal.api import FinetuneSpec
     from areal.api.cli_args import OptimizerConfig, TrainEngineConfig
-    from areal.api.io_struct import FinetuneSpec
-    from areal.engine.fsdp_engine import FSDPEngine
+    from areal.engine import FSDPEngine
 
     os.environ["WORLD_SIZE"] = "1"
     os.environ["RANK"] = "0"

--- a/tests/test_local_scheduler.py
+++ b/tests/test_local_scheduler.py
@@ -8,14 +8,11 @@ import psutil
 import pytest
 import requests
 
+from areal.api import Job, Worker
 from areal.api.cli_args import (
     SchedulingSpec,
     SchedulingStrategy,
     SchedulingStrategyType,
-)
-from areal.api.scheduler_api import (
-    Job,
-    Worker,
 )
 from areal.infra.scheduler.exceptions import (
     EngineCallError,

--- a/tests/test_math_verify_reward.py
+++ b/tests/test_math_verify_reward.py
@@ -1,6 +1,4 @@
-from areal.reward import get_math_verify_worker
-from areal.reward.geometry3k import geometry3k_reward_fn
-from areal.reward.gsm8k import gsm8k_reward_fn
+from areal.reward import geometry3k_reward_fn, get_math_verify_worker, gsm8k_reward_fn
 
 
 class TestGSM8KRewardFn:

--- a/tests/test_megatron_engine.py
+++ b/tests/test_megatron_engine.py
@@ -10,14 +10,13 @@ from transformers import AutoTokenizer
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec, SaveLoadMeta
 from areal.api.cli_args import (
     MegatronEngineConfig,
     OptimizerConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec, SaveLoadMeta
-from areal.engine.megatron_engine import MegatronEngine
+from areal.engine import MegatronEngine
 from areal.infra.platforms import current_platform
 from areal.utils import logging
 

--- a/tests/test_megatron_engine_distributed.py
+++ b/tests/test_megatron_engine_distributed.py
@@ -2,7 +2,7 @@ import subprocess
 
 import pytest
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import pytest
 
+from areal.api import WeightUpdateMeta
 from areal.api.cli_args import (
     BaseExperimentConfig,
     ClusterSpecConfig,
@@ -15,7 +16,6 @@ from areal.api.cli_args import (
     SFTConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import WeightUpdateMeta
 from areal.engine.core.model import get_model_update_meta
 
 

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -11,11 +11,9 @@ import torch.distributed as dist
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec
 from areal.api.cli_args import MegatronEngineConfig, OptimizerConfig, TrainEngineConfig
-from areal.api.io_struct import FinetuneSpec
-from areal.engine.fsdp_engine import FSDPEngine
-from areal.engine.megatron_engine import MegatronEngine
+from areal.engine import FSDPEngine, MegatronEngine
 from areal.infra.platforms import current_platform
 from areal.utils.network import find_free_ports
 from areal.utils.offload import get_tms_env_vars

--- a/tests/test_packed_vs_padded_consistency.py
+++ b/tests/test_packed_vs_padded_consistency.py
@@ -9,7 +9,7 @@ from torch.testing import assert_close
 from tests.utils import get_model_path
 
 from areal.api.cli_args import TrainEngineConfig
-from areal.engine.fsdp_engine import FSDPEngine
+from areal.engine import FSDPEngine
 from areal.infra.platforms import current_platform
 from areal.utils.data import concat_padded_tensors, tensor_container_to
 from areal.utils.hf_utils import load_hf_processor_and_tokenizer

--- a/tests/test_ray_scheduler.py
+++ b/tests/test_ray_scheduler.py
@@ -5,8 +5,8 @@ from unittest.mock import Mock, patch
 import pytest
 from ray.util.state import summarize_actors
 
-from areal.api.cli_args import BaseExperimentConfig, SchedulingStrategy
-from areal.api.scheduler_api import Job, SchedulingSpec, Worker
+from areal.api import Job, Worker
+from areal.api.cli_args import BaseExperimentConfig, SchedulingSpec, SchedulingStrategy
 from areal.infra.scheduler.ray import RayScheduler, RayWorkerInfo, ray_resource_type
 from areal.infra.utils.ray_placement_group import _create_bundle_specs_split
 

--- a/tests/test_rollout_controller.py
+++ b/tests/test_rollout_controller.py
@@ -7,16 +7,20 @@ import torch
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import (
+    AllocationMode,
+    ModelRequest,
+    ParamSpec,
+    WeightUpdateMeta,
+    Worker,
+)
 from areal.api.cli_args import (
     GenerationHyperparameters,
     InferenceEngineConfig,
     SchedulingSpec,
     SGLangConfig,
 )
-from areal.api.io_struct import ModelRequest, ParamSpec, WeightUpdateMeta
-from areal.api.scheduler_api import Worker
-from areal.engine.sglang_remote import RemoteSGLangEngine
+from areal.engine import RemoteSGLangEngine
 from areal.infra import RolloutController
 from areal.infra.scheduler.local import LocalScheduler
 from areal.utils.hf_utils import load_hf_tokenizer

--- a/tests/test_slurm_scheduler.py
+++ b/tests/test_slurm_scheduler.py
@@ -5,13 +5,13 @@ from pathlib import Path
 
 import pytest
 
+from areal.api import Job
 from areal.api.cli_args import (
     BaseExperimentConfig,
     SchedulingSpec,
     SchedulingStrategy,
     SchedulingStrategyType,
 )
-from areal.api.scheduler_api import Job
 from areal.infra.scheduler.exceptions import (
     EngineCreationError,
     WorkerCreationError,

--- a/tests/test_train_controller.py
+++ b/tests/test_train_controller.py
@@ -10,16 +10,16 @@ from unittest.mock import Mock
 import pytest
 import torch
 
-from areal.api.alloc_mode import ParallelStrategy
-from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
-from areal.api.engine_api import TrainEngine
-from areal.api.io_struct import (
+from areal.api import (
     AllocationMode,
     FinetuneSpec,
+    ParallelStrategy,
     SaveLoadMeta,
+    TrainEngine,
     WeightUpdateMeta,
+    Worker,
 )
-from areal.api.scheduler_api import Worker
+from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
 from areal.infra import TrainController
 
 

--- a/tests/test_train_engine.py
+++ b/tests/test_train_engine.py
@@ -10,8 +10,8 @@ from transformers import AutoTokenizer
 
 from tests.utils import get_model_path
 
+from areal.api import FinetuneSpec, SaveLoadMeta
 from areal.api.cli_args import MicroBatchSpec, OptimizerConfig, TrainEngineConfig
-from areal.api.io_struct import FinetuneSpec, SaveLoadMeta
 from areal.infra.platforms import current_platform
 
 VOCAB_SIZE = 100
@@ -52,7 +52,7 @@ def mock_input(
 
 
 def get_engine(engine_type: str, model_path: str):
-    from areal.engine.fsdp_engine import FSDPEngine
+    from areal.engine import FSDPEngine
 
     engine_cls = {"fsdp": FSDPEngine}[engine_type]
 

--- a/tests/test_tree_training.py
+++ b/tests/test_tree_training.py
@@ -6,15 +6,13 @@ import torch
 from tests.utils import get_model_path
 
 import areal
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec
 from areal.api.cli_args import (
     MicroBatchSpec,
     OptimizerConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec
-from areal.engine.fsdp_engine import FSDPEngine
-from areal.engine.megatron_engine import MegatronEngine
+from areal.engine import FSDPEngine, MegatronEngine
 from areal.experimental.engine.archon_engine import ArchonEngine
 from areal.infra.platforms import current_platform
 from areal.models.tree_attn.module import restore_patch_fsdp_for_tree_training

--- a/tests/test_workflow_detection.py
+++ b/tests/test_workflow_detection.py
@@ -4,7 +4,7 @@ import warnings
 
 import pytest
 
-from areal.api.workflow_api import AgentWorkflow, RolloutWorkflow
+from areal.api import AgentWorkflow, RolloutWorkflow
 
 
 class DummyRolloutWorkflow(RolloutWorkflow):

--- a/tests/torchrun/run_fsdp_dcp_distributed.py
+++ b/tests/torchrun/run_fsdp_dcp_distributed.py
@@ -11,10 +11,9 @@ from transformers import AutoTokenizer
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec, SaveLoadMeta
 from areal.api.cli_args import MicroBatchSpec, OptimizerConfig, TrainEngineConfig
-from areal.api.io_struct import FinetuneSpec, SaveLoadMeta
-from areal.engine.fsdp_engine import FSDPEngine
+from areal.engine import FSDPEngine
 from areal.infra.platforms import current_platform
 from areal.utils import seeding
 

--- a/tests/torchrun/run_fsdp_memory_efficient_lora.py
+++ b/tests/torchrun/run_fsdp_memory_efficient_lora.py
@@ -8,15 +8,14 @@ import torch.distributed as dist
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec
 from areal.api.cli_args import (
     FSDPEngineConfig,
     MicroBatchSpec,
     OptimizerConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec
-from areal.engine.fsdp_engine import FSDPEngine
+from areal.engine import FSDPEngine
 from areal.infra.platforms import current_platform
 
 MODEL_PATH = get_model_path(

--- a/tests/torchrun/run_fsdp_ulysses_forward.py
+++ b/tests/torchrun/run_fsdp_ulysses_forward.py
@@ -7,14 +7,13 @@ import torch.distributed as dist
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import ParallelStrategy
+from areal.api import FinetuneSpec, ParallelStrategy
 from areal.api.cli_args import (
     MicroBatchSpec,
     OptimizerConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec
-from areal.engine.fsdp_engine import FSDPEngine
+from areal.engine import FSDPEngine
 from areal.infra.platforms import current_platform
 
 MODEL_PATHS = {

--- a/tests/torchrun/run_fsdp_ulysses_train_batch.py
+++ b/tests/torchrun/run_fsdp_ulysses_train_batch.py
@@ -7,14 +7,13 @@ import torch.distributed as dist
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import ParallelStrategy
+from areal.api import FinetuneSpec, ParallelStrategy
 from areal.api.cli_args import (
     MicroBatchSpec,
     OptimizerConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec
-from areal.engine.fsdp_engine import FSDPEngine
+from areal.engine import FSDPEngine
 from areal.infra.platforms import current_platform
 from areal.utils.data import tensor_container_to
 

--- a/tests/torchrun/run_megatron_engine_distributed.py
+++ b/tests/torchrun/run_megatron_engine_distributed.py
@@ -11,16 +11,14 @@ from transformers import AutoTokenizer
 
 from tests.utils import get_model_path
 
-from areal.api.alloc_mode import AllocationMode
+from areal.api import AllocationMode, FinetuneSpec, SaveLoadMeta
 from areal.api.cli_args import (
     MegatronEngineConfig,
     MicroBatchSpec,
     OptimizerConfig,
     TrainEngineConfig,
 )
-from areal.api.io_struct import FinetuneSpec, SaveLoadMeta
-from areal.engine.fsdp_engine import FSDPEngine
-from areal.engine.megatron_engine import MegatronEngine
+from areal.engine import FSDPEngine, MegatronEngine
 from areal.infra.platforms import current_platform
 from areal.utils import seeding
 from areal.utils.data import broadcast_tensor_container


### PR DESCRIPTION
## Description

Add `__init__.py` with **fully lazy** re-exports (`__getattr__` + `__all__`) for `areal/api`, `areal/engine`, `areal/reward`, `areal/dataset`, and `areal/workflow`, then rewrite all external imports across ~100 files to use the shorter parent-package form.

For example: `from areal.api.engine_api import TrainEngine` → `from areal.api import TrainEngine`.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Key Changes

- **Fully lazy `__init__.py` re-exports**: all symbols use `__getattr__` — no eager top-level imports, making `areal.api` completely side-effect free at import time
- **`areal/api`** (+23 lazy symbols), **`areal/engine`** (+11), **`areal/reward`** (+3), **`areal/workflow`** (+3), **`areal/dataset`** (`__all__` only)
- **Flatten imports** in `areal/trainer/`, `areal/utils/`, `areal/models/`, `areal/engine/`, `areal/workflow/`, `areal/infra/`, `areal/experimental/`, `tests/`, `examples/`
- **Preserve `cli_args` deep imports** — dozens of config classes including `SchedulingSpec`; explicit path is clearer
- **Preserve intra-package imports** — avoids circular dependency issues
- **Reward submodules use sibling-relative imports** (`from . import get_math_verify_worker`) instead of absolute package imports, eliminating self-import coupling
- **Preserve non-exported symbols** (`DeviceRuntimeInfo`, `HttpRequest`, `HttpGenerationResult`, etc.) that remain as deep imports

## What is NOT changed

| Category | Reason |
|----------|--------|
| `from areal.api.cli_args import ...` (including `SchedulingSpec`) | Dozens of config classes — explicit sub-module path is more readable |
| `from areal.engine.core.*`, `fsdp_utils.*`, `megatron_utils.*` | Internal engine utilities, not part of public API |
| `from areal.api.io_struct import DeviceRuntimeInfo, HttpRequest, ...` | Not added to `__all__` — internal symbols |
| Intra-package imports (e.g., `areal/api/engine_api.py` importing from `areal/api/io_struct`) | Prevents circular imports |

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A — all old import paths still work. This is a purely additive refactoring.

## Additional Context

All re-exports use PEP 562 lazy `__getattr__` to ensure zero side effects at module load time. Symbols are only resolved when first accessed, eliminating circular import risks.

106 files changed, 425 insertions(+), 265 deletions(-)