### PR TITLE
docs: add Trackio configuration to CLI reference

### DIFF
--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -66,6 +66,7 @@ For detailed examples, see the experiment configurations in the `examples/` dire
 - [StatsLogger Configuration](section-stats-logger)
 - [Swanlab Configuration](section-swanlab)
 - [TensorBoard Configuration](section-tensor-board)
+- [Trackio Configuration](section-trackio)
 - [WandB Configuration](section-wand-b)
 
 ### Others
@@ -742,14 +743,15 @@ Configuration for model checkpoint saving scheduling and timing.
 
 Configuration for experiment statistics logging and tracking services.
 
-| Parameter         | Type                                        | Default      | Description                                            |
-| ----------------- | ------------------------------------------- | ------------ | ------------------------------------------------------ |
-| `experiment_name` | string                                      | **Required** | -                                                      |
-| `trial_name`      | string                                      | **Required** | -                                                      |
-| `fileroot`        | string                                      | **Required** | -                                                      |
-| `wandb`           | [`WandBConfig`](section-wand-b)             | **Required** | Weights & Biases configuration.                        |
-| `swanlab`         | [`SwanlabConfig`](section-swanlab)          | **Required** | SwanLab configuration.                                 |
-| `tensorboard`     | [`TensorBoardConfig`](section-tensor-board) | **Required** | TensorBoard configuration. Only 'path' field required. |
+| Parameter         | Type                                        | Default      | Description                                               |
+| ----------------- | ------------------------------------------- | ------------ | --------------------------------------------------------- |
+| `experiment_name` | string                                      | **Required** | -                                                         |
+| `trial_name`      | string                                      | **Required** | -                                                         |
+| `fileroot`        | string                                      | **Required** | -                                                         |
+| `wandb`           | [`WandBConfig`](section-wand-b)             | **Required** | Weights & Biases configuration.                           |
+| `swanlab`         | [`SwanlabConfig`](section-swanlab)          | **Required** | SwanLab configuration.                                    |
+| `tensorboard`     | [`TensorBoardConfig`](section-tensor-board) | **Required** | TensorBoard configuration. Only 'path' field required.    |
+| `trackio`         | [`TrackioConfig`](section-trackio)          | **Required** | Trackio configuration (Hugging Face experiment tracking). |
 
 (section-swanlab)=
 
@@ -775,6 +777,27 @@ Configuration for TensorBoard logging and visualization.
 | Parameter | Type           | Default | Description |
 | --------- | -------------- | ------- | ----------- |
 | `path`    | string \| None | `None`  | -           |
+
+(section-trackio)=
+
+## Trackio Configuration
+
+Configuration for Trackio experiment tracking (Hugging Face).
+
+Trackio is a lightweight, local-first experiment tracking library with a
+wandb-compatible API. Dashboards can be viewed locally or deployed to Hugging Face
+Spaces.
+
+```
+See: https://github.com/gradio-app/trackio
+```
+
+| Parameter  | Type           | Default      | Description |
+| ---------- | -------------- | ------------ | ----------- |
+| `mode`     | string         | `"disabled"` | -           |
+| `project`  | string \| None | `None`       | -           |
+| `name`     | string \| None | `None`       | -           |
+| `space_id` | string \| None | `None`       | -           |
 
 (section-wand-b)=
 

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -64,6 +64,7 @@ python3 train.py --config path/to/config.yaml actor.lr=1e-4 seed=42
 - [StatsLogger Configuration](section-stats-logger)
 - [Swanlab Configuration](section-swanlab)
 - [TensorBoard Configuration](section-tensor-board)
+- [Trackio Configuration](section-trackio)
 - [WandB Configuration](section-wand-b)
 
 ### Others
@@ -740,14 +741,15 @@ Configuration for model checkpoint saving scheduling and timing.
 
 Configuration for experiment statistics logging and tracking services.
 
-| Parameter         | Type                                        | Default      | Description                                            |
-| ----------------- | ------------------------------------------- | ------------ | ------------------------------------------------------ |
-| `experiment_name` | string                                      | **Required** | -                                                      |
-| `trial_name`      | string                                      | **Required** | -                                                      |
-| `fileroot`        | string                                      | **Required** | -                                                      |
-| `wandb`           | [`WandBConfig`](section-wand-b)             | **Required** | Weights & Biases configuration.                        |
-| `swanlab`         | [`SwanlabConfig`](section-swanlab)          | **Required** | SwanLab configuration.                                 |
-| `tensorboard`     | [`TensorBoardConfig`](section-tensor-board) | **Required** | TensorBoard configuration. Only 'path' field required. |
+| Parameter         | Type                                        | Default      | Description                                               |
+| ----------------- | ------------------------------------------- | ------------ | --------------------------------------------------------- |
+| `experiment_name` | string                                      | **Required** | -                                                         |
+| `trial_name`      | string                                      | **Required** | -                                                         |
+| `fileroot`        | string                                      | **Required** | -                                                         |
+| `wandb`           | [`WandBConfig`](section-wand-b)             | **Required** | Weights & Biases configuration.                           |
+| `swanlab`         | [`SwanlabConfig`](section-swanlab)          | **Required** | SwanLab configuration.                                    |
+| `tensorboard`     | [`TensorBoardConfig`](section-tensor-board) | **Required** | TensorBoard configuration. Only 'path' field required.    |
+| `trackio`         | [`TrackioConfig`](section-trackio)          | **Required** | Trackio configuration (Hugging Face experiment tracking). |
 
 (section-swanlab)=
 
@@ -773,6 +775,27 @@ Configuration for TensorBoard logging and visualization.
 | Parameter | Type           | Default | Description |
 | --------- | -------------- | ------- | ----------- |
 | `path`    | string \| None | `None`  | -           |
+
+(section-trackio)=
+
+## Trackio Configuration
+
+Configuration for Trackio experiment tracking (Hugging Face).
+
+Trackio is a lightweight, local-first experiment tracking library with a
+wandb-compatible API. Dashboards can be viewed locally or deployed to Hugging Face
+Spaces.
+
+```
+See: https://github.com/gradio-app/trackio
+```
+
+| Parameter  | Type           | Default      | Description |
+| ---------- | -------------- | ------------ | ----------- |
+| `mode`     | string         | `"disabled"` | -           |
+| `project`  | string \| None | `None`       | -           |
+| `name`     | string \| None | `None`       | -           |
+| `space_id` | string \| None | `None`       | -           |
 
 (section-wand-b)=
 


### PR DESCRIPTION
## Description

Add TrackioConfig section to both English and Chinese CLI reference docs, documenting `mode`, `project`, `name`, and `space_id` parameters for Hugging Face experiment tracking. This follows up on the Trackio backend added in #1113.

## Related Issue

Follow-up to #1113

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Files changed:
- `docs/en/cli_reference.md` — Add Trackio TOC entry + TrackioConfig section
- `docs/zh/cli_reference.md` — Add Trackio TOC entry + TrackioConfig section (Chinese)