### PR TITLE
feat(inference_service): add VLM image input support to OpenAI-compatible API

### DIFF
--- a/areal/experimental/inference_service/data_proxy/backend.py
+++ b/areal/experimental/inference_service/data_proxy/backend.py
@@ -138,6 +138,7 @@ class SGLangBridgeBackend:
 
         payload: dict[str, Any] = {
             "input_ids": list(req.input_ids),
+            "image_data": req.image_data,
             "sampling_params": sampling_params,
             "return_logprob": True,
             "stream": False,

--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import re
 import uuid
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from copy import deepcopy
@@ -34,7 +35,7 @@ from openai.types.chat.chat_completion_tool_choice_option_param import (
     ChatCompletionToolChoiceOptionParam,
 )
 from openai.types.completion_usage import CompletionUsage
-from openai.types.responses import ResponseInputItemParam, response_create_params
+from openai.types.responses import response_create_params
 from openai.types.responses.response import Response
 from openai.types.responses.response_input_param import ResponseInputParam
 from openai.types.responses.response_output_message import ResponseOutputMessage
@@ -138,6 +139,205 @@ def _find_kth(lst: list, target, k: int) -> int:
         return result
     except StopIteration:
         return -1
+
+
+# Regex for data URI: data:image/<subtype>;base64,<data>
+_DATA_URI_RE = re.compile(r"^data:image/[a-zA-Z0-9.+-]+;base64,(.+)$", re.DOTALL)
+
+
+def _extract_images_from_messages(
+    messages: list[dict[str, Any]],
+) -> tuple[list[str], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Extract image data from OpenAI-format messages.
+
+    Scans message ``content`` lists for ``image_url`` content parts,
+    extracts base64 data (or raw URLs), and converts messages to a
+    HuggingFace-compatible format for ``apply_chat_template``.
+
+    Args:
+        messages: Normalized list of message dicts (OpenAI format).
+
+    Returns:
+        A 3-tuple of:
+
+        - **image_data** – list of base64 image strings (no data-URI prefix)
+          or raw URL strings for each image found.
+        - **messages_for_tokenizer** – deep copy of *messages* where every
+          ``{"type": "image_url", ...}`` part is replaced by
+          ``{"type": "image"}`` so that HuggingFace VLM tokenizers insert
+          the correct image-placeholder tokens.
+        - **vision_messages_for_vllm** – deep copy of *messages* where
+          ``image_url`` parts retain the ``image_url`` key but the ``url``
+          value is replaced with a placeholder (the actual base64 data URI
+          is injected later by the vLLM backend from *image_data*).
+    """
+    image_data: list[str] = []
+    messages_for_tokenizer: list[dict[str, Any]] = []
+    vision_messages_for_vllm: list[dict[str, Any]] = []
+
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            messages_for_tokenizer.append(deepcopy(msg))
+            vision_messages_for_vllm.append(deepcopy(msg))
+            continue
+
+        tok_parts: list[dict[str, Any]] = []
+        vllm_parts: list[dict[str, Any]] = []
+
+        for part in content:
+            if not isinstance(part, dict):
+                tok_parts.append(part)
+                vllm_parts.append(deepcopy(part))
+                continue
+
+            if part.get("type") == "image_url":
+                image_url_obj = part.get("image_url", {})
+                url = (
+                    image_url_obj.get("url", "")
+                    if isinstance(image_url_obj, dict)
+                    else ""
+                )
+
+                if not url:
+                    raise ValueError(
+                        "image_url content part has an empty or missing URL. "
+                        "Provide a valid data URI or HTTP(S) URL in "
+                        "image_url.url."
+                    )
+
+                # Extract base64 payload from data URIs; keep raw URLs as-is.
+                m = _DATA_URI_RE.match(url)
+                if m:
+                    image_data.append(m.group(1))
+                else:
+                    image_data.append(url)
+
+                tok_parts.append({"type": "image"})
+
+                # vLLM backend injects actual data URI from req.image_data.
+                vllm_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "placeholder"},
+                    }
+                )
+            else:
+                tok_parts.append(deepcopy(part))
+                vllm_parts.append(deepcopy(part))
+
+        tok_msg = {**msg, "content": tok_parts}
+        vllm_msg = {**msg, "content": vllm_parts}
+        messages_for_tokenizer.append(tok_msg)
+        vision_messages_for_vllm.append(vllm_msg)
+
+    return image_data, messages_for_tokenizer, vision_messages_for_vllm
+
+
+def _convert_tool_output_format(
+    item: dict,
+) -> ChatCompletionToolMessageParam | dict:
+    """Convert custom tool output format to standard chat template format.
+
+    Converts openai.types.responses.response_input_item_param.FunctionCallOutput
+    to openai.types.chat.ChatCompletionToolMessageParam.
+
+    Args:
+        item: Input dict, could be FunctionCallOutput from openai-agents SDK
+            with format: {'call_id': str, 'output': str, 'type': 'function_call_output'}
+
+    Returns:
+        ChatCompletionToolMessageParam (TypedDict) with format:
+        {'role': 'tool', 'content': str, 'tool_call_id': str}
+        or the original dict if conversion is not needed.
+    """
+    if (
+        isinstance(item, dict)
+        and "output" in item
+        and item.get("type") == "function_call_output"
+    ):
+        converted = {
+            "role": "tool",
+            "content": item["output"],
+        }
+        # Add tool_call_id if present
+        if "call_id" in item:
+            converted["tool_call_id"] = item["call_id"]
+        return converted
+    return item
+
+
+def _build_messages_list(item: dict) -> list[dict]:
+    """Convert a Responses API input item into Chat Completions message dicts.
+
+    Handles ``output_text``, ``input_text``, ``input_image``, and
+    ``function_call_output`` content types.  When the item contains at
+    least one ``input_image`` part the returned message keeps a ``list``
+    content value (multimodal); otherwise each text part produces its own
+    flat ``{"role": …, "content": "…"}`` message.
+
+    Args:
+        item: A single normalised Responses-API input item (dict form of
+            :class:`ResponseInputItemParam`).
+
+    Returns:
+        One or more Chat-Completions-style message dicts.
+
+    Raises:
+        ValueError: On unsupported content types, non-dict content parts,
+            or ``input_image`` items that lack an ``image_url`` value.
+    """
+    messages_list: list[dict] = []
+    if "content" in item:
+        if isinstance(item["content"], str):
+            messages_list.append(
+                {"role": item["role"], "content": item["content"]},
+            )
+        elif isinstance(item["content"], Iterable):
+            content_parts: list[dict] = []
+            has_multimodal = False
+            for content in item["content"]:
+                if not isinstance(content, dict):
+                    raise ValueError("Unsupported content format")
+                ctype = content.get("type", "")
+                if ctype == "output_text" and "text" in content:
+                    content_parts.append({"type": "text", "text": content["text"]})
+                elif ctype == "input_text" and "text" in content:
+                    content_parts.append({"type": "text", "text": content["text"]})
+                elif ctype == "input_image":
+                    has_multimodal = True
+                    image_url = content.get("image_url", "")
+                    if not image_url:
+                        raise ValueError(
+                            "input_image content part requires a non-empty "
+                            "'image_url' field; file_id-only images are not "
+                            "supported."
+                        )
+                    image_url_dict: dict[str, Any] = {"url": image_url}
+                    if "detail" in content:
+                        image_url_dict["detail"] = content["detail"]
+                    content_parts.append(
+                        {
+                            "type": "image_url",
+                            "image_url": image_url_dict,
+                        }
+                    )
+                else:
+                    raise ValueError(f"Unsupported content format: {ctype}")
+            if has_multimodal:
+                messages_list.append({"role": item["role"], "content": content_parts})
+            else:
+                for cp in content_parts:
+                    messages_list.append(
+                        {"role": item["role"], "content": cp["text"]},
+                    )
+        else:
+            raise ValueError("Unsupported input item format")
+    else:
+        # Convert tool output format if needed
+        converted = _convert_tool_output_format(item)
+        messages_list.append(deepcopy(converted))
+    return messages_list
 
 
 def concat_prompt_token_ids_with_parent(
@@ -397,22 +597,35 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
             if not isinstance(tools, Iterable):
                 raise TypeError("tools must be an iterable of ChatCompletionToolParam")
             tools_list = list(tools)
+
+        image_data, messages_for_tokenizer, vision_messages_for_vllm = (
+            _extract_images_from_messages(messages_list)
+        )
+        has_images = len(image_data) > 0
+
+        tokenizer_messages = messages_for_tokenizer if has_images else messages_list
         if self.chat_template_type == "hf":
             prompt_token_ids = self.tokenizer.apply_chat_template(
-                messages_list,
+                tokenizer_messages,
                 tools=tools_list,
                 add_generation_prompt=True,
                 tokenize=True,
                 **extra_body.get("chat_template_kwargs", {}),
             )
         elif self.chat_template_type == "concat":
-            messages_list = (
+            concat_messages = (
                 interaction.remaining_messages
                 if interaction is not None
                 else messages_list
             )
+            if has_images:
+                _, concat_tok_messages, _ = _extract_images_from_messages(
+                    concat_messages
+                )
+            else:
+                concat_tok_messages = concat_messages
             prompt_token_ids = concat_prompt_token_ids_with_parent(
-                messages_list,
+                concat_tok_messages,
                 interaction.parent if interaction is not None else None,
                 self.tokenizer,
                 tools=tools_list,
@@ -515,6 +728,8 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
             rid=str(uuid.uuid4()),
             metadata=metadata if not is_omitted(metadata) else {},
             tokenizer=self.tokenizer,
+            image_data=image_data if has_images else None,
+            vision_msg_vllm=([vision_messages_for_vllm] if has_images else None),
         )
 
         # Call inference engine
@@ -756,65 +971,6 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
         if is_omitted(input):
             raise ValueError("input is required for Responses.create")
 
-        def _convert_tool_output_format(
-            item: dict,
-        ) -> ChatCompletionToolMessageParam | dict:
-            """Convert custom tool output format to standard chat template format.
-
-            Converts openai.types.responses.response_input_item_param.FunctionCallOutput
-            to openai.types.chat.ChatCompletionToolMessageParam.
-
-            Args:
-                item: Input dict, could be FunctionCallOutput from openai-agents SDK
-                    with format: {'call_id': str, 'output': str, 'type': 'function_call_output'}
-
-            Returns:
-                ChatCompletionToolMessageParam (TypedDict) with format:
-                {'role': 'tool', 'content': str, 'tool_call_id': str}
-                or the original dict if conversion is not needed.
-            """
-            if (
-                isinstance(item, dict)
-                and "output" in item
-                and item.get("type") == "function_call_output"
-            ):
-                converted = {
-                    "role": "tool",
-                    "content": item["output"],
-                }
-                # Add tool_call_id if present
-                if "call_id" in item:
-                    converted["tool_call_id"] = item["call_id"]
-                return converted
-            return item
-
-        def _build_messages_list(item: ResponseInputItemParam) -> list[dict]:
-            messages_list = []
-            if "content" in item:
-                if isinstance(item["content"], str):
-                    messages_list.append(
-                        {"role": item["role"], "content": item["content"]},
-                    )
-                elif isinstance(item["content"], Iterable):
-                    for content in item["content"]:
-                        if (
-                            isinstance(content, dict)
-                            and content.get("type") == "output_text"
-                            and "text" in content
-                        ):
-                            messages_list.append(
-                                {"role": item["role"], "content": content["text"]},
-                            )
-                        else:
-                            raise ValueError("Unsupported content format")
-                else:
-                    raise ValueError("Unsupported input item format")
-            else:
-                # Convert tool output format if needed
-                converted = _convert_tool_output_format(item)
-                messages_list.append(deepcopy(converted))
-            return messages_list
-
         if isinstance(input, str):
             input = [{"role": "user", "content": input}]
         if isinstance(input, list):
@@ -844,17 +1000,29 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
             if not isinstance(tools, Iterable):
                 raise TypeError("tools must be an iterable of ChatCompletionToolParam")
             tools_list = list(tools)
+
+        image_data, messages_for_tokenizer, vision_messages_for_vllm = (
+            _extract_images_from_messages(messages_list)
+        )
+        has_images = len(image_data) > 0
+
+        tokenizer_messages = messages_for_tokenizer if has_images else messages_list
         if self.chat_template_type == "hf":
             prompt_token_ids = self.tokenizer.apply_chat_template(
-                messages_list,
+                tokenizer_messages,
                 tools=tools_list,
                 add_generation_prompt=True,
                 tokenize=True,
                 **extra_body.get("chat_template_kwargs", {}),
             )
         elif self.chat_template_type == "concat":
+            remaining = interaction.remaining_messages
+            if has_images:
+                _, remaining_tok, _ = _extract_images_from_messages(remaining)
+            else:
+                remaining_tok = remaining
             prompt_token_ids = concat_prompt_token_ids_with_parent(
-                interaction.remaining_messages,
+                remaining_tok,
                 interaction.parent if interaction is not None else None,
                 self.tokenizer,
                 tools=tools_list,
@@ -916,6 +1084,8 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
             rid=str(uuid.uuid4()),
             metadata=metadata if not is_omitted(metadata) else {},
             tokenizer=self.tokenizer,
+            image_data=image_data if has_images else None,
+            vision_msg_vllm=([vision_messages_for_vllm] if has_images else None),
         )
 
         # Call inference engine

--- a/tests/experimental/inference_service/integration_utils.py
+++ b/tests/experimental/inference_service/integration_utils.py
@@ -28,6 +28,9 @@ SERVER_STARTUP_TIMEOUT = 180  # seconds
 EXPR_NAME = "test_gateway_controller_integration"
 TRIAL_NAME = "trial_0"
 
+VLM_LOCAL_MODEL_PATH = "/storage/openpsi/models/Qwen3-VL-2B-Instruct"
+VLM_HF_MODEL_ID = "Qwen/Qwen3-VL-2B-Instruct"
+
 
 # =============================================================================
 # Helper Functions
@@ -76,6 +79,15 @@ def get_test_model_path() -> str:
         str: Path to the test model, falling back to HuggingFace if not available locally.
     """
     return _get_model_path(LOCAL_MODEL_PATH, HF_MODEL_ID)
+
+
+def get_vlm_test_model_path() -> str:
+    """Get the VLM model path for tests (Qwen3-VL-2B-Instruct).
+
+    Returns:
+        str: Path to the VLM test model, falling back to HuggingFace if not available locally.
+    """
+    return _get_model_path(VLM_LOCAL_MODEL_PATH, VLM_HF_MODEL_ID)
 
 
 def check_server_health(base_url: str) -> bool:

--- a/tests/experimental/inference_service/test_controller_integration.py
+++ b/tests/experimental/inference_service/test_controller_integration.py
@@ -12,6 +12,8 @@ The test launches:
 
 from __future__ import annotations
 
+import base64
+import io
 import subprocess
 import sys
 import time
@@ -19,12 +21,14 @@ import time
 import httpx
 import pytest
 import torch
+from PIL import Image
 
 from tests.experimental.inference_service.integration_utils import (
     EXPR_NAME,
     TRIAL_NAME,
     check_server_health,
     get_test_model_path,
+    get_vlm_test_model_path,
     has_gpu,
 )
 
@@ -53,7 +57,7 @@ def sglang_server():
         sglang_config=SGLangConfig(
             skip_tokenizer_init=True,
             model_path=get_test_model_path(),
-            mem_fraction_static=0.3,
+            mem_fraction_static=0.15,
         ),
         host=host,
         port=port,
@@ -479,7 +483,7 @@ def gateway_controller_full_init(local_scheduler, model_path):
 
     server_args = {
         "skip_tokenizer_init": True,
-        "mem_fraction_static": 0.3,
+        "mem_fraction_static": 0.15,
     }
 
     ctrl = GatewayInferenceController(config=config, scheduler=local_scheduler)
@@ -761,7 +765,7 @@ def gateway_controller_full_init_vllm(local_scheduler, model_path):
     )
 
     server_args = {
-        "gpu_memory_utilization": 0.3,
+        "gpu_memory_utilization": 0.15,
     }
 
     ctrl = GatewayInferenceController(config=config, scheduler=local_scheduler)
@@ -859,3 +863,270 @@ class TestControllerFullInitVLLM:
 
         assert isinstance(traj["input_ids"], RTensor)
         assert traj["input_ids"].ndim == 2
+
+
+# =============================================================================
+# VLM image input tests (Qwen3-VL-2B, real images, no mocks)
+# =============================================================================
+
+
+def _make_solid_color_png_b64(width: int, height: int, color: tuple) -> str:
+    img = Image.new("RGB", (width, height), color=color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def _do_vlm_chat_session(
+    ctrl, task_id: str, messages: list, *, max_tokens: int = 64
+) -> dict:
+    """grant_capacity → start_session → chat/completions → end_session."""
+    gw = ctrl._gateway_addr
+    admin = "test-admin"
+
+    resp = httpx.post(
+        f"{gw}/grant_capacity",
+        headers={"Authorization": f"Bearer {admin}"},
+        timeout=10.0,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = httpx.post(
+        f"{gw}/rl/start_session",
+        json={"task_id": task_id},
+        headers={"Authorization": f"Bearer {admin}"},
+        timeout=30.0,
+    )
+    assert resp.status_code == 201, resp.text
+    session_api_key = resp.json()["api_key"]
+
+    resp = httpx.post(
+        f"{gw}/chat/completions",
+        json={
+            "model": "default",
+            "messages": messages,
+            "max_completion_tokens": max_tokens,
+            "temperature": 0.0,
+            "stream": False,
+        },
+        headers={"Authorization": f"Bearer {session_api_key}"},
+        timeout=120.0,
+    )
+    assert resp.status_code == 200, resp.text
+    completion = resp.json()
+    assert completion["object"] == "chat.completion"
+    assert len(completion["choices"]) == 1
+    assert len(completion["choices"][0]["message"]["content"]) > 0
+    assert completion["usage"]["completion_tokens"] > 0
+
+    resp = httpx.post(
+        f"{gw}/rl/end_session",
+        headers={"Authorization": f"Bearer {session_api_key}"},
+        timeout=10.0,
+    )
+    assert resp.status_code == 200, resp.text
+
+    return completion
+
+
+@pytest.fixture(scope="module")
+def vlm_model_path() -> str:
+    return get_vlm_test_model_path()
+
+
+@pytest.fixture(scope="module")
+def gateway_controller_full_init_vlm_sglang(local_scheduler, vlm_model_path):
+    if not has_gpu():
+        pytest.skip("GPU required")
+
+    from areal.api.cli_args import SchedulingSpec
+    from areal.experimental.inference_service.controller.config import (
+        GatewayControllerConfig,
+    )
+    from areal.experimental.inference_service.controller.controller import (
+        GatewayInferenceController,
+    )
+
+    config = GatewayControllerConfig(
+        tokenizer_path=vlm_model_path,
+        model_path=vlm_model_path,
+        backend="sglang:d1",
+        scheduling_spec=(
+            SchedulingSpec(
+                gpu=1, cmd="python -m areal.experimental.inference_service.guard"
+            ),
+        ),
+        admin_api_key="test-admin",
+        consumer_batch_size=8,
+        max_head_offpolicyness=1024,
+        setup_timeout=300.0,
+    )
+
+    ctrl = GatewayInferenceController(config=config, scheduler=local_scheduler)
+    ctrl.initialize(
+        role="rollout-vlm-sglang",
+        server_args={"skip_tokenizer_init": True, "mem_fraction_static": 0.25},
+    )
+
+    try:
+        yield ctrl
+    finally:
+        ctrl.destroy()
+
+
+@pytest.fixture(scope="module")
+def gateway_controller_full_init_vlm_vllm(local_scheduler, vlm_model_path):
+    if not has_gpu():
+        pytest.skip("GPU required")
+
+    from areal.api.cli_args import SchedulingSpec
+    from areal.experimental.inference_service.controller.config import (
+        GatewayControllerConfig,
+    )
+    from areal.experimental.inference_service.controller.controller import (
+        GatewayInferenceController,
+    )
+
+    config = GatewayControllerConfig(
+        tokenizer_path=vlm_model_path,
+        model_path=vlm_model_path,
+        backend="vllm:d1",
+        scheduling_spec=(
+            SchedulingSpec(
+                gpu=1, cmd="python -m areal.experimental.inference_service.guard"
+            ),
+        ),
+        admin_api_key="test-admin",
+        consumer_batch_size=8,
+        max_head_offpolicyness=1024,
+        setup_timeout=300.0,
+    )
+
+    ctrl = GatewayInferenceController(config=config, scheduler=local_scheduler)
+    ctrl.initialize(
+        role="rollout-vlm-vllm",
+        server_args={"gpu_memory_utilization": 0.25},
+    )
+
+    try:
+        yield ctrl
+    finally:
+        ctrl.destroy()
+
+
+@pytest.mark.slow
+@pytest.mark.ci
+@pytest.mark.sglang
+@pytest.mark.skipif(not has_gpu(), reason="GPU required")
+class TestControllerVLMImageSGLang:
+    def test_single_image_chat(self, gateway_controller_full_init_vlm_sglang):
+        img = _make_solid_color_png_b64(64, 64, (255, 0, 0))
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image briefly."},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{img}"},
+                    },
+                ],
+            }
+        ]
+        _do_vlm_chat_session(
+            gateway_controller_full_init_vlm_sglang, "vlm-sg-1img", messages
+        )
+
+    def test_multiple_images_chat(self, gateway_controller_full_init_vlm_sglang):
+        red = _make_solid_color_png_b64(32, 32, (255, 0, 0))
+        blue = _make_solid_color_png_b64(32, 32, (0, 0, 255))
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe these two images."},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{red}"},
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{blue}"},
+                    },
+                ],
+            }
+        ]
+        _do_vlm_chat_session(
+            gateway_controller_full_init_vlm_sglang,
+            "vlm-sg-2img",
+            messages,
+            max_tokens=128,
+        )
+
+    def test_text_only_on_vlm(self, gateway_controller_full_init_vlm_sglang):
+        messages = [{"role": "user", "content": "What is 2+2? Answer briefly."}]
+        _do_vlm_chat_session(
+            gateway_controller_full_init_vlm_sglang,
+            "vlm-sg-text",
+            messages,
+            max_tokens=32,
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.ci
+@pytest.mark.vllm
+@pytest.mark.skipif(not has_gpu(), reason="GPU required")
+class TestControllerVLMImageVLLM:
+    def test_single_image_chat(self, gateway_controller_full_init_vlm_vllm):
+        img = _make_solid_color_png_b64(64, 64, (255, 0, 0))
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image briefly."},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{img}"},
+                    },
+                ],
+            }
+        ]
+        _do_vlm_chat_session(
+            gateway_controller_full_init_vlm_vllm, "vlm-vl-1img", messages
+        )
+
+    def test_multiple_images_chat(self, gateway_controller_full_init_vlm_vllm):
+        red = _make_solid_color_png_b64(32, 32, (255, 0, 0))
+        blue = _make_solid_color_png_b64(32, 32, (0, 0, 255))
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe these two images."},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{red}"},
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{blue}"},
+                    },
+                ],
+            }
+        ]
+        _do_vlm_chat_session(
+            gateway_controller_full_init_vlm_vllm,
+            "vlm-vl-2img",
+            messages,
+            max_tokens=128,
+        )
+
+    def test_text_only_on_vlm(self, gateway_controller_full_init_vlm_vllm):
+        messages = [{"role": "user", "content": "What is 2+2? Answer briefly."}]
+        _do_vlm_chat_session(
+            gateway_controller_full_init_vlm_vllm,
+            "vlm-vl-text",
+            messages,
+            max_tokens=32,
+        )

