### PR TITLE
feat(archon): support multi-node inference in gateway controller

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1476,6 +1476,8 @@ class vLLMConfig:
         host: str | None = None,
         port: int | None = None,
         dist_init_addr: str | None = None,
+        n_nodes: int = 1,
+        node_rank: int = 0,
     ):
         args: dict = conf_as_dict(vllm_config)
         args = dict(
@@ -1491,6 +1493,17 @@ class vLLMConfig:
             args["port"] = port
         if host is not None:
             args["host"] = host
+        # Multi-node support
+        if n_nodes > 1:
+            args["nnodes"] = n_nodes
+            args["node_rank"] = node_rank
+            if dist_init_addr is not None:
+                host_part, _, port_part = dist_init_addr.rpartition(":")
+                if host_part:
+                    args["master_addr"] = host_part
+                    args["master_port"] = port_part
+            if node_rank > 0:
+                args["headless"] = True
         return args
 
     @staticmethod
@@ -1505,6 +1518,8 @@ class vLLMConfig:
         host: str | None = None,
         port: int | None = None,
         dist_init_addr: str | None = None,
+        n_nodes: int = 1,
+        node_rank: int = 0,
     ):
         args = vLLMConfig.build_args(
             vllm_config=vllm_config,
@@ -1513,6 +1528,8 @@ class vLLMConfig:
             host=host,
             port=port,
             dist_init_addr=dist_init_addr,
+            n_nodes=n_nodes,
+            node_rank=node_rank,
         )
         return vLLMConfig.build_cmd_from_args(args)
 

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1498,10 +1498,11 @@ class vLLMConfig:
             args["nnodes"] = n_nodes
             args["node_rank"] = node_rank
             if dist_init_addr is not None:
-                host_part, _, port_part = dist_init_addr.rpartition(":")
-                if host_part:
-                    args["master_addr"] = host_part
-                    args["master_port"] = port_part
+                from areal.utils.network import split_hostport
+
+                master_host, master_port = split_hostport(dist_init_addr)
+                args["master_addr"] = master_host
+                args["master_port"] = str(master_port)
             if node_rank > 0:
                 args["headless"] = True
         return args

--- a/areal/experimental/inference_service/controller/config.py
+++ b/areal/experimental/inference_service/controller/config.py
@@ -51,7 +51,7 @@ class GatewayControllerConfig:
     backend: str = "sglang:d1"
     scheduling_spec: tuple = field(default_factory=tuple)
     pause_grace_period: float = 0.5
-    nnodes: int = 1  # Number of physical nodes per inference instance
+    n_gpus_per_node: int | None = None  # GPUs per physical node; None = single-node
 
     # -- OpenAI proxy configuration (for agent-like workflows) ---------------
     openai: OpenAIProxyConfig = field(default_factory=lambda: OpenAIProxyConfig())

--- a/areal/experimental/inference_service/controller/config.py
+++ b/areal/experimental/inference_service/controller/config.py
@@ -51,6 +51,7 @@ class GatewayControllerConfig:
     backend: str = "sglang:d1"
     scheduling_spec: tuple = field(default_factory=tuple)
     pause_grace_period: float = 0.5
+    nnodes: int = 1  # Number of physical nodes per inference instance
 
     # -- OpenAI proxy configuration (for agent-like workflows) ---------------
     openai: OpenAIProxyConfig = field(default_factory=lambda: OpenAIProxyConfig())

--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -90,18 +90,23 @@ class GatewayInferenceController:
         # Parse allocation from config.backend
         self.rollout_alloc = ModelAllocation.from_str(config.backend)
 
-        # Multi-node validation
-        nnodes = config.nnodes
-        if nnodes < 1:
-            raise ValueError(f"nnodes must be >= 1, got {nnodes}")
+        # Multi-node: derive nnodes_per_instance from n_gpus_per_node
         total_gpus = (
             self.rollout_alloc.parallel.tp_size * self.rollout_alloc.parallel.pp_size
         )
-        if total_gpus % nnodes != 0:
-            raise ValueError(
-                f"tp_size * pp_size ({total_gpus}) must be divisible by nnodes ({nnodes})"
-            )
-        self._nnodes = nnodes
+        n_gpus_per_node = config.n_gpus_per_node
+        if n_gpus_per_node is None:
+            nnodes_per_instance = 1
+        else:
+            if n_gpus_per_node < 1:
+                raise ValueError(f"n_gpus_per_node must be >= 1, got {n_gpus_per_node}")
+            if total_gpus % n_gpus_per_node != 0:
+                raise ValueError(
+                    f"tp_size * pp_size ({total_gpus}) must be divisible "
+                    f"by n_gpus_per_node ({n_gpus_per_node})"
+                )
+            nnodes_per_instance = total_gpus // n_gpus_per_node
+        self._nnodes_per_instance = nnodes_per_instance
 
         # Worker management
         self.workers: list[Worker] = []
@@ -237,12 +242,12 @@ class GatewayInferenceController:
         inf_backend = alloc.backend
 
         # ==================================================================
-        # Step 0: Create RPCGuard workers (dp_size × nnodes)
+        # Step 0: Create RPCGuard workers (dp_size × nnodes_per_instance)
         # ==================================================================
         inf_spec = SchedulingSpec(**asdict(cfg.scheduling_spec[0]))
         instance_size = alloc.parallel.tp_size * alloc.parallel.pp_size
-        nnodes = self._nnodes
-        gpus_per_node = instance_size // nnodes
+        nnodes_per_instance = self._nnodes_per_instance
+        gpus_per_worker = instance_size // nnodes_per_instance
 
         if server_infos is not None:
             # Pre-existing inference servers — only need dp_size workers
