### PR TITLE
fix(infra): simplify RTensor serialization in data proxy

### DIFF
--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -359,14 +359,16 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         store.remove_session(body.session_id)
 
         # Serialize for HTTP transport, storing tensors locally as RTensor shards
-        # so that RTensor.localize() on the client can fetch them via /data/ endpoints.
-        serving_addr = config.serving_addr
-        if not serving_addr:
-            logger.warning(
-                "serving_addr not configured; tensors will be serialized "
-                "as plain lists (RTensor.localize() will not work remotely)"
-            )
-        serialized = serialize_interactions(interactions, node_addr=serving_addr)
+        from areal.infra.rpc.rtensor import RTensor
+
+        for item in interactions.values():
+            # Set the internal cache
+            item.to_tensor_dict()
+            # Remotize the tensor dict cache
+            item._cache = RTensor.remotize(item._cache, node_addr=config.serving_addr)
+
+        # serialize RTensors
+        serialized = serialize_interactions(interactions)
         return ExportTrajectoriesResponse(interactions=serialized)
 
     # NOTE: /grant_capacity has been removed from data proxy. Capacity-based

--- a/areal/experimental/openai/proxy/server.py
+++ b/areal/experimental/openai/proxy/server.py
@@ -5,7 +5,6 @@ import threading
 import time
 from typing import TYPE_CHECKING, Any
 
-import torch
 from pydantic import BaseModel
 
 from areal.experimental.openai.cache import InteractionCache
@@ -127,114 +126,35 @@ class SessionData:
 
 def serialize_interactions(
     interactions: dict[str, InteractionWithTokenLogpReward],
-    node_addr: str = "",
 ) -> dict[str, Any]:
-    """Serialize interactions for HTTP transport.
-
-    When ``node_addr`` is provided, tensors are stored in the local RTensor
-    storage (on the data proxy process) and only shard metadata is serialized.
-    This enables ``RTensor.localize()`` on the client to fetch tensors via
-    HTTP GET ``/data/{shard_id}`` from the data proxy.
-
-    When ``node_addr`` is empty (legacy mode), tensors are serialized as
-    plain lists for backward compatibility.
-
-    Parameters
-    ----------
-    interactions : dict[str, InteractionWithTokenLogpReward]
-        Interactions to serialize
-    node_addr : str
-        Data proxy's serving address (host:port) for RTensor shard storage.
-        If empty, falls back to plain tensor serialization.
-    """
-    from areal.infra.rpc.rtensor import get_backend
+    """Serialize interactions into a json-compatible format for HTTP transport."""
+    from areal.infra.rpc.serialization import serialize_value
 
     result = {}
     for key, interaction in interactions.items():
-        tensor_dict = interaction.to_tensor_dict()
-
-        if node_addr:
-            # Store tensors locally on the data proxy and serialize shard metadata
-            shard_dict = {}
-            shapes = {}
-            dtypes = {}
-            for k, v in tensor_dict.items():
-                tensor = v.detach().cpu()
-                shard_id = get_backend().store(tensor)
-                shard_dict[k] = {
-                    "shard_id": shard_id,
-                    "node_addr": node_addr,
-                }
-                shapes[k] = list(tensor.shape)
-                dtypes[k] = str(tensor.dtype)
-            result[key] = {
-                "shard_dict": shard_dict,
-                "shapes": shapes,
-                "dtypes": dtypes,
-                "reward": interaction.reward,
-                "interaction_id": interaction.interaction_id,
-            }
-        else:
-            # Legacy mode: serialize tensors as plain lists
-            result[key] = {
-                "tensor_dict": {k: v.tolist() for k, v in tensor_dict.items()},
-                "reward": interaction.reward,
-                "interaction_id": interaction.interaction_id,
-            }
-    return result
+        result[key] = {
+            "tensor_dict": interaction.to_tensor_dict(),
+            "reward": interaction.reward,
+            "interaction_id": interaction.interaction_id,
+        }
+    return serialize_value(result)
 
 
 def deserialize_interactions(
     data: dict[str, Any],
 ) -> dict[str, InteractionWithTokenLogpReward]:
