### PR TITLE
fix(dataloader): prevent data drop and padding during validation for accurate metrics

### DIFF
--- a/areal/utils/dataloader.py
+++ b/areal/utils/dataloader.py
@@ -4,7 +4,7 @@ from datasets import Dataset
 from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from areal.api.cli_args import _DatasetConfig, ValidDatasetConfig
+from areal.api.cli_args import ValidDatasetConfig, _DatasetConfig
 
 
 def create_dataloader(
@@ -70,13 +70,13 @@ class EvalDistributedSampler(DistributedSampler):
     """
 
     def __init__(
-            self,
-            dataset: Dataset,
-            num_replicas: int | None = None,
-            rank: int | None = None,
-            shuffle: bool = True,
-            seed: int = 0,
-            drop_last: bool = False,
+        self,
+        dataset: Dataset,
+        num_replicas: int | None = None,
+        rank: int | None = None,
+        shuffle: bool = True,
+        seed: int = 0,
+        drop_last: bool = False,
     ) -> None:
         super().__init__(dataset, num_replicas, rank, shuffle, seed, drop_last)
 


### PR DESCRIPTION
fix(dataloader): use EvalDistributedSampler for validation to ensure accurate metrics

## Description

This PR fixes a critical bug where the validation dataloader was producing inaccurate evaluation metrics due to hardcoded data dropping and standard distributed padding. 

Previously, `create_dataloader` hardcoded `drop_last=True` and used the standard `DistributedSampler` for all dataset configs. The standard `DistributedSampler` pads the dataset to make it evenly divisible by the number of replicas, which causes some validation samples to be evaluated twice. Combined with `drop_last=True`, this means the validation set was both artificially inflated (via padding) and truncated (via dropping), leading to biased evaluation results.

**Changes made:**
1. Introduced `EvalDistributedSampler`: A custom sampler designed specifically for evaluation that prevents dataset padding. It ensures every sample in the dataset is evaluated exactly once across the cluster.
2. Updated `create_dataloader`: Added logic to check if the config is a `ValidDatasetConfig`. If true, it dynamically applies the new `EvalDistributedSampler` and forces `drop_last=False`.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #1095

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