@@ -250,11 +255,11 @@ class GatewayInferenceController:
             total_workers = dp_size
             inf_spec.gpu = 0
         else:
-            total_workers = dp_size * nnodes
-            inf_spec.cpu *= gpus_per_node
-            inf_spec.mem *= gpus_per_node
+            total_workers = dp_size * nnodes_per_instance
+            inf_spec.cpu *= gpus_per_worker
+            inf_spec.mem *= gpus_per_worker
             if inf_spec.gpu > 0:
-                inf_spec.gpu = gpus_per_node
+                inf_spec.gpu = gpus_per_worker
 
         # Override cmd to launch RPCGuard instead of RPC server
         inf_spec.cmd = "python -m areal.experimental.inference_service.guard"
@@ -371,14 +376,15 @@ class GatewayInferenceController:
             # For each inference instance group: alloc ports, build cmd, fork servers
             for group_idx in range(dp_size):
                 group_workers = inf_workers[
-                    group_idx * nnodes : (group_idx + 1) * nnodes
+                    group_idx * nnodes_per_instance : (group_idx + 1)
+                    * nnodes_per_instance
                 ]
                 head_worker = group_workers[0]
                 head_guard_addr = f"http://{format_hostport(head_worker.ip, int(head_worker.worker_ports[0]))}"
 
                 # Allocate rendezvous port on head node for distributed init
                 dist_init_addr = None
-                if nnodes > 1:
+                if nnodes_per_instance > 1:
                     resp = requests.post(
                         f"{head_guard_addr}/alloc_ports",
                         json={"count": 1},
@@ -388,7 +394,7 @@ class GatewayInferenceController:
                     rendezvous_data = resp.json()
                     rendezvous_host = rendezvous_data["host"]
                     rendezvous_port = rendezvous_data["ports"][0]
-                    dist_init_addr = f"{rendezvous_host}:{rendezvous_port}"
+                    dist_init_addr = format_hostport(rendezvous_host, rendezvous_port)
 
                 head_inf_host = None
                 head_inf_port = None
@@ -412,14 +418,14 @@ class GatewayInferenceController:
                     cmd = _build_launch_cmd(
                         host=inf_host,
                         port=inf_port,
-                        n_nodes=nnodes,
+                        n_nodes=nnodes_per_instance,
                         node_rank=node_rank,
                         dist_init_addr=dist_init_addr,
                     )
 
                     fork_payload: dict[str, Any] = {
                         "role": "inf-server",
-                        "worker_index": group_idx * nnodes + node_rank,
+                        "worker_index": group_idx * nnodes_per_instance + node_rank,
                         "raw_cmd": cmd,
                     }
                     if inf_backend == "vllm":
@@ -449,7 +455,11 @@ class GatewayInferenceController:
                     )
                     resp.raise_for_status()
                     self._forked_services.append(
-                        (guard_addr, "inf-server", group_idx * nnodes + node_rank)
+                        (
+                            guard_addr,
+                            "inf-server",
+                            group_idx * nnodes_per_instance + node_rank,
+                        )
                     )
 
                     if node_rank == 0:
@@ -459,7 +469,7 @@ class GatewayInferenceController:
                 if head_inf_host is None or head_inf_port is None:
                     raise RuntimeError(
                         f"No head worker resolved for group {group_idx}; "
-                        f"expected {nnodes} workers per group"
+                        f"expected {nnodes_per_instance} workers per group"
                     )
 
                 # Only record the head node's address as the inference endpoint
@@ -530,7 +540,9 @@ class GatewayInferenceController:
 
         for group_idx in range(dp_size):
             head_worker = inf_workers[
-                group_idx if server_infos is not None else group_idx * nnodes
+                group_idx
+                if server_infos is not None
+                else group_idx * nnodes_per_instance
             ]
             guard_addr = f"http://{format_hostport(head_worker.ip, int(head_worker.worker_ports[0]))}"
             # Each data proxy connects to its group's head inference server

--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -90,6 +90,19 @@ class GatewayInferenceController:
         # Parse allocation from config.backend
         self.rollout_alloc = ModelAllocation.from_str(config.backend)
 
+        # Multi-node validation
+        nnodes = config.nnodes
+        if nnodes < 1:
+            raise ValueError(f"nnodes must be >= 1, got {nnodes}")
+        total_gpus = (
+            self.rollout_alloc.parallel.tp_size * self.rollout_alloc.parallel.pp_size
+        )
+        if total_gpus % nnodes != 0:
+            raise ValueError(
+                f"tp_size * pp_size ({total_gpus}) must be divisible by nnodes ({nnodes})"
+            )
+        self._nnodes = nnodes
+
         # Worker management
         self.workers: list[Worker] = []
         self.server_infos: list[LocalInfServerInfo] = []
@@ -224,27 +237,32 @@ class GatewayInferenceController:
         inf_backend = alloc.backend
 
         # ==================================================================
-        # Step 0: Always create dp_size RPCGuard workers
+        # Step 0: Create RPCGuard workers (dp_size × nnodes)
         # ==================================================================
         inf_spec = SchedulingSpec(**asdict(cfg.scheduling_spec[0]))
         instance_size = alloc.parallel.tp_size * alloc.parallel.pp_size
+        nnodes = self._nnodes
+        gpus_per_node = instance_size // nnodes
+
         if server_infos is not None:
-            # Pre-existing inference servers — RPCGuard workers only host
-            # CPU services (data proxy, router, gateway), no GPUs needed.
+            # Pre-existing inference servers — only need dp_size workers
+            # for CPU services (data proxy, router, gateway), no GPUs.
+            total_workers = dp_size
             inf_spec.gpu = 0
         else:
