### PR TITLE
fix(archon): add missing POST /data/batch endpoint to data proxy

### DIFF
--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -6,8 +6,8 @@ from contextlib import asynccontextmanager
 
 import orjson
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.responses import Response as RawResponse
-from fastapi.responses import StreamingResponse
 from openai.types.chat.completion_create_params import CompletionCreateParams
 from pydantic import BaseModel
 
@@ -392,38 +392,59 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         (``rpc_server.py``) so that ``HttpRTensorBackend._fetch_shard_group``
         works against data-proxy addresses.
         """
-        payload = await request.json()
-        shard_ids = payload.get("shard_ids", [])
-        if not isinstance(shard_ids, list) or not all(
-            isinstance(sid, str) for sid in shard_ids
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail="Expected JSON body with string list field 'shard_ids'",
-            )
-
-        data = []
-        missing: list[str] = []
-        for sid in shard_ids:
+        try:
             try:
-                data.append(rtensor_storage.fetch(sid))
-            except KeyError:
-                missing.append(sid)
+                payload = (await request.json()) or {}
+            except Exception:
+                payload = {}
+            if not isinstance(payload, dict):
+                payload = {}
+            shard_ids = payload.get("shard_ids", [])
+            if not isinstance(shard_ids, list) or not all(
+                isinstance(sid, str) for sid in shard_ids
+            ):
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "status": "error",
+                        "message": "Expected JSON body with string list field 'shard_ids'",
+                    },
+                )
 
-        if missing:
-            raise HTTPException(
-                status_code=400,
-                detail=f"One or more requested shards were not found: {missing}",
+            data = []
+            missing: list[str] = []
+            for sid in shard_ids:
+                try:
+                    data.append(rtensor_storage.fetch(sid))
+                except KeyError:
+                    missing.append(sid)
+
+            if missing:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "status": "error",
+                        "message": "One or more requested shards were not found",
+                        "missing_shard_ids": missing,
+                    },
+                )
+
+            serialized_data = serialize_value(data)
+            data_bytes = orjson.dumps(serialized_data)
+            logger.debug(
+                "Retrieved %d RTensor shards in batch (size=%d bytes)",
+                len(shard_ids),
+                len(data_bytes),
             )
-
-        serialized_data = serialize_value(data)
-        data_bytes = orjson.dumps(serialized_data)
-        logger.debug(
-            "Retrieved %d RTensor shards in batch (size=%d bytes)",
-            len(shard_ids),
-            len(data_bytes),
-        )
-        return RawResponse(content=data_bytes, media_type="application/octet-stream")
+            return RawResponse(
+                content=data_bytes, media_type="application/octet-stream"
+            )
+        except Exception as e:
+            logger.error("Error retrieving batch shards: %s", e, exc_info=True)
+            return JSONResponse(
+                status_code=500,
+                content={"status": "error", "message": str(e)},
+            )
 
     @app.put("/data/{shard_id}")
     async def store_data_shard(shard_id: str, request: Request):

--- a/tests/experimental/inference_service/test_data_proxy_rtensor.py
+++ b/tests/experimental/inference_service/test_data_proxy_rtensor.py
@@ -1,0 +1,346 @@
+"""Unit tests for RTensor storage endpoints in the data proxy FastAPI app.
+
+Covers all 4 RTensor endpoints:
+  PUT  /data/{shard_id}   — store a tensor shard
+  GET  /data/{shard_id}   — retrieve a tensor shard
+  POST /data/batch        — batch retrieve tensor shards
+  DELETE /data/clear      — clear specified tensor shards
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import orjson
+import pytest
+import pytest_asyncio
+import torch
+
+from areal.experimental.inference_service.data_proxy.app import create_app
+from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
+from areal.experimental.inference_service.data_proxy.session import SessionStore
+from areal.infra.rpc import rtensor as rtensor_storage
+from areal.infra.rpc.serialization import deserialize_value, serialize_value
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def clear_rtensor_storage():
+    rtensor_storage._storage.clear()
+    yield
+    rtensor_storage._storage.clear()
+
+
+@pytest.fixture
+def config():
+    return DataProxyConfig(
+        host="127.0.0.1",
+        port=18082,
+        backend_addr="http://mock-sglang:30000",
+        tokenizer_path="mock-tokenizer",
+        request_timeout=10.0,
+    )
+
+
+@pytest_asyncio.fixture
+async def client(config):
+    from areal.experimental.inference_service.data_proxy.pause import PauseState
+
+    app = create_app(config)
+    pause_state = PauseState()
+
+    app.state.tokenizer = MagicMock()
+    app.state.inf_bridge = MagicMock()
+    app.state.inf_bridge.pause = AsyncMock()
+    app.state.inf_bridge.resume = AsyncMock()
+    app.state.areal_client = MagicMock()
+    app.state.pause_state = pause_state
+    app.state.config = config
+    app.state.session_store = SessionStore()
+    app.state.version = 0
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _serialize_tensor_body(tensor: torch.Tensor) -> bytes:
+    return orjson.dumps(serialize_value(tensor))
+
+
+def _deserialize_response_bytes(content: bytes) -> torch.Tensor:
+    return deserialize_value(orjson.loads(content))
+
+
+def _deserialize_batch_response_bytes(content: bytes) -> list[torch.Tensor]:
+    return deserialize_value(orjson.loads(content))
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestDataProxyRTensor:
+    @pytest.mark.asyncio
+    async def test_put_store_shard(self, client):
+        """PUT /data/{shard_id} stores tensor → 200 with status ok."""
+        shard_id = str(uuid.uuid4())
+        tensor = torch.tensor([1.0, 2.0, 3.0])
+        body = _serialize_tensor_body(tensor)
+
+        resp = await client.put(
+            f"/data/{shard_id}",
+            content=body,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_get_retrieve_shard(self, client):
+        """PUT a tensor then GET it back → deserialized tensor matches original."""
+        shard_id = str(uuid.uuid4())
+        tensor = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        body = _serialize_tensor_body(tensor)
+
+        put_resp = await client.put(
+            f"/data/{shard_id}",
+            content=body,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert put_resp.status_code == 200
+
+        get_resp = await client.get(f"/data/{shard_id}")
+        assert get_resp.status_code == 200
+
+        retrieved = _deserialize_response_bytes(get_resp.content)
+        torch.testing.assert_close(retrieved, tensor)
+
+    @pytest.mark.asyncio
+    async def test_get_unknown_shard_returns_404(self, client):
+        """GET /data/{random-uuid} for a non-existent shard → 404."""
+        shard_id = str(uuid.uuid4())
+        resp = await client.get(f"/data/{shard_id}")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_post_batch_retrieve(self, client):
+        """PUT 3 tensors with different shapes, POST /data/batch → all 3 match originals."""
+        tensors = [
+            torch.tensor([1.0, 2.0, 3.0]),
+            torch.zeros(2, 4),
+            torch.ones(3, 3, 3),
+        ]
+        shard_ids = []
+
+        for tensor in tensors:
+            shard_id = str(uuid.uuid4())
+            shard_ids.append(shard_id)
+            body = _serialize_tensor_body(tensor)
+            put_resp = await client.put(
+                f"/data/{shard_id}",
+                content=body,
+                headers={"Content-Type": "application/octet-stream"},
+            )
+            assert put_resp.status_code == 200
+
+        batch_resp = await client.post(
+            "/data/batch",
+            json={"shard_ids": shard_ids},
+        )
+        assert batch_resp.status_code == 200
+
+        retrieved_list = _deserialize_batch_response_bytes(batch_resp.content)
+        assert len(retrieved_list) == len(tensors)
+        for original, retrieved in zip(tensors, retrieved_list):
+            torch.testing.assert_close(retrieved, original)
+
+    @pytest.mark.asyncio
+    async def test_post_batch_missing_shard_returns_400(self, client):
+        """POST /data/batch with a missing shard_id → 400 with error details."""
+        shard_id = str(uuid.uuid4())
+        tensor = torch.tensor([1.0, 2.0])
+        body = _serialize_tensor_body(tensor)
+        put_resp = await client.put(
+            f"/data/{shard_id}",
+            content=body,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert put_resp.status_code == 200
+
+        nonexistent_id = "nonexistent-id"
+        batch_resp = await client.post(
+            "/data/batch",
+            json={"shard_ids": [shard_id, nonexistent_id]},
+        )
+        assert batch_resp.status_code == 400
+        data = batch_resp.json()
+        assert data["status"] == "error"
+        assert data["message"] == "One or more requested shards were not found"
+        assert data["missing_shard_ids"] == [nonexistent_id]
+
+    @pytest.mark.asyncio
+    async def test_post_batch_invalid_body_returns_400(self, client):
+        """POST /data/batch with shard_ids as a non-list → 400 with error message."""
+        batch_resp = await client.post(
+            "/data/batch",
+            json={"shard_ids": "not-a-list"},
+        )
+        assert batch_resp.status_code == 400
+        data = batch_resp.json()
+        assert data["status"] == "error"
+        assert (
+            data["message"] == "Expected JSON body with string list field 'shard_ids'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_clear_shards(self, client):
+        """PUT 2 tensors, DELETE /data/clear → 200 with cleared_count. Then GET → 404."""
+        shard_ids = []
+        for _ in range(2):
+            shard_id = str(uuid.uuid4())
+            shard_ids.append(shard_id)
+            tensor = torch.rand(4)
+            body = _serialize_tensor_body(tensor)
+            put_resp = await client.put(
+                f"/data/{shard_id}",
+                content=body,
+                headers={"Content-Type": "application/octet-stream"},
+            )
+            assert put_resp.status_code == 200
+
+        delete_resp = await client.request(
+            "DELETE",
+            "/data/clear",
+            json={"shard_ids": shard_ids},
+        )
+        assert delete_resp.status_code == 200
+        data = delete_resp.json()
+        assert "cleared_count" in data
+        assert data["cleared_count"] == 2
+
+        for shard_id in shard_ids:
+            get_resp = await client.get(f"/data/{shard_id}")
+            assert get_resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_post_batch_malformed_json_returns_200_empty(self, client):
+        """POST /data/batch with non-JSON body → graceful fallback (empty batch).
+
+        Mirrors Flask's ``get_json(silent=True) or {}`` which silently
+        returns an empty dict on parse failure, yielding an empty 200.
+        """
+        resp = await client.post(
+            "/data/batch",
+            content=b"this is not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/octet-stream"
+        batch = _deserialize_batch_response_bytes(resp.content)
+        assert batch == []
+
+    @pytest.mark.asyncio
+    async def test_post_batch_serialization_error_returns_500(
+        self, client, monkeypatch
+    ):
+        """Serialization failure in /data/batch → 500 with Flask-compatible body."""
+        shard_id = str(uuid.uuid4())
+        tensor = torch.tensor([1.0, 2.0])
+        body = _serialize_tensor_body(tensor)
+        put_resp = await client.put(
+            f"/data/{shard_id}",
+            content=body,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert put_resp.status_code == 200
+
+        from areal.experimental.inference_service.data_proxy import app as app_module
+
+        def _boom(data):
+            raise RuntimeError("serialization kaboom")
+
+        monkeypatch.setattr(app_module, "serialize_value", _boom)
+
+        batch_resp = await client.post(
+            "/data/batch",
+            json={"shard_ids": [shard_id]},
+        )
+        assert batch_resp.status_code == 500
+        data = batch_resp.json()
+        assert data["status"] == "error"
+        assert "serialization kaboom" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_post_batch_null_json_returns_200_empty(self, client):
+        """POST /data/batch with ``null`` JSON body → empty batch 200.
+
+        Flask ``get_json(silent=True) or {}`` normalises falsy values to ``{}``.
+        """
+        resp = await client.post(
+            "/data/batch",
+            content=b"null",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/octet-stream"
+        batch = _deserialize_batch_response_bytes(resp.content)
+        assert batch == []
+
+    @pytest.mark.asyncio
+    async def test_post_batch_non_dict_json_returns_200_empty(self, client):
+        """POST /data/batch with a JSON array → empty batch 200.
+
+        Truthy non-dict payloads are normalised to ``{}`` to match Flask.
+        """
+        resp = await client.post(
+            "/data/batch",
+            content=b"[1, 2, 3]",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/octet-stream"
+        batch = _deserialize_batch_response_bytes(resp.content)
+        assert batch == []
+
+    @pytest.mark.asyncio
+    async def test_post_batch_fetch_runtime_error_returns_500(
+        self, client, monkeypatch
+    ):
+        """Non-KeyError failure during fetch → outer try/except returns 500."""
+        shard_id = str(uuid.uuid4())
+        tensor = torch.tensor([1.0])
+        body = _serialize_tensor_body(tensor)
+        put_resp = await client.put(
+            f"/data/{shard_id}",
+            content=body,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert put_resp.status_code == 200
+
+        def _broken_fetch(sid):
+            raise RuntimeError("storage corrupted")
+
+        monkeypatch.setattr(rtensor_storage, "fetch", _broken_fetch)
+
+        batch_resp = await client.post(
+            "/data/batch",
+            json={"shard_ids": [shard_id]},
+        )
+        assert batch_resp.status_code == 500
+        data = batch_resp.json()
+        assert data["status"] == "error"
+        assert "storage corrupted" in data["message"]


### PR DESCRIPTION
## Description

PR #1077 added batch RTensor fetching (`HttpRTensorBackend._fetch_shard_group`) which sends `POST /data/batch` to retrieve multiple tensor shards in one request. The corresponding endpoint was added to the Flask RPC server (`rpc_server.py`) but was missing from the FastAPI data proxy (`data_proxy/app.py`).

When integration tests use the data proxy, `RTensor.localize()` fails with **HTTP 405 Method Not Allowed** because FastAPI matches `/data/batch` to the `/data/{shard_id}` route (with `shard_id="batch"`), which only accepts GET/PUT.

This PR adds the missing `POST /data/batch` endpoint to the data proxy, declared before `/data/{shard_id}` to ensure correct FastAPI route matching.

## Related Issue

Fixes the 2 failing tests in CI ([run #23640526474](https://github.com/inclusionAI/AReaL/actions/runs/23640526474/job/68861035274)):
- `TestControllerFullInitialization::test_rtensor_localize_on_rollout_result`
- `TestControllerFullInitialization::test_rtensor_localize_batch4`

Refs: #1077

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

The new endpoint mirrors the existing `POST /data/batch` in `rpc_server.py` (Flask), adapted to FastAPI async style. Route ordering is critical — the `/data/batch` route must be declared before `/data/{shard_id}` to prevent FastAPI from capturing `"batch"` as a path parameter.

Files changed:
- `areal/experimental/inference_service/data_proxy/app.py`: Add `POST /data/batch` endpoint