### PR TITLE
fix: close sockets on bind failure, fix __exit__ traceback in trainers

### DIFF
--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -1018,5 +1018,4 @@ class PPOTrainer:
         if exc_type is not None:
             logger.error(f"Training failed with exception: {exc_value}", exc_info=True)
         self.close()
-        if exc_type is not None:
-            raise exc_value
+        return False

--- a/areal/trainer/sft_trainer.py
+++ b/areal/trainer/sft_trainer.py
@@ -403,5 +403,4 @@ class SFTTrainer:
         if exc_type is not None:
             logger.error(f"Training failed with exception: {exc_value}", exc_info=True)
         self.close()
-        if exc_type is not None:
-            raise exc_value
+        return False

--- a/areal/utils/network.py
+++ b/areal/utils/network.py
@@ -113,15 +113,17 @@ def is_port_free(port: int) -> bool:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         sock.bind(("", port))
-        sock.close()
     except OSError:
         return False
+    finally:
+        sock.close()
 
     # Check UDP
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         sock.bind(("", port))
-        sock.close()
         return True
     except OSError:
         return False
+    finally:
+        sock.close()


### PR DESCRIPTION
Fixes #1031

Two small fixes:

**1. Socket leak in `is_port_free()`**

When `sock.bind()` fails, the socket was never closed. Switched to `try/finally` so it's always cleaned up.

**2. Broken traceback in trainer `__exit__`**

`RLTrainer` and `SFTTrainer` both had `raise exc_value` in `__exit__`, which replaces the original traceback with one pointing at the raise statement. Returning `False` lets Python re-raise naturally with the full traceback.