### PR TITLE
feat: add MiniMax LLM provider support

### DIFF
--- a/areal/experimental/openai/proxy/workflow.py
+++ b/areal/experimental/openai/proxy/workflow.py
@@ -132,6 +132,8 @@ class OpenAIProxyWorkflow(RolloutWorkflow):
                 "OPENAI_API_KEY": session_api_key,
                 "ANTHROPIC_BASE_URL": self.proxy_addr,
                 "ANTHROPIC_API_KEY": session_api_key,
+                "MINIMAX_BASE_URL": self.proxy_addr,
+                "MINIMAX_API_KEY": session_api_key,
             }
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(

--- a/areal/workflow/minimax/__init__.py
+++ b/areal/workflow/minimax/__init__.py
@@ -1,0 +1,3 @@
+from areal.workflow.minimax.math_agent import MathAgent, MultiTurnMathAgent
+
+__all__ = ["MathAgent", "MultiTurnMathAgent"]

--- a/areal/workflow/minimax/math_agent.py
+++ b/areal/workflow/minimax/math_agent.py
@@ -1,0 +1,148 @@
+"""MiniMax-based math agent implementation for AReaL training.
+
+This module provides math agents using MiniMax's OpenAI-compatible API
+that integrate with AReaL's proxy-based training infrastructure via the
+AgentWorkflow pattern.
+
+MiniMax models supported:
+- MiniMax-M2.5: Peak performance, ultimate value
+- MiniMax-M2.5-highspeed: Same performance, faster and more agile
+
+API documentation: https://platform.minimax.io/docs/api-reference/text-openai-api
+"""
+
+import os
+
+from math_verify import parse, verify
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
+
+from areal.api import AsyncRewardWrapper
+
+MINIMAX_DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+
+
+def math_reward_fn(completions: str, answer: str) -> float:
+    ans = parse(completions)
+    gold = parse(answer)
+    return float(verify(ans, gold))
+
+
+class MathAgent:
+    """Simple single-turn math agent using MiniMax's OpenAI-compatible API.
+
+    MiniMax provides an OpenAI-compatible endpoint at https://api.minimax.io/v1,
+    allowing seamless integration with the OpenAI SDK.
+
+    Environment variables:
+        MINIMAX_BASE_URL: API base URL (default: https://api.minimax.io/v1)
+        MINIMAX_API_KEY: MiniMax API key for authentication
+    """
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs.copy()
+        self.kwargs.pop("max_tokens", None)
+        self.kwargs.pop("max_turns", None)
+        # MiniMax temperature must be in (0.0, 1.0], default to 1.0
+        self.kwargs.setdefault("temperature", 1.0)
+
+    async def run(self, data: dict, **extra_kwargs) -> float:
+        """Run the agent on a single problem.
+
+        Args:
+            data: Input data containing "messages" and "answer"
+            **extra_kwargs: Contains base_url, api_key, and http_client from proxy
+
+        Returns:
+            Reward value for this trajectory
+        """
+        http_client = extra_kwargs.get("http_client", None)
+        base_url = (
+            extra_kwargs.get("base_url", None)
+            or os.getenv("MINIMAX_BASE_URL")
+            or MINIMAX_DEFAULT_BASE_URL
+        )
+        api_key = extra_kwargs.get("api_key", None) or os.getenv("MINIMAX_API_KEY")
+        client = AsyncOpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=http_client,
+            max_retries=0,
+        )
+        comp: ChatCompletion = await client.chat.completions.create(
+            messages=data["messages"], model="default", **self.kwargs
+        )
+
+        reward_fn = AsyncRewardWrapper(math_reward_fn)
+        return await reward_fn(
+            completions=comp.choices[0].message.content, answer=data["answer"]
+        )
+
+
+class MultiTurnMathAgent:
+    """Multi-turn math agent using MiniMax's OpenAI-compatible API.
+
+    Supports iterative problem solving with multiple turns, retrying
+    when the answer is incorrect.
+
+    Environment variables:
+        MINIMAX_BASE_URL: API base URL (default: https://api.minimax.io/v1)
+        MINIMAX_API_KEY: MiniMax API key for authentication
+    """
+
+    def __init__(self, max_turns: int = 8, **kwargs):
+        self.max_turns = max_turns
+        self.kwargs = kwargs.copy()
+        self.kwargs.pop("max_tokens", None)
+        # MiniMax temperature must be in (0.0, 1.0], default to 1.0
+        self.kwargs.setdefault("temperature", 1.0)
+
+    async def run(self, data: dict, **extra_kwargs) -> dict:
+        """Run the agent on a single problem with multiple turns.
+
+        Args:
+            data: Input data containing "messages" and "answer"
+            **extra_kwargs: Contains base_url, api_key, and http_client from proxy
+
+        Returns:
+            Dictionary mapping response IDs to reward values
+        """
+        http_client = extra_kwargs.get("http_client", None)
+        base_url = (
+            extra_kwargs.get("base_url", None)
+            or os.getenv("MINIMAX_BASE_URL")
+            or MINIMAX_DEFAULT_BASE_URL
+        )
+        api_key = extra_kwargs.get("api_key", None) or os.getenv("MINIMAX_API_KEY")
+        messages = data["messages"].copy()
+        rewards = {}
+        client = AsyncOpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=http_client,
+            max_retries=0,
+        )
+        for _ in range(self.max_turns):
+            response: ChatCompletion = await client.chat.completions.create(
+                messages=messages,
+                model="default",
+                **self.kwargs,
+            )
+            message = response.choices[0].message
+            messages.append(message.model_dump(exclude_none=True))
+            reward_fn = AsyncRewardWrapper(math_reward_fn)
+            reward = await reward_fn(
+                completions=message.content, answer=data["answer"]
+            )
+            rewards[response.id] = reward
+            if reward == 1:
+                break
+            else:
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": "Your answer is either wrong or not parsable to the reward function. You may misunderstand the original question. "
+                        "Please carefully read the original question, check the previous errors, and try to answer it again.",
+                    }
+                )
+        return rewards