-    """Deserialize interactions from HTTP response.
+    """Deserialize interactions from HTTP response."""
+    from areal.experimental.openai.types import InteractionWithTokenLogpReward
+    from areal.infra.rpc.serialization import deserialize_value
 
-    Supports two formats:
-
-    1. **Shard metadata format** (``shard_dict`` key present): RTensors are
-       reconstructed from shard metadata. The actual tensor data stays on the
-       data proxy and will be fetched lazily via ``RTensor.localize()``.
-
-    2. **Legacy format** (``tensor_dict`` key present): Tensors are
-       reconstructed from plain lists and re-remotized locally. This path
-       exists for backward compatibility with data proxies that don't
-       support RTensor storage.
-    """
-    from areal.experimental.openai.types import (
-        InteractionWithTokenLogpReward,
-    )
-    from areal.infra.rpc.rtensor import RTensor, TensorShardInfo
-
+    data = deserialize_value(data)
     result = {}
     for key, item in data.items():
-        if "shard_dict" in item:
-            # Shard metadata format: reconstruct RTensors from shard info
-            tensor_dict = {}
-            for k, shard_info in item["shard_dict"].items():
-                shape = item["shapes"][k]
-                dtype_str = item["dtypes"][k].replace("torch.", "")
-                dtype = getattr(torch, dtype_str)
-                shard = TensorShardInfo(
-                    shard_id=shard_info["shard_id"],
-                    node_addr=shard_info["node_addr"],
-                )
-                # Create RTensor with meta placeholder — data fetched on localize()
-                tensor_dict[k] = RTensor(
-                    shard=shard,
-                    data=torch.empty(shape, dtype=dtype, device="meta"),
-                )
-        else:
-            # Legacy format: reconstruct tensors and remotize locally
-            from areal.utils.network import gethostip
-
-            node_addr = gethostip()
-            tensor_dict = {k: torch.tensor(v) for k, v in item["tensor_dict"].items()}
-            tensor_dict = RTensor.remotize(tensor_dict, node_addr=node_addr)
-
         # Create a minimal InteractionWithTokenLogpReward with cached tensor dict
         interaction = InteractionWithTokenLogpReward()
-        interaction._cache = tensor_dict
+        interaction._cache = item["tensor_dict"]
         interaction.reward = item["reward"]
+        interaction.interaction_id = item["interaction_id"]
         result[key] = interaction
     return result
 

--- a/areal/experimental/openai/types.py
+++ b/areal/experimental/openai/types.py
@@ -52,6 +52,9 @@ class InteractionWithTokenLogpReward:
     response: Response | None = None
     input_data: str | ResponseInputParam = field(default_factory=lambda: "")
 
+    # Interaction ID cache (used for deserialization)
+    _interaction_id: str | None = None
+
     @property
     def is_completion(self) -> bool:
         return self.completion is not None
@@ -101,8 +104,16 @@ class InteractionWithTokenLogpReward:
             return self.completion.id
         elif self.is_response:
             return self.response.id
+        elif self._interaction_id is not None:
+            return self._interaction_id
         else:
             return None
+
+    @interaction_id.setter
+    def interaction_id(self, value):
+        if self.is_completion or self.is_response:
+            raise ValueError("Cannot set ID for completion or responses")
+        self._interaction_id = value
 
     @property
     def created_at(self) -> float | None:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -853,6 +853,7 @@ def test_tau2(tmp_path_factory):
         kill_process_tree(user_llm_proc.pid, graceful=False)
 
 
+@pytest.mark.ci
 @pytest.mark.sglang
 @pytest.mark.multi_gpu
 def test_openclaw_online_rl(tmp_path_factory):


### PR DESCRIPTION
## Description

Replace dual-path serialize/deserialize logic (shard metadata vs legacy plain lists) with unified `serialize_value`/`deserialize_value` from `areal.infra.rpc.serialization`. `RTensor.remotize()` is now called directly on the data proxy side before serialization, removing the need for manual shard management in the transport layer. Also adds `interaction_id` setter to `InteractionWithTokenLogpReward` for proper ID preservation during deserialization.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Files changed:
- `areal/experimental/inference_service/data_proxy/app.py`: Move RTensor.remotize() to export endpoint, remove node_addr pass-through
- `areal/experimental/openai/proxy/server.py`: Replace manual shard/legacy serialization with serialize_value/deserialize_value
- `areal/experimental/openai/types.py`: Add _interaction_id field and setter
- `tests/test_examples.py`: Add @pytest.mark.ci to test_openclaw_online_rl