### PR TITLE
fix(api): add mode validation for WandBConfig and SwanlabConfig

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1968,7 +1968,13 @@ class RecoverConfig(_Timer):
 class WandBConfig:
     """Configuration for Weights & Biases experiment tracking."""
 
-    mode: str = "disabled"
+    mode: str = field(
+        default="disabled",
+        metadata={
+            "help": "Tracking mode. One of 'online', 'offline', 'disabled', or 'shared'.",
+            "choices": ["online", "offline", "disabled", "shared"],
+        },
+    )
     wandb_base_url: str = ""
     wandb_api_key: str = ""
     entity: str | None = None
@@ -1981,6 +1987,14 @@ class WandBConfig:
     config: dict | None = None
     id_suffix: str | None = "train"
 
+    def __post_init__(self):
+        """Validate WandB configuration."""
+        valid_modes = ("online", "offline", "disabled", "shared")
+        if self.mode not in valid_modes:
+            raise ValueError(
+                f"Invalid wandb mode: '{self.mode}'. Must be one of: {', '.join(valid_modes)}."
+            )
+
 
 @dataclass
 class SwanlabConfig:
@@ -1990,11 +2004,23 @@ class SwanlabConfig:
     name: str | None = None
     config: dict | None = None
     logdir: str | None = None
-    mode: str | None = "disabled"
+    mode: str = field(
+        default="disabled",
+        metadata={
+            "help": "Tracking mode. One of 'cloud', 'local', 'disabled', or 'offline'.",
+            "choices": ["cloud", "local", "disabled", "offline"],
+        },
+    )
     # set None to prevent info-leak in docs
     api_key: str | None = None
 
     def __post_init__(self):
+        """Validate SwanLab configuration."""
+        valid_modes = ("cloud", "local", "disabled", "offline")
+        if self.mode not in valid_modes:
+            raise ValueError(
+                f"Invalid swanlab mode: '{self.mode}'. Must be one of: {', '.join(valid_modes)}."
+            )
         if self.api_key is None:
             self.api_key = os.getenv("SWANLAB_API_KEY")
 

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -759,14 +759,14 @@ Configuration for experiment statistics logging and tracking services.
 
 Configuration for SwanLab experiment tracking and monitoring.
 
-| Parameter | Type           | Default      | Description |
-| --------- | -------------- | ------------ | ----------- |
-| `project` | string \| None | `None`       | -           |
-| `name`    | string \| None | `None`       | -           |
-| `config`  | `dict` \| None | `None`       | -           |
-| `logdir`  | string \| None | `None`       | -           |
-| `mode`    | string \| None | `"disabled"` | -           |
-| `api_key` | string \| None | `None`       | -           |
+| Parameter | Type           | Default      | Description                                                                                                            |
+| --------- | -------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `project` | string \| None | `None`       | -                                                                                                                      |
+| `name`    | string \| None | `None`       | -                                                                                                                      |
+| `config`  | `dict` \| None | `None`       | -                                                                                                                      |
+| `logdir`  | string \| None | `None`       | -                                                                                                                      |
+| `mode`    | string         | `"disabled"` | Tracking mode. One of 'cloud', 'local', 'disabled', or 'offline'. **Choices:** `cloud`, `local`, `disabled`, `offline` |
+| `api_key` | string \| None | `None`       | -                                                                                                                      |
 
 (section-tensor-board)=
 
@@ -805,20 +805,20 @@ See: https://github.com/gradio-app/trackio
 
 Configuration for Weights & Biases experiment tracking.
 
-| Parameter        | Type                   | Default      | Description |
-| ---------------- | ---------------------- | ------------ | ----------- |
-| `mode`           | string                 | `"disabled"` | -           |
-| `wandb_base_url` | string                 | `""`         | -           |
-| `wandb_api_key`  | string                 | `""`         | -           |
-| `entity`         | string \| None         | `None`       | -           |
-| `project`        | string \| None         | `None`       | -           |
-| `name`           | string \| None         | `None`       | -           |
-| `job_type`       | string \| None         | `None`       | -           |
-| `group`          | string \| None         | `None`       | -           |
-| `notes`          | string \| None         | `None`       | -           |
-| `tags`           | list of string \| None | `None`       | -           |
-| `config`         | `dict` \| None         | `None`       | -           |
-| `id_suffix`      | string \| None         | `"train"`    | -           |
+| Parameter        | Type                   | Default      | Description                                                                                                                |
+| ---------------- | ---------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `mode`           | string                 | `"disabled"` | Tracking mode. One of 'online', 'offline', 'disabled', or 'shared'. **Choices:** `online`, `offline`, `disabled`, `shared` |
+| `wandb_base_url` | string                 | `""`         | -                                                                                                                          |
+| `wandb_api_key`  | string                 | `""`         | -                                                                                                                          |
+| `entity`         | string \| None         | `None`       | -                                                                                                                          |
+| `project`        | string \| None         | `None`       | -                                                                                                                          |
+| `name`           | string \| None         | `None`       | -                                                                                                                          |
+| `job_type`       | string \| None         | `None`       | -                                                                                                                          |
+| `group`          | string \| None         | `None`       | -                                                                                                                          |
+| `notes`          | string \| None         | `None`       | -                                                                                                                          |
+| `tags`           | list of string \| None | `None`       | -                                                                                                                          |
+| `config`         | `dict` \| None         | `None`       | -                                                                                                                          |
+| `id_suffix`      | string \| None         | `"train"`    | -                                                                                                                          |
 
 (section-archon-engine)=
 

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -757,14 +757,14 @@ Configuration for experiment statistics logging and tracking services.
 
 Configuration for SwanLab experiment tracking and monitoring.
 
