### PR TITLE
Fix #1040: [Feature] Fixed bugs in Archon LoRA Backend

### DIFF
--- a/areal/engine/fsdp_utils/grad.py
+++ b/areal/engine/fsdp_utils/grad.py
@@ -99,10 +99,21 @@ def get_grad_norm_fp32(
     norm_type = float(norm_type)
     total_norm = 0.0
 
-    if not grads_for_norm:
-        return 0.0
-
     device = current_platform.current_device()
+
+    if not grads_for_norm:
+        # Still participate in all_reduce with zero contribution so that
+        # ranks with grads don't hang waiting for this rank (e.g. LoRA frozen ranks).
+        total_norm_cuda = torch.tensor(0.0, dtype=torch.float, device=device)
+        reduce_op = dist.ReduceOp.MAX if norm_type == torch.inf else dist.ReduceOp.SUM
+        if data_parallel_group:
+            dist.all_reduce(total_norm_cuda, op=reduce_op, group=data_parallel_group)
+        if model_parallel_group is not None:
+            dist.all_reduce(total_norm_cuda, op=reduce_op, group=model_parallel_group)
+        total_norm = float(total_norm_cuda.item())
+        if norm_type != torch.inf and total_norm > 0:
+            total_norm = total_norm ** (1.0 / norm_type)
+        return total_norm
 
     if norm_type == torch.inf:
         norms = [grad.abs().max() for grad in grads_for_norm]

--- a/tests/test_fsdp_grad.py
+++ b/tests/test_fsdp_grad.py
@@ -112,8 +112,17 @@ class TestGetGradNormFp32:
         return dp_group, mp_group
 
     def test_empty_grads_returns_zero(self, mock_process_groups):
+        # Empty grads must still participate in all_reduce (e.g. LoRA frozen ranks)
+        # so that ranks with real grads don't hang.
         dp_group, mp_group = mock_process_groups
-        result = get_grad_norm_fp32([], dp_group, mp_group)
+        with patch("torch.distributed.all_reduce") as mock_allreduce:
+            result = get_grad_norm_fp32([], dp_group, mp_group)
+        assert result == 0.0
+        assert mock_allreduce.call_count == 2  # called for dp_group and mp_group
+
+    def test_empty_grads_participates_in_allreduce_no_groups(self):
+        # With no process groups, empty grads should still return 0.0 without hanging.
+        result = get_grad_norm_fp32([], None, None)
         assert result == 0.0
 
     @pytest.mark.parametrize("norm_type", [1.0, 2.0, 3.0, float("inf")])


### PR DESCRIPTION
Closes #1040

## Description

Fixes a distributed deadlock in `get_grad_norm_fp32` (`areal/engine/fsdp_utils/grad.py`) where ranks with no gradients (e.g., LoRA frozen ranks in the Archon LoRA backend) would return early before participating in the `all_reduce` collective, causing ranks with real gradients to hang indefinitely waiting for the collective to complete.

**Root cause:** The original early-return on empty `grads_for_norm` bypassed the `dist.all_reduce` calls entirely. In a distributed setting, all ranks must call collective operations together.

**Fix:** When `grads_for_norm` is empty, the rank now contributes a zero tensor to `all_reduce` (using `ReduceOp.MAX` for `inf`-norm, `ReduceOp.SUM` otherwise) across both `data_parallel_group` and `model_parallel_group` before returning `0.0`. This keeps all ranks synchronized without affecting the computed norm on ranks that do have gradients.

## Related Issue

Fixes #1040

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Two tests updated/added in `tests/test_fsdp_grad.py`:

- `test_empty_grads_returns_zero`: patched `torch.distributed.all_reduce` to assert it is called exactly twice (once for `dp_group`, once for `mp_group`) even when the grad list is empty, and that the result is still `0.0`.
- `test_empty_grads_participates_in_allreduce_no_groups` (new): verifies that passing `None` for both process groups with an empty grad list returns `0.0` without hanging or erroring.

End-to-end validation was performed on Qwen 1.5B distill with the DAPO-Math-17k dataset as described in issue #1040 (see also https://github.com/inclusionAI/AReaL/pull/1015#issuecomment-4063437358).

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*