### PR TITLE
fix: sync XCCL LoRA registry names in OpenAIServingModels

### DIFF
--- a/areal/engine/vllm_ext/areal_vllm_server.py
+++ b/areal/engine/vllm_ext/areal_vllm_server.py
@@ -21,6 +21,11 @@ from vllm.entrypoints.openai.protocol import (
     OpenAIBaseModel,
 )
 from vllm.entrypoints.utils import cli_env_setup, load_aware_call, with_cancellation
+
+from areal.engine.vllm_ext.lora_registry import (
+    apply_pending_lora_registry_update,
+    cache_pending_lora_registry_update,
+)
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.v1.engine import EngineCoreOutput, EngineCoreOutputs, FinishReason
@@ -158,6 +163,11 @@ async def update_weight_lora_xccl(raw_request: Request):
     ret_list = await llm.engine_core.call_utility_async(
         "areal_injected_update_weight_lora_xccl",
     )
+    if all(success for success, _ in ret_list):
+        if apply_pending_lora_registry_update(raw_request.app.state):
+            logger.info(
+                "Updated OpenAIServingModels LoRA registry after XCCL LoRA refresh"
+            )
     return build_response(ret_list)
 
 
@@ -221,6 +231,13 @@ async def set_weight_meta_xccl_lora(
             request.base_model_name,
         ),
     )
+    if all(success for success, _ in ret_list):
+        cache_pending_lora_registry_update(
+            raw_request.app.state,
+            lora_name=request.lora_name,
+            lora_int_id=request.lora_int_id,
+            base_model_name=request.base_model_name,
+        )
     return build_response(ret_list)
 
 

--- a/areal/engine/vllm_ext/lora_registry.py
+++ b/areal/engine/vllm_ext/lora_registry.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+_PENDING_LORA_UPDATE_ATTR = "_areal_pending_lora_registry_update"
+
+
+def cache_pending_lora_registry_update(
+    app_state: Any,
+    *,
+    lora_name: str,
+    lora_int_id: int,
+    base_model_name: str,
+) -> None:
+    """Cache the next LoRA registry rename for the API server.
+
+    The XCCL LoRA update flow sends adapter metadata first and performs the
+    actual in-place update in a follow-up request. The OpenAI serving layer
+    needs that metadata later so it can re-key ``lora_requests`` from the old
+    versioned adapter name to the new one once the update succeeds.
+    """
+
+    setattr(
+        app_state,
+        _PENDING_LORA_UPDATE_ATTR,
+        {
+            "lora_name": lora_name,
+            "lora_int_id": lora_int_id,
+            "base_model_name": base_model_name,
+        },
+    )
+
+
+def clear_pending_lora_registry_update(app_state: Any) -> None:
+    if hasattr(app_state, _PENDING_LORA_UPDATE_ATTR):
+        delattr(app_state, _PENDING_LORA_UPDATE_ATTR)
+
+
+def apply_pending_lora_registry_update(app_state: Any) -> bool:
+    """Apply the cached LoRA registry rename to ``openai_serving_models``.
+
+    Returns ``True`` when an existing adapter entry was found and updated.
+    Returns ``False`` when no cached update exists or the current server state
+    does not expose a matching LoRA request.
+    """
+
+    pending = getattr(app_state, _PENDING_LORA_UPDATE_ATTR, None)
+    if not pending:
+        return False
+
+    serving_models = getattr(app_state, "openai_serving_models", None)
+    if serving_models is None:
+        return False
+
+    lora_requests = getattr(serving_models, "lora_requests", None)
+    if not isinstance(lora_requests, dict):
+        return False
+
+    target_request = None
+    keys_to_remove: list[str] = []
+    for key, request in list(lora_requests.items()):
+        if getattr(request, "lora_int_id", None) == pending["lora_int_id"]:
+            if target_request is None:
+                target_request = request
+            if key != pending["lora_name"]:
+                keys_to_remove.append(key)
+
+    if target_request is None:
+        return False
+
+    for key in keys_to_remove:
+        lora_requests.pop(key, None)
+
+    target_request.lora_name = pending["lora_name"]
+    if pending["base_model_name"]:
+        target_request.base_model_name = pending["base_model_name"]
+    lora_requests[pending["lora_name"]] = target_request
+    clear_pending_lora_registry_update(app_state)
+    return True