-| Parameter | Type           | Default      | Description |
-| --------- | -------------- | ------------ | ----------- |
-| `project` | string \| None | `None`       | -           |
-| `name`    | string \| None | `None`       | -           |
-| `config`  | `dict` \| None | `None`       | -           |
-| `logdir`  | string \| None | `None`       | -           |
-| `mode`    | string \| None | `"disabled"` | -           |
-| `api_key` | string \| None | `None`       | -           |
+| Parameter | Type           | Default      | Description                                                                                                            |
+| --------- | -------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `project` | string \| None | `None`       | -                                                                                                                      |
+| `name`    | string \| None | `None`       | -                                                                                                                      |
+| `config`  | `dict` \| None | `None`       | -                                                                                                                      |
+| `logdir`  | string \| None | `None`       | -                                                                                                                      |
+| `mode`    | string         | `"disabled"` | Tracking mode. One of 'cloud', 'local', 'disabled', or 'offline'. **Choices:** `cloud`, `local`, `disabled`, `offline` |
+| `api_key` | string \| None | `None`       | -                                                                                                                      |
 
 (section-tensor-board)=
 
@@ -803,20 +803,20 @@ See: https://github.com/gradio-app/trackio
 
 Configuration for Weights & Biases experiment tracking.
 
-| Parameter        | Type                   | Default      | Description |
-| ---------------- | ---------------------- | ------------ | ----------- |
-| `mode`           | string                 | `"disabled"` | -           |
-| `wandb_base_url` | string                 | `""`         | -           |
-| `wandb_api_key`  | string                 | `""`         | -           |
-| `entity`         | string \| None         | `None`       | -           |
-| `project`        | string \| None         | `None`       | -           |
-| `name`           | string \| None         | `None`       | -           |
-| `job_type`       | string \| None         | `None`       | -           |
-| `group`          | string \| None         | `None`       | -           |
-| `notes`          | string \| None         | `None`       | -           |
-| `tags`           | list of string \| None | `None`       | -           |
-| `config`         | `dict` \| None         | `None`       | -           |
-| `id_suffix`      | string \| None         | `"train"`    | -           |
+| Parameter        | Type                   | Default      | Description                                                                                                                |
+| ---------------- | ---------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `mode`           | string                 | `"disabled"` | Tracking mode. One of 'online', 'offline', 'disabled', or 'shared'. **Choices:** `online`, `offline`, `disabled`, `shared` |
+| `wandb_base_url` | string                 | `""`         | -                                                                                                                          |
+| `wandb_api_key`  | string                 | `""`         | -                                                                                                                          |
+| `entity`         | string \| None         | `None`       | -                                                                                                                          |
+| `project`        | string \| None         | `None`       | -                                                                                                                          |
+| `name`           | string \| None         | `None`       | -                                                                                                                          |
+| `job_type`       | string \| None         | `None`       | -                                                                                                                          |
+| `group`          | string \| None         | `None`       | -                                                                                                                          |
+| `notes`          | string \| None         | `None`       | -                                                                                                                          |
+| `tags`           | list of string \| None | `None`       | -                                                                                                                          |
+| `config`         | `dict` \| None         | `None`       | -                                                                                                                          |
+| `id_suffix`      | string \| None         | `"train"`    | -                                                                                                                          |
 
 (section-archon-engine)=
 


### PR DESCRIPTION
## Description

Add `__post_init__` validation for tracking mode fields in `WandBConfig` and `SwanlabConfig` to catch configuration errors early. Also fix type hint inconsistency in `SwanlabConfig.mode` (`str | None` → `str`) to align with validation behavior.

## Related Issue

None

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My branch is up to date with main
- [x] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

Invalid mode values that were previously silently accepted will now raise `ValueError` at config initialization. This helps users catch configuration errors early rather than failing silently.

## Additional Context

Files changed:
- `areal/api/cli_args.py`: Add validation and docstrings for mode fields
- `docs/en/cli_reference.md`: Update SwanlabConfig.mode type in docs
- `docs/zh/cli_reference.md`: Update SwanlabConfig.mode type in docs