### PR TITLE
fix(rpc): batch HTTP RTensor fetches for large multimodal batches

### DIFF
--- a/areal/infra/rpc/rpc_server.py
+++ b/areal/infra/rpc/rpc_server.py
@@ -845,6 +845,60 @@ def retrieve_batch_data(shard_id: str):
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
+@app.route("/data/batch", methods=["POST"])
+def retrieve_batch_data_many():
+    """Retrieve multiple batch data shards in one request."""
+
+    try:
+        payload = request.get_json(silent=True) or {}
+        shard_ids = payload.get("shard_ids", [])
+        if not isinstance(shard_ids, list) or not all(
+            isinstance(shard_id, str) for shard_id in shard_ids
+        ):
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "message": "Expected JSON body with string list field 'shard_ids'",
+                    }
+                ),
+                400,
+            )
+
+        data = []
+        missing_shard_ids = []
+        for shard_id in shard_ids:
+            try:
+                data.append(rtensor.fetch(shard_id))
+            except KeyError:
+                missing_shard_ids.append(shard_id)
+
+        if missing_shard_ids:
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "message": "One or more requested shards were not found",
+                        "missing_shard_ids": missing_shard_ids,
+                    }
+                ),
+                400,
+            )
+
+        serialized_data = serialize_value(data)
+        data_bytes = orjson.dumps(serialized_data)
+        logger.debug(
+            "Retrieved %s batch shards (size=%s bytes)",
+            len(shard_ids),
+            len(data_bytes),
+        )
+        return Response(data_bytes, mimetype="application/octet-stream")
+
+    except Exception as e:
+        logger.error(f"Error retrieving batch shards: {e}\n{traceback.format_exc()}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
 @app.route("/data/clear", methods=["DELETE"])
 def clear_batch_data():
     """Clear specified batch data shards.

--- a/areal/infra/rpc/rtensor.py
+++ b/areal/infra/rpc/rtensor.py
@@ -5,7 +5,7 @@ import uuid
 from collections import defaultdict
 from dataclasses import dataclass
 from threading import Lock
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 import aiohttp
 import orjson
@@ -83,6 +83,11 @@ class TensorShardInfo:
 
 
 class HttpRTensorBackend:
+    def __init__(self, max_shards_per_request: int = 32) -> None:
+        if max_shards_per_request <= 0:
+            raise ValueError("max_shards_per_request must be positive")
+        self.max_shards_per_request = max_shards_per_request
+
     def _create_session(self) -> aiohttp.ClientSession:
         """Create a properly configured aiohttp session for large tensor transfers."""
         timeout = aiohttp.ClientTimeout(
@@ -114,8 +119,10 @@ class HttpRTensorBackend:
             try:
                 async with session.get(url) as resp:
                     if resp.status != 200:
+                        error_body = (await resp.text()).strip()
+                        detail = f" body={error_body}" if error_body else ""
                         raise RuntimeError(
-                            f"Failed to fetch shard from {url}: {resp.status}"
+                            f"Failed to fetch shard from {url}: {resp.status}{detail}"
                         )
                     data_bytes = await resp.read()
                     serialized_data = orjson.loads(data_bytes)
@@ -138,17 +145,96 @@ class HttpRTensorBackend:
             f"Last error: {repr(last_exception)}"
         )
 
+    async def _fetch_shard_group(
+        self,
+        session: aiohttp.ClientSession,
+        node_addr: str,
+        grouped: list[tuple[int, TensorShardInfo]],
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+    ) -> list[torch.Tensor]:
+        from areal.infra.rpc.serialization import deserialize_value
+
+        shard_ids = [shard.shard_id for _, shard in grouped]
+        url = f"http://{node_addr}/data/batch"
+        last_exception = None
+
+        for attempt in range(max_retries):
+            try:
+                async with session.post(url, json={"shard_ids": shard_ids}) as resp:
+                    if resp.status != 200:
+                        error_body = (await resp.text()).strip()
+                        detail = f" body={error_body}" if error_body else ""
+                        raise RuntimeError(
+                            f"Failed to fetch shard batch from {url}: {resp.status}{detail}"
+                        )
+
+                    data_bytes = await resp.read()
+                    serialized_data = orjson.loads(data_bytes)
+                    tensors = cast(
+                        list[torch.Tensor], deserialize_value(serialized_data)
+                    )
+                    if len(tensors) != len(grouped):
+                        raise RuntimeError(
+                            f"Batch fetch from {url} returned {len(tensors)} shards for {len(grouped)} requested"
+                        )
+                    return tensors
+            except (TimeoutError, aiohttp.ClientError) as e:
+                last_exception = e
+                logger.warning(
+                    "RTensor batch fetch from %s failed: %s: %s (attempt %d/%d)",
+                    url,
+                    e.__class__.__name__,
+                    str(e),
+                    attempt + 1,
+                    max_retries,
+                )
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(retry_delay)
+
+        raise RuntimeError(
+            f"Failed to fetch shard batch from {url} after {max_retries} attempts. "
+            f"Last error: {repr(last_exception)}"
+        )
+
     def fetch(self, shards: list[TensorShardInfo]) -> list[torch.Tensor]:
         """Fetch multiple shards concurrently via HTTP using a single session."""
         if not shards:
             return []
 
         async def _fetch():
+            indexed_shards = list(enumerate(shards))
+            shards_by_node: dict[str, list[tuple[int, TensorShardInfo]]] = defaultdict(
+                list
+            )
+            for index, shard in indexed_shards:
+                shards_by_node[shard.node_addr].append((index, shard))
+
+            results: list[torch.Tensor | None] = [None] * len(shards)
+
             async with self._create_session() as session:
-                tasks = [
-                    self._fetch_tensor(session, s.shard_id, s.node_addr) for s in shards
-                ]
-                return await asyncio.gather(*tasks)
+
+                async def _fetch_node(
+                    node_addr: str, grouped: list[tuple[int, TensorShardInfo]]
+                ) -> None:
+                    for start in range(0, len(grouped), self.max_shards_per_request):
+                        chunk = grouped[start : start + self.max_shards_per_request]
+                        tensors = await self._fetch_shard_group(
+                            session, node_addr, chunk
+                        )
+                        for (original_index, _), tensor in zip(
+                            chunk, tensors, strict=True
+                        ):
+                            results[original_index] = tensor
+
+                await asyncio.gather(
+                    *[
+                        _fetch_node(node_addr, grouped)
+                        for node_addr, grouped in shards_by_node.items()
+                    ]
+                )
+
+            return cast(list[torch.Tensor], results)
 
         return run_async_task(_fetch)
 

--- a/tests/test_rtensor.py
+++ b/tests/test_rtensor.py
@@ -1,5 +1,6 @@
 """Integration tests for RTensor with RPC server."""
 
+import asyncio
 import subprocess
 import sys
 import time
@@ -11,10 +12,11 @@ import requests
 import torch
 
 from areal.infra.rpc.rtensor import (
+    HttpRTensorBackend,
     RTensor,
     TensorShardInfo,
 )
-from areal.infra.rpc.serialization import serialize_value
+from areal.infra.rpc.serialization import deserialize_value, serialize_value
 from areal.infra.utils.proc import kill_process_tree
 from areal.utils.network import find_free_ports
 
@@ -211,6 +213,128 @@ class TestRTensorIntegration:
         for shard_id in shard_ids:
             resp = requests.get(f"http://{rpc_server}/data/{shard_id}")
             assert resp.status_code == 404
+
+    def test_batch_shard_retrieval(self, rpc_server):
+        """Retrieve multiple shards with one HTTP request."""
+        tensors = [torch.randn(2, 3).cpu(), torch.randn(4, 5).cpu()]
+        shard_ids = [str(uuid.uuid4()) for _ in tensors]
+
+        for shard_id, tensor in zip(shard_ids, tensors):
+            serialized = serialize_value(tensor)
+            resp = requests.put(
+                f"http://{rpc_server}/data/{shard_id}",
+                data=orjson.dumps(serialized),
+            )
+            assert resp.status_code == 200
+
+        resp = requests.post(
+            f"http://{rpc_server}/data/batch",
+            json={"shard_ids": shard_ids},
+        )
+        assert resp.status_code == 200
+        serialized_batch = orjson.loads(resp.content)
+        localized = deserialize_value(serialized_batch)
+        assert len(localized) == len(tensors)
+        for actual, expected in zip(localized, tensors):
+            assert torch.allclose(actual, expected)
+
+    def test_batch_shard_retrieval_reports_missing_shards(self, rpc_server):
+        """Missing shards return a structured client error instead of a compatibility 404."""
+        tensor = torch.randn(2, 3).cpu()
+        present_shard_id = str(uuid.uuid4())
+        missing_shard_id = str(uuid.uuid4())
+
+        resp = requests.put(
+            f"http://{rpc_server}/data/{present_shard_id}",
+            data=orjson.dumps(serialize_value(tensor)),
+        )
+        assert resp.status_code == 200
+
+        resp = requests.post(
+            f"http://{rpc_server}/data/batch",
+            json={"shard_ids": [present_shard_id, missing_shard_id]},
+        )
+        assert resp.status_code == 400
+        payload = resp.json()
+        assert payload["status"] == "error"
+        assert payload["missing_shard_ids"] == [missing_shard_id]
+
+
+class TestHttpRTensorBackendBatching:
+    """Unit tests for HTTP batch fetching behavior."""
+
+    def test_fetch_chunks_large_requests(self, monkeypatch):
+        """Large same-node fetches are split into bounded batch requests."""
+        backend = HttpRTensorBackend(max_shards_per_request=2)
+        shards = [
+            TensorShardInfo(shard_id=f"s{i}", node_addr="node-a") for i in range(5)
+        ]
+        requested_chunks = []
+
+        class _FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        async def fake_fetch_shard_group(self, session, node_addr, grouped):
+            requested_chunks.append(
+                (node_addr, [shard.shard_id for _, shard in grouped])
+            )
+            return [torch.tensor([int(shard.shard_id[1:])]) for _, shard in grouped]
+
+        monkeypatch.setattr(
+            backend,
+            "_create_session",
+            lambda: _FakeSession(),
+        )
+        monkeypatch.setattr(
+            backend,
+            "_fetch_shard_group",
+            fake_fetch_shard_group.__get__(backend, HttpRTensorBackend),
+        )
+
+        results = backend.fetch(shards)
+
+        assert requested_chunks == [
+            ("node-a", ["s0", "s1"]),
+            ("node-a", ["s2", "s3"]),
+            ("node-a", ["s4"]),
+        ]
+        assert [int(tensor.item()) for tensor in results] == [0, 1, 2, 3, 4]
+
+    def test_fetch_shard_group_raises_on_missing_batch_endpoint(self):
+        """404 on /data/batch surfaces as an error."""
+        backend = HttpRTensorBackend()
+        grouped = [
+            (0, TensorShardInfo(shard_id="s0", node_addr="node-a")),
+            (1, TensorShardInfo(shard_id="s1", node_addr="node-a")),
+        ]
+
+        class _FakeResponse:
+            status = 404
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def text(self):
+                return "missing endpoint"
+
+        class _FakeSession:
+            def post(self, url, json):
+                assert url == "http://node-a/data/batch"
+                assert json == {"shard_ids": ["s0", "s1"]}
+                return _FakeResponse()
+
+        with pytest.raises(
+            RuntimeError,
+            match="Failed to fetch shard batch from http://node-a/data/batch: 404 body=missing endpoint",
+        ):
+            asyncio.run(backend._fetch_shard_group(_FakeSession(), "node-a", grouped))
 
 
 class TestRTensorErrorHandling:


### PR DESCRIPTION
  ## Description

  This PR fixes the RTensor fetch failure reported in #1071 for large multimodal training batches, especially when samples contain multiple images.

  In the failing setup, `RTensor.localize(...)` issued one HTTP request per shard during `compute_logp`. For multi-image samples, this led to a large number of RTensor fetch requests in a single batch and made the transfer path fragile in end-to-end training.

  This PR reduces request fan-out by:
  - adding `/data/batch` on the RPC server to fetch multiple shards in one request
  - batching HTTP shard fetches in `HttpRTensorBackend` by `node_addr`
  - splitting large fetches into bounded chunks via `max_shards_per_request`
  - preserving request order across grouped and chunked batch fetches
  - adding regression tests for batched fetches, chunking behavior, and missing-shard reporting

  ## Related Issue

  Fixes #1071

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [x] ⚡ Performance improvement
  - [ ] ✅ Test coverage improvement

  ## Checklist

  - [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
  - [x] Relevant tests pass; new tests added for new functionality
  - [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
  - [x] Branch is up to date with `main`
  - [ ] Self-reviewed via `/review-pr` command
  - [ ] This PR was created by a coding agent via `/create-pr`
  - [ ] This PR is a breaking change

  **Breaking Change Details (if applicable):**

  N/A

  ## Additional Context

  Issue #1071 was reproduced in real multimodal training, where training failed during `compute_logp` with `Connection reset by peer` while localizing RTensor inputs over HTTP.

  This PR was validated in the affected training setup and resolved the failure there. In addition, the RTensor RPC regression tests pass:

  - `tests/test_rtensor.py`
  - Result: `32 passed`

  Additional verification:
  - `pre-commit run --files areal/infra/rpc/rpc_server.py areal/infra/rpc/rtensor.py areal/infra/rpc/serialization.py tests/test_rtensor.py`

  Added coverage includes:
  - batched shard retrieval through `/data/batch`
  - structured reporting for missing shards
  - chunking behavior for large same-node fetches