### PR TITLE
feat(inference-service): complete vLLM backend support in inference service

### DIFF
--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -8,9 +8,11 @@ server processes are forked through RPCGuard (a lightweight process manager).
 
 from __future__ import annotations
 
+import os
 import sys
 import time
 import traceback
+import uuid
 from collections.abc import AsyncGenerator
 from threading import Lock
 from typing import TYPE_CHECKING, Any
@@ -42,7 +44,7 @@ class GatewayInferenceController:
     directly over HTTP — no engine creation or RPC calls on workers.
 
     The inference backend is determined from ``config.backend``
-    (currently ``"sglang"`` is supported; ``"vllm"`` is planned).
+    (``"sglang"`` and ``"vllm"`` are supported).
     """
 
     # Worker role suffix for RPCGuard workers
@@ -235,7 +237,7 @@ class GatewayInferenceController:
                 if server_args:
                     for k, v in server_args.items():
                         if hasattr(sglang_config, k):
-                            object.__setattr__(sglang_config, k, v)
+                            setattr(sglang_config, k, v)
                         else:
                             logger.warning(
                                 "SGLangConfig has no attribute %r, ignoring "
@@ -254,10 +256,29 @@ class GatewayInferenceController:
                     )
 
             elif inf_backend == "vllm":
-                raise NotImplementedError(
-                    "vLLM backend is not yet supported by the gateway "
-                    "rollout controller."
-                )
+                from areal.api.cli_args import vLLMConfig
+
+                vllm_config = vLLMConfig(model=cfg.model_path or cfg.tokenizer_path)
+                for k, v in (server_args or {}).items():
+                    if hasattr(vllm_config, k):
+                        setattr(vllm_config, k, v)
+                    else:
+                        logger.warning(
+                            "vLLMConfig has no attribute %r, ignoring "
+                            "server_args entry (value=%r)",
+                            k,
+                            v,
+                        )
+
+                def _build_launch_cmd(host: str, port: int) -> list[str]:
+                    return vLLMConfig.build_cmd(
+                        vllm_config=vllm_config,
+                        tp_size=tp_size,
+                        pp_size=alloc.parallel.pp_size,
+                        host=host,
+                        port=port,
+                    )
+
             else:
                 raise ValueError(f"Unsupported inference backend: {inf_backend!r}")
 
@@ -279,13 +300,34 @@ class GatewayInferenceController:
 
                 cmd = _build_launch_cmd(inf_host, inf_port)
 
+                fork_payload: dict[str, Any] = {
+                    "role": "inf-server",
+                    "worker_index": rank,
+                    "raw_cmd": cmd,
+                }
+                if inf_backend == "vllm":
+                    from areal.infra.utils.launcher import (
+                        TRITON_CACHE_PATH as _TRITON_CACHE,
+                    )
+                    from areal.infra.utils.launcher import (
+                        VLLM_CACHE_ROOT as _VLLM_CACHE,
+                    )
+
+                    fork_payload["env"] = {
+                        "TRITON_CACHE_PATH": os.path.join(
+                            os.environ.get("TRITON_CACHE_PATH", _TRITON_CACHE),
+                            str(uuid.uuid4()),
+                        ),
+                        "VLLM_CACHE_ROOT": os.path.join(
+                            os.environ.get("VLLM_CACHE_ROOT", _VLLM_CACHE),
+                            str(uuid.uuid4()),
+                        ),
+                        "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True",
+                    }
+
                 resp = requests.post(
                     f"{guard_addr}/fork",
-                    json={
-                        "role": "inf-server",
-                        "worker_index": rank,
-                        "raw_cmd": cmd,
-                    },
+                    json=fork_payload,
                     timeout=30,
                 )
                 resp.raise_for_status()
@@ -359,6 +401,8 @@ class GatewayInferenceController:
             data_proxy_cmd = data_proxy_base_cmd + [
                 "--backend-addr",
                 self._inf_addrs[rank],
+                "--backend-type",
+                inf_backend or "sglang",
             ]
             data_proxy_host, data_proxy_port = self._fork_on_guard(
                 guard_addr=guard_addr,

--- a/areal/experimental/inference_service/data_proxy/__main__.py
+++ b/areal/experimental/inference_service/data_proxy/__main__.py
@@ -19,6 +19,11 @@ def main():
         default="http://localhost:30000",
     )
     parser.add_argument(
+        "--backend-type",
+        default="sglang",
+        choices=("sglang", "vllm"),
+    )
+    parser.add_argument(
         "--tokenizer-path",
         required=True,
     )
@@ -48,6 +53,7 @@ def main():
         host=args.host,
         port=args.port,
         backend_addr=args.backend_addr,
+        backend_type=args.backend_type,
         tokenizer_path=args.tokenizer_path,
         log_level=args.log_level,
         request_timeout=args.request_timeout,

--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -11,7 +11,10 @@ from fastapi.responses import Response as RawResponse
 from openai.types.chat.completion_create_params import CompletionCreateParams
 from pydantic import BaseModel
 
-from areal.experimental.inference_service.data_proxy.backend import SGLangBridgeBackend
+from areal.experimental.inference_service.data_proxy.backend import (
+    SGLangBridgeBackend,
+    VLLMBridgeBackend,
+)
 from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
 from areal.experimental.inference_service.data_proxy.inf_bridge import InfBridge
 from areal.experimental.inference_service.data_proxy.pause import PauseState
@@ -91,8 +94,15 @@ def _create_inf_bridge(
     config: DataProxyConfig,
 ) -> InfBridge:
     """Create an InfBridge instance from proxy config."""
+    if config.backend_type == "sglang":
+        backend = SGLangBridgeBackend()
+    elif config.backend_type == "vllm":
+        backend = VLLMBridgeBackend()
+    else:
+        raise ValueError(f"Unsupported backend_type: {config.backend_type!r}")
+
     return InfBridge(
-        backend=SGLangBridgeBackend(),
+        backend=backend,
         backend_addr=backend_addr,
         pause_state=pause_state,
         request_timeout=config.request_timeout,

--- a/areal/experimental/inference_service/data_proxy/backend.py
+++ b/areal/experimental/inference_service/data_proxy/backend.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import numpy as np
 
-from areal.api.io_struct import HttpGenerationResult, HttpRequest
+from areal.api.io_struct import (
+    HttpGenerationResult,
+    HttpRequest,
+    get_versioned_lora_name,
+)
 
 if TYPE_CHECKING:
     from areal.api.io_struct import ModelRequest
@@ -70,6 +74,20 @@ class InfBridgeBackend(Protocol):
         """Return the HTTP request that resumes generation on the backend."""
         ...
 
+    def get_generation_max_new_tokens(self, http_req: HttpRequest) -> int:
+        """Return the current generation budget encoded in ``http_req``."""
+        ...
+
+    def patch_generation_request(
+        self,
+        http_req: HttpRequest,
+        req: ModelRequest,
+        accumulated_tokens: list[int],
+        remaining_tokens: int,
+    ) -> None:
+        """Mutate ``http_req`` for an abort/resubmit iteration."""
+        ...
+
 
 # ---------------------------------------------------------------------------
 # SGLang backend
@@ -92,8 +110,6 @@ class SGLangBridgeBackend:
         version: int = -1,
     ) -> HttpRequest:
         """Build a ``/generate`` request for SGLang."""
-        from areal.api.io_struct import get_versioned_lora_name
-
         gconfig = req.gconfig
 
         if gconfig.use_beam_search:
@@ -185,3 +201,137 @@ class SGLangBridgeBackend:
 
     def get_resume_request(self) -> HttpRequest:
         return HttpRequest(endpoint="/continue_generation", payload={})
+
+    def get_generation_max_new_tokens(self, http_req: HttpRequest) -> int:
+        return int(http_req.payload["sampling_params"]["max_new_tokens"])
+
+    def patch_generation_request(
+        self,
+        http_req: HttpRequest,
+        req: ModelRequest,
+        accumulated_tokens: list[int],
+        remaining_tokens: int,
+    ) -> None:
+        http_req.payload["input_ids"] = list(req.input_ids) + accumulated_tokens
+        http_req.payload["sampling_params"]["max_new_tokens"] = remaining_tokens
+
+
+class VLLMBridgeBackend:
+    """vLLM-specific backend for :class:`InfBridge`.
+
+    Mirrors the relevant subset of
+    :class:`areal.engine.vllm_remote.VLLMBackend`.
+    """
+
+    def build_generation_request(
+        self,
+        req: ModelRequest,
+        with_lora: bool,
+        version: int = -1,
+    ) -> HttpRequest:
+        """Build a ``/v1/completions`` or ``/v1/chat/completions`` request."""
+        gconfig = req.gconfig
+
+        # Compute effective max_new_tokens (cap by remaining context window)
+        max_new_tokens = min(
+            gconfig.max_tokens - len(req.input_ids),
+            gconfig.max_new_tokens,
+        )
+
+        payload: dict[str, Any] = {
+            "top_p": gconfig.top_p,
+            "top_k": gconfig.top_k,
+            "max_tokens": max_new_tokens,
+            "temperature": 0.0 if gconfig.greedy else gconfig.temperature,
+            "stop_token_ids": gconfig.stop_token_ids,
+            "ignore_eos": gconfig.ignore_eos,
+            "skip_special_tokens": gconfig.skip_special_tokens,
+            "return_tokens_as_token_ids": True,
+            "logprobs": 0,
+            "use_beam_search": gconfig.use_beam_search,
+            "stream": False,
+        }
+
+        if with_lora:
+            lora_name = gconfig.lora_name
+            if not lora_name:
+                raise ValueError(
+                    "LoRA name (gconfig.lora_name) is required when use_lora is enabled."
+                )
+            payload["model"] = get_versioned_lora_name(lora_name, version)
+
+        if req.vision_msg_vllm:
+            images = iter(req.image_data or [])
+            parsed_input = req.vision_msg_vllm[0]
+            for msg in parsed_input:
+                if isinstance(msg["content"], list):
+                    for content in msg["content"]:
+                        if content.get("type") == "image_url":
+                            try:
+                                base64_img = next(images)
+                            except StopIteration as exc:
+                                raise ValueError(
+                                    "Not enough images in req.image_data to match image_url entries."
+                                ) from exc
+                            content["image_url"] = {
+                                "url": f"data:image/jpeg;base64,{base64_img}"
+                            }
+            payload["messages"] = parsed_input.copy()
+            payload["logprobs"] = True
+            return HttpRequest(endpoint="/v1/chat/completions", payload=payload)
+
+        payload["prompt"] = list(req.input_ids)
+        return HttpRequest(endpoint="/v1/completions", payload=payload)
+
+    def parse_generation_response(
+        self,
+        response: dict[str, Any],
+    ) -> HttpGenerationResult:
+        """Parse vLLM JSON into :class:`HttpGenerationResult`."""
+        meta_info = response["choices"][0]
+        stop_reason = meta_info["finish_reason"]
+
+        if "tokens" in meta_info["logprobs"]:
+            output_tokens = [
+                int(token.split(":")[1]) for token in meta_info["logprobs"]["tokens"]
+            ]
+            output_logprobs = meta_info["logprobs"]["token_logprobs"]
+        elif "content" in meta_info["logprobs"]:
+            outputs = meta_info["logprobs"]["content"]
+            output_tokens = [int(token["token"].split(":")[1]) for token in outputs]
+            output_logprobs = [token["logprob"] for token in outputs]
+        else:
+            raise ValueError("Unexpected vLLM response format.")
+
+        if stop_reason == "abort" and len(output_tokens) == 0:
+            return HttpGenerationResult(
+                output_tokens=[],
+                output_logprobs=[],
+                stop_reason=stop_reason,
+            )
+
+        return HttpGenerationResult(
+            output_tokens=output_tokens,
+            output_logprobs=output_logprobs,
+            stop_reason=stop_reason,
+        )
+
+    def get_pause_request(self) -> HttpRequest:
+        return HttpRequest(endpoint="/areal_pause_generation", payload={})
+
+    def get_resume_request(self) -> HttpRequest:
+        return HttpRequest(endpoint="/areal_continue_generation", payload={})
+
+    def get_generation_max_new_tokens(self, http_req: HttpRequest) -> int:
+        return int(http_req.payload["max_tokens"])
+
+    def patch_generation_request(
+        self,
+        http_req: HttpRequest,
+        req: ModelRequest,
+        accumulated_tokens: list[int],
+        remaining_tokens: int,
+    ) -> None:
+        http_req.payload["max_tokens"] = remaining_tokens
+        if "prompt" in http_req.payload:
+            http_req.payload["prompt"] = list(req.input_ids) + accumulated_tokens

--- a/areal/experimental/inference_service/data_proxy/config.py
+++ b/areal/experimental/inference_service/data_proxy/config.py
@@ -6,6 +6,7 @@ class DataProxyConfig:
     host: str = "0.0.0.0"
     port: int = 8082
     backend_addr: str = "http://localhost:30000"  # co-located SGLang/vLLM
+    backend_type: str = "sglang"
     tokenizer_path: str = ""
     log_level: str = "info"
     request_timeout: float = 120.0  # seconds per SGLang call

--- a/areal/experimental/inference_service/data_proxy/inf_bridge.py
+++ b/areal/experimental/inference_service/data_proxy/inf_bridge.py
@@ -159,7 +159,7 @@ class InfBridge:
         )
 
         # Extract effective max_new_tokens from the payload the backend built
-        ori_max_new_tokens: int = http_req.payload["sampling_params"]["max_new_tokens"]
+        ori_max_new_tokens = self.backend.get_generation_max_new_tokens(http_req)
         if ori_max_new_tokens <= 0:
             raise ValueError(
                 f"max_new_tokens must be > 0, got {ori_max_new_tokens} "
@@ -187,9 +187,12 @@ class InfBridge:
                 break
 
             # Patch the payload for this iteration (extend input, shrink budget)
-            payload = http_req.payload
-            payload["input_ids"] = list(req.input_ids) + accumulated_tokens
-            payload["sampling_params"]["max_new_tokens"] = remaining
+            self.backend.patch_generation_request(
+                http_req,
+                req,
+                accumulated_tokens,
+                remaining,
+            )
 
             data = await self._send_request(http_req)
             result = self.backend.parse_generation_response(data)

--- a/areal/experimental/inference_service/guard/app.py
+++ b/areal/experimental/inference_service/guard/app.py
@@ -192,6 +192,9 @@ def fork_worker():
             child_port = ports[0]
             _allocated_ports.add(child_port)
 
+        # Optional per-process environment overrides (e.g. TRITON_CACHE_PATH)
+        env_overrides: dict[str, str] = data.get("env", {})
+
         # Determine if this is raw-command mode or module-path mode
         is_raw_mode = raw_cmd is not None
 
@@ -237,13 +240,15 @@ def fork_worker():
 
         logger.info(f"Forked worker logs will be written to: {log_file}")
 
-        # Use streaming log utility for terminal, role log, and merged log output
+        child_env = os.environ.copy()
+        child_env.update(env_overrides)
+
         child_process = run_with_streaming_logs(
             cmd,
             log_file,
             merged_log,
             role,
-            env=os.environ.copy(),
+            env=child_env,
         )
 
         with _forked_children_lock:

--- a/tests/experimental/inference_service/integration_utils.py
+++ b/tests/experimental/inference_service/integration_utils.py
@@ -8,6 +8,11 @@ for Python 3.10 compatibility.
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
+import time
+import uuid
+from typing import Any
 
 import requests
 import torch
@@ -87,3 +92,60 @@ def check_server_health(base_url: str) -> bool:
         return response.status_code == 200
     except requests.exceptions.RequestException:
         return False
+
+
+def launch_vllm_server(
+    model_path: str,
+    startup_timeout: int = SERVER_STARTUP_TIMEOUT,
+) -> tuple[subprocess.Popen, dict[str, Any]]:
+    """Launch a vLLM server subprocess and wait for it to become healthy.
+
+    Returns:
+        Tuple of (process, info_dict) where info_dict has keys
+        ``host``, ``port``, ``base_url``.  Caller is responsible for
+        calling ``kill_process_tree(process.pid)`` on cleanup.
+    """
+    from areal.api.cli_args import vLLMConfig
+    from areal.infra.utils.launcher import TRITON_CACHE_PATH, VLLM_CACHE_ROOT
+    from areal.utils import network
+
+    host = network.gethostip()
+    (port,) = network.find_free_ports(1)
+
+    cmd = vLLMConfig.build_cmd(
+        vllm_config=vLLMConfig(
+            model=model_path,
+            gpu_memory_utilization=0.3,
+        ),
+        tp_size=1,
+        pp_size=1,
+        host=host,
+        port=port,
+    )
+
+    env = os.environ.copy()
+    env["TRITON_CACHE_PATH"] = os.path.join(
+        env.get("TRITON_CACHE_PATH", TRITON_CACHE_PATH), str(uuid.uuid4())
+    )
+    env["VLLM_CACHE_ROOT"] = os.path.join(
+        env.get("VLLM_CACHE_ROOT", VLLM_CACHE_ROOT), str(uuid.uuid4())
+    )
+    env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
+
+    process = subprocess.Popen(cmd, env=env, stdout=sys.stdout, stderr=sys.stdout)
+    base_url = f"http://{host}:{port}"
+
+    t0 = time.time()
+    while time.time() - t0 < startup_timeout:
+        if check_server_health(base_url):
+            break
+        time.sleep(1)
+    else:
+        from areal.infra.utils.proc import kill_process_tree
+
+        kill_process_tree(process.pid, graceful=True)
+        raise RuntimeError(
+            f"vLLM server did not become healthy within {startup_timeout}s"
+        )
+
+    return process, {"host": host, "port": port, "base_url": base_url}

--- a/tests/experimental/inference_service/test_controller_integration.py
+++ b/tests/experimental/inference_service/test_controller_integration.py
@@ -28,7 +28,6 @@ from tests.experimental.inference_service.integration_utils import (
     has_gpu,
 )
 
-pytestmark = pytest.mark.sglang
 SERVER_STARTUP_TIMEOUT = 180  # seconds
 
 
@@ -168,6 +167,7 @@ def gateway_controller(sglang_server, local_scheduler, model_path):
 # =============================================================================
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not has_gpu(), reason="GPU required")
 class TestControllerLifecycle:
     """Verify controller lifecycle: init starts services, properties set, destroy cleans up."""
@@ -214,6 +214,7 @@ class TestControllerLifecycle:
 # =============================================================================
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not has_gpu(), reason="GPU required")
 class TestControllerVersioning:
     """Verify version management on the controller."""
@@ -249,6 +250,7 @@ class TestControllerVersioning:
 # =============================================================================
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not has_gpu(), reason="GPU required")
 class TestControllerPauseResume:
     """Verify pause/resume broadcasts to workers."""
@@ -296,6 +298,7 @@ class TestControllerPauseResume:
 # =============================================================================
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not has_gpu(), reason="GPU required")
 class TestControllerRolloutBatch:
     """Test rollout_batch through the controller with SimpleAgent workflow."""
@@ -349,6 +352,7 @@ class _FakeDataLoader:
         yield self._items
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not has_gpu(), reason="GPU required")
 class TestControllerPrepareBatch:
     """Test prepare_batch through the controller with SimpleAgent workflow."""
@@ -388,6 +392,7 @@ class TestControllerPrepareBatch:
 # =============================================================================
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not has_gpu(), reason="GPU required")
 class TestControllerSubmitWait:
     """Test submit/wait API on the controller."""
@@ -489,6 +494,7 @@ def gateway_controller_full_init(local_scheduler, model_path):
         ctrl.destroy()
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not has_gpu(), reason="GPU required")
 class TestControllerFullInitialization:
     """Test the full initialization path where the controller launches SGLang itself.