-            inf_spec.cpu *= instance_size
-            inf_spec.mem *= instance_size
+            total_workers = dp_size * nnodes
+            inf_spec.cpu *= gpus_per_node
+            inf_spec.mem *= gpus_per_node
             if inf_spec.gpu > 0:
-                inf_spec.gpu = instance_size
+                inf_spec.gpu = gpus_per_node
 
         # Override cmd to launch RPCGuard instead of RPC server
         inf_spec.cmd = "python -m areal.experimental.inference_service.guard"
 
         inf_role = f"{self._worker_role}{self._INF_SUFFIX}"
         inf_job = Job(
-            replicas=dp_size,
-            tasks=[inf_spec for _ in range(dp_size)],
+            replicas=total_workers,
+            tasks=[inf_spec for _ in range(total_workers)],
             scheduling_strategy=SchedulingStrategy(),
             role=inf_role,
         )
@@ -252,6 +270,11 @@ class GatewayInferenceController:
         self.scheduler.create_workers(job=inf_job)
         self._service_roles.append(inf_role)
         inf_workers = self.scheduler.get_workers(role=inf_role)
+        if len(inf_workers) != total_workers:
+            raise RuntimeError(
+                f"Expected {total_workers} workers for role {inf_role!r}, "
+                f"got {len(inf_workers)}"
+            )
         self.workers = inf_workers
         logger.info("RPCGuard workers ready: %s", [w.id for w in inf_workers])
 
@@ -291,13 +314,22 @@ class GatewayInferenceController:
                                 v,
                             )
 
-                def _build_launch_cmd(host: str, port: int) -> list[str]:
+                def _build_launch_cmd(
+                    host: str | None,
+                    port: int | None,
+                    n_nodes: int = 1,
+                    node_rank: int = 0,
+                    dist_init_addr: str | None = None,
+                ) -> list[str]:
                     return SGLangConfig.build_cmd(
                         sglang_config=sglang_config,
                         tp_size=tp_size,
                         base_gpu_id=0,
                         host=host,
                         port=port,
+                        dist_init_addr=dist_init_addr,
+                        n_nodes=n_nodes,
+                        node_rank=node_rank,
                     )
 
             elif inf_backend == "vllm":
@@ -315,79 +347,133 @@ class GatewayInferenceController:
                             v,
                         )
 
-                def _build_launch_cmd(host: str, port: int) -> list[str]:
+                def _build_launch_cmd(
+                    host: str | None,
+                    port: int | None,
+                    n_nodes: int = 1,
+                    node_rank: int = 0,
+                    dist_init_addr: str | None = None,
+                ) -> list[str]:
                     return vLLMConfig.build_cmd(
                         vllm_config=vllm_config,
                         tp_size=tp_size,
                         pp_size=alloc.parallel.pp_size,
                         host=host,
                         port=port,
+                        dist_init_addr=dist_init_addr,
+                        n_nodes=n_nodes,
+                        node_rank=node_rank,
                     )
 
             else:
                 raise ValueError(f"Unsupported inference backend: {inf_backend!r}")
 
-            # For each RPCGuard worker: alloc port, build cmd, fork server
-            for rank, worker in enumerate(inf_workers):
-                guard_addr = (
-                    f"http://{format_hostport(worker.ip, int(worker.worker_ports[0]))}"
-                )
+            # For each inference instance group: alloc ports, build cmd, fork servers
+            for group_idx in range(dp_size):
+                group_workers = inf_workers[
+                    group_idx * nnodes : (group_idx + 1) * nnodes
+                ]
+                head_worker = group_workers[0]
+                head_guard_addr = f"http://{format_hostport(head_worker.ip, int(head_worker.worker_ports[0]))}"
 
