### PR TITLE
docs(github): improve PR template checklist and type-of-change section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,31 +10,28 @@ Fixes #(issue)
 
 ## Type of Change
 
-<!-- Mark the relevant option with an 'x' -->
+<!-- Select ONE that best describes this PR -->
 
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not
-  work as expected)
-- [ ] Documentation update
-- [ ] Code refactoring (no functional changes)
-- [ ] Performance improvement
-- [ ] Test coverage improvement
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] 💥 Breaking change
+- [ ] 📝 Documentation update
+- [ ] ♻️ Refactoring
+- [ ] ⚡ Performance improvement
+- [ ] ✅ Test coverage improvement
 
 ## Checklist
 
 <!-- Mark with 'x' what you've done -->
 
 - [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
-- [ ] I have run formatting tools (pre-commit or manual)
-- [ ] I have run relevant unit tests and they pass
-- [ ] I have added tests for new functionality
-- [ ] I have updated documentation if needed
-- [ ] My branch is up to date with main
-- [ ] This PR introduces breaking changes (if yes, fill out details below)
-- [ ] If this PR changes documentation, I have built and previewed it locally with
-  `jb build docs`
-- [ ] No critical issues raised by AI reviewers (`/gemini review`)
+- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
+- [ ] Relevant tests pass; new tests added for new functionality
+- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
+- [ ] Branch is up to date with `main`
+- [ ] Self-reviewed via `/review-pr` command
+- [ ] This PR was created by a coding agent via `/create-pr`
+- [ ] This PR is a breaking change
 
 **Breaking Change Details (if applicable):**
 


### PR DESCRIPTION
## Description

Improve the PR template with clearer structure: make the Type of Change section mutually exclusive, consolidate verbose checklist items into succinct ones, and add markers for AI-assisted PR workflows (`/create-pr`, `/review-pr`).

## Related Issue

N/A — template housekeeping.

## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Key changes:
- **Type of Change**: Comment changed to "Select ONE" for mutual exclusivity; emoji prefixes added for visual scanning
- **Checklist**: Consolidated from 10 items to 8; merged formatting/test/docs items; fixed docs build command to canonical `./docs/build_all.sh`
- **New items**: `/review-pr` self-review marker, `/create-pr` coding agent marker
- **Removed**: `/gemini review` reference (replaced by above)