@@ -718,3 +724,138 @@ class TestControllerFullInitialization:
             assert isinstance(local_traj["input_ids"], torch.Tensor)
             assert not local_traj["input_ids"].is_meta
             assert local_traj["input_ids"].ndim == 2
+
+
+# =============================================================================
+# vLLM backend variants
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def gateway_controller_full_init_vllm(local_scheduler, model_path):
+    """Controller that launches vLLM via the full init path."""
+    if not has_gpu():
+        pytest.skip("GPU required")
+
+    from areal.api.cli_args import SchedulingSpec
+    from areal.experimental.inference_service.controller.config import (
+        GatewayControllerConfig,
+    )
+    from areal.experimental.inference_service.controller.controller import (
+        GatewayInferenceController,
+    )
+
+    config = GatewayControllerConfig(
+        tokenizer_path=model_path,
+        model_path=model_path,
+        backend="vllm:d1",
+        scheduling_spec=(
+            SchedulingSpec(
+                gpu=1, cmd="python -m areal.experimental.inference_service.guard"
+            ),
+        ),
+        admin_api_key="test-admin",
+        consumer_batch_size=8,
+        max_head_offpolicyness=1024,
+        setup_timeout=300.0,
+    )
+
+    server_args = {
+        "gpu_memory_utilization": 0.3,
+    }
+
+    ctrl = GatewayInferenceController(config=config, scheduler=local_scheduler)
+    ctrl.initialize(
+        role="rollout-vllm",
+        server_args=server_args,
+    )
+
+    try:
+        yield ctrl
+    finally:
+        ctrl.destroy()
+
+
+@pytest.mark.vllm
+@pytest.mark.skipif(not has_gpu(), reason="GPU required")
+class TestControllerFullInitVLLM:
+    def test_chat_completion_via_gateway_vllm(self, gateway_controller_full_init_vllm):
+        """Full e2e: controller init (vLLM) → start_session → chat → end."""
+        ctrl = gateway_controller_full_init_vllm
+        gw = ctrl._gateway_addr
+        admin_key = "test-admin"
+
+        resp = httpx.post(
+            f"{gw}/grant_capacity",
+            headers={"Authorization": f"Bearer {admin_key}"},
+            timeout=10.0,
+        )
+        assert resp.status_code == 200, resp.text
+
+        resp = httpx.post(
+            f"{gw}/rl/start_session",
+            json={"task_id": "vllm-ctrl-chat"},
+            headers={"Authorization": f"Bearer {admin_key}"},
+            timeout=30.0,
+        )
+        assert resp.status_code == 201, resp.text
+        session = resp.json()
+        session_api_key = session["api_key"]
+
+        resp = httpx.post(
+            f"{gw}/chat/completions",
+            json={
+                "model": "vllm",
+                "messages": [{"role": "user", "content": "What is 2+2?"}],
+                "max_completion_tokens": 64,
+                "temperature": 0.0,
+                "stream": False,
+            },
+            headers={"Authorization": f"Bearer {session_api_key}"},
+            timeout=60.0,
+        )
+        assert resp.status_code == 200, resp.text
+        completion = resp.json()
+        assert completion["object"] == "chat.completion"
+        assert len(completion["choices"]) == 1
+        choice = completion["choices"][0]
+        assert choice["message"]["role"] == "assistant"
+        assert len(choice["message"]["content"]) > 0
+        assert choice["finish_reason"] in ("stop", "length")
+        assert completion["usage"]["completion_tokens"] > 0
+
+        resp = httpx.post(
+            f"{gw}/rl/end_session",
+            headers={"Authorization": f"Bearer {session_api_key}"},
+            timeout=10.0,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["interaction_count"] == 1
+
+    def test_rollout_batch_with_simple_agent_vllm(
+        self, gateway_controller_full_init_vllm
+    ):
+        """rollout_batch with SimpleAgent via vLLM backend."""
+        ctrl = gateway_controller_full_init_vllm
+        data = [
+            {
+                "messages": [{"role": "user", "content": "What is 2+2?"}],
+                "answer": "4",
+            }
+        ]
+
+        result = ctrl.rollout_batch(
+            data=data,
+            workflow="tests.experimental.openai.utils.SimpleAgent",
+        )
+
+        assert result is not None
+        assert isinstance(result, list)
+        assert len(result) == 1
+        traj = result[0]
+        assert isinstance(traj, dict)
+        assert "input_ids" in traj
+        from areal.infra.rpc.rtensor import RTensor
+
+        assert isinstance(traj["input_ids"], RTensor)
+        assert traj["input_ids"].ndim == 2

--- a/tests/experimental/inference_service/test_data_proxy_integration.py
+++ b/tests/experimental/inference_service/test_data_proxy_integration.py
@@ -28,7 +28,6 @@ from areal.utils import network
 # Configuration
 # ---------------------------------------------------------------------------
 
-pytestmark = pytest.mark.sglang
 LOCAL_MODEL_PATH = "/storage/openpsi/models/Qwen__Qwen3-0.6B/"
 HF_MODEL_ID = "Qwen/Qwen3-0.6B"
 SERVER_STARTUP_TIMEOUT = 180  # seconds
@@ -99,6 +98,23 @@ def sglang_server():
 
 
 @pytest.fixture(scope="module")
+def vllm_server():
+    """Launch a vLLM server and yield its ``(host, port, base_url)``."""
+    if not _has_gpu():
+        pytest.skip("GPU required for vLLM server")
+
+    from tests.experimental.inference_service.integration_utils import (
+        launch_vllm_server,
+    )
+
+    from areal.infra.utils.proc import kill_process_tree
+
+    process, info = launch_vllm_server(_get_test_model_path())
+    yield info
+    kill_process_tree(process.pid, graceful=True)
+
+
+@pytest.fixture(scope="module")
 def model_path() -> str:
     return _get_test_model_path()
 
@@ -155,9 +171,56 @@ def _create_data_proxy_app_with_sessions(sglang_server, model_path):
     return app, store
 
 
+def _create_data_proxy_app_vllm(vllm_server, model_path):
+    """Create a data proxy app backed by vLLM with session support."""
+    from areal.experimental.inference_service.data_proxy.app import create_app
+    from areal.experimental.inference_service.data_proxy.backend import (
+        VLLMBridgeBackend,
+    )
+    from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
+    from areal.experimental.inference_service.data_proxy.inf_bridge import InfBridge
+    from areal.experimental.inference_service.data_proxy.pause import PauseState
+    from areal.experimental.inference_service.data_proxy.session import SessionStore
+    from areal.experimental.inference_service.data_proxy.tokenizer_proxy import (
+        TokenizerProxy,
+    )
+    from areal.experimental.openai.client import ArealOpenAI
+
+    config = DataProxyConfig(
+        host="127.0.0.1",
+        port=0,
+        backend_addr=vllm_server["base_url"],
+        backend_type="vllm",
+        tokenizer_path=model_path,
+        request_timeout=60.0,
+    )
+    app = create_app(config)
+
+    tok = TokenizerProxy(model_path)
+    pause_state = PauseState()
+    backend = InfBridge(
+        backend=VLLMBridgeBackend(),
+        backend_addr=vllm_server["base_url"],
+        pause_state=pause_state,
+        request_timeout=60.0,
+    )
+    store = SessionStore()
+
+    app.state.tokenizer = tok
+    app.state.inf_bridge = backend
+    app.state.areal_client = ArealOpenAI(engine=backend, tokenizer=tok._tok)
+    app.state.pause_state = pause_state
+    app.state.config = config
+    app.state.session_store = store
+    app.state.version = 0
+
+    return app, store
+
+
 ADMIN_KEY = "areal-admin-key"
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not _has_gpu(), reason="GPU required")
 class TestChatCompletionsIntegration:
     """Test the full /chat/completions endpoint with a real SGLang backend."""