-                resp = requests.post(
-                    f"{guard_addr}/alloc_ports",
-                    json={"count": 1},
-                    timeout=30,
-                )
-                resp.raise_for_status()
-                port_data = resp.json()
-                inf_host = port_data["host"]
-                inf_port = port_data["ports"][0]
-
-                cmd = _build_launch_cmd(inf_host, inf_port)
-
-                fork_payload: dict[str, Any] = {
-                    "role": "inf-server",
-                    "worker_index": rank,
-                    "raw_cmd": cmd,
-                }
-                if inf_backend == "vllm":
-                    from areal.infra.utils.launcher import (
-                        TRITON_CACHE_PATH as _TRITON_CACHE,
+                # Allocate rendezvous port on head node for distributed init
+                dist_init_addr = None
+                if nnodes > 1:
+                    resp = requests.post(
+                        f"{head_guard_addr}/alloc_ports",
+                        json={"count": 1},
+                        timeout=30,
                     )
-                    from areal.infra.utils.launcher import (
-                        VLLM_CACHE_ROOT as _VLLM_CACHE,
+                    resp.raise_for_status()
+                    rendezvous_data = resp.json()
+                    rendezvous_host = rendezvous_data["host"]
+                    rendezvous_port = rendezvous_data["ports"][0]
+                    dist_init_addr = f"{rendezvous_host}:{rendezvous_port}"
+
+                head_inf_host = None
+                head_inf_port = None
+
+                for node_rank, worker in enumerate(group_workers):
+                    guard_addr = f"http://{format_hostport(worker.ip, int(worker.worker_ports[0]))}"
+
+                    # Allocate port for inference server on this node
+                    resp = requests.post(
+                        f"{guard_addr}/alloc_ports",
+                        json={"count": 1},
+                        timeout=30,
+                    )
+                    resp.raise_for_status()
+                    port_data = resp.json()
+                    inf_host = port_data["host"]
+                    inf_port = port_data["ports"][0]
+
+                    # Worker nodes (rank > 0) don't need to serve HTTP,
+                    # but we still pass host/port for the server to bind
+                    cmd = _build_launch_cmd(
+                        host=inf_host,
+                        port=inf_port,
+                        n_nodes=nnodes,
+                        node_rank=node_rank,
+                        dist_init_addr=dist_init_addr,
                     )
 
-                    fork_payload["env"] = {
-                        "TRITON_CACHE_PATH": os.path.join(
-                            os.environ.get("TRITON_CACHE_PATH", _TRITON_CACHE),
-                            str(uuid.uuid4()),
-                        ),
-                        "VLLM_CACHE_ROOT": os.path.join(
-                            os.environ.get("VLLM_CACHE_ROOT", _VLLM_CACHE),
-                            str(uuid.uuid4()),
-                        ),
-                        "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True",
+                    fork_payload: dict[str, Any] = {
+                        "role": "inf-server",
+                        "worker_index": group_idx * nnodes + node_rank,
+                        "raw_cmd": cmd,
                     }
+                    if inf_backend == "vllm":
+                        from areal.infra.utils.launcher import (
+                            TRITON_CACHE_PATH as _TRITON_CACHE,
+                        )
+                        from areal.infra.utils.launcher import (
+                            VLLM_CACHE_ROOT as _VLLM_CACHE,
+                        )
 
-                resp = requests.post(
-                    f"{guard_addr}/fork",
-                    json=fork_payload,
-                    timeout=30,
-                )
-                resp.raise_for_status()
+                        fork_payload["env"] = {
+                            "TRITON_CACHE_PATH": os.path.join(
+                                os.environ.get("TRITON_CACHE_PATH", _TRITON_CACHE),
+                                str(uuid.uuid4()),
+                            ),
+                            "VLLM_CACHE_ROOT": os.path.join(
+                                os.environ.get("VLLM_CACHE_ROOT", _VLLM_CACHE),
+                                str(uuid.uuid4()),
+                            ),
+                            "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True",
+                        }
 
-                addr = f"http://{format_hostport(inf_host, inf_port)}"
+                    resp = requests.post(
+                        f"{guard_addr}/fork",
+                        json=fork_payload,
+                        timeout=30,
+                    )
+                    resp.raise_for_status()
+                    self._forked_services.append(
+                        (guard_addr, "inf-server", group_idx * nnodes + node_rank)
+                    )
+
+                    if node_rank == 0:
+                        head_inf_host = inf_host
+                        head_inf_port = inf_port
+
+                if head_inf_host is None or head_inf_port is None:
+                    raise RuntimeError(
+                        f"No head worker resolved for group {group_idx}; "
+                        f"expected {nnodes} workers per group"
+                    )
+
+                # Only record the head node's address as the inference endpoint
+                addr = f"http://{format_hostport(head_inf_host, head_inf_port)}"
                 self._inf_addrs.append(addr)
                 self.server_infos.append(
                     LocalInfServerInfo(
-                        host=inf_host,
-                        port=inf_port,
+                        host=head_inf_host,
+                        port=head_inf_port,
                         process=None,  # type: ignore[arg-type]  # RPCGuard manages process
                     )
                 )
 
-            # Wait for inference servers to be healthy
+            # Wait for inference servers to be healthy (only head nodes)
             for i, addr in enumerate(self._inf_addrs):
                 self._wait_for_service(
                     f"{addr}/health", f"InfServer-{i}", timeout=cfg.setup_timeout
@@ -442,21 +528,22 @@ class GatewayInferenceController:
             f"http://{self.callback_addr}",
         ]
 
-        for rank, worker in enumerate(inf_workers):
-            guard_addr = (
-                f"http://{format_hostport(worker.ip, int(worker.worker_ports[0]))}"
-            )
-            # Each data proxy connects to its corresponding inference server
+        for group_idx in range(dp_size):
+            head_worker = inf_workers[
+                group_idx if server_infos is not None else group_idx * nnodes
+            ]
+            guard_addr = f"http://{format_hostport(head_worker.ip, int(head_worker.worker_ports[0]))}"
+            # Each data proxy connects to its group's head inference server
             data_proxy_cmd = data_proxy_base_cmd + [
                 "--backend-addr",
-                self._inf_addrs[rank],
+                self._inf_addrs[group_idx],
                 "--backend-type",
                 inf_backend or "sglang",
             ]
             data_proxy_host, data_proxy_port = self._fork_on_guard(
                 guard_addr=guard_addr,
                 role="data-proxy",
-                worker_index=rank,
+                worker_index=group_idx,
                 raw_cmd=data_proxy_cmd,
             )
             self._data_proxy_addrs.append(

--- a/tests/experimental/inference_service/test_controller.py
+++ b/tests/experimental/inference_service/test_controller.py
@@ -615,3 +615,196 @@ class TestInferenceServiceWorkflow:
         workflow._export_interactions.assert_awaited_once_with(
             mock_http_session, "sess-1", trajectory_id=None
         )
+
+
+# =============================================================================
+# Multi-node inference configuration
+# =============================================================================
+
+
+class TestMultiNodeConfig:
+    def test_nnodes_default_is_1(self):
+        cfg = GatewayControllerConfig()
+        assert cfg.nnodes == 1
+
+    def test_nnodes_custom(self):
+        cfg = GatewayControllerConfig(nnodes=2)
+        assert cfg.nnodes == 2
+
+    def test_nnodes_zero_raises(self):
+        cfg = GatewayControllerConfig(nnodes=0, backend="sglang:d1t8")
+        with pytest.raises(ValueError, match="nnodes must be >= 1"):
+            GatewayInferenceController(config=cfg, scheduler=MagicMock())
+
+    def test_gpus_not_divisible_raises(self):
+        cfg = GatewayControllerConfig(nnodes=3, backend="sglang:d1t8")
+        with pytest.raises(ValueError, match="must be divisible by nnodes"):
+            GatewayInferenceController(config=cfg, scheduler=MagicMock())
+
+    def test_single_node_backward_compat(self):
+        cfg = GatewayControllerConfig(backend="sglang:d2t4")
+        controller = GatewayInferenceController(config=cfg, scheduler=MagicMock())
+        assert controller._nnodes == 1
+
+    def test_multi_node_valid_config(self):
+        cfg = GatewayControllerConfig(nnodes=2, backend="sglang:d1t16")
+        controller = GatewayInferenceController(config=cfg, scheduler=MagicMock())
+        assert controller._nnodes == 2
+
+    @pytest.mark.asyncio
+    async def test_async_initialize_multinode_worker_count(self):
+        """With nnodes=2 and pre-existing server_infos, should create dp_size workers."""
+        from areal.api.cli_args import SchedulingSpec
+        from areal.api.io_struct import LocalInfServerInfo
+
+        worker0 = MagicMock()
+        worker0.ip = "10.0.0.1"
+        worker0.worker_ports = [18000]
+        worker0.id = "w0"
+
+        worker1 = MagicMock()
+        worker1.ip = "10.0.0.2"
+        worker1.worker_ports = [18000]
+        worker1.id = "w1"
+
+        scheduler = MagicMock()
+        scheduler.get_workers.return_value = [worker0]
+
+        cfg = GatewayControllerConfig(
+            tokenizer_path="mock-tokenizer",
+            backend="sglang:d1t8",
+            nnodes=2,
+            scheduling_spec=(SchedulingSpec(gpu=1, cpu=1, mem=1, cmd="mock"),),
+            openai=OpenAIProxyConfig(admin_api_key="test-key"),
+        )
+        controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
+        controller._callback_host = "127.0.0.1"
+        controller._callback_port = 19000
+
+        with patch.object(controller, "_fork_on_guard") as mock_fork:
+            mock_fork.side_effect = [
+                ("127.0.0.1", 18081),  # router
+                ("127.0.0.1", 18082),  # data proxy (only 1, on head)
+                ("127.0.0.1", 18080),  # gateway
+            ]
+
+            await controller._async_initialize(
+                server_args=None,
+                server_infos=[
+                    LocalInfServerInfo(
+                        host="10.0.0.1", port=30000, process=MagicMock()
+                    ),
+                ],
+            )
+
+        # With server_infos, total_workers = dp_size = 1 (not dp_size * nnodes)
+        create_call = scheduler.create_workers.call_args
+        job = create_call.kwargs.get("job") or create_call.args[0]
+        assert job.replicas == 1
+
+        # 3 forks: router + data-proxy + gateway (all on head worker)
+        assert mock_fork.call_count == 3
+        data_proxy_calls = [
+            c for c in mock_fork.call_args_list if c.kwargs.get("role") == "data-proxy"
+        ]
+        assert len(data_proxy_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_initialize_multinode_fork_path(self):
+        """Exercise the full multi-node fork path (server_infos=None)."""
+        from areal.api.cli_args import SchedulingSpec
+
+        worker0 = MagicMock()
+        worker0.ip = "10.0.0.1"
+        worker0.worker_ports = [18000]
+        worker0.id = "w0"
+
+        worker1 = MagicMock()
+        worker1.ip = "10.0.0.2"
+        worker1.worker_ports = [18000]
+        worker1.id = "w1"
+
+        scheduler = MagicMock()
+        scheduler.get_workers.return_value = [worker0, worker1]
+
+        cfg = GatewayControllerConfig(
+            tokenizer_path="mock-tokenizer",
+            backend="sglang:d1t8",
+            nnodes=2,
+            scheduling_spec=(SchedulingSpec(gpu=1, cpu=1, mem=1, cmd="mock"),),
+            openai=OpenAIProxyConfig(admin_api_key="test-key"),
+        )
+        controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
+        controller._callback_host = "127.0.0.1"
+        controller._callback_port = 19000
+
+        # Track requests.post calls to /alloc_ports and /fork
+        alloc_port_counter = 0
+        fork_calls = []
+
+        def mock_requests_post(url, json=None, timeout=None):
+            nonlocal alloc_port_counter
+            resp = MagicMock()
+            resp.status_code = 200
+            if "/alloc_ports" in url:
+                alloc_port_counter += 1
+                resp.json.return_value = {
+                    "status": "success",
+                    "host": url.split("//")[1].split(":")[0],
+                    "ports": [30000 + alloc_port_counter],
+                }
+            elif "/fork" in url:
+                fork_calls.append(json)
+                resp.json.return_value = {"status": "success"}
+            return resp
+
+        with (
+            patch("requests.post", side_effect=mock_requests_post) as mock_post,
+            patch.object(controller, "_fork_on_guard") as mock_fork,
+            patch.object(controller, "_wait_for_service"),
+            patch(
+                "areal.api.cli_args.pkg_version.is_version_greater_or_equal",
+                return_value=True,
+            ),
+            patch("areal.api.cli_args.is_version_less", return_value=False),
+        ):
+            mock_fork.side_effect = [
+                ("10.0.0.1", 18081),  # router
+                ("10.0.0.1", 18082),  # data proxy
+                ("10.0.0.1", 18080),  # gateway
+            ]
+
+            await controller._async_initialize(
+                server_args=None,
+                server_infos=None,
+            )
+
+        # dp_size=1, nnodes=2: total_workers = 2
+        create_call = scheduler.create_workers.call_args
+        job = create_call.kwargs.get("job") or create_call.args[0]
+        assert job.replicas == 2
+
+        # requests.post calls:
+        # 1 rendezvous alloc (nnodes > 1) + 2 node allocs + 2 forks = 5
+        post_calls = mock_post.call_args_list
+        alloc_calls = [c for c in post_calls if "/alloc_ports" in str(c)]
+        fork_post_calls = [c for c in post_calls if "/fork" in str(c)]
+        assert len(alloc_calls) == 3  # 1 rendezvous + 2 per-node
+        assert len(fork_post_calls) == 2  # 1 per node in the group
+
+        # Verify fork payloads have correct worker_index and role
+        assert fork_calls[0]["role"] == "inf-server"
+        assert fork_calls[0]["worker_index"] == 0
+        assert fork_calls[1]["role"] == "inf-server"
+        assert fork_calls[1]["worker_index"] == 1
+
+        # Verify dist_init_addr propagated to fork commands
+        for fc in fork_calls:
+            cmd_str = " ".join(fc["raw_cmd"])
+            assert "--dist-init-addr" in cmd_str or "--dist_init_addr" in cmd_str
+
+        # Only 1 data proxy (dp_size=1, on head worker only)
+        data_proxy_calls = [
+            c for c in mock_fork.call_args_list if c.kwargs.get("role") == "data-proxy"
+        ]
+        assert len(data_proxy_calls) == 1

--- a/tests/experimental/inference_service/test_controller.py
+++ b/tests/experimental/inference_service/test_controller.py
@@ -623,37 +623,38 @@ class TestInferenceServiceWorkflow:
 
 
 class TestMultiNodeConfig:
-    def test_nnodes_default_is_1(self):
+    def test_n_gpus_per_node_default_is_none(self):
         cfg = GatewayControllerConfig()
-        assert cfg.nnodes == 1
+        assert cfg.n_gpus_per_node is None
 
-    def test_nnodes_custom(self):
-        cfg = GatewayControllerConfig(nnodes=2)
-        assert cfg.nnodes == 2
+    def test_n_gpus_per_node_custom(self):
+        cfg = GatewayControllerConfig(n_gpus_per_node=4)
+        assert cfg.n_gpus_per_node == 4
 
-    def test_nnodes_zero_raises(self):
-        cfg = GatewayControllerConfig(nnodes=0, backend="sglang:d1t8")
-        with pytest.raises(ValueError, match="nnodes must be >= 1"):
+    def test_n_gpus_per_node_zero_raises(self):
+        cfg = GatewayControllerConfig(n_gpus_per_node=0, backend="sglang:d1t8")
+        with pytest.raises(ValueError, match="n_gpus_per_node must be >= 1"):
             GatewayInferenceController(config=cfg, scheduler=MagicMock())
 
     def test_gpus_not_divisible_raises(self):
-        cfg = GatewayControllerConfig(nnodes=3, backend="sglang:d1t8")
-        with pytest.raises(ValueError, match="must be divisible by nnodes"):
+        cfg = GatewayControllerConfig(n_gpus_per_node=3, backend="sglang:d1t8")
+        with pytest.raises(ValueError, match="must be divisible by n_gpus_per_node"):
             GatewayInferenceController(config=cfg, scheduler=MagicMock())
 
     def test_single_node_backward_compat(self):
         cfg = GatewayControllerConfig(backend="sglang:d2t4")
         controller = GatewayInferenceController(config=cfg, scheduler=MagicMock())
-        assert controller._nnodes == 1
+        assert controller._nnodes_per_instance == 1
 
     def test_multi_node_valid_config(self):
-        cfg = GatewayControllerConfig(nnodes=2, backend="sglang:d1t16")
+        # tp=16, n_gpus_per_node=8 → nnodes_per_instance=2
+        cfg = GatewayControllerConfig(n_gpus_per_node=8, backend="sglang:d1t16")
         controller = GatewayInferenceController(config=cfg, scheduler=MagicMock())
-        assert controller._nnodes == 2
+        assert controller._nnodes_per_instance == 2
 
     @pytest.mark.asyncio
     async def test_async_initialize_multinode_worker_count(self):
-        """With nnodes=2 and pre-existing server_infos, should create dp_size workers."""
+        """With multi-node and pre-existing server_infos, should create dp_size workers."""
         from areal.api.cli_args import SchedulingSpec
         from areal.api.io_struct import LocalInfServerInfo
 
@@ -670,10 +671,11 @@ class TestMultiNodeConfig:
         scheduler = MagicMock()
         scheduler.get_workers.return_value = [worker0]
 
+        # tp=8, n_gpus_per_node=4 → nnodes_per_instance=2
         cfg = GatewayControllerConfig(
             tokenizer_path="mock-tokenizer",
             backend="sglang:d1t8",
-            nnodes=2,
+            n_gpus_per_node=4,
             scheduling_spec=(SchedulingSpec(gpu=1, cpu=1, mem=1, cmd="mock"),),
             openai=OpenAIProxyConfig(admin_api_key="test-key"),
         )
@@ -697,7 +699,7 @@ class TestMultiNodeConfig:
                 ],
             )
 
-        # With server_infos, total_workers = dp_size = 1 (not dp_size * nnodes)
+        # With server_infos, total_workers = dp_size = 1 (not dp_size * nnodes_per_instance)
         create_call = scheduler.create_workers.call_args
         job = create_call.kwargs.get("job") or create_call.args[0]
         assert job.replicas == 1
@@ -727,10 +729,11 @@ class TestMultiNodeConfig:
         scheduler = MagicMock()
         scheduler.get_workers.return_value = [worker0, worker1]
 
+        # tp=8, n_gpus_per_node=4 → nnodes_per_instance=2
         cfg = GatewayControllerConfig(
             tokenizer_path="mock-tokenizer",
             backend="sglang:d1t8",
-            nnodes=2,
+            n_gpus_per_node=4,
             scheduling_spec=(SchedulingSpec(gpu=1, cpu=1, mem=1, cmd="mock"),),
             openai=OpenAIProxyConfig(admin_api_key="test-key"),
         )
@@ -779,13 +782,13 @@ class TestMultiNodeConfig:
                 server_infos=None,
             )
 
-        # dp_size=1, nnodes=2: total_workers = 2
+        # dp_size=1, nnodes_per_instance=2: total_workers = 2
         create_call = scheduler.create_workers.call_args
         job = create_call.kwargs.get("job") or create_call.args[0]
         assert job.replicas == 2
 
         # requests.post calls:
-        # 1 rendezvous alloc (nnodes > 1) + 2 node allocs + 2 forks = 5
+        # 1 rendezvous alloc (nnodes_per_instance > 1) + 2 node allocs + 2 forks = 5
         post_calls = mock_post.call_args_list
         alloc_calls = [c for c in post_calls if "/alloc_ports" in str(c)]
         fork_post_calls = [c for c in post_calls if "/fork" in str(c)]

--- a/tests/experimental/inference_service/test_sglang_multinode.py
+++ b/tests/experimental/inference_service/test_sglang_multinode.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for SGLang multi-node CLI generation."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from areal.api.cli_args import SGLangConfig
+
+
+class TestSGLangMultiNode:
+    """Mirror of TestVLLMMultiNode for the SGLang backend."""
+
+    def _build_args(self, **kwargs):
+        """Helper that patches sglang version checks away."""
+        defaults = dict(
+            sglang_config=SGLangConfig(model_path="test-model"),
+            tp_size=8,
+            base_gpu_id=0,
+        )
+        defaults.update(kwargs)
+        with (
+            patch(
+                "areal.api.cli_args.pkg_version.is_version_greater_or_equal",
+                return_value=True,
+            ),
+            patch("areal.api.cli_args.is_version_less", return_value=False),
+        ):
+            return SGLangConfig.build_args(**defaults)
+
+    def _build_cmd(self, **kwargs):
+        """Helper that patches sglang version checks away."""
+        defaults = dict(
+            sglang_config=SGLangConfig(model_path="test-model"),
+            tp_size=8,
+            base_gpu_id=0,
+        )
+        defaults.update(kwargs)
+        with (
+            patch(
+                "areal.api.cli_args.pkg_version.is_version_greater_or_equal",
+                return_value=True,
+            ),
+            patch("areal.api.cli_args.is_version_less", return_value=False),
+        ):
+            return SGLangConfig.build_cmd(**defaults)
+
+    def test_build_args_single_node_defaults(self):
+        """Single-node (default) should have nnodes=1, node_rank=0."""
+        args = self._build_args()
+        assert args["nnodes"] == 1
+        assert args["node_rank"] == 0
+        assert args.get("dist_init_addr") is None
+
+    def test_build_args_multi_node_head(self):
+        """Head node (rank 0) with n_nodes > 1 should set nnodes and dist_init_addr."""
+        args = self._build_args(
+            tp_size=16,
+            n_nodes=2,
+            node_rank=0,
+            dist_init_addr="10.0.0.1:29500",
+        )
+        assert args["nnodes"] == 2
+        assert args["node_rank"] == 0
+        assert args["dist_init_addr"] == "10.0.0.1:29500"
+
+    def test_build_args_multi_node_worker(self):
+        """Worker node (rank > 0) should set nnodes and node_rank."""
+        args = self._build_args(
+            tp_size=16,
+            n_nodes=2,
+            node_rank=1,
+            dist_init_addr="10.0.0.1:29500",
+        )
+        assert args["nnodes"] == 2
+        assert args["node_rank"] == 1
+        assert args["dist_init_addr"] == "10.0.0.1:29500"
+
+    def test_build_args_multi_node_no_dist_init_addr(self):
+        """Multi-node without dist_init_addr should have dist_init_addr=None."""
+        args = self._build_args(
+            tp_size=16,
+            n_nodes=2,
+            node_rank=0,
+        )
+        assert args["nnodes"] == 2
+        assert args["node_rank"] == 0
+        assert args.get("dist_init_addr") is None
+
+    def test_build_cmd_multi_node_produces_flags(self):
+        """build_cmd with multi-node should produce CLI flags for nnodes and node-rank."""
+        cmd = self._build_cmd(
+            tp_size=16,
+            n_nodes=2,
+            node_rank=1,
+            dist_init_addr="10.0.0.1:29500",
+        )
+        cmd_str = " ".join(cmd)
+        assert "--nnodes" in cmd_str
+        assert "--node-rank" in cmd_str
+        assert "--dist-init-addr" in cmd_str

--- a/tests/experimental/inference_service/test_vllm_multinode.py
+++ b/tests/experimental/inference_service/test_vllm_multinode.py
@@ -1,0 +1,84 @@
+"""Tests for vLLM multi-node CLI generation."""
+
+from __future__ import annotations
+
+from areal.api.cli_args import vLLMConfig
+
+
+class TestVLLMMultiNode:
+    def test_build_args_single_node_no_extra_flags(self):
+        """Single-node (default) should not add nnodes/node_rank/headless."""
+        cfg = vLLMConfig(model="test-model")
+        args = vLLMConfig.build_args(cfg, tp_size=8, pp_size=1)
+        assert "nnodes" not in args
+        assert "node_rank" not in args
+        assert "headless" not in args
+        assert "master_addr" not in args
+        assert "master_port" not in args
+
+    def test_build_args_multi_node_head(self):
+        """Head node (rank 0) with n_nodes > 1 should add nnodes/node_rank but NOT headless."""
+        cfg = vLLMConfig(model="test-model")
+        args = vLLMConfig.build_args(
+            cfg,
+            tp_size=16,
+            pp_size=1,
+            n_nodes=2,
+            node_rank=0,
+            dist_init_addr="10.0.0.1:29500",
+        )
+        assert args["nnodes"] == 2
+        assert args["node_rank"] == 0
+        assert "headless" not in args
+        assert args["master_addr"] == "10.0.0.1"
+        assert args["master_port"] == "29500"
+
+    def test_build_args_multi_node_worker(self):
+        """Worker node (rank > 0) should add headless=True."""
+        cfg = vLLMConfig(model="test-model")
+        args = vLLMConfig.build_args(
+            cfg,
+            tp_size=16,
+            pp_size=1,
+            n_nodes=2,
+            node_rank=1,
+            dist_init_addr="10.0.0.1:29500",
+        )
+        assert args["nnodes"] == 2
+        assert args["node_rank"] == 1
+        assert args["headless"] is True
+        assert args["master_addr"] == "10.0.0.1"
+        assert args["master_port"] == "29500"
+
+    def test_build_args_multi_node_no_dist_init_addr(self):
+        """Multi-node without dist_init_addr should not add master_addr/master_port."""
+        cfg = vLLMConfig(model="test-model")
+        args = vLLMConfig.build_args(
+            cfg,
+            tp_size=16,
+            pp_size=1,
+            n_nodes=2,
+            node_rank=0,
+        )
+        assert args["nnodes"] == 2
+        assert args["node_rank"] == 0
+        assert "master_addr" not in args
+        assert "master_port" not in args
+
+    def test_build_cmd_multi_node_produces_flags(self):
+        """build_cmd with multi-node should produce CLI flags for nnodes and node-rank."""
+        cfg = vLLMConfig(model="test-model")
+        cmd = vLLMConfig.build_cmd(
+            cfg,
+            tp_size=16,
+            pp_size=1,
+            n_nodes=2,
+            node_rank=1,
+            dist_init_addr="10.0.0.1:29500",
+        )
+        cmd_str = " ".join(cmd)
+        assert "--nnodes" in cmd_str
+        assert "--node-rank" in cmd_str
+        assert "--headless" in cmd_str
+        assert "--master-addr" in cmd_str
+        assert "--master-port" in cmd_str


### PR DESCRIPTION
## Description

Enable inference instances to span multiple physical nodes for large models (e.g. Llama-3.1 405B with `tp_size=16` across 2× 8-GPU nodes). When `nnodes > 1`, the controller groups every `nnodes` workers into one inference instance, allocates rendezvous ports for distributed init, forks inference servers on all nodes per group, and only records the head node as the HTTP endpoint. When `nnodes=1` (default), behavior is identical to the existing code.

Key changes:
- Add `nnodes` field to `GatewayControllerConfig` (default `1`, backward-compatible)
- Extend `vLLMConfig.build_args()`/`build_cmd()` with `n_nodes`/`node_rank` params (SGLang already supported these)
- Restructure controller fork loop: group workers by `nnodes`, allocate rendezvous ports on head node, fork on all nodes per group
- Data proxies only fork on head nodes (one per DP group)
- `server_infos` mode allocates `dp_size` workers (not `dp_size × nnodes`)
- Defensive checks: worker count validation, `RuntimeError` over bare `assert`

## Related Issue

Fixes #1149

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A — `nnodes` defaults to `1`, all existing configurations work without changes.

## Additional Context

**Tests added** (all pass on CPU):
- `test_vllm_multinode.py` — 5 tests for vLLM multi-node CLI generation
- `TestMultiNodeConfig` — 8 tests for config validation, backward compat, worker allocation, and full fork-path coverage (incl. rendezvous port allocation, per-node fork calls, `dist_init_addr` propagation)

**Test commands run:**
```
pytest tests/experimental/inference_service/test_vllm_multinode.py -v  # 5 passed
pytest tests/experimental/inference_service/test_controller.py -v      # 43 passed, 4 pre-existing failures (macOS network binding)
pre-commit run --files <all changed files>                             # all passed
```

**Known follow-ups (not in scope):**
- IPv6 safety: replace `rpartition(":")` with `split_hostport()` (pre-existing issue across multiple files)
- Fork failure rollback (pre-existing design — RPCGuard cascade-kill is the safety net)
- Non-head node health checks (SGLang/vLLM worker nodes don't expose HTTP)

Files changed:
- `areal/experimental/inference_service/controller/config.py` — add `nnodes` field
- `areal/api/cli_args.py` — extend `vLLMConfig` with multi-node params
- `areal/experimental/inference_service/controller/controller.py` — validation, grouped fork loop, head-only data proxies
- `tests/experimental/inference_service/test_controller.py` — multi-node config + fork-path tests
- `tests/experimental/inference_service/test_vllm_multinode.py` — new vLLM CLI tests