### PR TITLE
feat(service): add vllm backend support for inference service demo

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -746,6 +746,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
                     self.tool_call_parser,
                     self.reasoning_parser,
                     response.stop_reason,
+                    tokenizer=self.tokenizer,
                 )
         except json.JSONDecodeError as e:
             logger.warning(
@@ -1103,6 +1104,7 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
                     self.reasoning_parser,
                     engine_resp.stop_reason,
                     use_responses=True,
+                    tokenizer=self.tokenizer,
                 )
         except json.JSONDecodeError as e:
             logger.warning(

--- a/areal/experimental/openai/tool_call_parser.py
+++ b/areal/experimental/openai/tool_call_parser.py
@@ -1,5 +1,6 @@
 import traceback
 import uuid
+from types import SimpleNamespace
 from typing import Any
 
 from openai.types.chat.chat_completion_message_function_tool_call import (
@@ -11,6 +12,21 @@ from openai.types.responses.response_function_tool_call import ResponseFunctionT
 from areal.utils import logging
 
 logger = logging.getLogger("ToolCallParser")
+
+_SGLANG_TO_VLLM_TOOL_PARSER: dict[str, str] = {
+    "qwen": "qwen3_xml",
+    "qwen25": "qwen3_xml",
+    "qwen3": "qwen3_xml",
+    "qwen3_xml": "qwen3_xml",
+    "qwen3_coder": "qwen3_coder",
+    "hermes": "hermes",
+    "llama3": "llama3_json",
+    "llama3_json": "llama3_json",
+    "llama4_json": "llama4_json",
+    "mistral": "mistral",
+    "openai": "openai",
+    "deepseek_v3": "deepseek_v3",
+}
 
 
 def _detect_think_and_return_ori_think(
@@ -40,8 +56,7 @@ def _detect_think_and_return_ori_think(
     return think_start_token + reasoning_text + think_end_token, normal_text
 
 
-# Modified from sglang
-def process_tool_calls(
+def _process_tool_calls_sglang(
     text: str,
     tools: list[Any],
     tool_call_parser: str,
@@ -53,7 +68,6 @@ def process_tool_calls(
     str,
     str,
 ]:
-    """Process tool calls in the response"""
     from sglang.srt.entrypoints.openai.protocol import Function as SglFunction
     from sglang.srt.entrypoints.openai.protocol import Tool as SglTool
     from sglang.srt.function_call.function_call_parser import FunctionCallParser
@@ -120,7 +134,163 @@ def process_tool_calls(
         except Exception as e:
             logger.error(f"Tool call parsing error: {e}")
             traceback.print_exc()
-            # Return error but don't fail the whole request
             return None, text, finish_reason
 
+    return None, text, finish_reason
+
+
+def _process_tool_calls_vllm(
+    text: str,
+    tools: list[Any],
+    tool_call_parser: str,
+    reasoning_parser: str,
+    finish_reason: str,
+    use_responses: bool = False,
+    tokenizer: Any = None,
+) -> tuple[
+    list[ChatCompletionMessageFunctionToolCall | ResponseFunctionToolCall] | None,
+    str,
+    str,
+]:
+    from vllm.reasoning import ReasoningParserManager
+    from vllm.tool_parsers import ToolParserManager
+
+    # Use vllm's reasoning parser to get the think start/end tokens,
+    # mirroring the sglang path which uses ReasoningParser.detector tokens.
+    if tokenizer is not None and reasoning_parser:
+        try:
+            reasoning_parser_cls = ReasoningParserManager.get_reasoning_parser(
+                reasoning_parser
+            )
+            reasoning_parser_inst = reasoning_parser_cls(tokenizer)
+            if hasattr(reasoning_parser_inst, "start_token") and hasattr(
+                reasoning_parser_inst, "end_token"
+            ):
+                reasoning_text, content_text = _detect_think_and_return_ori_think(
+                    text,
+                    reasoning_parser_inst.start_token,
+                    reasoning_parser_inst.end_token,
+                )
+            else:
+                reasoning_text, content_text = "", text
+        except Exception as e:
+            logger.warning(
+                "Failed to initialize vLLM reasoning parser '%s': %s. "
+                "Skipping reasoning extraction.",
+                reasoning_parser,
+                e,
+            )
+            reasoning_text, content_text = "", text
+    else:
+        reasoning_text, content_text = "", text
+
+    vllm_name = _SGLANG_TO_VLLM_TOOL_PARSER.get(tool_call_parser, tool_call_parser)
+    try:
+        tool_parser_cls = ToolParserManager.get_tool_parser(vllm_name)
+    except KeyError:
+        logger.warning(
+            "vLLM tool parser '%s' (mapped from '%s') not found; skipping tool call parsing.",
+            vllm_name,
+            tool_call_parser,
+        )
+        return None, text, finish_reason
+
+    if tokenizer is None:
+        logger.warning(
+            "vLLM tool parser requires a tokenizer but none was provided; skipping tool call parsing."
+        )
+        return None, text, finish_reason
+
+    tool_parser = tool_parser_cls(tokenizer)
+    request = SimpleNamespace(
+        tools=tools,
+        tool_choice=None,
+        skip_special_tokens=True,
+    )
+
+    try:
+        tool_call_info = tool_parser.extract_tool_calls(content_text, request)
+    except Exception as e:
+        logger.error("vLLM tool call parsing error: %s", e)
+        traceback.print_exc()
+        return None, text, finish_reason
+
+    if not tool_call_info.tools_called:
+        return None, text, finish_reason
+
+    if finish_reason == "stop":
+        finish_reason = "tool_calls"
+
+    remaining_content = tool_call_info.content or ""
+
+    if use_responses:
+        result_tool_calls = [
+            ResponseFunctionToolCall(
+                type="function_call",
+                id=f"fc-{uuid.uuid4().hex[:24]}",
+                call_id=f"call_{uuid.uuid4().hex[:24]}",
+                name=tc.function.name,
+                arguments=tc.function.arguments,
+                status="completed",
+            )
+            for tc in tool_call_info.tool_calls
+        ]
+    else:
+        result_tool_calls = [
+            ChatCompletionMessageFunctionToolCall(
+                type="function",
+                id=f"call_{uuid.uuid4().hex[:24]}",
+                function=Function(
+                    name=tc.function.name,
+                    arguments=tc.function.arguments,
+                ),
+            )
+            for tc in tool_call_info.tool_calls
+        ]
+
+    return result_tool_calls, reasoning_text + remaining_content, finish_reason
+
+
+def process_tool_calls(
+    text: str,
+    tools: list[Any],
+    tool_call_parser: str,
+    reasoning_parser: str,
+    finish_reason: str,
+    use_responses: bool = False,
+    tokenizer: Any = None,
+) -> tuple[
+    list[ChatCompletionMessageFunctionToolCall | ResponseFunctionToolCall] | None,
+    str,
+    str,
+]:
+    """Process tool calls in the response"""
+    try:
+        return _process_tool_calls_sglang(
+            text,
+            tools,
+            tool_call_parser,
+            reasoning_parser,
+            finish_reason,
+            use_responses,
+        )
+    except ModuleNotFoundError:
+        pass
+
+    try:
+        return _process_tool_calls_vllm(
+            text,
+            tools,
+            tool_call_parser,
+            reasoning_parser,
+            finish_reason,
+            use_responses,
+            tokenizer=tokenizer,
+        )
+    except ModuleNotFoundError:
+        pass
+
+    logger.warning(
+        "Neither sglang nor vllm is installed; skipping tool call parsing. Install one of them for tool call support."
+    )
     return None, text, finish_reason

--- a/examples/experimental/inference_service/human_in_the_loop_demo.py
+++ b/examples/experimental/inference_service/human_in_the_loop_demo.py
@@ -36,6 +36,7 @@ DEFAULT_ADMIN_KEY = "sk-test123456"
 DEFAULT_REQUEST_TIMEOUT = 3600
 DEFAULT_GATEWAY_WAIT_SECS = 600
 DEFAULT_QUESTION = "how many r's are in the word strawberry?"
+DEFAULT_INFERENCE_BACKEND = "sglang"
 CORRECT_ANSWER_RE = re.compile(r"\b3\b|three", re.IGNORECASE)
 BATCH_SIZE = 4
 ROLLOUT_COMPLETE_WAIT_SECS = 60
@@ -207,6 +208,12 @@ def main() -> None:
     parser.add_argument(
         "--question", default=DEFAULT_QUESTION, help="Question for each HITL round"
     )
+    parser.add_argument(
+        "--inference-backend",
+        choices=("sglang", "vllm"),
+        default=DEFAULT_INFERENCE_BACKEND,
+        help="Inference backend used by online_rollout.py",
+    )
     args = parser.parse_args()
 
     online_rollout = (
@@ -248,6 +255,8 @@ def main() -> None:
                 "--config",
                 str(config_yaml),
                 f"actor.path={args.actor_path}",
+                f"rollout.backend={args.inference_backend}:d1",
+                f"rollout.openai.admin_api_key={args.admin_key}",
                 f"rollout.request_timeout={args.request_timeout}",
             ],
             stdout=log_fh,

--- a/examples/experimental/inference_service/online_rollout.py
+++ b/examples/experimental/inference_service/online_rollout.py
@@ -14,6 +14,7 @@ def main(args: list[str]) -> None:
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
 
+    from areal.api.alloc_mode import ModelAllocation
     from areal.api.cli_args import PPOConfig, load_expr_config
     from areal.experimental.inference_service.controller.config import (
         GatewayControllerConfig,
@@ -37,14 +38,6 @@ def main(args: list[str]) -> None:
         raise NotImplementedError(
             "online_rollout.py requires single-controller execution (for example: scheduler.type=local)."
         )
-    from areal.api.alloc_mode import ModelAllocation
-
-    rollout_alloc = ModelAllocation.from_str(config.rollout.backend)
-    if rollout_alloc.backend == "vllm":
-        raise NotImplementedError(
-            "online_rollout.py currently supports only the SGLang generation backend."
-        )
-
     from areal.infra.scheduler.local import LocalScheduler
     from areal.infra.scheduler.slurm import SlurmScheduler
 
@@ -74,12 +67,19 @@ def main(args: list[str]) -> None:
         request_timeout=config.rollout.request_timeout,
         openai=openai_cfg,
     )
+    rollout_alloc = ModelAllocation.from_str(config.rollout.backend, name="rollout")
+    if rollout_alloc.backend == "sglang":
+        server_args = asdict(config.sglang)
+    elif rollout_alloc.backend == "vllm":
+        server_args = asdict(config.vllm)
+    else:
+        raise ValueError(f"Unsupported rollout backend: {rollout_alloc.backend}")
 
     ctrl = GatewayInferenceController(config=ctrl_config, scheduler=scheduler)
     try:
         ctrl.initialize(
             role="rollout",
-            server_args=asdict(config.sglang),
+            server_args=server_args,
         )
 
         logger.info("Proxy gateway available at %s", ctrl.proxy_gateway_addr)

--- a/examples/experimental/inference_service/tau2_rollout.py
+++ b/examples/experimental/inference_service/tau2_rollout.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from datasets import Dataset
 
+from areal.api.alloc_mode import ModelAllocation
 from areal.api.cli_args import (
     BaseExperimentConfig,
     GenerationHyperparameters,
@@ -210,12 +211,18 @@ def main(argv: list[str]) -> None:
         raise NotImplementedError(f"Unknown scheduler type: {sched_type}")
 
     # --- Controller ---
-    sglang_args = asdict(config.sglang)
+    rollout_alloc = ModelAllocation.from_str(config.rollout.backend, name="rollout")
+    if rollout_alloc.backend == "sglang":
+        server_args = asdict(config.sglang)
+    elif rollout_alloc.backend == "vllm":
+        server_args = asdict(config.vllm)
+    else:
+        raise ValueError(f"Unsupported rollout backend: {rollout_alloc.backend}")
 
     ctrl = GatewayInferenceController(config=ctrl_config, scheduler=scheduler)
     ctrl.initialize(
         role="rollout",
-        server_args=sglang_args,
+        server_args=server_args,
     )
 
     # --- Workflow kwargs (identical to examples/tau2/train.py) ---

--- a/tests/experimental/openai/test_tool_call_parser.py
+++ b/tests/experimental/openai/test_tool_call_parser.py
@@ -1,15 +1,11 @@
+from types import SimpleNamespace
+
 import pytest
+from openai.types.chat import ChatCompletionMessageToolCall, ChatCompletionToolParam
 
-# This module requires sglang (tool_call_parser imports sglang internals)
-pytest.importorskip("sglang", reason="sglang is required for tool_call_parser tests")
-pytestmark = pytest.mark.sglang
+from areal.experimental.openai import tool_call_parser as parser_module
 
-# Tools constructed as Iterable[ChatCompletionToolParam]
-from openai.types.chat import ChatCompletionToolParam  # noqa: E402
-
-from areal.experimental.openai.tool_call_parser import process_tool_calls  # noqa: E402
-
-tools: list[ChatCompletionToolParam] = [
+TOOLS: list[ChatCompletionToolParam] = [
     {
         "type": "function",
         "function": {
@@ -55,43 +51,29 @@ tools: list[ChatCompletionToolParam] = [
     },
 ]
 
+TEXT = (
+    '<think>\nOkay, so the user is asking whether the director of "Scary Movie" and the director of "The Preacher\'s Wife" are from the same country. Let me think about how to approach this.\n\n'
+    'First, I need to confirm the countries of these directors. I remember that "Scary Movie" is directed by Joe Anderson, and "The Preacher\'s Wife" is directed by David Fincher. Wait, but actually, "The Preacher\'s Wife" is directed by Christopher Nolan and David Fincher? No, I think I mixed up. Let me check my memory. \n\n'
+    "Wait, no. The Preacher's Wife is a movie directed by Christopher Nolan. And David Fincher directed The Preacher. So the directors are different. Then the user is asking if they are both from the same country. The answer would be no, because the two directors are from different countries. \n\n"
+    'But maybe I should verify this to be sure. Since I can use the web search function, I should use the "access" tool to get the URLs of the directors\' websites to confirm. So first, I\'ll search for "director of Scary Movie country" and "director of The Preacher\'s Wife country" to get precise data. Then, analyze the results to see if they have the same country affiliations.\n</think>\n\n'
+    '<tool_call>\n{"name": "search", "arguments": {"query": "director of Scary Movie country"}}\n</tool_call>\n\n'
+    '<tool_call>\n{"name": "search", "arguments": {"query": "director of The Preacher\'s Wife country"}}\n</tool_call><|im_end|>'
+)
 
-def test_process_tool_calls_qwen25_chat_completions():
-    """
-    Validate that process_tool_calls extracts tool calls from assistant text
-    using the qwen25 parser and returns ChatCompletionMessageToolCall entries
-    when use_responses=False.
-    """
-    text = (
-        '<think>\nOkay, so the user is asking whether the director of "Scary Movie" and the director of "The Preacher\'s Wife" are from the same country. Let me think about how to approach this.\n\n'
-        'First, I need to confirm the countries of these directors. I remember that "Scary Movie" is directed by Joe Anderson, and "The Preacher\'s Wife" is directed by David Fincher. Wait, but actually, "The Preacher\'s Wife" is directed by Christopher Nolan and David Fincher? No, I think I mixed up. Let me check my memory. \n\n'
-        "Wait, no. The Preacher's Wife is a movie directed by Christopher Nolan. And David Fincher directed The Preacher. So the directors are different. Then the user is asking if they are both from the same country. The answer would be no, because the two directors are from different countries. \n\n"
-        'But maybe I should verify this to be sure. Since I can use the web search function, I should use the "access" tool to get the URLs of the directors\' websites to confirm. So first, I\'ll search for "director of Scary Movie country" and "director of The Preacher\'s Wife country" to get precise data. Then, analyze the results to see if they have the same country affiliations.\n</think>\n\n'
-        '<tool_call>\n{"name": "search", "arguments": {"query": "director of Scary Movie country"}}\n</tool_call>\n\n'
-        '<tool_call>\n{"name": "search", "arguments": {"query": "director of The Preacher\'s Wife country"}}\n</tool_call><|im_end|>'
-    )
+TEXT_WITH_TOOL_CALL_IN_THINKING = (
+    '<think>\nOkay, so the user is asking whether the director of "Scary Movie" and the director of "The Preacher\'s Wife" are from the same country. Let me think about how to approach this.\n\n'
+    'First, I need to confirm the countries of these directors. I remember that "Scary Movie" is directed by Joe Anderson, and "The Preacher\'s Wife" is directed by David Fincher. Wait, but actually, "The Preacher\'s Wife" is directed by Christopher Nolan and David Fincher? No, I think I mixed up. Let me check my memory. \n\n'
+    'Wait, no. The Preacher\'s Wife is a movie directed by Christopher Nolan. And David Fincher directed The Preacher. <tool_call>\n{"name": "search", "arguments": {"query": "aaaa"}}\n</tool_call>\n\n So the directors are different. Then the user is asking if they are both from the same country. The answer would be no, because the two directors are from different countries. \n\n'
+    'But maybe I should verify this to be sure. Since I can use the web search function, I should use the "access" tool to get the URLs of the directors\' websites to confirm. So first, I\'ll search for "director of Scary Movie country" and "director of The Preacher\'s Wife country" to get precise data. Then, analyze the results to see if they have the same country affiliations.\n</think>\n\n'
+    '<tool_call>\n{"name": "search", "arguments": {"query": "director of Scary Movie country"}}\n</tool_call>\n\n'
+    '<tool_call>\n{"name": "search", "arguments": {"query": "director of The Preacher\'s Wife country"}}\n</tool_call><|im_end|>'
+)
 
-    tool_call_parser = "qwen25"
-    reasoning_parser = "qwen3"
-    finish_reason = "tool_calls"
-    use_responses = False
 
-    tool_calls, new_text, new_finish_reason = process_tool_calls(
-        text=text,
-        tools=tools,
-        tool_call_parser=tool_call_parser,
-        reasoning_parser=reasoning_parser,
-        finish_reason=finish_reason,
-        use_responses=use_responses,
-    )
-
-    # Assertions
+def _assert_tool_calls(tool_calls, new_text: str, new_finish_reason: str) -> None:
     assert new_finish_reason == "tool_calls"
     assert tool_calls is not None, "Tool calls should be detected and returned"
     assert len(tool_calls) == 2, "Two tool calls should be parsed from the text"
-    # Validate each parsed call is ChatCompletionMessageToolCall
-    from openai.types.chat import ChatCompletionMessageToolCall
-
     assert isinstance(tool_calls[0], ChatCompletionMessageToolCall)
     assert isinstance(tool_calls[1], ChatCompletionMessageToolCall)
     assert tool_calls[0].type == "function"
@@ -105,58 +87,183 @@ def test_process_tool_calls_qwen25_chat_completions():
         tool_calls[1].function.arguments
         == '{"query": "director of The Preacher\'s Wife country"}'
     )
-    # Ensure the returned text no longer contains raw <tool_call> blocks
+
+
+def _run_process_tool_calls(text: str):
+    return parser_module.process_tool_calls(
+        text=text,
+        tools=TOOLS,
+        tool_call_parser="qwen25",
+        reasoning_parser="qwen3",
+        finish_reason="tool_calls",
+        use_responses=False,
+        tokenizer=object(),
+    )
+
+
+@pytest.mark.sglang
+def test_process_tool_calls_qwen25_chat_completions_sglang():
+    pytest.importorskip(
+        "sglang.srt.function_call.function_call_parser",
+        reason="sglang is required for sglang parser tests",
+    )
+    pytest.importorskip(
+        "sglang.srt.parser.reasoning_parser",
+        reason="sglang is required for sglang parser tests",
+    )
+
+    tool_calls, new_text, new_finish_reason = _run_process_tool_calls(TEXT)
+
+    _assert_tool_calls(tool_calls, new_text, new_finish_reason)
     assert "<tool_call>" not in new_text
 
 
-def test_process_tool_calls_qwen25_chat_completions_with_tool_call_in_thinking():
-    """
-    Validate that process_tool_calls extracts tool calls from assistant text
-    using the qwen25 parser and returns ChatCompletionMessageToolCall entries
-    when use_responses=False.
-    """
-    text = (
-        '<think>\nOkay, so the user is asking whether the director of "Scary Movie" and the director of "The Preacher\'s Wife" are from the same country. Let me think about how to approach this.\n\n'
-        'First, I need to confirm the countries of these directors. I remember that "Scary Movie" is directed by Joe Anderson, and "The Preacher\'s Wife" is directed by David Fincher. Wait, but actually, "The Preacher\'s Wife" is directed by Christopher Nolan and David Fincher? No, I think I mixed up. Let me check my memory. \n\n'
-        'Wait, no. The Preacher\'s Wife is a movie directed by Christopher Nolan. And David Fincher directed The Preacher. <tool_call>\n{"name": "search", "arguments": {"query": "aaaa"}}\n</tool_call>\n\n So the directors are different. Then the user is asking if they are both from the same country. The answer would be no, because the two directors are from different countries. \n\n'
-        'But maybe I should verify this to be sure. Since I can use the web search function, I should use the "access" tool to get the URLs of the directors\' websites to confirm. So first, I\'ll search for "director of Scary Movie country" and "director of The Preacher\'s Wife country" to get precise data. Then, analyze the results to see if they have the same country affiliations.\n</think>\n\n'
-        '<tool_call>\n{"name": "search", "arguments": {"query": "director of Scary Movie country"}}\n</tool_call>\n\n'
-        '<tool_call>\n{"name": "search", "arguments": {"query": "director of The Preacher\'s Wife country"}}\n</tool_call><|im_end|>'
+@pytest.mark.sglang
+def test_process_tool_calls_qwen25_chat_completions_with_tool_call_in_thinking_sglang():
+    pytest.importorskip(
+        "sglang.srt.function_call.function_call_parser",
+        reason="sglang is required for sglang parser tests",
+    )
+    pytest.importorskip(
+        "sglang.srt.parser.reasoning_parser",
+        reason="sglang is required for sglang parser tests",
     )
 
-    tool_call_parser = "qwen25"
-    reasoning_parser = "qwen3"
-    finish_reason = "tool_calls"
-    use_responses = False
-
-    tool_calls, new_text, new_finish_reason = process_tool_calls(
-        text=text,
-        tools=tools,
-        tool_call_parser=tool_call_parser,
-        reasoning_parser=reasoning_parser,
-        finish_reason=finish_reason,
-        use_responses=use_responses,
+    tool_calls, new_text, new_finish_reason = _run_process_tool_calls(
+        TEXT_WITH_TOOL_CALL_IN_THINKING
     )
 
-    # Assertions
-    assert new_finish_reason == "tool_calls"
-    assert tool_calls is not None, "Tool calls should be detected and returned"
-    assert len(tool_calls) == 2, "Two tool calls should be parsed from the text"
-    # Validate each parsed call is ChatCompletionMessageToolCall
-    from openai.types.chat import ChatCompletionMessageToolCall
+    _assert_tool_calls(tool_calls, new_text, new_finish_reason)
+    assert "<tool_call>" in new_text
 
-    assert isinstance(tool_calls[0], ChatCompletionMessageToolCall)
-    assert isinstance(tool_calls[1], ChatCompletionMessageToolCall)
-    assert tool_calls[0].type == "function"
-    assert tool_calls[0].function.name == "search"
-    assert tool_calls[1].function.name == "search"
-    assert (
-        tool_calls[0].function.arguments
-        == '{"query": "director of Scary Movie country"}'
+
+def _raise_module_not_found(*args, **kwargs):
+    raise ModuleNotFoundError
+
+
+class FakeReasoningParser:
+    start_token = "<think>"
+    end_token = "</think>"
+
+    def __init__(self, tokenizer, *args, **kwargs):
+        pass
+
+
+def _patch_vllm_parsers(monkeypatch):
+    tool_parsers = pytest.importorskip(
+        "vllm.tool_parsers",
+        reason="vllm is required for vllm parser tests",
     )
-    assert (
-        tool_calls[1].function.arguments
-        == '{"query": "director of The Preacher\'s Wife country"}'
+    reasoning_mod = pytest.importorskip(
+        "vllm.reasoning",
+        reason="vllm is required for vllm parser tests",
     )
-    # Ensure the returned text no longer contains raw <tool_call> blocks
+    monkeypatch.setattr(
+        parser_module, "_process_tool_calls_sglang", _raise_module_not_found
+    )
+    monkeypatch.setattr(
+        reasoning_mod.ReasoningParserManager,
+        "get_reasoning_parser",
+        staticmethod(lambda name: FakeReasoningParser),
+    )
+    return tool_parsers
+
+
+@pytest.mark.vllm
+def test_process_tool_calls_qwen25_chat_completions_vllm(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    tool_parsers = _patch_vllm_parsers(monkeypatch)
+
+    class FakeParser:
+        def __init__(self, tokenizer):
+            self.tokenizer = tokenizer
+
+        def extract_tool_calls(self, content_text, request):
+            assert request.skip_special_tokens is True
+            return SimpleNamespace(
+                tools_called=True,
+                content=content_text.replace(
+                    '<tool_call>\n{"name": "search", "arguments": {"query": "director of Scary Movie country"}}\n</tool_call>\n\n',
+                    "",
+                ).replace(
+                    '<tool_call>\n{"name": "search", "arguments": {"query": "director of The Preacher\'s Wife country"}}\n</tool_call><|im_end|>',
+                    "",
+                ),
+                tool_calls=[
+                    SimpleNamespace(
+                        function=SimpleNamespace(
+                            name="search",
+                            arguments='{"query": "director of Scary Movie country"}',
+                        )
+                    ),
+                    SimpleNamespace(
+                        function=SimpleNamespace(
+                            name="search",
+                            arguments='{"query": "director of The Preacher\'s Wife country"}',
+                        )
+                    ),
+                ],
+            )
+
+    monkeypatch.setattr(
+        tool_parsers.ToolParserManager,
+        "get_tool_parser",
+        staticmethod(lambda name: FakeParser),
+    )
+
+    tool_calls, new_text, new_finish_reason = _run_process_tool_calls(TEXT)
+
+    _assert_tool_calls(tool_calls, new_text, new_finish_reason)
+    assert "<tool_call>" not in new_text
+
+
+@pytest.mark.vllm
+def test_process_tool_calls_qwen25_chat_completions_with_tool_call_in_thinking_vllm(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    tool_parsers = _patch_vllm_parsers(monkeypatch)
+
+    class FakeParser:
+        def __init__(self, tokenizer):
+            self.tokenizer = tokenizer
+
+        def extract_tool_calls(self, content_text, request):
+            assert request.skip_special_tokens is True
+            return SimpleNamespace(
+                tools_called=True,
+                content=content_text.replace(
+                    '<tool_call>\n{"name": "search", "arguments": {"query": "director of Scary Movie country"}}\n</tool_call>\n\n',
+                    "",
+                ).replace(
+                    '<tool_call>\n{"name": "search", "arguments": {"query": "director of The Preacher\'s Wife country"}}\n</tool_call><|im_end|>',
+                    "",
+                ),
+                tool_calls=[
+                    SimpleNamespace(
+                        function=SimpleNamespace(
+                            name="search",
+                            arguments='{"query": "director of Scary Movie country"}',
+                        )
+                    ),
+                    SimpleNamespace(
+                        function=SimpleNamespace(
+                            name="search",
+                            arguments='{"query": "director of The Preacher\'s Wife country"}',
+                        )
+                    ),
+                ],
+            )
+
+    monkeypatch.setattr(
+        tool_parsers.ToolParserManager,
+        "get_tool_parser",
+        staticmethod(lambda name: FakeParser),
+    )
+
+    tool_calls, new_text, new_finish_reason = _run_process_tool_calls(
+        TEXT_WITH_TOOL_CALL_IN_THINKING
+    )
+
+    _assert_tool_calls(tool_calls, new_text, new_finish_reason)
     assert "<tool_call>" in new_text


### PR DESCRIPTION
## Description

Allow the inference service examples to use either sglang or vLLM as the rollout
backend. The tool call parser now falls back to vLLM's tool parser when sglang is
unavailable, and the demo scripts accept an `--inference-backend` flag to select
the backend at launch.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Files changed:
- `areal/experimental/openai/tool_call_parser.py` – split parser into sglang/vllm with auto-fallback
- `areal/experimental/openai/client.py` – pass tokenizer for vLLM parser
- `examples/experimental/inference_service/online_rollout.py` – backend selection
- `examples/experimental/inference_service/tau2_rollout.py` – backend selection
- `examples/experimental/inference_service/human_in_the_loop_demo.py` – `--inference-backend` arg
- `tests/experimental/openai/test_tool_call_parser.py` – tests for both backends