### PR TITLE
feat: estimators for kl divergence

### DIFF
--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -992,21 +992,22 @@ def _log_proximal_approximation_stats(
                     prox_logp_gt=prox_logp_gt,
                 )
         if logprobs is not None:
-            # We calculate the difference between Training and Inference
-            # .float() is used for NPU high-precision comparison
+            # Log KL divergence estimators to check for policy drift between the
+            # training-time policy (logprobs) and the inference-time policy (old_logp).
             log_ratio = (logprobs.float() - old_logp.float()).detach()
             
-            # Implementation of k1, k2, k3
-            k1 = -log_ratio
-            k2 = log_ratio**2 / 2.0
-            k3 = log_ratio.exp() - 1 - log_ratio
- 
+            # Implementation of different estimators for KL divergence.
+            # See: https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/#true-on-policy-rl
+            kl_div_estimator_direct = -log_ratio
+            kl_div_estimator_taylor = log_ratio**2 / 2.0
+            kl_div_estimator_dual = log_ratio.exp() - 1 - log_ratio
+
             # Register these to TensorBoard
             stats_tracker.stat(
-                parity_k1=k1,
-                parity_k2=k2,
-                parity_k3=k3,
-                denominator="n_valid_tokens", # Normalizes by active tokens
+                kl_div_direct=kl_div_estimator_direct,
+                kl_div_taylor=kl_div_estimator_taylor,
+                kl_div_dual=kl_div_estimator_dual,
+                denominator="n_valid_tokens",
             )
 
 


### PR DESCRIPTION
Estimators to check log probs between inference and training in case of divergence.

## Description

https://xihuai18.github.io/reinforcement-learning/2025/12/01/kl-estimators-en.html
https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/#true-on-policy-rl

KL estimators that provide information about the KL difference between policies between inference and training. In case of True On-policy, they play an important role.



## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [x ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