@@ -494,6 +557,7 @@ class TestChatCompletionsIntegration:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not _has_gpu(), reason="GPU required")
 class TestPauseResumeIntegration:
     """Test /pause_generation and /continue_generation with real SGLang backend.
@@ -718,6 +782,7 @@ class TestPauseResumeIntegration:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not _has_gpu(), reason="GPU required")
 class TestConcurrentPauseDuringGeneration:
     """Test the real abort/resubmit cycle by pausing SGLang mid-generation.
@@ -889,3 +954,167 @@ class TestConcurrentPauseDuringGeneration:
                 c for c in chunks if c["choices"][0]["delta"].get("content")
             ]
             assert len(content_chunks) >= 1
+
+
+# ---------------------------------------------------------------------------
+# vLLM backend variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.vllm
+@pytest.mark.skipif(not _has_gpu(), reason="GPU required")
+class TestChatCompletionsVLLM:
+    @pytest.mark.asyncio
+    async def test_non_streaming_chat_completion_vllm(self, vllm_server, model_path):
+        """Full lifecycle: start → chat → set_reward → end → export via vLLM."""
+        app, _store = _create_data_proxy_app_vllm(vllm_server, model_path)
+
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/rl/start_session",
+                json={"task_id": "vllm-ns"},
+                headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+                timeout=10.0,
+            )
+            assert resp.status_code == 201, resp.text
+            session = resp.json()
+            session_api_key = session["api_key"]
+            session_id = session["session_id"]
+
+            resp = await client.post(
+                "/chat/completions",
+                json={
+                    "model": "vllm",
+                    "messages": [{"role": "user", "content": "What is 2+2?"}],
+                    "max_completion_tokens": 64,
+                    "temperature": 0.0,
+                    "stream": False,
+                },
+                headers={"Authorization": f"Bearer {session_api_key}"},
+                timeout=60.0,
+            )
+            assert resp.status_code == 200, resp.text
+            completion = resp.json()
+            assert completion["object"] == "chat.completion"
+            assert len(completion["choices"]) == 1
+            choice = completion["choices"][0]
+            assert choice["message"]["role"] == "assistant"
+            assert len(choice["message"]["content"]) > 0
+            assert choice["finish_reason"] in ("stop", "length")
+            assert completion["usage"]["prompt_tokens"] > 0
+            assert completion["usage"]["completion_tokens"] > 0
+
+            resp = await client.post(
+                "/rl/set_reward",
+                json={"reward": 1.0},
+                headers={"Authorization": f"Bearer {session_api_key}"},
+                timeout=10.0,
+            )
+            assert resp.status_code == 200, resp.text
+
+            resp = await client.post(
+                "/rl/end_session",
+                headers={"Authorization": f"Bearer {session_api_key}"},
+                timeout=10.0,
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["interaction_count"] == 1
+
+            resp = await client.post(
+                "/export_trajectories",
+                json={"session_id": session_id},
+                headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+                timeout=10.0,
+            )
+            assert resp.status_code == 200, resp.text
+            interactions = resp.json()["interactions"]
+            assert len(interactions) == 1
+            for _key, item in interactions.items():
+                assert item["reward"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_streaming_chat_completion_vllm(self, vllm_server, model_path):
+        """Streaming /chat/completions through vLLM backend."""
+        app, _store = _create_data_proxy_app_vllm(vllm_server, model_path)
+
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/rl/start_session",
+                json={"task_id": "vllm-stream"},
+                headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+                timeout=10.0,
+            )
+            assert resp.status_code == 201, resp.text
+            session_api_key = resp.json()["api_key"]
+
+            resp = await client.post(
+                "/chat/completions",
+                json={
+                    "model": "vllm",
+                    "messages": [{"role": "user", "content": "Say hello"}],
+                    "max_completion_tokens": 32,
+                    "temperature": 0.0,
+                    "stream": True,
+                },
+                headers={"Authorization": f"Bearer {session_api_key}"},
+                timeout=60.0,
+            )
+            assert resp.status_code == 200, resp.text
+            assert "text/event-stream" in resp.headers.get("content-type", "")
+
+            chunks = []
+            for line in resp.content.decode().strip().split("\n"):
+                line = line.strip()
+                if line.startswith("data: "):
+                    payload = line[6:]
+                    if payload == "[DONE]":
+                        break
+                    chunks.append(json.loads(payload))
+
+            assert len(chunks) >= 2
+            assert chunks[0]["choices"][0]["delta"].get("role") == "assistant"
+            assert chunks[-1]["choices"][0]["finish_reason"] in ("stop", "length")
+
+            resp = await client.post(
+                "/rl/end_session",
+                headers={"Authorization": f"Bearer {session_api_key}"},
+                timeout=10.0,
+            )
+            assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.vllm
+@pytest.mark.skipif(not _has_gpu(), reason="GPU required")
+class TestPauseResumeVLLM:
+    @pytest.mark.asyncio
+    async def test_pause_continue_endpoints_respond_vllm(self, vllm_server, model_path):
+        """Verify /pause_generation and /continue_generation work with vLLM."""
+        app, _store = _create_data_proxy_app_vllm(vllm_server, model_path)
+
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.get("/health")
+            assert resp.status_code == 200
+            assert resp.json()["paused"] is False
+
+            resp = await client.post("/pause_generation")
+            assert resp.status_code == 200
+            assert resp.json()["paused"] is True
+
+            resp = await client.get("/health")
+            assert resp.json()["paused"] is True
+
+            resp = await client.post("/continue_generation")
+            assert resp.status_code == 200
+            assert resp.json()["paused"] is False
+
+            resp = await client.get("/health")
+            assert resp.json()["paused"] is False

--- a/tests/experimental/inference_service/test_data_proxy_standalone.py
+++ b/tests/experimental/inference_service/test_data_proxy_standalone.py
@@ -123,6 +123,28 @@ def admin_headers():
 
 
 class TestStandaloneChat:
+    def test_config_can_select_vllm_backend(self):
+        """backend_type=vllm creates a vLLM-backed InfBridge."""
+        from areal.experimental.inference_service.data_proxy.app import (
+            _create_inf_bridge,
+        )
+        from areal.experimental.inference_service.data_proxy.backend import (
+            VLLMBridgeBackend,
+        )
+        from areal.experimental.inference_service.data_proxy.pause import PauseState
+
+        config = DataProxyConfig(
+            host="127.0.0.1",
+            port=18082,
+            backend_addr="http://mock-vllm:30000",
+            backend_type="vllm",
+            tokenizer_path="mock-tokenizer",
+        )
+
+        bridge = _create_inf_bridge(config.backend_addr, PauseState(), config)
+
+        assert isinstance(bridge.backend, VLLMBridgeBackend)
+
     @pytest.mark.asyncio
     async def test_no_auth_chat_completions_returns_valid_response(self, client):
         """No auth header → standalone mode, returns valid response."""

--- a/tests/experimental/inference_service/test_gateway_integration.py
+++ b/tests/experimental/inference_service/test_gateway_integration.py
@@ -35,7 +35,6 @@ from areal.utils import network
 # Configuration
 # ---------------------------------------------------------------------------
 
-pytestmark = pytest.mark.sglang
 LOCAL_MODEL_PATH = "/storage/openpsi/models/Qwen__Qwen3-0.6B/"
 HF_MODEL_ID = "Qwen/Qwen3-0.6B"
 SERVER_STARTUP_TIMEOUT = 180  # seconds
@@ -128,6 +127,23 @@ def sglang_server():
 
     yield {"host": host, "port": port, "base_url": base_url}
 
+    kill_process_tree(process.pid, graceful=True)
+
+
+@pytest.fixture(scope="module")
+def vllm_server():
+    """Launch a vLLM server and yield its ``(host, port, base_url)``."""
+    if not _has_gpu():
+        pytest.skip("GPU required for vLLM server")
+
+    from tests.experimental.inference_service.integration_utils import (
+        launch_vllm_server,
+    )
+
+    from areal.infra.utils.proc import kill_process_tree
+
+    process, info = launch_vllm_server(_get_test_model_path())
+    yield info
     kill_process_tree(process.pid, graceful=True)
 
 
@@ -259,6 +275,7 @@ def gateway_stack(sglang_server, model_path):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not _has_gpu(), reason="GPU required")
 class TestGatewayStackHealth:
     """Verify all services are healthy after stack launch."""
