### PR TITLE
fix(dataloader): prevent data drop and padding during validation for accurate metrics

### DIFF
--- a/areal/utils/dataloader.py
+++ b/areal/utils/dataloader.py
@@ -1,9 +1,10 @@
 from collections.abc import Callable
 
+from datasets import Dataset
 from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from areal.api.cli_args import _DatasetConfig
+from areal.api.cli_args import ValidDatasetConfig, _DatasetConfig
 
 
 def create_dataloader(
@@ -26,17 +27,61 @@ def create_dataloader(
         raise ValueError(
             f"batch size({dataset_config.batch_size}) must be divisible by world_size({world_size})!"
         )
+
+    sampler_cls = DistributedSampler
+    drop_sampler_last = True
+    if isinstance(dataset_config, ValidDatasetConfig):
+        sampler_cls = EvalDistributedSampler
+        drop_sampler_last = False
+
     return StatefulDataLoader(
         dataset,
         batch_size=dataset_config.batch_size // world_size,
-        sampler=DistributedSampler(
+        sampler=sampler_cls(
             dataset,
             world_size,
             rank,
             shuffle=dataset_config.shuffle,
-            drop_last=True,
+            drop_last=drop_sampler_last,
         ),
         drop_last=dataset_config.drop_last,
         num_workers=dataset_config.num_workers,
         collate_fn=collate_fn or (lambda x: x),
     )
+
+
+class EvalDistributedSampler(DistributedSampler):
+    r"""A DistributedSampler specifically designed for evaluation (Validation/Testing).
+
+    Unlike the standard :class:`~torch.utils.data.DistributedSampler`, this sampler
+    **does not pad** the dataset to make it evenly divisible by the number of replicas.
+
+    In the standard implementation, extra indices are added to ensure every rank has
+    the exact same `num_samples`. While useful for training (synchronized batch sizes),
+    this causes some validation samples to be evaluated twice, leading to biased metrics
+    (e.g., inaccurate accuracy or loss).
+
+    **Key Behaviors:**
+    1. **Exact Evaluation:** Ensures every sample in the dataset is evaluated exactly
+       once across the entire cluster.
+    2. **Uneven Split:** Ranks may receive different amounts of data (difference is at most 1).
+       For example, if N=10 and Replicas=3, ranks get [4, 3, 3] samples respectively,
+       instead of [4, 4, 4] with padding.
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        num_replicas: int | None = None,
+        rank: int | None = None,
+        shuffle: bool = True,
+        seed: int = 0,
+        drop_last: bool = False,
+    ) -> None:
+        super().__init__(dataset, num_replicas, rank, shuffle, seed, drop_last)
+
+        if not drop_last:
+            self.total_size = len(dataset)
+
+        if self.rank + (self.num_samples - 1) * self.num_replicas >= self.total_size:
+            self.num_samples -= 1


### PR DESCRIPTION
fix(dataloader): use EvalDistributedSampler for validation to ensure accurate metrics

## Description

This PR fixes a critical bug where the validation dataloader was producing inaccurate evaluation metrics due to hardcoded data dropping and standard distributed padding. 

Previously, `create_dataloader` hardcoded `drop_last=True` and used the standard `DistributedSampler` for all dataset configs. The standard `DistributedSampler` pads the dataset to make it evenly divisible by the number of replicas, which causes some validation samples to be evaluated twice. Combined with `drop_last=True`, this means the validation set was both artificially inflated (via padding) and truncated (via dropping), leading to biased evaluation results.

**Changes made:**
1. Introduced `EvalDistributedSampler`: A custom sampler designed specifically for evaluation that prevents dataset padding. It ensures every sample in the dataset is evaluated exactly once across the cluster.
2. Updated `create_dataloader`: Added logic to check if the config is a `ValidDatasetConfig`. If true, it dynamically applies the new `EvalDistributedSampler` and forces `drop_last=False`.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #1095

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