--- a/tests/experimental/inference_service/test_image_input.py
+++ b/tests/experimental/inference_service/test_image_input.py
@@ -1,0 +1,1076 @@
+"""Tests for VLM image input through the OpenAI-compatible API.
+
+Uses real base64-encoded PNG images (tiny 1x1 and 2x2 pixels) generated
+at test time -- no mocks for image data.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from copy import deepcopy
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from PIL import Image
+
+from areal.api.cli_args import GenerationHyperparameters
+from areal.api.io_struct import ModelRequest
+from areal.experimental.inference_service.data_proxy.backend import (
+    SGLangBridgeBackend,
+    VLLMBridgeBackend,
+)
+from areal.experimental.inference_service.data_proxy.inf_bridge import InfBridge
+from areal.experimental.inference_service.data_proxy.pause import PauseState
+from areal.experimental.openai.client import (
+    _build_messages_list,
+    _extract_images_from_messages,
+)
+
+# ---------------------------------------------------------------------------
+# Real image fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_png_base64(width: int = 1, height: int = 1, color="red") -> str:
+    """Create a real PNG image and return its raw base64 string (no URI prefix)."""
+    img = Image.new("RGB", (width, height), color=color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def _make_data_uri(b64: str, mime: str = "image/png") -> str:
+    return f"data:{mime};base64,{b64}"
+
+
+def _materialize(obj):
+    """Recursively convert Pydantic ValidatorIterators (and other iterables) to plain lists/dicts."""
+    if isinstance(obj, dict):
+        return {k: _materialize(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_materialize(item) for item in obj]
+    if isinstance(obj, str):
+        return obj
+    try:
+        return [_materialize(item) for item in obj]
+    except TypeError:
+        return obj
+
+
+@pytest.fixture
+def red_pixel_b64():
+    return _make_png_base64(1, 1, "red")
+
+
+@pytest.fixture
+def blue_pixel_b64():
+    return _make_png_base64(1, 1, "blue")
+
+
+# =========================================================================
+# _extract_images_from_messages — pure function, real image data
+# =========================================================================
+
+
+class TestExtractImagesFromMessages:
+    def test_single_base64_image(self, red_pixel_b64):
+        data_uri = _make_data_uri(red_pixel_b64)
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image"},
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                ],
+            }
+        ]
+
+        image_data, tok_msgs, vllm_msgs = _extract_images_from_messages(messages)
+
+        assert len(image_data) == 1
+        assert image_data[0] == red_pixel_b64
+
+        tok_content = tok_msgs[0]["content"]
+        assert tok_content[0] == {"type": "text", "text": "Describe this image"}
+        assert tok_content[1] == {"type": "image"}
+
+        vllm_content = vllm_msgs[0]["content"]
+        assert vllm_content[1]["type"] == "image_url"
+        assert vllm_content[1]["image_url"]["url"] == "placeholder"
+
+    def test_multiple_images_in_single_message(self, red_pixel_b64, blue_pixel_b64):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Compare these two images"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": _make_data_uri(red_pixel_b64)},
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": _make_data_uri(blue_pixel_b64)},
+                    },
+                ],
+            }
+        ]
+
+        image_data, tok_msgs, vllm_msgs = _extract_images_from_messages(messages)
+
+        assert len(image_data) == 2
+        assert image_data[0] == red_pixel_b64
+        assert image_data[1] == blue_pixel_b64
+
+        tok_content = tok_msgs[0]["content"]
+        assert len(tok_content) == 3
+        assert tok_content[1] == {"type": "image"}
+        assert tok_content[2] == {"type": "image"}
+
+    def test_images_across_multiple_messages(self, red_pixel_b64, blue_pixel_b64):
+        messages = [
+            {"role": "system", "content": "You are a VLM assistant."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "First image"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": _make_data_uri(red_pixel_b64)},
+                    },
+                ],
+            },
+            {"role": "assistant", "content": "I see a red pixel."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Second image"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": _make_data_uri(blue_pixel_b64)},
+                    },
+                ],
+            },
+        ]
+
+        image_data, tok_msgs, vllm_msgs = _extract_images_from_messages(messages)
+
+        assert len(image_data) == 2
+        assert image_data[0] == red_pixel_b64
+        assert image_data[1] == blue_pixel_b64
+
+        assert tok_msgs[0] == {"role": "system", "content": "You are a VLM assistant."}
+        assert tok_msgs[2] == {"role": "assistant", "content": "I see a red pixel."}
+
+    def test_http_url_preserved_as_is(self):
+        url = "https://example.com/photo.jpg"
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe"},
+                    {"type": "image_url", "image_url": {"url": url}},
+                ],
+            }
+        ]
+
+        image_data, tok_msgs, _ = _extract_images_from_messages(messages)
+
+        assert len(image_data) == 1
+        assert image_data[0] == url
+        assert tok_msgs[0]["content"][1] == {"type": "image"}
+
+    def test_no_images_returns_empty(self):
+        messages = [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "4"},
+        ]
+
+        image_data, tok_msgs, vllm_msgs = _extract_images_from_messages(messages)
+
+        assert image_data == []
+        assert tok_msgs[0] == messages[0]
+        assert tok_msgs[1] == messages[1]
+
+    def test_string_content_passes_through(self):
+        messages = [{"role": "user", "content": "Hello"}]
+
+        image_data, tok_msgs, vllm_msgs = _extract_images_from_messages(messages)
+
+        assert image_data == []
+        assert tok_msgs[0]["content"] == "Hello"
+        assert vllm_msgs[0]["content"] == "Hello"
+
+    def test_original_messages_not_mutated(self, red_pixel_b64):
+        data_uri = _make_data_uri(red_pixel_b64)
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe"},
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                ],
+            }
+        ]
+        original = deepcopy(messages)
+
+        _extract_images_from_messages(messages)
+
+        assert messages == original
+
+    def test_jpeg_data_uri(self):
+        jpeg_b64 = base64.b64encode(b"\xff\xd8\xff\xe0fake-jpeg").decode()
+        data_uri = _make_data_uri(jpeg_b64, mime="image/jpeg")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                ],
+            }
+        ]
+
+        image_data, _, _ = _extract_images_from_messages(messages)
+
+        assert len(image_data) == 1
+        assert image_data[0] == jpeg_b64
+
+    def test_detail_parameter_ignored_for_extraction(self, red_pixel_b64):
+        data_uri = _make_data_uri(red_pixel_b64)
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": data_uri, "detail": "high"},
+                    },
+                ],
+            }
+        ]
+
+        image_data, _, _ = _extract_images_from_messages(messages)
+
+        assert len(image_data) == 1
+        assert image_data[0] == red_pixel_b64
+
+    def test_real_png_roundtrip(self):
+        """Create a real 4x4 image, encode it, extract it, and decode back."""
+        original = Image.new("RGB", (4, 4), color=(42, 128, 200))
+        buf = io.BytesIO()
+        original.save(buf, format="PNG")
+        raw_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+        data_uri = _make_data_uri(raw_b64)
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What color?"},
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                ],
+            }
+        ]
+
+        image_data, _, _ = _extract_images_from_messages(messages)
+
+        decoded_bytes = base64.b64decode(image_data[0])
+        decoded_img = Image.open(io.BytesIO(decoded_bytes))
+        assert decoded_img.size == (4, 4)
+        assert decoded_img.getpixel((0, 0)) == (42, 128, 200)
+
+
+# =========================================================================
+# SGLangBridgeBackend — image_data forwarding
+# =========================================================================
+
+
+class TestSGLangBridgeBackendImageForwarding:
+    def test_image_data_included_in_payload(self, red_pixel_b64):
+        backend = SGLangBridgeBackend()
+        gconfig = GenerationHyperparameters(
+            n_samples=1,
+            max_new_tokens=10,
+            max_tokens=32768,
+        )
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            image_data=[red_pixel_b64],
+        )
+
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+
+        assert http_req.endpoint == "/generate"
+        assert http_req.payload["image_data"] == [red_pixel_b64]
+        assert http_req.payload["input_ids"] == [1, 2, 3]
+
+    def test_image_data_none_included_in_payload(self):
+        backend = SGLangBridgeBackend()
+        gconfig = GenerationHyperparameters(
+            n_samples=1,
+            max_new_tokens=10,
+            max_tokens=32768,
+        )
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            image_data=None,
+        )
+
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+
+        assert http_req.payload["image_data"] is None
+
+    def test_multiple_images_in_payload(self, red_pixel_b64, blue_pixel_b64):
+        backend = SGLangBridgeBackend()
+        gconfig = GenerationHyperparameters(
+            n_samples=1,
+            max_new_tokens=10,
+            max_tokens=32768,
+        )
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            image_data=[red_pixel_b64, blue_pixel_b64],
+        )
+
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+
+        assert http_req.payload["image_data"] == [red_pixel_b64, blue_pixel_b64]
+
+
+# =========================================================================
+# VLLMBridgeBackend — vision message construction with real images
+# =========================================================================
+
+
+class TestVLLMBridgeBackendVisionMessages:
+    def test_vision_messages_get_real_data_uris(self, red_pixel_b64):
+        backend = VLLMBridgeBackend()
+        gconfig = GenerationHyperparameters(
+            n_samples=1,
+            max_new_tokens=10,
+            max_tokens=32768,
+        )
+        vision_msgs = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "placeholder"},
+                        },
+                    ],
+                }
+            ]
+        ]
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            image_data=[red_pixel_b64],
+            vision_msg_vllm=vision_msgs,
+        )
+
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+
+        assert http_req.endpoint == "/v1/chat/completions"
+        msg_content = http_req.payload["messages"][0]["content"]
+        image_part = msg_content[1]
+        assert image_part["type"] == "image_url"
+        expected_uri = f"data:image/jpeg;base64,{red_pixel_b64}"
+        assert image_part["image_url"]["url"] == expected_uri
+
+    def test_multiple_vision_images_injected(self, red_pixel_b64, blue_pixel_b64):
+        backend = VLLMBridgeBackend()
+        gconfig = GenerationHyperparameters(
+            n_samples=1,
+            max_new_tokens=10,
+            max_tokens=32768,
+        )
+        vision_msgs = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Compare"},
+                        {"type": "image_url", "image_url": {"url": "placeholder"}},
+                        {"type": "image_url", "image_url": {"url": "placeholder"}},
+                    ],
+                }
+            ]
+        ]
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            image_data=[red_pixel_b64, blue_pixel_b64],
+            vision_msg_vllm=vision_msgs,
+        )
+
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+
+        msg_content = http_req.payload["messages"][0]["content"]
+        assert (
+            msg_content[1]["image_url"]["url"]
+            == f"data:image/jpeg;base64,{red_pixel_b64}"
+        )
+        assert (
+            msg_content[2]["image_url"]["url"]
+            == f"data:image/jpeg;base64,{blue_pixel_b64}"
+        )
+
+    def test_mismatched_image_count_raises(self, red_pixel_b64):
+        backend = VLLMBridgeBackend()
+        gconfig = GenerationHyperparameters(
+            n_samples=1,
+            max_new_tokens=10,
+            max_tokens=32768,
+        )
+        vision_msgs = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "placeholder"}},
+                        {"type": "image_url", "image_url": {"url": "placeholder"}},
+                    ],
+                }
+            ]
+        ]
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            image_data=[red_pixel_b64],
+            vision_msg_vllm=vision_msgs,
+        )
+
+        with pytest.raises(ValueError, match="Not enough images"):
+            backend.build_generation_request(req, with_lora=False, version=0)
+
+    def test_real_image_survives_data_uri_roundtrip(self):
+        """Encode a real 2x2 PNG, build vLLM request, decode from the payload."""
+        original = Image.new("RGB", (2, 2), color=(255, 0, 0))
+        buf = io.BytesIO()
+        original.save(buf, format="PNG")
+        raw_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+        backend = VLLMBridgeBackend()
+        gconfig = GenerationHyperparameters(
+            n_samples=1, max_new_tokens=10, max_tokens=32768
+        )
+        vision_msgs = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "placeholder"}},
+                    ],
+                }
+            ]
+        ]
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            image_data=[raw_b64],
+            vision_msg_vllm=vision_msgs,
+        )
+
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+
+        full_url = http_req.payload["messages"][0]["content"][0]["image_url"]["url"]
+        assert full_url.startswith("data:image/jpeg;base64,")
+        b64_payload = full_url.split(",", 1)[1]
+        decoded = base64.b64decode(b64_payload)
+        recovered = Image.open(io.BytesIO(decoded))
+        assert recovered.size == (2, 2)
+
+
+# =========================================================================
+# InfBridge — image_data preserved through abort/resubmit loop
+# =========================================================================
+
+
+def _make_sglang_response(
+    token_logprobs: list[tuple[float, int]],
+    finish_reason_type: str = "stop",
+) -> dict[str, Any]:
+    return {
+        "meta_info": {
+            "finish_reason": {"type": finish_reason_type},
+            "output_token_logprobs": token_logprobs,
+        },
+    }
+
+
+class TestInfBridgeImagePreservation:
+    @pytest.mark.asyncio
+    async def test_image_data_present_in_initial_request(self, red_pixel_b64):
+        """image_data is forwarded in the first HTTP payload."""
+        captured_payloads: list[dict] = []
+
+        async def mock_send(http_req, **kwargs):
+            captured_payloads.append(dict(http_req.payload))
+            return _make_sglang_response([(-0.5, 100)], "stop")
+
+        pause_state = PauseState()
+        bridge = InfBridge(
+            backend=SGLangBridgeBackend(),
+            backend_addr="http://mock",
+            pause_state=pause_state,
+            resubmit_wait=0.01,
+        )
+        bridge._send_request = mock_send
+
+        gconfig = GenerationHyperparameters(
+            n_samples=1, max_new_tokens=10, max_tokens=32768
+        )
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            image_data=[red_pixel_b64],
+        )
+
+        resp = await bridge.agenerate(req)
+
+        assert len(captured_payloads) == 1
+        assert captured_payloads[0]["image_data"] == [red_pixel_b64]
+        assert resp.stop_reason == "stop"
+
+    @pytest.mark.asyncio
+    async def test_image_data_persists_through_resubmit(self, red_pixel_b64):
+        """image_data stays in payload across abort/resubmit iterations."""
+        captured_payloads: list[dict] = []
+        call_count = 0
+
+        async def mock_send(http_req, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            captured_payloads.append(dict(http_req.payload))
+            if call_count == 1:
+                return _make_sglang_response([(-0.5, 100)], "abort")
+            return _make_sglang_response([(-0.3, 200)], "stop")
+
+        pause_state = PauseState()
+        bridge = InfBridge(
+            backend=SGLangBridgeBackend(),
+            backend_addr="http://mock",
+            pause_state=pause_state,
+            resubmit_wait=0.01,
+        )
+        bridge._send_request = mock_send
+
+        gconfig = GenerationHyperparameters(
+            n_samples=1, max_new_tokens=20, max_tokens=32768
+        )
+        req = ModelRequest(
+            input_ids=[1, 2, 3],
+            gconfig=gconfig,
+            metadata={},
+            image_data=[red_pixel_b64],
+        )
+
+        resp = await bridge.agenerate(req)
+
+        assert call_count == 2
+        assert captured_payloads[0]["image_data"] == [red_pixel_b64]
+        assert captured_payloads[1]["image_data"] == [red_pixel_b64]
+        assert resp.output_tokens == [100, 200]
+
+
+# =========================================================================
+# Data proxy /chat/completions — image messages passed to ArealOpenAI
+# =========================================================================
+
+
+ADMIN_KEY = "areal-admin-key"
+
+
+def _make_mock_areal_client_for_images():
+    """Mock ArealOpenAI client that captures kwargs and returns a ChatCompletion."""
+    from openai.types.chat import ChatCompletion, ChatCompletionMessage
+    from openai.types.chat.chat_completion import Choice
+    from openai.types.completion_usage import CompletionUsage
+
+    from areal.experimental.openai.types import InteractionWithTokenLogpReward
+
+    mock_client = MagicMock()
+    captured_calls: list[dict] = []
+
+    completion = ChatCompletion(
+        id="chatcmpl-vision-test",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                logprobs=None,
+                message=ChatCompletionMessage(
+                    content="I see a red pixel.", role="assistant"
+                ),
+            )
+        ],
+        created=1234567890,
+        model="vlm-model",
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=5, prompt_tokens=10, total_tokens=15),
+    )
+
+    async def _mock_create(*, areal_cache=None, **kwargs):
+        import torch
+
+        raw_messages = kwargs.get("messages", [])
+        messages = (
+            list(raw_messages) if not isinstance(raw_messages, list) else raw_messages
+        )
+        kwargs["messages"] = messages
+        captured_calls.append(kwargs)
+
+        interaction = InteractionWithTokenLogpReward(
+            messages=messages if isinstance(messages, list) else list(messages),
+            completion=completion,
+            output_message_list=[
+                {"role": "assistant", "content": "I see a red pixel."}
+            ],
+        )
+        interaction._cache = {
+            "input_ids": torch.tensor([[100, 200, 300, 400, 500, 2]]),
+            "loss_mask": torch.tensor([[0, 0, 0, 1, 1, 1]]),
+            "logprobs": torch.tensor([[0.0, 0.0, 0.0, -0.5, -0.3, -0.1]]),
+            "versions": torch.tensor([[-1, -1, -1, 0, 0, 0]]),
+            "attention_mask": torch.ones(6, dtype=torch.bool).unsqueeze(0),
+            "rewards": torch.tensor([0.0]),
+        }
+        if areal_cache is not None:
+            areal_cache[completion.id] = interaction
+        return completion
+
+    mock_client.chat.completions.create = AsyncMock(side_effect=_mock_create)
+    mock_client._captured_calls = captured_calls
+    return mock_client
+
+
+@pytest_asyncio.fixture
+async def image_test_client():
+    """Data proxy test client wired with an image-capturing mock."""
+    from areal.experimental.inference_service.data_proxy.app import create_app
+    from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
+    from areal.experimental.inference_service.data_proxy.session import SessionStore
+
+    config = DataProxyConfig(
+        host="127.0.0.1",
+        port=18082,
+        backend_addr="http://mock-sglang:30000",
+        tokenizer_path="mock-tokenizer",
+        request_timeout=10.0,
+    )
+    mock_client = _make_mock_areal_client_for_images()
+
+    mock_tok = MagicMock()
+    mock_tok._tok = MagicMock()
+    mock_tok._tok.eos_token_id = 2
+    mock_tok._tok.pad_token_id = 0
+
+    app = create_app(config)
+
+    pause_state = PauseState()
+    inf_bridge = InfBridge(
+        backend=SGLangBridgeBackend(),
+        backend_addr=config.backend_addr,
+        pause_state=pause_state,
+        request_timeout=config.request_timeout,
+        max_resubmit_retries=5,
+        resubmit_wait=0.01,
+    )
+    app.state.tokenizer = mock_tok
+    app.state.inf_bridge = inf_bridge
+    app.state.areal_client = mock_client
+    app.state.pause_state = pause_state
+    app.state.config = config
+    app.state.session_store = SessionStore()
+    app.state.version = 0
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c, mock_client
+
+
+class TestDataProxyImagePassthrough:
+    @pytest.mark.asyncio
+    async def test_image_url_messages_passed_through(self, image_test_client):
+        client, mock_areal = image_test_client
+        b64 = _make_png_base64(1, 1, "green")
+        data_uri = _make_data_uri(b64)
+
+        resp = await client.post(
+            "/chat/completions",
+            json={
+                "model": "vlm-model",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Describe this image"},
+                            {"type": "image_url", "image_url": {"url": data_uri}},
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["object"] == "chat.completion"
+        assert data["choices"][0]["message"]["content"] == "I see a red pixel."
+
+        assert len(mock_areal._captured_calls) == 1
+        call_kwargs = mock_areal._captured_calls[0]
+        messages = _materialize(call_kwargs["messages"])
+        assert isinstance(messages[0]["content"], list)
+        assert messages[0]["content"][1]["type"] == "image_url"
+        assert messages[0]["content"][1]["image_url"]["url"] == data_uri
+
+    @pytest.mark.asyncio
+    async def test_session_lifecycle_with_image_messages(self, image_test_client):
+        """Full lifecycle: start → image chat → reward → end → export."""
+        client, mock_areal = image_test_client
+        b64 = _make_png_base64(2, 2, "yellow")
+        data_uri = _make_data_uri(b64)
+
+        # 1. Start session
+        resp = await client.post(
+            "/rl/start_session",
+            json={"task_id": "vision-lifecycle"},
+            headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+        )
+        assert resp.status_code == 201
+        session_id = resp.json()["session_id"]
+        api_key = resp.json()["api_key"]
+
+        # 2. Chat with image
+        resp = await client.post(
+            "/chat/completions",
+            json={
+                "model": "vlm-model",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "What do you see?"},
+                            {"type": "image_url", "image_url": {"url": data_uri}},
+                        ],
+                    }
+                ],
+            },
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["object"] == "chat.completion"
+
+        # 3. Set reward
+        resp = await client.post(
+            "/rl/set_reward",
+            json={"reward": 1.0},
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200
+
+        # 4. End session
+        resp = await client.post(
+            "/rl/end_session",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["interaction_count"] == 1
+
+        # 5. Export trajectories
+        resp = await client.post(
+            "/export_trajectories",
+            json={
+                "session_id": session_id,
+                "discount": 1.0,
+                "style": "individual",
+            },
+            headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "interactions" in data
+        assert len(data["interactions"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_mixed_text_and_image_messages(self, image_test_client):
+        """Multiple messages with only some containing images."""
+        client, mock_areal = image_test_client
+        b64 = _make_png_base64(1, 1, "white")
+        data_uri = _make_data_uri(b64)
+
+        resp = await client.post(
+            "/chat/completions",
+            json={
+                "model": "vlm-model",
+                "messages": [
+                    {"role": "system", "content": "You are a vision assistant."},
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Look at this:"},
+                            {"type": "image_url", "image_url": {"url": data_uri}},
+                        ],
+                    },
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_areal._captured_calls[-1]
+        msgs = _materialize(call_kwargs["messages"])
+        assert msgs[0] == {"role": "system", "content": "You are a vision assistant."}
+        assert msgs[1]["content"][1]["type"] == "image_url"
+
+    @pytest.mark.asyncio
+    async def test_plain_text_still_works(self, image_test_client):
+        """Non-image requests still work after image support is added."""
+        client, mock_areal = image_test_client
+
+        resp = await client.post(
+            "/chat/completions",
+            json={
+                "model": "text-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_areal._captured_calls[-1]
+        msgs = _materialize(call_kwargs["messages"])
+        assert msgs[0] == {"role": "user", "content": "Hello"}
+
+
+# =========================================================================
+# _build_messages_list — Responses API input → Chat Completions messages
+# =========================================================================
+
+
+class TestBuildMessagesList:
+    def test_string_content(self):
+        result = _build_messages_list({"role": "user", "content": "Hello"})
+        assert result == [{"role": "user", "content": "Hello"}]
+
+    def test_output_text_flattened(self):
+        item = {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Answer A"}],
+        }
+        result = _build_messages_list(item)
+        assert result == [{"role": "assistant", "content": "Answer A"}]
+
+    def test_multiple_output_text_each_becomes_message(self):
+        item = {
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": "Part 1"},
+                {"type": "output_text", "text": "Part 2"},
+            ],
+        }
+        result = _build_messages_list(item)
+        assert result == [
+            {"role": "assistant", "content": "Part 1"},
+            {"role": "assistant", "content": "Part 2"},
+        ]
+
+    def test_input_text_flattened(self):
+        item = {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Describe this"}],
+        }
+        result = _build_messages_list(item)
+        assert result == [{"role": "user", "content": "Describe this"}]
+
+    def test_input_image_produces_multimodal_message(self, red_pixel_b64):
+        data_uri = _make_data_uri(red_pixel_b64)
+        item = {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "What is this?"},
+                {"type": "input_image", "image_url": data_uri},
+            ],
+        }
+        result = _build_messages_list(item)
+        assert len(result) == 1
+        msg = result[0]
+        assert msg["role"] == "user"
+        assert isinstance(msg["content"], list)
+        assert msg["content"][0] == {"type": "text", "text": "What is this?"}
+        assert msg["content"][1] == {
+            "type": "image_url",
+            "image_url": {"url": data_uri},
+        }
+
+    def test_input_image_with_detail_forwarded(self, red_pixel_b64):
+        data_uri = _make_data_uri(red_pixel_b64)
+        item = {
+            "role": "user",
+            "content": [
+                {"type": "input_image", "image_url": data_uri, "detail": "high"},
+            ],
+        }
+        result = _build_messages_list(item)
+        assert len(result) == 1
+        img_part = result[0]["content"][0]
+        assert img_part == {
+            "type": "image_url",
+            "image_url": {"url": data_uri, "detail": "high"},
+        }
+
+    def test_input_image_without_detail_omits_key(self, red_pixel_b64):
+        data_uri = _make_data_uri(red_pixel_b64)
+        item = {
+            "role": "user",
+            "content": [
+                {"type": "input_image", "image_url": data_uri},
+            ],
+        }
+        result = _build_messages_list(item)
+        img_part = result[0]["content"][0]
+        assert "detail" not in img_part["image_url"]
+
+    def test_input_image_missing_image_url_raises(self):
+        item = {
+            "role": "user",
+            "content": [{"type": "input_image"}],
+        }
+        with pytest.raises(ValueError, match="image_url"):
+            _build_messages_list(item)
+
+    def test_input_image_empty_image_url_raises(self):
+        item = {
+            "role": "user",
+            "content": [{"type": "input_image", "image_url": ""}],
+        }
+        with pytest.raises(ValueError, match="image_url"):
+            _build_messages_list(item)
+
+    def test_mixed_text_and_image(self, red_pixel_b64):
+        data_uri = _make_data_uri(red_pixel_b64)
+        item = {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Look at this image"},
+                {"type": "input_image", "image_url": data_uri},
+                {"type": "input_text", "text": "and describe it"},
+            ],
+        }
+        result = _build_messages_list(item)
+        assert len(result) == 1
+        parts = result[0]["content"]
+        assert len(parts) == 3
+        assert parts[0] == {"type": "text", "text": "Look at this image"}
+        assert parts[1]["type"] == "image_url"
+        assert parts[2] == {"type": "text", "text": "and describe it"}
+
+    def test_unsupported_content_type_raises(self):
+        item = {
+            "role": "user",
+            "content": [{"type": "input_file", "file_id": "file-123"}],
+        }
+        with pytest.raises(ValueError, match="Unsupported content format: input_file"):
+            _build_messages_list(item)
+
+    def test_non_dict_content_part_raises(self):
+        item = {
+            "role": "user",
+            "content": ["plain string"],
+        }
+        with pytest.raises(ValueError, match="Unsupported content format"):
+            _build_messages_list(item)
+
+    def test_function_call_output_converted(self):
+        item = {
+            "type": "function_call_output",
+            "call_id": "call_abc",
+            "output": '{"result": 42}',
+        }
+        result = _build_messages_list(item)
+        assert len(result) == 1
+        assert result[0]["role"] == "tool"
+        assert result[0]["content"] == '{"result": 42}'
+        assert result[0]["tool_call_id"] == "call_abc"
+
+    def test_function_call_output_without_call_id(self):
+        item = {
+            "type": "function_call_output",
+            "output": "done",
+        }
+        result = _build_messages_list(item)
+        assert len(result) == 1
+        assert result[0]["role"] == "tool"
+        assert result[0]["content"] == "done"
+        assert "tool_call_id" not in result[0]
+
+
+# =========================================================================
+# _extract_images_from_messages — empty URL validation
+# =========================================================================
+
+
+class TestExtractImagesValidation:
+    def test_empty_url_raises(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": ""}},
+                ],
+            }
+        ]
+        with pytest.raises(ValueError, match="empty or missing URL"):
+            _extract_images_from_messages(messages)
+
+    def test_missing_url_key_raises(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {}},
+                ],
+            }
+        ]
+        with pytest.raises(ValueError, match="empty or missing URL"):
+            _extract_images_from_messages(messages)
+
+    def test_missing_image_url_obj_raises(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url"},
+                ],
+            }
+        ]
+        with pytest.raises(ValueError, match="empty or missing URL"):
+            _extract_images_from_messages(messages)
+
+    def test_non_dict_image_url_obj_raises(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": "not-a-dict"},
+                ],
+            }
+        ]
+        with pytest.raises(ValueError, match="empty or missing URL"):
+            _extract_images_from_messages(messages)


### PR DESCRIPTION
## Description

Add image input support to the inference service's OpenAI-compatible client, enabling VLM models (e.g., Qwen3-VL) to receive `image_url` content parts through both the Chat Completions and Responses APIs. Images are extracted from messages, forwarded as base64 data to SGLang/vLLM backends, and tokenized with HF-compatible image placeholders. Includes input validation for empty/missing image URLs and comprehensive test coverage (41 unit tests + 6 GPU integration tests).

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [x] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Key changes:
- `areal/experimental/openai/client.py`: Add `_extract_images_from_messages()` to parse OpenAI-format `image_url` content parts. Extract `_build_messages_list()` to module level for Responses API `input_image`/`input_text`/`output_text` conversion with validation. Update `AsyncCompletionsWithReward.create()` and `AsyncResponsesWithReward.create()` to extract images before tokenization, set `image_data` and `vision_msg_vllm` on `ModelRequest`. Validate empty/missing image URLs with clear error messages. Forward `detail` field from Responses API `input_image` content parts.
- `areal/experimental/inference_service/data_proxy/backend.py`: Forward `image_data` in `SGLangBridgeBackend` payload.
- `tests/experimental/inference_service/test_image_input.py`: 41 unit tests covering image extraction, Responses API message conversion, SGLang/vLLM payload construction, InfBridge persistence, data proxy passthrough, and input validation.
- `tests/experimental/inference_service/test_controller_integration.py`: 6 GPU integration tests (3 SGLang + 3 vLLM) using Qwen3-VL-2B with real PNG images. Reduced GPU memory fractions (non-VLM: 0.15, VLM: 0.25) so module-scoped server fixtures coexist on a single CI GPU without OOM.

Implementation verified against SGLang's `process_content_for_template_format()` and OpenAI SDK v2.29.0 type definitions. GPU integration tests require a Qwen3-VL-2B-capable GPU — not runnable locally.