### PR TITLE
fix: fix `pad_packed_tensor_dict`

### DIFF
--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -917,6 +917,13 @@ def pad_packed_tensor_dict(
         raise ValueError(
             f"pad_to_length {pad_to_length} is smaller than total length {total_length}."
         )
+    elif pad_length == 0:
+        return (
+            data,
+            pad_length,
+            old_cu_seqlens,
+            align_to_length,
+        )
     new_cu_seqlens = F.pad(cu_seqlens, (0, 1), value=pad_to_length)
     new_max_seqlen = max(max_seqlen, pad_length)
     padded_data = {}


### PR DESCRIPTION
## Description

This PR adds an early return in `pad_packed_tensor_dict` to prevent appending a duplicate index to `cu_seqlens` when the batch's `total_length` perfectly matches the `pad_to_length` (i.e., when `pad_length == 0`).

Previously, a `pad_length` of 0 still triggered `F.pad(cu_seqlens, (0, 1), value=pad_to_length)`. This created a 0-length dummy sequence at the end of the batch, which caused PyTorch's `nn.Conv1d` to throw a `RuntimeError` during the sequence slicing loop in Qwen3.5's `GatedDeltaNet`.

## Related Issue

Fixes #1103 

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

N/A

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