--- a/tests/test_vllm_lora_registry.py
+++ b/tests/test_vllm_lora_registry.py
@@ -1,0 +1,87 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import SimpleNamespace
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "areal"
+    / "engine"
+    / "vllm_ext"
+    / "lora_registry.py"
+)
+_SPEC = spec_from_file_location("test_lora_registry", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_lora_registry = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_lora_registry)
+
+apply_pending_lora_registry_update = (
+    _lora_registry.apply_pending_lora_registry_update
+)
+cache_pending_lora_registry_update = (
+    _lora_registry.cache_pending_lora_registry_update
+)
+
+
+class DummyLoRARequest:
+    def __init__(
+        self,
+        *,
+        lora_name: str,
+        lora_int_id: int,
+        path: str,
+        base_model_name: str,
+    ):
+        self.lora_name = lora_name
+        self.lora_int_id = lora_int_id
+        self.path = path
+        self.base_model_name = base_model_name
+
+
+def test_apply_pending_lora_registry_update_rekeys_existing_request():
+    app_state = SimpleNamespace(
+        openai_serving_models=SimpleNamespace(
+            lora_requests={
+                "lora-gsm8k-v0": DummyLoRARequest(
+                    lora_name="lora-gsm8k-v0",
+                    lora_int_id=7,
+                    path="/tmp/lora-v0",
+                    base_model_name="base-model",
+                )
+            }
+        )
+    )
+
+    cache_pending_lora_registry_update(
+        app_state,
+        lora_name="lora-gsm8k-v1",
+        lora_int_id=7,
+        base_model_name="base-model",
+    )
+
+    assert apply_pending_lora_registry_update(app_state) is True
+
+    lora_requests = app_state.openai_serving_models.lora_requests
+    assert "lora-gsm8k-v0" not in lora_requests
+    assert "lora-gsm8k-v1" in lora_requests
+    updated = lora_requests["lora-gsm8k-v1"]
+    assert updated.lora_name == "lora-gsm8k-v1"
+    assert updated.lora_int_id == 7
+    assert updated.path == "/tmp/lora-v0"
+    assert updated.base_model_name == "base-model"
+    assert not hasattr(app_state, "_areal_pending_lora_registry_update")
+
+
+def test_apply_pending_lora_registry_update_returns_false_without_matching_request():
+    app_state = SimpleNamespace(
+        openai_serving_models=SimpleNamespace(lora_requests={})
+    )
+
+    cache_pending_lora_registry_update(
+        app_state,
+        lora_name="lora-gsm8k-v1",
+        lora_int_id=99,
+        base_model_name="base-model",
+    )
+
+    assert apply_pending_lora_registry_update(app_state) is False
+    assert hasattr(app_state, "_areal_pending_lora_registry_update")


### PR DESCRIPTION
## Summary
- cache pending XCCL LoRA metadata on the API server when `/areal_set_update_weight_meta_lora` succeeds
- re-key `openai_serving_models.lora_requests` after `/areal_update_weights_lora_xccl` succeeds so the new versioned LoRA name is routable immediately
- add a focused regression test for the registry rename helper without requiring the full vLLM/AReaL runtime stack

## Testing
- `python3 -m pytest tests/test_vllm_lora_registry.py`
- `python3 -m compileall areal/engine/vllm_ext/lora_registry.py areal/engine/vllm_ext/areal_vllm_server.py tests/test_vllm_lora_registry.py`

Closes #1020
