### PR TITLE
chore(docker): add openclaw, ironclaw, zeroclaw, and nanobot-ai to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,7 +197,16 @@ RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "$FNM_D
     && curl -fsSL https://claude.ai/install.sh | bash \
     && curl -fsSL https://opencode.ai/install | bash \
     && npm install -g @openai/codex \
-    && npm install -g @google/gemini-cli
+    && npm install -g @google/gemini-cli \
+    && npm install -g openclaw@latest
+
+ENV PATH="/root/.cargo/bin:$PATH"
+RUN curl --proto '=https' --tlsv1.2 -LsSf \
+    https://github.com/nearai/ironclaw/releases/latest/download/ironclaw-installer.sh | sh
+RUN curl -fsSL \
+    https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/install.sh \
+    | bash -s -- --prefer-prebuilt --skip-onboard
+RUN uv pip install nanobot-ai
 
 ##############################################################
 # STAGE 3: Install project dependencies from pyproject.toml


### PR DESCRIPTION
## Description

Add four new AI coding tools to the Docker runtime image: openclaw (npm), ironclaw (Rust binary from nearai), zeroclaw (from zeroclaw-labs), and nanobot-ai (Python). These extend the existing AI tool chain in stage 2.5 of the Dockerfile alongside Claude Code, OpenCode, Codex, and Gemini CLI.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

New tools added:
- **openclaw** (`npm install -g openclaw@latest`): appended to existing Node.js tool install chain
- **ironclaw** (Rust binary): installed via `ironclaw-installer.sh` from `nearai/ironclaw` GitHub releases
- **zeroclaw** (binary): installed via `install.sh` from `zeroclaw-labs/zeroclaw` GitHub releases
- **nanobot-ai** (Python): installed via `uv pip install nanobot-ai`

The `PATH` is extended with `/root/.cargo/bin` to make ironclaw accessible.

Files changed:
- `Dockerfile`: Add tool installations in stage 2.5 (Node.js and tools section)