@@ -285,6 +302,7 @@ class TestGatewayStackHealth:
             assert resp.json()["status"] == "ok"
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not _has_gpu(), reason="GPU required")
 class TestGatewayChatCompletions:
     """Test /chat/completions endpoint through the full stack."""
@@ -482,6 +500,7 @@ class TestGatewayChatCompletions:
             assert resp.json()["interaction_count"] == 2
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not _has_gpu(), reason="GPU required")
 class TestGatewaySessionLifecycle:
     """Test full RL session lifecycle through the gateway stack."""
@@ -594,6 +613,7 @@ class TestGatewaySessionLifecycle:
             assert resp.status_code == 200
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not _has_gpu(), reason="GPU required")
 class TestGatewayAuth:
     """Test authentication enforcement through the gateway."""
@@ -635,6 +655,7 @@ class TestGatewayAuth:
             assert resp.status_code == 403
 
 
+@pytest.mark.sglang
 @pytest.mark.skipif(not _has_gpu(), reason="GPU required")
 class TestGatewayPauseContinue:
     """Test pause/continue generation through the gateway (targets worker by ID)."""
@@ -752,3 +773,189 @@ class TestGatewayPauseContinue:
             assert completion["choices"][0]["message"]["role"] == "assistant"
             assert len(completion["choices"][0]["message"]["content"]) > 0
             assert completion["choices"][0]["finish_reason"] in ("stop", "length")