--- a/examples/agent_workflow/README.md
+++ b/examples/agent_workflow/README.md
@@ -59,3 +59,23 @@ See `areal/workflow/openai/` for concrete examples.
    (i.e., setting `rollout.openai.mode=subproc`) to run the agent. While this provides
    more flexibility for writing the agent, using a subprocess will introduce even larger
    overhead.
+## Using MiniMax
+
+To use [MiniMax](https://www.minimax.io/) models (MiniMax-M2.5, MiniMax-M2.5-highspeed)
+with the agent workflow:
+
+```bash
+export MINIMAX_API_KEY="your-minimax-api-key"
+
+python3 examples/agent_workflow/train.py \
+    --config examples/agent_workflow/config_minimax.yaml \
+    scheduler.type=local
+```
+
+MiniMax provides an OpenAI-compatible API, so no additional dependencies are required.
+The workflow uses `AsyncOpenAI` with MiniMax's base URL (`https://api.minimax.io/v1`).
+For China mainland users, set `MINIMAX_BASE_URL=https://api.minimaxi.com/v1`.
+
+See [`areal/workflow/minimax/math_agent.py`](../../areal/workflow/minimax/math_agent.py)
+for the implementation.
+

--- a/examples/agent_workflow/config_minimax.yaml
+++ b/examples/agent_workflow/config_minimax.yaml
@@ -1,0 +1,197 @@
+experiment_name: gsm8k-grpo-minimax
+trial_name: trial0
+
+seed: 1
+enable_offload: false
+total_train_epochs: 10
+tokenizer_path: ${actor.path}
+
+workflow: areal.workflow.minimax.math_agent.MathAgent
+eval_workflow: ${workflow}
+
+cluster:
+  n_nodes: 1
+  n_gpus_per_node: 8
+  fileroot: /tmp/areal/experiments
+  name_resolve:
+    type: nfs
+    nfs_record_root: /tmp/areal/name_resolve
+
+allocation_mode: sglang:d4p1t1+d4p1t1
+
+scheduler:
+  type: null
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  tokenizer_path: ${tokenizer_path}
+  max_concurrent_rollouts: 256
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 2
+  enable_rollout_tracing: false
+  scheduling_spec: ${actor.scheduling_spec}
+  dump_to_file: true
+  openai:
+    mode: inline
+    tool_call_parser: qwen25
+    reasoning_parser: qwen3
+    export_style: individual
+    turn_discount: 1.0
+
+gconfig:
+  n_samples: 4
+  min_new_tokens: 0
+  max_new_tokens: 1024
+  max_tokens: 2048
+  greedy: false
+  temperature: 1.0
+
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen2.5-1.5B-Instruct
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: true
+  dtype: bfloat16
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer:
+    type: adam
+    lr: 1.70e-5
+    weight_decay: 0.017
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+  eps_clip: 0.4
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  behave_imp_weight_cap: 5.0
+  reward_norm: null
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  weight_update_mode: xccl
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_spec:
+    - task_type: worker
+      port_count: 2
+      gpu: 1
+      cmd: python3 -m areal.infra.rpc.rpc_server
+      env_vars:
+        NCCL_DEBUG: "WARN"
+        NCCL_IB_DISABLE: "0"
+        NCCL_SOCKET_IFNAME: "bond0"
+        NCCL_NET: "IB"
+        NCCL_NET_PLUGIN: ""
+        NCCL_IB_GID_INDEX: "3"
+        NCCL_IB_TIMEOUT: "22"
+        NCCL_IB_RETRY_CNT: "7"
+        NCCL_IB_SL: "5"
+        NCCL_IB_TC: "136"
+        NCCL_IB_HCA: "mlx5_bond"
+        NCCL_IB_QPS_PER_CONNECTION: "8"
+        NCCL_SET_THREAD_NAME: "1"
+        PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+
+ref:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  init_from_scratch: false
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+# SGLang
+sglang:
+  model_path: ${actor.path}
+  random_seed: ${seed}
+  skip_tokenizer_init: true
+  dtype: ${actor.dtype}
+  max_running_requests: null
+  context_length: 32768
+  mem_fraction_static: 0.8
+
+vllm:
+  model: ${actor.path}
+  seed: ${seed}
+  skip_tokenizer_init: false
+  dtype: ${actor.dtype}
+  max_model_len: 32768
+  gpu_memory_utilization: 0.8
+
+# datasets
+train_dataset:
+  batch_size: 256
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+  max_length: 1024
+
+valid_dataset:
+  batch_size: 256
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+
+# Utilities
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: disabled
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: 3600
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: disabled
+
+perf_tracer:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  enabled: false
+  session_tracer:
+    enabled: false

--- a/tests/test_minimax_workflow.py
+++ b/tests/test_minimax_workflow.py
@@ -1,0 +1,192 @@
+"""Unit tests for MiniMax workflow agents."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestMiniMaxMathAgent:
+    """Tests for MiniMax MathAgent workflow."""
+
+    def test_import(self):
+        """MiniMax workflow module can be imported."""
+        from areal.workflow.minimax.math_agent import MathAgent, MultiTurnMathAgent
+
+        assert MathAgent is not None
+        assert MultiTurnMathAgent is not None
+
+    def test_init_from_package(self):
+        """MiniMax agents can be imported from package __init__."""
+        from areal.workflow.minimax import MathAgent, MultiTurnMathAgent
+
+        assert MathAgent is not None
+        assert MultiTurnMathAgent is not None
+
+    def test_math_agent_init_default_kwargs(self):
+        """MathAgent sets default temperature to 1.0."""
+        from areal.workflow.minimax.math_agent import MathAgent
+
+        agent = MathAgent()
+        assert agent.kwargs.get("temperature") == 1.0
+
+    def test_math_agent_init_strips_max_tokens(self):
+        """MathAgent strips max_tokens from kwargs."""
+        from areal.workflow.minimax.math_agent import MathAgent
+
+        agent = MathAgent(max_tokens=1024, max_turns=5, temperature=0.8)
+        assert "max_tokens" not in agent.kwargs
+        assert "max_turns" not in agent.kwargs
+        assert agent.kwargs["temperature"] == 0.8
+
+    def test_multi_turn_agent_init_default(self):
+        """MultiTurnMathAgent initializes with correct defaults."""
+        from areal.workflow.minimax.math_agent import MultiTurnMathAgent
+
+        agent = MultiTurnMathAgent()
+        assert agent.max_turns == 8
+        assert agent.kwargs.get("temperature") == 1.0
+
+    def test_multi_turn_agent_custom_turns(self):
+        """MultiTurnMathAgent respects custom max_turns."""
+        from areal.workflow.minimax.math_agent import MultiTurnMathAgent
+
+        agent = MultiTurnMathAgent(max_turns=3)
+        assert agent.max_turns == 3
+
+    def test_default_base_url(self):
+        """Default base URL points to MiniMax overseas API."""
+        from areal.workflow.minimax.math_agent import MINIMAX_DEFAULT_BASE_URL
+
+        assert MINIMAX_DEFAULT_BASE_URL == "https://api.minimax.io/v1"
+
+    @pytest.mark.asyncio
+    async def test_math_agent_uses_minimax_env_vars(self):
+        """MathAgent reads MINIMAX_API_KEY and MINIMAX_BASE_URL from env."""
+        from areal.workflow.minimax.math_agent import MathAgent
+
+        agent = MathAgent()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "42"
+
+        with (
+            patch("areal.workflow.minimax.math_agent.AsyncOpenAI") as mock_openai_cls,
+            patch.dict(
+                "os.environ",
+                {
+                    "MINIMAX_API_KEY": "test-minimax-key",
+                    "MINIMAX_BASE_URL": "https://custom.minimax.io/v1",
+                },
+            ),
+            patch(
+                "areal.workflow.minimax.math_agent.math_reward_fn", return_value=1.0
+            ),
+        ):
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_openai_cls.return_value = mock_client
+
+            data = {
+                "messages": [{"role": "user", "content": "What is 6*7?"}],
+                "answer": "42",
+            }
+            await agent.run(data)
+
+            mock_openai_cls.assert_called_once_with(
+                base_url="https://custom.minimax.io/v1",
+                api_key="test-minimax-key",
+                http_client=None,
+                max_retries=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_math_agent_uses_default_base_url(self):
+        """MathAgent falls back to default base URL when env var is not set."""
+        from areal.workflow.minimax.math_agent import MathAgent
+
+        agent = MathAgent()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "42"
+
+        with (
+            patch("areal.workflow.minimax.math_agent.AsyncOpenAI") as mock_openai_cls,
+            patch.dict(
+                "os.environ",
+                {"MINIMAX_API_KEY": "test-key"},
+                clear=False,
+            ),
+            patch(
+                "areal.workflow.minimax.math_agent.math_reward_fn", return_value=1.0
+            ),
+        ):
+            # Ensure MINIMAX_BASE_URL is not set
+            import os
+
+            os.environ.pop("MINIMAX_BASE_URL", None)
+
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_openai_cls.return_value = mock_client
+
+            data = {
+                "messages": [{"role": "user", "content": "What is 6*7?"}],
+                "answer": "42",
+            }
+            await agent.run(data)
+
+            mock_openai_cls.assert_called_once_with(
+                base_url="https://api.minimax.io/v1",
+                api_key="test-key",
+                http_client=None,
+                max_retries=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_math_agent_extra_kwargs_override_env(self):
+        """extra_kwargs take priority over environment variables."""
+        from areal.workflow.minimax.math_agent import MathAgent
+
+        agent = MathAgent()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "42"
+
+        with (
+            patch("areal.workflow.minimax.math_agent.AsyncOpenAI") as mock_openai_cls,
+            patch.dict(
+                "os.environ",
+                {
+                    "MINIMAX_API_KEY": "env-key",
+                    "MINIMAX_BASE_URL": "https://env.minimax.io/v1",
+                },
+            ),
+            patch(
+                "areal.workflow.minimax.math_agent.math_reward_fn", return_value=1.0
+            ),
+        ):
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_openai_cls.return_value = mock_client
+
+            mock_http_client = MagicMock()
+            data = {
+                "messages": [{"role": "user", "content": "What is 6*7?"}],
+                "answer": "42",
+            }
+            await agent.run(
+                data,
+                base_url="https://proxy.example.com/v1",
+                api_key="proxy-key",
+                http_client=mock_http_client,
+            )
+
+            mock_openai_cls.assert_called_once_with(
+                base_url="https://proxy.example.com/v1",
+                api_key="proxy-key",
+                http_client=mock_http_client,
+                max_retries=0,
+            )


### PR DESCRIPTION
## Summary

Add MiniMax as a new LLM provider for AReaL's agent workflow training infrastructure.

### Changes

- **New module**: `areal/workflow/minimax/` with `MathAgent` and `MultiTurnMathAgent` classes
  - Uses MiniMax's OpenAI-compatible API at `https://api.minimax.io/v1`
  - Follows the same async pattern as existing OpenAI agents (`extra_kwargs` for proxy integration)
  - Respects MiniMax temperature constraints: range (0.0, 1.0], default 1.0
  - Supports env vars: `MINIMAX_BASE_URL`, `MINIMAX_API_KEY`
  - China mainland users can set `MINIMAX_BASE_URL=https://api.minimaxi.com/v1`

- **Proxy workflow update**: Added `MINIMAX_BASE_URL` and `MINIMAX_API_KEY` to subprocess mode environment variables in `areal/experimental/openai/proxy/workflow.py`

- **Example config**: Added `examples/agent_workflow/config_minimax.yaml` for GSM8K training with MiniMax

- **Documentation**: Added "Using MiniMax" section to `examples/agent_workflow/README.md`

- **Tests**: Added `tests/test_minimax_workflow.py` covering initialization, env var handling, and extra_kwargs override

### MiniMax Models Supported

- **MiniMax-M2.5**: Peak performance, ultimate value
- **MiniMax-M2.5-highspeed**: Same performance, faster and more agile

### Usage



## Test Plan

- [ ] Unit tests pass: `pytest tests/test_minimax_workflow.py -v`
- [ ] Import verification: `from areal.workflow.minimax import MathAgent, MultiTurnMathAgent`
- [ ] Config references valid module path: `areal.workflow.minimax.math_agent.MathAgent`
