### PR TITLE
fix(engine): remove duplicate trust_remote_code kwarg in MegatronBridge init

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -353,7 +353,9 @@ class MegatronEngine(TrainEngine):
 
     def _build_hf_mcore_bridge(self):
         if self.bridge_cls == "mbridge":
-            self.bridge = mbridge.AutoBridge.from_pretrained(self.config.path, trust_remote_code=True)
+            self.bridge = mbridge.AutoBridge.from_pretrained(
+                self.config.path, trust_remote_code=True
+            )
             self.bridge.dtype = self.dtype
             if self.config.gradient_checkpointing:
                 self.bridge.set_extra_args(
@@ -376,7 +378,6 @@ class MegatronEngine(TrainEngine):
                 self.config.path,
                 trust_remote_code=True,
                 dtype=self.config.dtype,
-                trust_remote_code=True,
             )
             self.logger.info(
                 "Using megatron-bridge to create models and hf model save/load in MegatronEngine."


### PR DESCRIPTION
## Description

Remove duplicate `trust_remote_code=True` keyword argument in `MegatronBridgeAutoBridge.from_hf_pretrained()` inside `MegatronEngine._build_hf_mcore_bridge()`. This duplicate kwarg causes a `SyntaxError` at import/call time. Also reformats the `mbridge.AutoBridge.from_pretrained()` call for line length compliance.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Introduced in 722e235a3 (`feat: megatron bridge adaptation (#1056)`). The `megatron-bridge` code path was unusable due to this SyntaxError.

Files changed:
- `areal/engine/megatron_engine.py`: Remove duplicate kwarg, reformat long line