### PR TITLE
feat: estimators for kl divergence

### DIFF
--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -1006,7 +1006,7 @@ def _log_proximal_approximation_stats(
             # Log KL divergence estimators to check for policy drift between the
             # training-time policy (logprobs) and the inference-time policy (old_logp).
             log_ratio = (logprobs.float() - old_logp.float()).detach()
-            
+
             # Implementation of different estimators for KL divergence.
             # See: https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/#true-on-policy-rl
             kl_div_estimator_direct = -log_ratio


### PR DESCRIPTION
## Description

https://xihuai18.github.io/reinforcement-learning/2025/12/01/kl-estimators-en.html
https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/#true-on-policy-rl

KL estimators that provide information about the KL difference between policies between inference and training. In case of True On-policy, they play an important role.

## Issue

https://github.com/inclusionAI/AReaL/issues/1058

Issues #1058 

## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
