### PR TITLE
fix: harden padded distributed eval across training engines

### DIFF
--- a/areal/engine/core/train_engine.py
+++ b/areal/engine/core/train_engine.py
@@ -56,8 +56,10 @@ def compute_total_loss_weight(
         .clone()
         .to(dtype=torch.float32)
     )
-    assert total_weight != 0, "Total loss weight must be non-zero"
     dist.all_reduce(total_weight, group=dp_group)
+    assert total_weight > 0, (
+        "Global total loss weight must be positive after all_reduce"
+    )
     return total_weight
 
 

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -1658,6 +1658,10 @@ class FSDPEngine(TrainEngine):
         loss_multiplier: float = 1.0,
     ) -> torch.Tensor:
         """Compute logprobs/entropy and return scaled loss."""
+        local_weight = loss_weight_fn(ctx.mb_input)
+        if local_weight == 0:
+            return logits.mean() * 0.0
+
         if self.config.is_critic and self.enable_tree_training:
             raise NotImplementedError(
                 "Tree training with critic model is not supported yet."
@@ -1669,7 +1673,7 @@ class FSDPEngine(TrainEngine):
                 if ctx.trie_node is None or not ctx.trie_node.all_sequence_ids:
                     # Return zero loss that maintains gradient connection to logits
                     # This ensures backward() works correctly for FSDP synchronization
-                    return logits.sum() * 0.0
+                    return logits.mean() * 0.0
 
                 # For tree training, use gather_packed_tree_vocab_stats to properly
                 # unpack vocab stats from tree structure back to per-sequence format.
@@ -1712,7 +1716,7 @@ class FSDPEngine(TrainEngine):
                 values = values[: -ctx.pad_length]
             loss = loss_fn(values, ctx.mb_input)
 
-        loss_scale = loss_weight_fn(ctx.mb_input) / total_loss_weight * loss_multiplier
+        loss_scale = local_weight / total_loss_weight * loss_multiplier
         return loss * loss_scale
 
     def _compute_forward_result(

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1546,6 +1546,10 @@ class MegatronEngine(TrainEngine):
         total_loss_weight: torch.Tensor,
         loss_multiplier: float = 1.0,
     ) -> torch.Tensor:
+        local_weight = loss_weight_fn(inputs)
+        if local_weight == 0:
+            return output.mean() * 0.0
+
         if self.config.is_critic and self.enable_tree_training:
             raise NotImplementedError(
                 "Tree training with critic model is not supported yet."
@@ -1558,7 +1562,7 @@ class MegatronEngine(TrainEngine):
                 if trie_node is None or not trie_node.all_sequence_ids:
                     # Return zero loss that maintains gradient connection to output
                     # This ensures backward() works correctly for distributed synchronization
-                    return output.sum() * 0.0
+                    return output.mean() * 0.0
 
                 # For tree training, use gather_packed_tree_vocab_stats to properly
                 # unpack vocab stats from tree structure back to per-sequence format.
@@ -1599,7 +1603,7 @@ class MegatronEngine(TrainEngine):
             values = output.squeeze(-1)
             loss = loss_fn(values, inputs)
 
-        loss_scale = loss_weight_fn(inputs) / total_loss_weight * loss_multiplier
+        loss_scale = local_weight / total_loss_weight * loss_multiplier
         return loss * loss_scale
 
     def _compute_forward_result(

--- a/areal/experimental/engine/archon_engine.py
+++ b/areal/experimental/engine/archon_engine.py
@@ -1154,10 +1154,14 @@ class ArchonEngine(TrainEngine):
         loss_multiplier: float = 1.0,
     ) -> torch.Tensor:
         """Compute logprobs/entropy and return scaled loss."""
+        local_weight = loss_weight_fn(ctx.mb_input)
+        if local_weight == 0:
+            return logits.mean() * 0.0
+
         if not self.config.is_critic:
             result = self._gather_actor_train_outputs(logits, ctx)
             if result is None:
-                return logits.sum() * 0.0
+                return logits.mean() * 0.0
             logprobs, entropy, vocab_min_logits, vocab_max_logits = result
             loss = loss_fn(
                 logprobs,
@@ -1170,7 +1174,7 @@ class ArchonEngine(TrainEngine):
             values = self._gather_critic_output(logits, ctx)
             loss = loss_fn(values, ctx.mb_input)
 
-        loss_scale = loss_weight_fn(ctx.mb_input) / total_loss_weight * loss_multiplier
+        loss_scale = local_weight / total_loss_weight * loss_multiplier
         return loss * loss_scale
 
     def _compute_forward_result(

--- a/areal/experimental/engine/archon_runner.py
+++ b/areal/experimental/engine/archon_runner.py
@@ -273,13 +273,13 @@ class PipelinedRunner(ForwardBackwardRunner):
                     pred = pred.squeeze(0)
                 loss = process_output_fn(pred, ctx.to_dict())
                 if loss is None:
-                    return pred.sum() * 0.0
+                    return pred.mean() * 0.0
                 return loss
         else:
             # Non-last stage: dummy loss that keeps all elements in computation graph
             # so autograd can compute complete pred.grad for upstream stage
             def pp_loss_fn(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-                return pred.sum() * 0.0
+                return pred.mean() * 0.0
 
         return pp_loss_fn
 

--- a/areal/infra/controller/train_controller.py
+++ b/areal/infra/controller/train_controller.py
@@ -21,6 +21,7 @@ from areal.api.cli_args import PerfTracerConfig, TrainEngineConfig
 from areal.infra.rpc.rtensor import RTensor
 from areal.infra.utils.concurrent import run_async_task
 from areal.utils import logging, stats_tracker
+from areal.utils.data import make_dummy_eval_item
 from areal.utils.network import find_free_ports
 from areal.utils.seqpack import balanced_greedy_partition
 
@@ -55,32 +56,97 @@ def _is_tensor_like(obj: Any) -> bool:
     )
 
 
+def _item_weight(d: dict[str, Any]) -> int:
+    attn_mask = d.get("attention_mask")
+    if isinstance(attn_mask, torch.Tensor):
+        return int(attn_mask.sum().item())
+    if isinstance(attn_mask, RTensor):
+        return attn_mask.data.numel()
+    # Fallback: first tensor's numel
+    for v in d.values():
+        if isinstance(v, RTensor):
+            return v.data.numel()
+        if isinstance(v, torch.Tensor) and v.ndim >= 2:
+            return v.numel()
+    return 1
+
+
 def _dispatch_tensors(
     item_list: list[dict[str, Any]],
     dp_size: int,
+    group_size: int = 1,
 ) -> tuple[list[list[dict[str, Any]]], list[list[int]]]:
-    """Partition trajectories across DP groups by balanced token count."""
-    token_weights: list[int] = []
-    for d in item_list:
-        attn_mask = d.get("attention_mask")
-        if isinstance(attn_mask, torch.Tensor):
-            token_weights.append(int(attn_mask.sum().item()))
-        elif isinstance(attn_mask, RTensor):
-            token_weights.append(attn_mask.data.numel())
-        else:
-            # Fallback: first tensor's numel
-            w = 1
-            for v in d.values():
-                if isinstance(v, RTensor):
-                    w = v.data.numel()
-                    break
-                if isinstance(v, torch.Tensor) and v.ndim >= 2:
-                    w = v.numel()
-                    break
-            token_weights.append(w)
-    group_indices = balanced_greedy_partition(token_weights, K=dp_size)
-    splits = [[item_list[i] for i in idxs] for idxs in group_indices]
+    """Partition trajectories across DP groups by balanced token count.
+
+    Args:
+        group_size: number of consecutive items that form an atomic dispatch
+            unit (e.g. 2 for chosen/rejected RW pairs).  Groups are never
+            split across DP ranks.  ``group_size=1`` degenerates to per-item
+            partitioning.
+    """
+    n = len(item_list)
+    if n % group_size != 0:
+        raise ValueError(
+            f"item count ({n}) must be divisible by group_size ({group_size})"
+        )
+
+    token_weights = [_item_weight(d) for d in item_list]
+    n_groups = n // group_size
+
+    group_weights = [
+        sum(token_weights[g * group_size + k] for k in range(group_size))
+        for g in range(n_groups)
+    ]
+
+    gpart = balanced_greedy_partition(group_weights, K=dp_size)
+
+    group_indices: list[list[int]] = []
+    splits: list[list[dict[str, Any]]] = []
+    for gidxs in gpart:
+        item_idxs: list[int] = []
+        items: list[dict[str, Any]] = []
+        for g in gidxs:
+            for k in range(group_size):
+                idx = g * group_size + k
+                item_idxs.append(idx)
+                items.append(item_list[idx])
+        group_indices.append(item_idxs)
+        splits.append(items)
+
+    assert all(len(s) % group_size == 0 for s in splits), (
+        f"Post-dispatch invariant violated: shard sizes "
+        f"{[len(s) for s in splits]} not all divisible by group_size={group_size}"
+    )
     return splits, group_indices
+
+
+def _pad_eval_batch(
+    args: tuple[Any, ...], dp_size: int, group_size: int = 1
+) -> tuple[Any, ...]:
+    """Pad the first tensor-like arg to a multiple of ``dp_size * group_size``.
+
+    Called before dispatch for explicit evaluation controller paths so that
+    ``balanced_greedy_partition`` always receives a divisible input.
+    Dummy items have zero attention/loss masks and contribute nothing
+    to metrics or loss.
+    """
+    result = list(args)
+    pad_target = dp_size * group_size
+    for i, arg in enumerate(result):
+        if isinstance(arg, list) and arg and _is_tensor_like(arg):
+            n = len(arg)
+            pad_count = (-n) % pad_target
+            if pad_count > 0:
+                padded = list(arg)
+                template = arg[0]
+                padded.extend(make_dummy_eval_item(template) for _ in range(pad_count))
+                result[i] = padded
+                logger.info(
+                    f"Eval dispatch: padded {pad_count} dummy items "
+                    f"(total {len(padded)}) for dp_size={dp_size}"
+                )
+            break  # only pad the first tensor-like arg
+    return tuple(result)
 
 
 def _merge_tensors(
@@ -388,6 +454,20 @@ class TrainController:
         results = await self._call_workers(method, dp_args, dp_kwargs)
         return self._collect_results(results, group_indices)
 
+    def _pad_eval_dispatch_args(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        *,
+        group_size: int,
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        """Pad eval batches for explicit algorithm-level evaluation dispatch."""
+        kwargs = dict(kwargs)
+        args = _pad_eval_batch(
+            args, self.parallel_strategy.dp_size, group_size=group_size
+        )
+        return args, kwargs
+
     def _prepare_dispatch(
         self, *args, **kwargs
     ) -> tuple[list[list[Any]], dict[str, list[Any]], list[list[int]] | None]:
@@ -396,12 +476,13 @@ class TrainController:
         Returns (dp_split_args, dp_split_kwargs, group_indices).
         group_indices is non-None only for tensor dispatches.
         """
+        group_size = kwargs.pop("group_size", 1)
         if _is_tensor_like(args) or _is_tensor_like(kwargs):
-            return self._partition_inputs(*args, **kwargs)
+            return self._partition_inputs(group_size, *args, **kwargs)
         return self._replicate_inputs(*args, **kwargs)
 
     def _partition_inputs(
-        self, *args, **kwargs
+        self, group_size: int, /, *args, **kwargs
     ) -> tuple[list[list[Any]], dict[str, list[Any]], list[list[int]]]:
         """Partition tensor args across DP groups; replicate others."""
         dp_size = self.parallel_strategy.dp_size
@@ -411,7 +492,9 @@ class TrainController:
             nonlocal group_indices
             if _is_tensor_like(item):
                 if group_indices is None:
-                    splits, group_indices = _dispatch_tensors(item, dp_size)
+                    splits, group_indices = _dispatch_tensors(
+                        item, dp_size, group_size=group_size
+                    )
                     return splits
                 return [[item[i] for i in idxs] for idxs in group_indices]
             return [item] * dp_size

--- a/areal/trainer/rw/rw_engine.py
+++ b/areal/trainer/rw/rw_engine.py
@@ -4,12 +4,32 @@ import torch
 
 from areal.api import TrainEngine
 from areal.infra import TrainController
-from areal.infra.platforms import current_platform
 from areal.utils import logging, stats_tracker
 from areal.utils.data import batched_call
 from areal.utils.perf_tracer import trace_perf
 
 logger = logging.getLogger("RWEngine")
+
+
+def _rw_valid_pairs(x: dict[str, Any]) -> torch.Tensor:
+    seqlens = x["cu_seqlens"][1:] - x["cu_seqlens"][:-1]
+    return seqlens.view(-1, 2).ne(0).all(dim=1)
+
+
+def _rw_loss_weight(x: dict[str, Any]) -> torch.Tensor:
+    return _rw_valid_pairs(x).count_nonzero().float()
+
+
+def _log_empty_rw_stats(device: torch.device) -> None:
+    n_pairs = torch.zeros(1, dtype=torch.bool, device=device)
+    stats_tracker.denominator(n_pairs=n_pairs)
+    stats_tracker.stat(
+        correct_ratio=torch.zeros(1, dtype=torch.float32, device=device),
+        pos_score=torch.zeros(1, dtype=torch.float32, device=device),
+        neg_score=torch.zeros(1, dtype=torch.float32, device=device),
+        loss=torch.zeros(1, dtype=torch.float32, device=device),
+        denominator="n_pairs",
+    )
 
 
 class RWEngine:
@@ -23,15 +43,13 @@ class RWEngine:
 
     def _train_rw(self, data: dict[str, Any]) -> None:
         """Train on a batch (reward model)."""
+        if _rw_loss_weight(data) == 0:
+            _log_empty_rw_stats(data["cu_seqlens"].device)
         self.engine.train()
         stats = self.engine.train_batch(
             input_=data,
             loss_fn=compute_rw_loss,
-            loss_weight_fn=lambda x: torch.tensor(
-                x["cu_seqlens"].shape[0] - 1,
-                dtype=torch.float,
-                device=current_platform.current_device(),
-            ),
+            loss_weight_fn=_rw_loss_weight,
         )
         stats_tracker.scalar(**stats)
 
@@ -41,15 +59,13 @@ class RWEngine:
         batched_call(self._evaluate_rw, data, unpack=False)
 
     def _evaluate_rw(self, data: dict[str, Any]) -> None:
+        if _rw_loss_weight(data) == 0:
+            _log_empty_rw_stats(data["cu_seqlens"].device)
         self.engine.eval()
         self.engine.eval_batch(
             input_=data,
             loss_fn=compute_rw_loss,
-            loss_weight_fn=lambda x: torch.tensor(
-                x["cu_seqlens"].shape[0] - 1,
-                dtype=torch.float,
-                device=current_platform.current_device(),
-            ),
+            loss_weight_fn=_rw_loss_weight,
         )
 
 
@@ -58,16 +74,27 @@ class RWController(TrainController):
         self._custom_function_call("train_rw", *args, **kwargs)
 
     def evaluate_rw(self, *args, **kwargs):
-        self._custom_function_call("evaluate_rw", *args, **kwargs)
+        # rw_modeling_collate_fn produces 2 sequences (chosen + rejected) per
+        # example; group_size=2 keeps each pair on the same DP rank.
+        args, kwargs = self._pad_eval_dispatch_args(args, kwargs, group_size=2)
+        self._custom_function_call("evaluate_rw", *args, group_size=2, **kwargs)
 
 
 def compute_rw_loss(scores: torch.Tensor, input_: dict[str, Any]) -> torch.Tensor:
+    device = scores.device
     cu_seqlens = input_["cu_seqlens"]
     seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).cpu()
-    n_pairs = (cu_seqlens.shape[0] - 1) // 2
+    valid_pairs = _rw_valid_pairs(input_)
+    if not valid_pairs.any():
+        _log_empty_rw_stats(device)
+        return torch.zeros((), dtype=torch.float32, device=device)
+
+    valid_pair_mask = valid_pairs.to(device=device)
+    terminal_indices = seqlens.cumsum(0).to(device=device) - 1
 
     assert scores.shape[0] == seqlens.sum(), (scores.shape, seqlens.sum())
-    scores = scores[seqlens.cumsum(0) - 1].view(-1, 2).float()
+    scores = scores[terminal_indices].view(-1, 2)[valid_pair_mask].float()
+
     loss = -(torch.nn.functional.logsigmoid(scores[:, 0] - scores[:, 1]))
     logging_loss = loss.detach()
     loss = loss.mean()
@@ -75,7 +102,7 @@ def compute_rw_loss(scores: torch.Tensor, input_: dict[str, Any]) -> torch.Tenso
     # Logging.
     with torch.no_grad():
         stats_tracker.denominator(
-            n_pairs=torch.ones(n_pairs, dtype=torch.bool, device=scores.device),
+            n_pairs=torch.ones(scores.shape[0], dtype=torch.bool, device=device),
         )
         stats_tracker.stat(
             correct_ratio=(scores[:, 0] > scores[:, 1]).detach().float(),

--- a/areal/trainer/sft/lm_engine.py
+++ b/areal/trainer/sft/lm_engine.py
@@ -46,6 +46,7 @@ class LMController(TrainController):
         self._custom_function_call("train_lm", *args, **kwargs)
 
     def evaluate_lm(self, *args, **kwargs):
+        args, kwargs = self._pad_eval_dispatch_args(args, kwargs, group_size=1)
         self._custom_function_call("evaluate_lm", *args, **kwargs)
 
 

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1639,3 +1639,36 @@ class KLEstimator:
         if apply_clamp:
             log_ratio = log_ratio.clamp(min=-10, max=10)
         return log_ratio
+
+
+def make_dummy_eval_item(template: dict[str, Any]) -> dict[str, Any]:
+    """Create a zero-contribution dummy item matching *template*'s schema.
+
+    Every tensor field is replaced with a minimal all-zeros tensor that
+    preserves dtype and device.  ``attention_mask`` and ``loss_mask`` are
+    set to zero so that downstream loss/metric code treats the item as
+    contributing nothing.
+    """
+
+    def _zero_tensor_like(tensor: torch.Tensor) -> torch.Tensor:
+        return torch.zeros((1, 1), dtype=tensor.dtype, device=tensor.device)
+
+    dummy: dict[str, Any] = {}
+    for key, value in template.items():
+        if key in {"attention_mask", "loss_mask"}:
+            if isinstance(value, torch.Tensor):
+                dummy[key] = _zero_tensor_like(value)
+            else:
+                dummy[key] = torch.zeros((1, 1), dtype=torch.bool)
+            continue
+
+        if key.startswith("multi_modal_input"):
+            dummy[key] = [{}]
+            continue
+
+        if isinstance(value, torch.Tensor):
+            dummy[key] = _zero_tensor_like(value)
+        else:
+            dummy[key] = copy.deepcopy(value)
+
+    return dummy

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -66,6 +66,7 @@ For detailed examples, see the experiment configurations in the `examples/` dire
 - [StatsLogger Configuration](section-stats-logger)
 - [Swanlab Configuration](section-swanlab)
 - [TensorBoard Configuration](section-tensor-board)
+- [Trackio Configuration](section-trackio)
 - [WandB Configuration](section-wand-b)
 
 ### Others
@@ -742,14 +743,15 @@ Configuration for model checkpoint saving scheduling and timing.
 
 Configuration for experiment statistics logging and tracking services.
 
-| Parameter         | Type                                        | Default      | Description                                            |
-| ----------------- | ------------------------------------------- | ------------ | ------------------------------------------------------ |
-| `experiment_name` | string                                      | **Required** | -                                                      |
-| `trial_name`      | string                                      | **Required** | -                                                      |
-| `fileroot`        | string                                      | **Required** | -                                                      |
-| `wandb`           | [`WandBConfig`](section-wand-b)             | **Required** | Weights & Biases configuration.                        |
-| `swanlab`         | [`SwanlabConfig`](section-swanlab)          | **Required** | SwanLab configuration.                                 |
-| `tensorboard`     | [`TensorBoardConfig`](section-tensor-board) | **Required** | TensorBoard configuration. Only 'path' field required. |
+| Parameter         | Type                                        | Default      | Description                                               |
+| ----------------- | ------------------------------------------- | ------------ | --------------------------------------------------------- |
+| `experiment_name` | string                                      | **Required** | -                                                         |
+| `trial_name`      | string                                      | **Required** | -                                                         |
+| `fileroot`        | string                                      | **Required** | -                                                         |
+| `wandb`           | [`WandBConfig`](section-wand-b)             | **Required** | Weights & Biases configuration.                           |
+| `swanlab`         | [`SwanlabConfig`](section-swanlab)          | **Required** | SwanLab configuration.                                    |
+| `tensorboard`     | [`TensorBoardConfig`](section-tensor-board) | **Required** | TensorBoard configuration. Only 'path' field required.    |
+| `trackio`         | [`TrackioConfig`](section-trackio)          | **Required** | Trackio configuration (Hugging Face experiment tracking). |
 
 (section-swanlab)=
 
@@ -775,6 +777,27 @@ Configuration for TensorBoard logging and visualization.
 | Parameter | Type           | Default | Description |
 | --------- | -------------- | ------- | ----------- |
 | `path`    | string \| None | `None`  | -           |
+
+(section-trackio)=
+
+## Trackio Configuration
+
+Configuration for Trackio experiment tracking (Hugging Face).
+
+Trackio is a lightweight, local-first experiment tracking library with a
+wandb-compatible API. Dashboards can be viewed locally or deployed to Hugging Face
+Spaces.
+
+```
+See: https://github.com/gradio-app/trackio
+```
+
+| Parameter  | Type           | Default      | Description |
+| ---------- | -------------- | ------------ | ----------- |
+| `mode`     | string         | `"disabled"` | -           |
+| `project`  | string \| None | `None`       | -           |
+| `name`     | string \| None | `None`       | -           |
+| `space_id` | string \| None | `None`       | -           |
 
 (section-wand-b)=
 

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -64,6 +64,7 @@ python3 train.py --config path/to/config.yaml actor.lr=1e-4 seed=42
 - [StatsLogger Configuration](section-stats-logger)
 - [Swanlab Configuration](section-swanlab)
 - [TensorBoard Configuration](section-tensor-board)
+- [Trackio Configuration](section-trackio)
 - [WandB Configuration](section-wand-b)
 
 ### Others
@@ -740,14 +741,15 @@ Configuration for model checkpoint saving scheduling and timing.
 
 Configuration for experiment statistics logging and tracking services.
 
-| Parameter         | Type                                        | Default      | Description                                            |
-| ----------------- | ------------------------------------------- | ------------ | ------------------------------------------------------ |
-| `experiment_name` | string                                      | **Required** | -                                                      |
-| `trial_name`      | string                                      | **Required** | -                                                      |
-| `fileroot`        | string                                      | **Required** | -                                                      |
-| `wandb`           | [`WandBConfig`](section-wand-b)             | **Required** | Weights & Biases configuration.                        |
-| `swanlab`         | [`SwanlabConfig`](section-swanlab)          | **Required** | SwanLab configuration.                                 |
-| `tensorboard`     | [`TensorBoardConfig`](section-tensor-board) | **Required** | TensorBoard configuration. Only 'path' field required. |
+| Parameter         | Type                                        | Default      | Description                                               |
+| ----------------- | ------------------------------------------- | ------------ | --------------------------------------------------------- |
+| `experiment_name` | string                                      | **Required** | -                                                         |
+| `trial_name`      | string                                      | **Required** | -                                                         |
+| `fileroot`        | string                                      | **Required** | -                                                         |
+| `wandb`           | [`WandBConfig`](section-wand-b)             | **Required** | Weights & Biases configuration.                           |
+| `swanlab`         | [`SwanlabConfig`](section-swanlab)          | **Required** | SwanLab configuration.                                    |
+| `tensorboard`     | [`TensorBoardConfig`](section-tensor-board) | **Required** | TensorBoard configuration. Only 'path' field required.    |
+| `trackio`         | [`TrackioConfig`](section-trackio)          | **Required** | Trackio configuration (Hugging Face experiment tracking). |
 
 (section-swanlab)=
 
@@ -773,6 +775,27 @@ Configuration for TensorBoard logging and visualization.
 | Parameter | Type           | Default | Description |
 | --------- | -------------- | ------- | ----------- |
 | `path`    | string \| None | `None`  | -           |
+
+(section-trackio)=
+
+## Trackio Configuration
+
+Configuration for Trackio experiment tracking (Hugging Face).
+
+Trackio is a lightweight, local-first experiment tracking library with a
+wandb-compatible API. Dashboards can be viewed locally or deployed to Hugging Face
+Spaces.
+
+```
+See: https://github.com/gradio-app/trackio
+```
+
+| Parameter  | Type           | Default      | Description |
+| ---------- | -------------- | ------------ | ----------- |
+| `mode`     | string         | `"disabled"` | -           |
+| `project`  | string \| None | `None`       | -           |
+| `name`     | string \| None | `None`       | -           |
+| `space_id` | string \| None | `None`       | -           |
 
 (section-wand-b)=
 

--- a/tests/test_eval_dispatch.py
+++ b/tests/test_eval_dispatch.py
@@ -1,0 +1,434 @@
+from types import MethodType, SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from areal.api.cli_args import MicroBatchSpec
+from areal.engine.core.train_engine import compute_total_loss_weight
+from areal.infra.controller.train_controller import (
+    _dispatch_tensors,
+    _pad_eval_batch,
+)
+from areal.trainer.rw.rw_engine import (
+    RWController,
+    RWEngine,
+    _rw_loss_weight,
+    compute_rw_loss,
+)
+from areal.trainer.sft.lm_engine import LMController
+from areal.utils.data import (
+    MicroBatchList,
+    concat_padded_tensors,
+    make_dummy_eval_item,
+    split_padded_tensor_dict_into_mb_list,
+)
+from areal.utils.stats_tracker import DistributedStatsTracker
+
+
+def _make_item(idx: int, seqlen: int = 2) -> dict[str, object]:
+    return {
+        "input_ids": torch.full((1, seqlen), idx + 1, dtype=torch.long),
+        "attention_mask": torch.ones((1, seqlen), dtype=torch.bool),
+        "loss_mask": torch.ones((1, seqlen), dtype=torch.bool),
+        "meta": {"id": idx},
+    }
+
+
+def _flatten_splits(splits: list[list[dict[str, object]]]) -> list[dict[str, object]]:
+    return [item for group in splits for item in group]
+
+
+def _count_dummies(items: list[dict[str, object]]) -> int:
+    return sum(
+        int(cast(torch.Tensor, item["attention_mask"]).sum().item() == 0)
+        for item in items
+    )
+
+
+def _make_rw_pair(
+    pair_idx: int, chosen_len: int = 3, rejected_len: int = 2
+) -> tuple[dict[str, object], dict[str, object]]:
+    chosen: dict[str, object] = {
+        "input_ids": torch.full((1, chosen_len), pair_idx * 2 + 1, dtype=torch.long),
+        "attention_mask": torch.ones((1, chosen_len), dtype=torch.bool),
+        "meta": {"pair": pair_idx, "role": "chosen"},
+    }
+    rejected: dict[str, object] = {
+        "input_ids": torch.full((1, rejected_len), pair_idx * 2 + 2, dtype=torch.long),
+        "attention_mask": torch.ones((1, rejected_len), dtype=torch.bool),
+        "meta": {"pair": pair_idx, "role": "rejected"},
+    }
+    return chosen, rejected
+
+
+def _build_rw_batch(n_pairs: int, chosen_len: int = 3, rejected_len: int = 2):
+    items: list[dict[str, object]] = []
+    for p in range(n_pairs):
+        c, r = _make_rw_pair(p, chosen_len, rejected_len)
+        items.extend([c, r])
+    return items
+
+
+def _make_rw_input(seqlens: list[int]) -> dict[str, torch.Tensor]:
+    cu_seqlens = [0]
+    for seqlen in seqlens:
+        cu_seqlens.append(cu_seqlens[-1] + seqlen)
+    return {"cu_seqlens": torch.tensor(cu_seqlens, dtype=torch.int32)}
+
+
+class TestEvalBatchPadding:
+    def test_pad_eval_batch_no_padding_when_divisible(self):
+        items = [_make_item(i) for i in range(8)]
+        (padded,) = _pad_eval_batch((items,), dp_size=4)
+        assert len(padded) == 8
+        assert _count_dummies(padded) == 0
+
+    def test_pad_eval_batch_pads_when_not_divisible(self):
+        items = [_make_item(i) for i in range(7)]
+        (padded,) = _pad_eval_batch((items,), dp_size=4)
+        assert len(padded) == 8
+        assert _count_dummies(padded) == 1
+
+    def test_pad_eval_batch_pads_when_n_less_than_dp(self):
+        items = [_make_item(i) for i in range(2)]
+        (padded,) = _pad_eval_batch((items,), dp_size=4)
+        assert len(padded) == 4
+        assert _count_dummies(padded) == 2
+
+    def test_dispatch_tensors_raises_when_not_divisible(self):
+        items = [_make_item(i) for i in range(7)]
+        with pytest.raises(ValueError, match="divisible"):
+            _dispatch_tensors(items, dp_size=4)
+
+    def test_pad_then_dispatch_end_to_end(self):
+        items = [_make_item(i) for i in range(7)]
+        (padded,) = _pad_eval_batch((items,), dp_size=4)
+        splits, _ = _dispatch_tensors(padded, dp_size=4)
+        assert all(len(group) == 2 for group in splits)
+        assert _count_dummies(_flatten_splits(splits)) == 1
+
+    def test_make_dummy_eval_item_schema(self):
+        template: dict[str, object] = {
+            "input_ids": torch.tensor([[2, 3, 4]], dtype=torch.long),
+            "attention_mask": torch.tensor([[True, True, False]], dtype=torch.bool),
+            "loss_mask": torch.tensor([[1, 1, 0]], dtype=torch.int32),
+            "multi_modal_input": [{"image": torch.tensor([1.0])}],
+            "meta": {"tag": ["x"]},
+        }
+
+        dummy = make_dummy_eval_item(template)
+        assert set(dummy.keys()) == set(template.keys())
+        assert dummy["multi_modal_input"] == [{}]
+        torch.testing.assert_close(
+            dummy["attention_mask"],
+            torch.zeros((1, 1), dtype=torch.bool),
+            rtol=0.0,
+            atol=0.0,
+        )
+        torch.testing.assert_close(
+            dummy["loss_mask"],
+            torch.zeros((1, 1), dtype=cast(torch.Tensor, template["loss_mask"]).dtype),
+            rtol=0.0,
+            atol=0.0,
+        )
+        torch.testing.assert_close(
+            dummy["input_ids"],
+            torch.zeros((1, 1), dtype=cast(torch.Tensor, template["input_ids"]).dtype),
+            rtol=0.0,
+            atol=0.0,
+        )
+        cast(dict[str, list[str]], template["meta"])["tag"].append("y")
+        assert dummy["meta"] == {"tag": ["x"]}
+
+    def test_pad_eval_batch_keeps_multimodal_payload_aligned(self):
+        items: list[dict[str, object]] = []
+        for _ in range(3):
+            items.append(
+                {
+                    "input_ids": torch.tensor([[11, 12, 13]], dtype=torch.long),
+                    "attention_mask": torch.tensor(
+                        [[True, True, True]], dtype=torch.bool
+                    ),
+                    "loss_mask": torch.tensor([[1, 1, 1]], dtype=torch.int32),
+                    "multi_modal_input": [
+                        {
+                            "pixel_values": torch.ones((1, 2, 2), dtype=torch.float32),
+                            "image_grid_thw": torch.tensor(
+                                [[1, 1, 1]], dtype=torch.int32
+                            ),
+                        }
+                    ],
+                }
+            )
+
+        (padded,) = _pad_eval_batch((items,), dp_size=4)
+        batched = concat_padded_tensors(padded)
+        mb_list = split_padded_tensor_dict_into_mb_list(batched, MicroBatchSpec())
+
+        assert len(padded) == 4
+        assert len(batched["multi_modal_input"]) == batched["attention_mask"].shape[0]
+        assert padded[-1]["multi_modal_input"] == [{}]
+        for mb in mb_list.mbs:
+            assert len(mb["multi_modal_input"]) == mb["attention_mask"].shape[0]
+
+    def test_pad_eval_batch_group_size_odd_dp(self):
+        items = [_make_item(i) for i in range(2)]
+        (padded,) = _pad_eval_batch((items,), dp_size=3, group_size=2)
+        assert len(padded) == 6
+        assert len(padded) % 2 == 0
+        assert len(padded) % 3 == 0
+        assert _count_dummies(padded) == 4
+
+    def test_pad_eval_batch_group_size_even_dp(self):
+        items = [_make_item(i) for i in range(6)]
+        (padded,) = _pad_eval_batch((items,), dp_size=4, group_size=2)
+        assert len(padded) == 8
+        assert len(padded) % 2 == 0
+        assert len(padded) % 4 == 0
+        assert _count_dummies(padded) == 2
+
+    def test_pad_eval_batch_group_size_no_pad_needed(self):
+        items = [_make_item(i) for i in range(6)]
+        (padded,) = _pad_eval_batch((items,), dp_size=3, group_size=2)
+        assert len(padded) == 6
+        assert _count_dummies(padded) == 0
+
+    def test_pad_eval_batch_default_group_size_unchanged(self):
+        items = [_make_item(i) for i in range(7)]
+        (padded,) = _pad_eval_batch((items,), dp_size=4)
+        assert len(padded) == 8
+        assert _count_dummies(padded) == 1
+
+    def test_compute_total_loss_weight_allows_local_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        mb_list = MicroBatchList(
+            data={},
+            mb_spec=MicroBatchSpec(),
+            mbs=[{"attention_mask": torch.zeros((1, 1), dtype=torch.bool)}],
+            group_lens=[1],
+        )
+
+        def _mock_all_reduce(
+            tensor: torch.Tensor, group: dist.ProcessGroup | None = None
+        ):
+            del group
+            tensor.add_(3.0)
+
+        monkeypatch.setattr(dist, "all_reduce", _mock_all_reduce)
+
+        total_weight = compute_total_loss_weight(
+            mb_list=mb_list,
+            loss_weight_fn=lambda _mb: torch.tensor(0.0),
+            dp_group=cast(dist.ProcessGroup, object()),
+        )
+
+        torch.testing.assert_close(total_weight, torch.tensor(3.0), rtol=0.0, atol=0.0)
+
+
+class TestRWDispatchGrouping:
+    def test_dispatch_group_size_preserves_rw_pairs(self):
+        dp_size = 4
+        items = _build_rw_batch(n_pairs=8)
+        (padded,) = _pad_eval_batch((items,), dp_size=dp_size, group_size=2)
+        assert len(padded) == 16
+        splits, _ = _dispatch_tensors(padded, dp_size=dp_size, group_size=2)
+
+        for shard_items in splits:
+            assert len(shard_items) % 2 == 0, (
+                f"Shard received odd item count {len(shard_items)}"
+            )
+            for j in range(0, len(shard_items), 2):
+                c_meta = shard_items[j].get("meta", {})
+                r_meta = shard_items[j + 1].get("meta", {})
+                if c_meta.get("pair") is not None:
+                    assert c_meta["pair"] == r_meta["pair"], (
+                        f"Pair split across items: {c_meta} vs {r_meta}"
+                    )
+                    assert c_meta["role"] == "chosen"
+                    assert r_meta["role"] == "rejected"
+
+    def test_dispatch_group_size_rw_5_examples_dp4(self):
+        dp_size = 4
+        items = _build_rw_batch(n_pairs=5)
+        assert len(items) == 10
+
+        (padded,) = _pad_eval_batch((items,), dp_size=dp_size, group_size=2)
+        assert len(padded) == 16
+        assert len(padded) % (dp_size * 2) == 0
+
+        splits, _ = _dispatch_tensors(padded, dp_size=dp_size, group_size=2)
+        assert len(splits) == dp_size
+        for shard_items in splits:
+            assert len(shard_items) % 2 == 0, (
+                f"Shard received odd item count {len(shard_items)}, view(-1, 2) would fail"
+            )
+
+    def test_dispatch_group_size_not_divisible_raises(self):
+        items = _build_rw_batch(n_pairs=3)
+        items.append(items[0])
+        with pytest.raises(ValueError, match="divisible by group_size"):
+            _dispatch_tensors(items, dp_size=2, group_size=2)
+
+    def test_dispatch_group_size_1_unchanged(self):
+        items = [_make_item(i, seqlen=i + 1) for i in range(8)]
+        _, indices_default = _dispatch_tensors(items, dp_size=4)
+        _, indices_gs1 = _dispatch_tensors(items, dp_size=4, group_size=1)
+        assert indices_default == indices_gs1
+
+    @pytest.mark.parametrize(
+        "dp_size, group_size, n_items",
+        [
+            (3, 2, 12),
+            (4, 2, 16),
+            (6, 2, 24),
+            (4, 3, 24),
+            (3, 2, 6),
+            (4, 2, 8),
+        ],
+    )
+    def test_pad_and_dispatch_group_matrix(
+        self, dp_size: int, group_size: int, n_items: int
+    ):
+        items = [_make_item(i, seqlen=i % 5 + 1) for i in range(n_items)]
+        (padded,) = _pad_eval_batch((items,), dp_size=dp_size, group_size=group_size)
+        assert len(padded) % (dp_size * group_size) == 0
+
+        splits, _ = _dispatch_tensors(padded, dp_size=dp_size, group_size=group_size)
+        assert len(splits) == dp_size
+        for shard in splits:
+            assert len(shard) % group_size == 0
+
+    @pytest.mark.parametrize(
+        "dp_size, group_size, n_raw",
+        [
+            (3, 2, 5),
+            (4, 2, 7),
+            (4, 3, 10),
+            (6, 2, 3),
+        ],
+    )
+    def test_pad_aligns_non_divisible_input(
+        self, dp_size: int, group_size: int, n_raw: int
+    ):
+        items = [_make_item(i) for i in range(n_raw)]
+        (padded,) = _pad_eval_batch((items,), dp_size=dp_size, group_size=group_size)
+        target = dp_size * group_size
+        assert len(padded) % target == 0
+        assert len(padded) >= n_raw
+
+
+class TestRWDummyPairSemantics:
+    def test_rw_loss_weight_counts_only_valid_pairs(self):
+        input_data = _make_rw_input([5, 4, 0, 0])
+
+        loss_weight = _rw_loss_weight(input_data)
+
+        torch.testing.assert_close(loss_weight, torch.tensor(1.0), rtol=0.0, atol=0.0)
+
+    def test_compute_rw_loss_ignores_dummy_pairs_in_loss_and_metrics(self):
+        tracker = DistributedStatsTracker()
+        input_data = _make_rw_input([5, 4, 0, 0])
+        scores = torch.tensor([0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 1.0])
+        expected_loss = -F.logsigmoid(torch.tensor(2.0))
+
+        with patch("areal.trainer.rw.rw_engine.stats_tracker", tracker):
+            loss = compute_rw_loss(scores, input_data)
+
+        stats = tracker.export(reset=True)
+
+        torch.testing.assert_close(loss, expected_loss, rtol=1e-5, atol=1e-6)
+        assert stats["n_pairs"] == 1.0
+        assert stats["correct_ratio/avg"] == 1.0
+        assert stats["pos_score/avg"] == 3.0
+        assert stats["neg_score/avg"] == 1.0
+        torch.testing.assert_close(
+            torch.tensor(stats["loss/avg"]),
+            expected_loss,
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+    def test_compute_rw_loss_returns_zero_for_all_dummy_pairs(self):
+        tracker = DistributedStatsTracker()
+        input_data = _make_rw_input([0, 0])
+
+        with patch("areal.trainer.rw.rw_engine.stats_tracker", tracker):
+            loss = compute_rw_loss(torch.tensor([], dtype=torch.float32), input_data)
+
+        stats = tracker.export(reset=True)
+
+        torch.testing.assert_close(loss, torch.tensor(0.0), rtol=0.0, atol=0.0)
+        assert stats["n_pairs"] == 0.0
+        assert "loss/avg" not in stats
+
+
+class TestExplicitEvalDispatchControllers:
+    def test_lm_controller_evaluate_lm_explicitly_pads_batch(self):
+        controller = LMController.__new__(LMController)
+        cast(Any, controller).train_alloc = SimpleNamespace(
+            parallel=SimpleNamespace(dp_size=4)
+        )
+        captured: dict[str, Any] = {}
+
+        def _capture_call(self, method: str, *args, **kwargs):
+            captured["method"] = method
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return None
+
+        controller._custom_function_call = MethodType(_capture_call, controller)
+
+        items = [_make_item(i) for i in range(7)]
+        controller.evaluate_lm(items)
+
+        assert captured["method"] == "evaluate_lm"
+        padded_items = cast(list[dict[str, object]], captured["args"][0])
+        assert len(padded_items) == 8
+        assert captured["kwargs"] == {}
+
+    def test_rw_controller_evaluate_rw_explicitly_pads_pairs(self):
+        controller = RWController.__new__(RWController)
+        cast(Any, controller).train_alloc = SimpleNamespace(
+            parallel=SimpleNamespace(dp_size=4)
+        )
+        captured: dict[str, Any] = {}
+
+        def _capture_call(self, method: str, *args, **kwargs):
+            captured["method"] = method
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return None
+
+        controller._custom_function_call = MethodType(_capture_call, controller)
+
+        items = _build_rw_batch(n_pairs=5)
+        controller.evaluate_rw(items)
+
+        assert captured["method"] == "evaluate_rw"
+        assert captured["kwargs"]["group_size"] == 2
+        padded_items = cast(list[dict[str, object]], captured["args"][0])
+        assert len(padded_items) == 16
+
+    def test_evaluate_rw_logs_zero_pair_denominator_for_all_dummy_local_batch(self):
+        tracker = DistributedStatsTracker()
+
+        class _DummyEngine:
+            def eval(self) -> None:
+                return None
+
+            def eval_batch(self, **kwargs) -> None:
+                del kwargs
+                return None
+
+        with patch("areal.trainer.rw.rw_engine.stats_tracker", tracker):
+            RWEngine(_DummyEngine())._evaluate_rw(_make_rw_input([0, 0]))
+
+        stats = tracker.export(reset=True)
+
+        assert stats["n_pairs"] == 0.0
+        assert "loss/avg" not in stats


### PR DESCRIPTION
## Description

Pad evaluation inputs with zero-weight dummy items when `drop_last=False` leaves a remainder that cannot be evenly sharded across distributed workers. Then harden FSDP, Megatron, and Archon zero-loss handling so those padded shards remain loss-neutral while distributed and pipeline-parallel synchronization still succeeds.

This also keeps reward-model chosen/rejected pairs on the same DP rank, adds regression coverage for the dispatch logic, and refreshes the generated CLI reference docs that changed with the branch.

## Related Issue

Refs #1095
Follow-up to #1100 and #898

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Validation run on the squashed branch:
- `pre-commit run --all-files`
- `uv run pytest tests/test_eval_dispatch.py tests/test_train_controller.py`
- `./docs/build_all.sh`

`./docs/build_all.sh` succeeded with the repository's existing `examples/openclaw/README` cross-reference warnings in:
- `docs/en/tutorial/online_proxy.md`
- `docs/zh/tutorial/online_proxy.md`