### PR TITLE
feat(commands): add fork workflow support to create-pr skill

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -62,16 +62,23 @@ gh repo view --json owner,name,viewerPermission
 
 **Logic for Determining Push Remote:**
 
-1. **If `origin` is writable**: Use `origin` directly (maintainer workflow)
-2. **If `origin` is NOT writable**: Look for a fork remote
-   - Common fork remote names: `fork`, `user`, `<username>`, or any remote pointing to user's fork
-   - Verify the fork remote points to user's own fork via `gh repo view <remote-url> --json owner`
-3. **If no fork remote found**: Ask user to add their fork as a remote:
-   ```bash
-   git remote add fork https://github.com/<username>/AReaL.git
-   ```
+**If `origin` is writable**: Use `origin` directly (maintainer workflow)
+
+**If `origin` is NOT writable**: Look for a fork remote
+
+- Common fork remote names: `fork`, `user`, `<username>`, or any remote pointing to
+  user's fork
+- Verify the fork remote points to user's own fork via
+  `gh repo view <remote-url> --json owner`
+
+**If no fork remote found**: Ask user to add their fork as a remote:
+
+```bash
+git remote add fork https://github.com/<username>/AReaL.git
+```
 
 **Store for later use:**
+
 - `PUSH_REMOTE`: The remote to push to (e.g., `origin` or `fork`)
 - `UPSTREAM_REPO`: The upstream repo for PR target (e.g., `inclusionAI/AReaL`)
 - `FORK_OWNER`: Fork owner username (for `--head` parameter if needed)


### PR DESCRIPTION
## Description

Add automatic detection of push remote to the `/create-pr` skill, enabling
both maintainer and contributor workflows. The skill now detects whether
the user has write access to `origin` and automatically finds the fork
remote if needed, using correct `--repo` and `--head` parameters for
cross-repository PRs.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Key changes:
- Add Step 1.5: Determine Push Remote (Fork Support)
- Detect if origin is writable via `git push --dry-run`
- Find fork remote from git remote list
- Use `--repo` and `--head` parameters for cross-repo PR creation
- Update examples and error handling for fork workflow

Files changed:
- `.claude/commands/create-pr.md`: Added fork detection logic and updated examples