+
+
+# ---------------------------------------------------------------------------
+# vLLM backend variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def gateway_stack_vllm(vllm_server, model_path):
+    """Launch the full gateway stack backed by vLLM on free ports."""
+    from areal.experimental.inference_service.data_proxy.app import (
+        create_app as create_dp_app,
+    )
+    from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
+    from areal.experimental.inference_service.gateway.app import (
+        create_app as create_gw_app,
+    )
+    from areal.experimental.inference_service.gateway.config import GatewayConfig
+    from areal.experimental.inference_service.router.app import (
+        create_app as create_router_app,
+    )
+    from areal.experimental.inference_service.router.config import RouterConfig
+
+    bind_host = "127.0.0.1"
+    data_proxy_port = _find_free_port()
+    router_port = _find_free_port()
+    gateway_port = _find_free_port()
+
+    data_proxy_addr = f"http://{bind_host}:{data_proxy_port}"
+    router_addr = f"http://{bind_host}:{router_port}"
+    gateway_addr = f"http://{bind_host}:{gateway_port}"
+
+    dp_config = DataProxyConfig(
+        host=bind_host,
+        port=data_proxy_port,
+        backend_addr=vllm_server["base_url"],
+        backend_type="vllm",
+        tokenizer_path=model_path,
+        request_timeout=60.0,
+        admin_api_key=ADMIN_KEY,
+    )
+    dp_app = create_dp_app(dp_config)
+
+    router_config = RouterConfig(
+        host=bind_host,
+        port=router_port,
+        admin_api_key=ADMIN_KEY,
+        poll_interval=2.0,
+        worker_health_timeout=2.0,
+        routing_strategy="round_robin",
+    )
+    router_app = create_router_app(router_config)
+
+    gw_config = GatewayConfig(
+        host=bind_host,
+        port=gateway_port,
+        admin_api_key=ADMIN_KEY,
+        router_addr=router_addr,
+        router_timeout=5.0,
+        forward_timeout=60.0,
+    )
+    gw_app = create_gw_app(gw_config)
+
+    threads = []
+    for app, port in [
+        (dp_app, data_proxy_port),
+        (router_app, router_port),
+        (gw_app, gateway_port),
+    ]:
+        t = threading.Thread(
+            target=_run_uvicorn,
+            args=(app, bind_host, port),
+            daemon=True,
+        )
+        t.start()
+        threads.append(t)
+
+    _wait_for_health(data_proxy_addr, SERVICE_STARTUP_TIMEOUT, "Data Proxy (vLLM)")
+    _wait_for_health(router_addr, SERVICE_STARTUP_TIMEOUT, "Router (vLLM)")
+    _wait_for_health(gateway_addr, SERVICE_STARTUP_TIMEOUT, "Gateway (vLLM)")
+
+    resp = httpx.post(
+        f"{router_addr}/register",
+        json={"worker_addr": data_proxy_addr},
+        headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+        timeout=5.0,
+    )
+    assert resp.status_code == 200, f"Failed to register worker: {resp.text}"
+    worker_id = resp.json()["worker_id"]
+
+    time.sleep(3)
+
+    for _ in range(10):
+        resp = httpx.post(
+            f"{router_addr}/grant_capacity",
+            headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+            timeout=5.0,
+        )
+        assert resp.status_code == 200, f"Failed to grant capacity: {resp.text}"
+
+    yield {
+        "gateway_addr": gateway_addr,
+        "router_addr": router_addr,
+        "data_proxy_addr": data_proxy_addr,
+        "admin_key": ADMIN_KEY,
+        "worker_id": worker_id,
+    }
+
+
+@pytest.mark.vllm
+@pytest.mark.skipif(not _has_gpu(), reason="GPU required")
+class TestGatewayVLLM:
+    @pytest.mark.asyncio
+    async def test_admin_non_streaming_chat_vllm(self, gateway_stack_vllm):
+        """Admin key non-streaming /chat/completions through full vLLM stack."""
+        gw = gateway_stack_vllm["gateway_addr"]
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(
+                f"{gw}/chat/completions",
+                json={
+                    "model": "vllm",
+                    "messages": [{"role": "user", "content": "What is 2+2?"}],
+                    "max_completion_tokens": 32,
+                    "temperature": 0.0,
+                },
+                headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["object"] == "chat.completion"
+            assert len(data["choices"]) == 1
+            assert data["choices"][0]["message"]["role"] == "assistant"
+            assert len(data["choices"][0]["message"]["content"]) > 0
+            assert data["choices"][0]["finish_reason"] in ("stop", "length")
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle_vllm(self, gateway_stack_vllm):
+        """Full RL lifecycle through vLLM gateway stack."""
+        gw = gateway_stack_vllm["gateway_addr"]
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(
+                f"{gw}/rl/start_session",
+                json={"task_id": "vllm-gw-lifecycle"},
+                headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+            )
+            assert resp.status_code == 201, resp.text
+            session = resp.json()
+            session_api_key = session["api_key"]
+            session_id = session["session_id"]
+
+            resp = await client.post(
+                f"{gw}/chat/completions",
+                json={
+                    "model": "vllm",
+                    "messages": [{"role": "user", "content": "What is 10-3?"}],
+                    "max_completion_tokens": 64,
+                    "temperature": 0.0,
+                },
+                headers={"Authorization": f"Bearer {session_api_key}"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            resp = await client.post(
+                f"{gw}/rl/set_reward",
+                json={"reward": 1.0},
+                headers={"Authorization": f"Bearer {session_api_key}"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            resp = await client.post(
+                f"{gw}/rl/end_session",
+                headers={"Authorization": f"Bearer {session_api_key}"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["interaction_count"] == 1
+
+            resp = await client.post(
+                f"{gw}/export_trajectories",
+                json={"session_id": session_id},
+                headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+            )
+            assert resp.status_code == 200, resp.text
+            interactions = resp.json()["interactions"]
+            assert len(interactions) == 1
+            for _iid, item in interactions.items():
+                assert item["reward"] == 1.0

--- a/tests/experimental/inference_service/test_inf_bridge.py
+++ b/tests/experimental/inference_service/test_inf_bridge.py
@@ -9,8 +9,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from areal.api.cli_args import GenerationHyperparameters
-from areal.api.io_struct import ModelRequest, ModelResponse
-from areal.experimental.inference_service.data_proxy.backend import SGLangBridgeBackend
+from areal.api.io_struct import ModelRequest, ModelResponse, get_versioned_lora_name
+from areal.experimental.inference_service.data_proxy.backend import (
+    SGLangBridgeBackend,
+    VLLMBridgeBackend,
+)
 from areal.experimental.inference_service.data_proxy.inf_bridge import InfBridge
 from areal.experimental.inference_service.data_proxy.pause import PauseState
 
@@ -40,6 +43,25 @@ def _make_sglang_response(
     }
 
 
+def _make_vllm_response(
+    tokens: list[int],
+    token_logprobs: list[float],
+    finish_reason: str = "stop",
+) -> dict[str, Any]:
+    """Build a minimal vLLM completions JSON response."""
+    return {
+        "choices": [
+            {
+                "finish_reason": finish_reason,
+                "logprobs": {
+                    "tokens": [f"token:{token}" for token in tokens],
+                    "token_logprobs": token_logprobs,
+                },
+            }
+        ]
+    }
+
+
 def _make_request(
     input_ids: list[int] | None = None,
     max_new_tokens: int = 20,
@@ -48,6 +70,7 @@ def _make_request(
     greedy: bool = False,
     temperature: float = 1.0,
     metadata: dict[str, Any] | None = None,
+    lora_name: str | None = None,
 ) -> ModelRequest:
     """Create a ModelRequest with sensible defaults for testing."""
     if input_ids is None:
@@ -59,6 +82,8 @@ def _make_request(
         greedy=greedy,
         temperature=temperature,
     )
+    if lora_name is not None:
+        gconfig.lora_name = lora_name
     return ModelRequest(
         input_ids=input_ids,
         gconfig=gconfig,
@@ -68,15 +93,18 @@ def _make_request(
 
 def _make_bridge(
     pause_state: PauseState | None = None,
+    backend: SGLangBridgeBackend | VLLMBridgeBackend | None = None,
     **kwargs: Any,
 ) -> InfBridge:
-    """Create an InfBridge with SGLangBridgeBackend and sensible test defaults."""
+    """Create an InfBridge with a pluggable backend and sensible defaults."""
     if pause_state is None:
         pause_state = PauseState()
+    if backend is None:
+        backend = SGLangBridgeBackend()
     kwargs.setdefault("backend_addr", "http://mock")
     kwargs.setdefault("resubmit_wait", 0.01)
     return InfBridge(
-        backend=SGLangBridgeBackend(),
+        backend=backend,
         pause_state=pause_state,
         **kwargs,
     )
@@ -402,3 +430,234 @@ class TestInfBridge:
 
         assert resp.stop_reason == "length"
         bridge._send_request.assert_called_once()
+
+
+class TestVLLMBridgeBackend:
+    @pytest.mark.asyncio
+    async def test_vllm_text_abort_then_stop_accumulates_tokens(self):
+        """vLLM text completions resubmit by extending prompt + shrinking max_tokens."""
+        calls: list[dict[str, Any]] = []
+
+        async def mock_send(http_req, **kwargs):
+            calls.append(
+                {
+                    "prompt": list(http_req.payload["prompt"]),
+                    "max_tokens": http_req.payload["max_tokens"],
+                }
+            )
+            if len(calls) == 1:
+                return _make_vllm_response([100, 101], [-0.5, -0.3], "abort")
+            return _make_vllm_response([200], [-0.2], "stop")
+
+        bridge = _make_bridge(backend=VLLMBridgeBackend())
+        bridge._send_request = mock_send
+
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=5)
+        resp = await bridge.agenerate(req)
+
+        assert calls == [
+            {"prompt": [1, 2, 3], "max_tokens": 5},
+            {"prompt": [1, 2, 3, 100, 101], "max_tokens": 3},
+        ]
+        assert resp.output_tokens == [100, 101, 200]
+        assert resp.output_logprobs == [-0.5, -0.3, -0.2]
+        assert resp.stop_reason == "stop"
+
+    def test_vllm_build_generation_request_for_text(self):
+        """vLLM bridge uses flat completions payload for text requests."""
+        backend = VLLMBridgeBackend()
+        req = _make_request(input_ids=[11, 12], max_new_tokens=7)
+
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+
+        assert http_req.endpoint == "/v1/completions"
+        assert http_req.payload["prompt"] == [11, 12]
+        assert http_req.payload["max_tokens"] == 7
+        assert http_req.payload["stream"] is False
+
+    def test_vllm_parse_generation_response_for_chat_format(self):
+        """vLLM bridge parses chat logprobs content format."""
+        backend = VLLMBridgeBackend()
+        response = {
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "logprobs": {
+                        "content": [
+                            {"token": "token:42", "logprob": -0.1},
+                            {"token": "token:43", "logprob": -0.2},
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = backend.parse_generation_response(response)
+
+        assert result.output_tokens == [42, 43]
+        assert result.output_logprobs == [-0.1, -0.2]
+        assert result.stop_reason == "stop"
+
+    # -- 4. max_new_tokens capped by max_tokens ----------------------------------
+
+    @pytest.mark.asyncio
+    async def test_vllm_max_new_tokens_capped_by_max_tokens(self):
+        """vLLM: max_tokens = min(max_tokens - input_len, max_new_tokens)."""
+        calls: list[dict[str, Any]] = []
+
+        async def mock_send(http_req, **kwargs):
+            calls.append(
+                {
+                    "prompt": list(http_req.payload["prompt"]),
+                    "max_tokens": http_req.payload["max_tokens"],
+                }
+            )
+            return _make_vllm_response([100], [-0.5], "stop")
+
+        bridge = _make_bridge(backend=VLLMBridgeBackend())
+        bridge._send_request = mock_send
+
+        # input_len=3, max_tokens=10 -> effective max_new_tokens = min(7, 20) = 7
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=20, max_tokens=10)
+        await bridge.agenerate(req)
+
+        assert calls[0]["max_tokens"] == 7
+
+    # -- 5. greedy sets temperature zero -----------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_vllm_greedy_sets_temperature_zero(self):
+        """vLLM: gconfig.greedy=True -> temperature=0.0 in HTTP payload."""
+        calls: list[dict[str, Any]] = []
+
+        async def mock_send(http_req, **kwargs):
+            calls.append({"temperature": http_req.payload["temperature"]})
+            return _make_vllm_response([100], [-0.5], "stop")
+
+        bridge = _make_bridge(backend=VLLMBridgeBackend())
+        bridge._send_request = mock_send
+
+        req = _make_request(input_ids=[1, 2, 3], greedy=True, temperature=0.8)
+        await bridge.agenerate(req)
+
+        assert calls[0]["temperature"] == 0.0
+
+    # -- 6. LoRA name in payload --------------------------------------------------
+
+    def test_vllm_lora_name_in_payload(self):
+        """vLLM: with_lora=True sets payload['model'] to versioned lora name."""
+        backend = VLLMBridgeBackend()
+        req = _make_request(input_ids=[1, 2], lora_name="my_lora")
+
+        http_req = backend.build_generation_request(req, with_lora=True, version=3)
+
+        expected_model = get_versioned_lora_name("my_lora", 3)
+        assert http_req.payload["model"] == expected_model
+
+    # -- 7. Vision request uses chat endpoint ------------------------------------
+
+    def test_vllm_vision_request_uses_chat_endpoint(self):
+        """vLLM: vision_msg_vllm field routes request to /v1/chat/completions."""
+        backend = VLLMBridgeBackend()
+        gconfig = GenerationHyperparameters(
+            n_samples=1,
+            max_new_tokens=20,
+            max_tokens=32768,
+        )
+        vision_msgs = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "placeholder"},
+                        },
+                    ],
+                }
+            ]
+        ]
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            vision_msg_vllm=vision_msgs,
+            image_data=["base64data"],
+        )
+
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+
+        assert http_req.endpoint == "/v1/chat/completions"
+        assert "messages" in http_req.payload
+
+    # -- 8. Pause blocks vLLM backend -------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_vllm_pause_blocks_until_resumed(self):
+        """vLLM: while paused, agenerate waits; after resume, it completes."""
+        vllm_resp = _make_vllm_response([100], [-0.5], "stop")
+
+        pause_state = PauseState()
+        bridge = _make_bridge(pause_state=pause_state, backend=VLLMBridgeBackend())
+        bridge._send_request = AsyncMock(return_value=vllm_resp)
+
+        await pause_state.set_paused(True)
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=5)
+        task = asyncio.create_task(bridge.agenerate(req))
+        await asyncio.sleep(0.05)  # let it start
+        assert not task.done()  # blocked by pause
+
+        await pause_state.set_paused(False)  # unblock
+        resp = await asyncio.wait_for(task, timeout=2.0)
+        assert resp.stop_reason == "stop"
+        assert resp.output_tokens == [100]
+
+    # -- 9. length stop reason passthrough ---------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_vllm_length_stop_reason_passthrough(self):
+        """vLLM: stop_reason='length' exits the loop normally without resubmit."""
+        vllm_resp = _make_vllm_response([100], [-0.5], "length")
+
+        bridge = _make_bridge(backend=VLLMBridgeBackend())
+        bridge._send_request = AsyncMock(return_value=vllm_resp)
+
+        req = _make_request(input_ids=[1, 2], max_new_tokens=20)
+        resp = await bridge.agenerate(req)
+
+        assert resp.stop_reason == "length"
+        bridge._send_request.assert_called_once()
+
+    # -- 10. output_versions populated correctly ---------------------------------
+
+    @pytest.mark.asyncio
+    async def test_vllm_output_versions_populated(self):
+        """vLLM: output_versions = [version] * len(output_tokens)."""
+        vllm_resp = _make_vllm_response([100, 101, 102], [-0.5, -0.3, -0.2], "stop")
+
+        bridge = _make_bridge(version=42, backend=VLLMBridgeBackend())
+        bridge._send_request = AsyncMock(return_value=vllm_resp)
+
+        req = _make_request(input_ids=[1, 2, 3])
+        resp = await bridge.agenerate(req)
+
+        assert resp.output_versions == [42, 42, 42]
+        assert len(resp.output_versions) == len(resp.output_tokens)
+
+    # -- 11. max retries abort becomes length ------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_vllm_max_retries_abort_becomes_length(self):
+        """vLLM: after max retries, final abort is converted to 'length'."""
+        vllm_resp = _make_vllm_response([10], [-0.1], "abort")
+
+        bridge = _make_bridge(max_resubmit_retries=3, backend=VLLMBridgeBackend())
+        bridge._send_request = AsyncMock(return_value=vllm_resp)
+
+        req = _make_request(input_ids=[1, 2], max_new_tokens=100)
+        resp = await bridge.agenerate(req)
+
+        assert bridge._send_request.call_count == 3
+        assert resp.stop_reason == "length"
+        assert len(resp.output_tokens) == 3  # 1 token per retry


### PR DESCRIPTION
## Description

Wire VLLMBridgeBackend into the full inference service stack with feature parity to the SGLang path, including pluggable backend selection, max_new_tokens context-window capping, per-process environment isolation for vLLM servers, and comprehensive test coverage (unit + e2e integration).

## Related Issue

N/A — continuation of the inference service architecture work.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [x] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

### Production changes

**Data Proxy (`data_proxy/`)**
- `config.py`: Add `backend_type` field (default `"sglang"`)
- `__main__.py`: Add `--backend-type` CLI arg with `sglang`/`vllm` choices
- `app.py`: Wire `VLLMBridgeBackend` selection in `_create_inf_bridge()`
- `backend.py`: Cap `max_new_tokens` in `VLLMBridgeBackend.build_generation_request()` to `min(max_tokens - input_len, max_new_tokens)`, matching `SGLangBridgeBackend`
- `inf_bridge.py`: Delegate abort/resubmit payload patching to backend protocol methods instead of hardcoded SGLang payload access

**RPCGuard (`guard/`)**
- `app.py`: Accept optional `"env"` dict in `/fork` request payload (backward-compatible)

**Controller (`controller/`)**
- `controller.py`: Pass per-process vLLM env vars (`TRITON_CACHE_PATH`, `VLLM_CACHE_ROOT`, `VLLM_ALLOW_RUNTIME_LORA_UPDATING`) when launching vLLM servers. Update docstring from "vllm is planned" to "supported".

### Tests

**Unit tests** (`test_inf_bridge.py`): 8 new vLLM test methods covering max_new_tokens capping, greedy mode, LoRA, vision, pause/resume, stop reasons, version tracking, abort retries.

**E2e integration tests** (7 vLLM variants added to existing SGLang tests):

| Test File | vLLM Tests | Coverage |
|-----------|-----------|----------|
| `test_data_proxy_integration.py` | 3 | Non-streaming + lifecycle, streaming, pause/resume |
| `test_gateway_integration.py` | 2 | Full-stack chat, RL lifecycle through gateway |
| `test_controller_integration.py` | 2 | Controller full-init (`backend="vllm:d1"`), rollout_batch |

Also adds `launch_vllm_server()` helper to `integration_utils.py` and replaces module-level `pytestmark=sglang` with per-class decorators for clean `-m vllm` vs `-m sglang` selection.

### Test results

```
26 passed — tests/experimental/inference_service/test_inf_bridge.py
 7 passed — tests/experimental/inference_service/test_data_proxy_standalone.py
```

Pre-commit: all hooks pass.