### PR TITLE
perf(fsdp): pipeline distributed weight sync with a single pending bucket

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -160,6 +160,14 @@ class FSDPTrainContext:
         return {f.name: getattr(self, f.name) for f in dataclasses.fields(self)}
 
 
+@dataclasses.dataclass
+class _PendingWeightUpdateBucket:
+    handles: list[Any]
+    fut: Future[None]
+    named_tensors: list[tuple[str, torch.Tensor]]
+    stream: torch.cuda.Stream | None = None
+
+
 class FSDPEngine(TrainEngine):
     def __init__(self, config: TrainEngineConfig):
         self.config = config
@@ -1031,14 +1039,15 @@ class FSDPEngine(TrainEngine):
                 tensor = tensor.to(current_platform.device_type)
             return tensor
 
-    def _update_bucket_weights_from_distributed(
+    def _update_bucket_weights_from_distributed_async(
         self,
         meta: WeightUpdateMeta,
         named_tensors: list[tuple[str, nn.Parameter | torch.Tensor]],
-    ):
+        stream: torch.cuda.Stream | None = None,
+    ) -> _PendingWeightUpdateBucket | None:
         # Early exit when chunk size is relatively small
         if not named_tensors:
-            return
+            return None
 
         param_specs = [
             ParamSpec(
@@ -1067,18 +1076,48 @@ class FSDPEngine(TrainEngine):
         fut = self.rollout_engine.update_weights_from_distributed(meta, param_specs)
 
         handles = []
-        for _, tensor in named_tensors:
-            handles.append(
-                dist.broadcast(
-                    tensor, src=0, group=self.weight_update_group, async_op=True
+        if stream is not None:
+            stream.wait_stream(torch.cuda.current_stream())
+            context = torch.cuda.stream(stream)
+        else:
+            context = nullcontext()
+
+        with context:
+            for _, tensor in named_tensors:
+                handles.append(
+                    dist.broadcast(
+                        tensor, src=0, group=self.weight_update_group, async_op=True
+                    )
                 )
-            )
-        for handle in handles:
+
+        return _PendingWeightUpdateBucket(
+            handles=handles,
+            fut=fut,
+            named_tensors=named_tensors,
+            stream=stream,
+        )
+
+    def _wait_pending_weight_update_bucket(
+        self, pending_bucket: _PendingWeightUpdateBucket | None
+    ):
+        if pending_bucket is None:
+            return
+
+        for handle in pending_bucket.handles:
             handle.wait()
 
-        fut.result()
+        pending_bucket.fut.result()
+        pending_bucket.named_tensors.clear()
 
-        named_tensors.clear()
+    def _update_bucket_weights_from_distributed(
+        self,
+        meta: WeightUpdateMeta,
+        named_tensors: list[tuple[str, nn.Parameter | torch.Tensor]],
+    ):
+        pending_bucket = self._update_bucket_weights_from_distributed_async(
+            meta, named_tensors
+        )
+        self._wait_pending_weight_update_bucket(pending_bucket)
 
     def _init_weight_update_from_distributed(self, meta: WeightUpdateMeta):
         assert meta.type == "xccl"
@@ -1116,23 +1155,32 @@ class FSDPEngine(TrainEngine):
 
     @trace_perf("fsdp_engine.update_weights_from_distributed", category="comm")
     def _update_weights_from_distributed(self, meta: WeightUpdateMeta):
-        """Broadcast parameters (chunked) from rank 0 (FSDP2 compatible)."""
+        """Broadcast parameters with single-pending-bucket pipelining."""
 
         # Reset weight weight meta with local info
         meta.nccl_master_address = self.weight_update_master_addr
         meta.nccl_master_port = self.weight_update_master_port
         meta.nccl_group_name = self.weight_update_group_name
 
-        if dist.get_rank() == 0:
+        main_rank = dist.get_rank() == 0
+        if main_rank:
             self.rollout_engine.pause_generation()
 
         dist.barrier(group=self.cpu_group)
 
         weight_chunked_mem_size = meta.weight_chunked_mem_mb * 1024 * 1024
-        main_rank = dist.get_rank() == 0
+        broadcast_stream = None
+
+        if (
+            main_rank
+            and current_platform.device_type == "cuda"
+            and torch.cuda.is_available()
+        ):
+            broadcast_stream = torch.cuda.Stream()
 
         buffer_size = 0
         named_tensors: list[tuple[str, torch.Tensor]] = []
+        pending_bucket: _PendingWeightUpdateBucket | None = None
 
         if self.config.use_lora:
             # For LoRA, only iterate over trainable LoRA parameters
@@ -1145,29 +1193,50 @@ class FSDPEngine(TrainEngine):
             # For full model, iterate over all parameters
             param_iterator = self._get_model_name_parameters()
 
-        for name, param in param_iterator:
-            tensor = self._get_full_tensor(param)
+        try:
+            for name, param in param_iterator:
+                # Ranks other than 0 only help to get the full tensor
+                tensor = self._get_full_tensor(param)
+                if not main_rank:
+                    continue
 
-            # Ranks other than 0 only help to get the full tensor
-            if not main_rank:
-                continue
+                tensor_size = tensor.numel() * tensor.element_size()
+                bucket_overflow = (
+                    buffer_size > 0
+                    and tensor_size + buffer_size > weight_chunked_mem_size
+                )
+                if bucket_overflow:
+                    # Only middle buckets need drain+align before the next all-gather.
+                    if pending_bucket is not None:
+                        self._wait_pending_weight_update_bucket(pending_bucket)
+                        pending_bucket = None
 
-            tensor_size = tensor.numel() * tensor.element_size()
+                    pending_bucket = self._update_bucket_weights_from_distributed_async(
+                        meta,
+                        named_tensors,
+                        stream=broadcast_stream,
+                    )
 
-            if tensor_size + buffer_size > weight_chunked_mem_size:
+                    named_tensors = []
+                    buffer_size = 0
+
+                buffer_size += tensor_size
+                named_tensors.append((name, tensor))
+
+            if pending_bucket:
+                self._wait_pending_weight_update_bucket(pending_bucket)
+                pending_bucket = None
+
+            # Process remaining parameters
+            if buffer_size > 0:
                 self._update_bucket_weights_from_distributed(meta, named_tensors)
-                buffer_size = 0
-
-            named_tensors.append((name, tensor))
-            buffer_size += tensor_size
-
-        # Process remaining parameters
-        if named_tensors:
-            self._update_bucket_weights_from_distributed(meta, named_tensors)
+        finally:
+            if main_rank and pending_bucket is not None:
+                self._wait_pending_weight_update_bucket(pending_bucket)
+                pending_bucket = None
 
         dist.barrier(group=self.cpu_group)
-
-        if dist.get_rank() == 0:
+        if main_rank:
             self.rollout_engine.continue_generation()
 
         current_platform.synchronize()


### PR DESCRIPTION
- Split distributed weight update into async bucket start + explicit wait
- Add `_PendingWeightUpdateBucket` to track one in-flight bucket safely
- Overlap bucket $N-1$ broadcast with bucket $N$ full-tensor materialization
- Keep training ranks aligned before entering the next incompatible collective

## Description

This PR reduces exposed communication stall in distributed weight update by pipelining bucket transmission with the preparation of the next bucket.

Previously, the FSDP weight-update path was effectively serialized per bucket:

1. materialize full tensors for bucket $i$
2. notify the inference side about bucket $i$
3. broadcast bucket $i$
4. wait for bucket $i$ to finish
5. start materializing bucket $i+1$

This makes the communication latency of almost every bucket visible on the critical path.

This PR changes the scheduling policy to:

1. materialize bucket $i$
2. start bucket $i$ broadcast asynchronously
3. while bucket $i$ is in flight, materialize bucket $i+1$
4. explicitly wait before the next incompatible collective or the final flush

To keep the implementation simple and memory-bounded, this PR allows at most one pending bucket at a time.

Although this PR is implemented in the FSDP path, the optimization itself is not FSDP-specific. It is a backend-agnostic scheduling idea:

- prepare a bucket locally
- start transport asynchronously
- overlap transport of bucket $i$ with preparation of bucket $i+1$
- explicitly drain before the next conflicting collective

So this PR should be read as validating the scheduling idea in FSDP first. The same principle should also apply to Megatron, Archon, or other backends that expose:
- a bucketized update path,
- an asynchronous communication primitive,
- and an explicit synchronization point before the next conflicting collective.

## Theoretical Analysis

Let:

- $K$ be the number of buckets
- $G_i$ be the time to materialize / gather full tensors for bucket $i$
- $B_i$ be the time to broadcast / receive / apply bucket $i$

For the original serialized schedule, the total time is approximately:

$$
T_{\mathrm{sync}} = \sum_{i=1}^{K}(G_i + B_i)
$$

In other words, the communication cost of every bucket is exposed.

With a single pending bucket, bucket $i$ communication can overlap with bucket $i+1$ preparation. The pipelined schedule is approximately:

$$
T_{\mathrm{pipe}} \approx G_1 + \sum_{i=1}^{K-1}\max(B_i, G_{i+1}) + B_K
$$

The exposed communication part becomes approximately:

$$
C_{\mathrm{pipe}} \approx \sum_{i=1}^{K-1}\max(0, B_i - G_{i+1}) + B_K
$$

This gives the expected behavior:

- if $G_{i+1} \ll B_i$, only a small part of communication is hidden
- if $G_{i+1} \approx B_i$, most of bucket $i$'s communication can be hidden
- if the model is larger or the interconnect is slower, $B_i$ tends to become a larger fraction of the critical path, so this scheduling change should matter more

So the goal of this PR is not to change semantics, but to remove avoidable per-bucket synchronization stall.

## Experimental Results

All experiments were performed on the Qwen2.5-32B model, using a single machine with 8 H20 GPUs and 
`allocation_mode: sglang:d4p1t1+d4p1t1`

To keep the comparison focused, this PR reports two metrics:

1. communication-stage time
2. end-to-end `timeperf/update_weights`

For the baseline implementation, the communication-stage metric is `broadcast_sync_total_s`.

For the pipelined implementation, the comparable communication-stage time is the exposed communication part of the new path:

$$
0.0190 + 0.1800 + 0.003741 = 0.202741
$$

The measured results are:

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Communication stage | 0.2387 s | 0.202741 s | -15.1% |
| End-to-end `timeperf/update_weights` | 1.13 s | 0.99 s | -12.4% |

These results suggest that the single-pending-bucket pipeline removes a measurable amount of exposed communication stall and also improves the end-to-end weight update path.

The gain is moderate rather than dramatic on the current setup, which is consistent with the expectation that weight transport is only part of the full update path. The main point of this PR is therefore not that FSDP alone is special, but that this scheduling idea is backend-agnostic: when a backend supports bucketized preparation, asynchronous transport, and an explicit drain point, the same overlap pattern should also be applicable beyond FSDP, such as in Megatron or Archon.




## Scope and Safety

- Keeps at most one pending bucket in flight
- Preserves ordering by explicitly waiting before the next incompatible collective
- Does not change model semantics or numerical results
- The change is limited to scheduling of distributed weight synchronization

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

This PR intentionally lands the optimization in the FSDP path first, because it is the smallest and safest place to validate the scheduling idea and benchmark methodology.
