### PR TITLE
fix(engine): for broken tree training due to bad indent in PR #1056

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -262,15 +262,15 @@ class MegatronEngine(TrainEngine):
             self._check_and_apply_fp8_config()
             self._validate_fp8_consistency()
 
-        with self.device:
-            models = make_mcore_model(
-                hf_config=self.hf_config,
-                tf_config=self.tf_config,
-                mcore_config=self.mcore_config,
-                bridge=self.bridge,
-                bridge_type=self.bridge_cls,
-                is_critic=self.config.is_critic,
-            )
+            with self.device:
+                models = make_mcore_model(
+                    hf_config=self.hf_config,
+                    tf_config=self.tf_config,
+                    mcore_config=self.mcore_config,
+                    bridge=self.bridge,
+                    bridge_type=self.bridge_cls,
+                    is_critic=self.config.is_critic,
+                )
 
         self.model = _MegatronModelList(models)
 


### PR DESCRIPTION
## Description

This fixes a regression introduced in PR #1056, feat: megatron bridge adaptation.

In that PR, the tree-training bridge patch scope in megatron_engine.py was accidentally narrowed by indentation, so make_mcore_model was no longer covered by patch_bridge_for_tree_training. As a result, tree-training behavior could be skipped or incorrectly initialized for Megatron Bridge paths.

This fix restores the correct scope so model construction remains inside the intended tree-training patch context.

## Related Issue

Fixes: bug raised by [szluyu99](https://github.com/szluyu99) in #1056

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Testing
- 2-step smoke run passed for mbridge
- 2-step smoke run passed for megatron-bridge
- 2-step mbridge tree-training smoke passed with tree overrides:
  - +actor.enable_tree_training=true
  - +actor.pad_to_maximum=true
- Runtime evidence confirms tree path activation:
  - “Using PytorchFlexAttention for tree training attention” in the tree-training smoke test