### PR TITLE
Fix disk weight update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,9 @@ wandb/
 outputs/
 sympy/
 !/docs/figures/*
+
+# Awex/AReaL validation & comms debug dumps
+*communication_plan_*.json
+*_params_meta_*.json
+*_params_raw_meta_*.json
+*_params_non_converted_raw_meta_*.json

--- a/Dockerfile.a2
+++ b/Dockerfile.a2
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the AReaL project.
+#
+
+FROM quay.io/ascend/vllm-ascend:v0.14.0rc1
+
+ARG MEGATRON_TAG=core_v0.12.1
+ARG MINDSPEED_TAG=v2.3.0_core_r0.12.1
+ARG SGLANG_TAG=v0.5.7
+
+# Update pip and install uv
+RUN python3 -m pip install -U pip "setuptools>=77.0.3,<80" uv && \
+    python3 -m pip install 'ray>=2.53.0' && \
+    python3 -m pip cache purge
+
+# Install Megatron & MindSpeed
+RUN git clone --depth 1 --branch ${MEGATRON_TAG} https://github.com/NVIDIA/Megatron-LM.git /areal-workspace/Megatron-LM && \
+    git clone --depth 1 --branch ${MINDSPEED_TAG} https://gitcode.com/Ascend/MindSpeed.git /areal-workspace/MindSpeed && \
+    cp -r /areal-workspace/Megatron-LM/megatron /areal-workspace/MindSpeed/megatron && \
+    python3 -m pip install -e /areal-workspace/MindSpeed --no-deps && \
+    python3 -m pip install mbridge==0.15.1 && \
+    python3 -m pip cache purge
+
+# Install SGLang
+RUN git clone --depth 1 --branch ${SGLANG_TAG} https://github.com/sgl-project/sglang.git /areal-workspace/sglang && \
+    cd /areal-workspace/sglang && \
+    mv python/pyproject_other.toml python/pyproject.toml && \
+    pip install -e python[srt_npu] && \
+    python3 -m pip cache purge
+
+# Install AReaL dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv pip install -r pyproject.toml --system --extra npu --group dev
+
+# Copy AReaL source code
+COPY . /AReaL
+
+# Install areal package in editable mode without dependencies
+RUN uv pip install --no-deps -e /AReaL --system
+
+# Add MindSpeed to PYTHONPATH as per official doc
+ENV PYTHONPATH="/areal-workspace/MindSpeed:$PYTHONPATH"

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the AReaL project.
+#
+
+FROM quay.io/ascend/vllm-ascend:v0.14.0rc1-a3
+
+ARG MEGATRON_TAG=core_v0.12.1
+ARG MINDSPEED_TAG=v2.3.0_core_r0.12.1
+ARG SGLANG_TAG=v0.5.7
+
+# Update pip and install uv
+RUN python3 -m pip install -U pip "setuptools>=77.0.3,<80" uv && \
+    python3 -m pip install 'ray>=2.53.0' && \
+    python3 -m pip cache purge
+
+# Install Megatron & MindSpeed
+RUN git clone --depth 1 --branch ${MEGATRON_TAG} https://github.com/NVIDIA/Megatron-LM.git /areal-workspace/Megatron-LM && \
+    git clone --depth 1 --branch ${MINDSPEED_TAG} https://gitcode.com/Ascend/MindSpeed.git /areal-workspace/MindSpeed && \
+    cp -r /areal-workspace/Megatron-LM/megatron /areal-workspace/MindSpeed/megatron && \
+    python3 -m pip install -e /areal-workspace/MindSpeed --no-deps && \
+    python3 -m pip install mbridge==0.15.1 && \
+    python3 -m pip cache purge
+
+# Install SGLang
+RUN git clone --depth 1 --branch ${SGLANG_TAG} https://github.com/sgl-project/sglang.git /areal-workspace/sglang && \
+    cd /areal-workspace/sglang && \
+    mv python/pyproject_other.toml python/pyproject.toml && \
+    pip install -e python[srt_npu] && \
+    python3 -m pip cache purge
+
+# Install AReaL dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv pip install -r pyproject.toml --system --extra npu --group dev
+
+# Copy AReaL source code
+COPY . /AReaL
+
+# Install areal package in editable mode without dependencies
+RUN uv pip install --no-deps -e /AReaL --system
+
+# Add MindSpeed to PYTHONPATH as per official doc
+ENV PYTHONPATH="/areal-workspace/MindSpeed:$PYTHONPATH"

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -939,7 +939,10 @@ class TrainEngineConfig:
 
     weight_update_mode: str = field(
         default="xccl",
-        metadata={"help": "Weight update backend type.", "choices": ["disk", "xccl"]},
+        metadata={
+            "help": "Weight update backend type.",
+            "choices": ["disk", "xccl", "awex"],
+        },
     )
     fsdp: FSDPEngineConfig = field(default_factory=FSDPEngineConfig)
     archon: ArchonEngineConfig = field(default_factory=ArchonEngineConfig)
@@ -1278,6 +1281,7 @@ class vLLMConfig:
     enforce_eager: bool = False
     dtype: str = "bfloat16"
     distributed_executor_backend: str = "mp"
+    load_format: str = "auto"
     # original
     max_num_seqs: int = 256
     # kv_cache_type: str = "auto"
@@ -1333,7 +1337,6 @@ class vLLMConfig:
         args = dict(
             # Model and tokenizer
             tokenizer=vllm_config.model,
-            load_format="auto",
             trust_remote_code=True,
             **args,
         )
@@ -1521,6 +1524,75 @@ class SGLangConfig:
         if is_version_less("sglang", "0.4.10.post2"):
             args.pop("max_loaded_loras", None)
         return args
+
+
+@dataclass
+class AwexConfig:
+    """Configuration for Awex weight updates."""
+
+    device_backend: str = field(
+        default="cuda",
+        metadata={"help": "Device backend for Awex. Options: cuda/npu."},
+    )
+    use_mindspeed: bool = field(
+        default=False,
+        metadata={"help": "Enable MindSpeed patches when device_backend=npu."},
+    )
+    meta_server_addr: str = field(
+        default="",
+        metadata={"help": "Awex meta server address, e.g. 127.0.0.1:12345."},
+    )
+    comm_backend: str = field(
+        default="file",
+        metadata={"help": "Awex comm backend. Options: file/nccl/hccl/astate."},
+    )
+    weights_exchange_ipc_backend: str = field(
+        default="cuda",
+        metadata={"help": "IPC backend for Awex weights exchange."},
+    )
+    weights_comm_nccl_group_size: int = field(
+        default=1,
+        metadata={"help": "NCCL group size for Awex weights exchange."},
+    )
+    enable_debug_mode: bool = field(
+        default=False, metadata={"help": "Enable Awex debug mode."}
+    )
+    debug_mode_config: dict[str, Any] = field(
+        default_factory=dict,
+        metadata={"help": "Extra debug config passed to Awex."},
+    )
+    disable_weights_exchange_pipeline: bool = field(
+        default=False,
+        metadata={"help": "Disable Awex pipelined weights exchange."},
+    )
+    enable_colocate_mode: bool = field(
+        default=False,
+        metadata={"help": "Enable Awex colocate mode."},
+    )
+    weights_validation_steps: int = field(
+        default=0,
+        metadata={"help": "Number of steps to validate weights on inference side."},
+    )
+    validate_weights_every_n_steps: int = field(
+        default=1,
+        metadata={"help": "Validate weights every N steps when enabled."},
+    )
+    dump_weights_list_for_validation: list[str] = field(
+        default_factory=list,
+        metadata={"help": "List of parameter names to dump for validation."},
+    )
+    dump_weights_dir_for_validation: str = field(
+        default="",
+        metadata={"help": "Directory to dump weights for validation."},
+    )
+    nnodes: int | None = field(
+        default=None,
+        metadata={"help": "Total number of nodes for vLLM server (optional)."},
+    )
+    node_rank: int | None = field(
+        default=None,
+        metadata={"help": "Node rank for vLLM server (optional)."},
+    )
 
 
 @dataclass
@@ -2130,6 +2202,7 @@ class BaseExperimentConfig:
 
     sglang: SGLangConfig = field(default_factory=SGLangConfig)
     vllm: vLLMConfig = field(default_factory=vLLMConfig)
+    awex: AwexConfig = field(default_factory=AwexConfig)
 
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
 

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -769,6 +769,69 @@ class MegatronEngineConfig:
 
     # FP8 Training Configuration
     fp8_config: FP8EngineConfig | None = None
+    num_layers_in_first_pipeline_stage: int | None = field(
+        default=None, metadata={"help": "Number of layers in the first pipeline stage"}
+    )
+    num_layers_in_last_pipeline_stage: int | None = field(
+        default=None, metadata={"help": "Number of layers in the last pipeline stage"}
+    )
+    account_for_embedding_in_pipeline_split: bool = field(default=False)
+    account_for_loss_in_pipeline_split: bool = field(default=False)
+
+
+@dataclass
+class MindSpeedEngineConfig:
+    """Additional config options for MindSpeed's Megatron adapter
+    Any Megatron-specific settings will be taken from the MegatronEngineConfig
+    Any MindSpeed-exclusive features will be supported here
+    Other MindSpeed parameters can be added below
+    """
+
+    # should always be true in mindspeed
+    use_flash_attn: bool = True
+    context_parallel_algo: str = field(
+        default="megatron_cp_algo",
+        metadata={
+            "help": "Context parallel algorithm used by MindSpeed. "
+            "Options: 'megatron_cp_algo', 'hybrid_cp_algo', 'ulysses_cp_algo"
+        },
+    )
+    sequence_parallel: bool = False
+    use_legacy_models: bool = False
+
+    swap_optimizer: bool = False
+    use_fused_rotary_pos_emb: bool = False
+    use_fused_swiglu: bool = False
+    use_cp_send_recv_overlap: bool = False
+    use_fused_ring_attention_update: bool = False
+    cp_window_size: int = 1
+    moe_alltoall_overlap_comm: bool = False
+    moe_grouped_gemm: bool = True
+    moe_zero_memory: str = field(
+        default="disable",
+        metadata={
+            "help": "MoE zero memory level. Defines how much recomputation occurs in "
+            "experts when using communications overlaps. "
+            "Requires moe_alltoall_overlap_comm. Options: 'disable', 'level0', 'level1'."
+        },
+    )
+    moe_permute_fusion: bool = False
+    gemm_gradient_accumulation_fusion: bool = False
+    position_embedding_type: str = field(
+        default="rope",
+        metadata={"help": "Position embedding type. Options: 'rope', 'alibi'"},
+    )
+    moe_aux_loss_coeff: float = field(default=0.0)
+    moe_router_load_balancing_type: str = field(default="aux_loss")
+    moe_token_dispatcher_type: str = field(
+        default="allgather",
+        metadata={
+            "help": "Type of token dispatcher. Options: 'allgather','alltoall' and 'flex'."
+        },
+    )
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 class SchedulingStrategyType(str, Enum):
@@ -947,6 +1010,7 @@ class TrainEngineConfig:
     fsdp: FSDPEngineConfig = field(default_factory=FSDPEngineConfig)
     archon: ArchonEngineConfig = field(default_factory=ArchonEngineConfig)
     megatron: MegatronEngineConfig = field(default_factory=MegatronEngineConfig)
+    mindspeed: MindSpeedEngineConfig = field(default_factory=MindSpeedEngineConfig)
 
     # Lora
     use_lora: bool = field(

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1318,6 +1318,10 @@ class PPOCriticConfig(TrainEngineConfig):
 def get_py_cmd(module: str, args: dict[str, Any]):
     # convert to flags
     cmd = ["python3", "-m", module]
+    return process_args(cmd, args)
+
+
+def process_args(cmd, args):
     for k, v in args.items():
         if v is None or v is False or v == "" or (isinstance(v, list) and not v):
             continue
@@ -1404,6 +1408,8 @@ class vLLMConfig:
             trust_remote_code=True,
             **args,
         )
+
+        # only add the given distributed sizes if not specified in config
         if args["tensor_parallel_size"] is None:
             args["tensor_parallel_size"] = tp_size
         if args["pipeline_parallel_size"] is None:
@@ -1418,6 +1424,15 @@ class vLLMConfig:
     @staticmethod
     def build_cmd_from_args(args: dict[str, Any]):
         return get_py_cmd("areal.engine.vllm_ext.areal_vllm_server", args)
+
+    @staticmethod
+    def build_cmd_from_args_headless(args: dict[str, Any]):
+        args = args.copy()
+        model = args.pop("model")
+        args["headless"] = True
+        # vllm serve needed for headless mode
+        # need to add model directly following vllm serve
+        return process_args(["vllm", "serve", model], args)
 
     @staticmethod
     def build_cmd(

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1314,6 +1314,11 @@ class vLLMConfig:
     max_lora_rank: int = 16  # vllm's default
     max_loras: int = 8  # override default
     lora_modules: list[str] | None = None  # lora_modules is automatically filled
+    data_parallel_size: int = 1
+    # will use explicit vllm config tp and pp if specified otherwise use allocmode
+    tensor_parallel_size: int | None = None
+    pipeline_parallel_size: int | None = None
+    enable_expert_parallel: bool = False
 
     @staticmethod
     def build_args(
@@ -1330,10 +1335,13 @@ class vLLMConfig:
             tokenizer=vllm_config.model,
             load_format="auto",
             trust_remote_code=True,
-            tensor_parallel_size=tp_size,
-            pipeline_parallel_size=pp_size,
             **args,
         )
+        if args["tensor_parallel_size"] is None:
+            args["tensor_parallel_size"] = tp_size
+        if args["pipeline_parallel_size"] is None:
+            args["pipeline_parallel_size"] = pp_size
+
         if port is not None:
             args["port"] = port
         if host is not None:

--- a/areal/api/engine_api.py
+++ b/areal/api/engine_api.py
@@ -680,6 +680,30 @@ class InferenceEngine(abc.ABC):
         """
         raise NotImplementedError()
 
+    def update_weights_from_awex(
+        self,
+        meta: WeightUpdateMeta,
+        step_id: int | None = None,
+        kwargs: dict | None = None,
+    ) -> Future[None]:
+        """Update weights in the inference engine via Awex.
+
+        Parameters
+        ----------
+        meta : WeightUpdateMeta
+            Metadata containing information about the weight update
+        step_id : int | None
+            Step id to report to Awex (defaults to engine version if None)
+        kwargs : dict | None
+            Extra kwargs forwarded to Awex update endpoint
+
+        Returns
+        -------
+        Future[None]
+            A future object representing the asynchronous weight update operation
+        """
+        raise NotImplementedError()
+
     def set_version(self, version: int) -> None:
         """Set the current weight version in the inference engine.
 

--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -163,7 +163,7 @@ def get_versioned_lora_name(lora_name: str, version: int) -> str:
 
 @dataclass
 class WeightUpdateMeta:
-    type: Literal["disk", "nccl"]
+    type: Literal["disk", "xccl", "awex"]
     path: str | None = None
     alloc_mode: AllocationMode | None = None
 
@@ -181,6 +181,23 @@ class WeightUpdateMeta:
     clear_checkpoint_after_load: bool = True
 
     version: int | None = None
+
+    # Awex-specific fields
+    meta_server_addr: str | None = None
+    comm_backend: str | None = None
+    weights_exchange_ipc_backend: str | None = None
+    weights_comm_nccl_group_size: int = 1
+    enable_debug_mode: bool = False
+    debug_mode_config: dict = field(default_factory=dict)
+    disable_weights_exchange_pipeline: bool = False
+    enable_colocate_mode: bool = False
+    weights_validation_steps: int = 0
+    validate_weights_every_n_steps: int = 1
+    dump_weights_list_for_validation: list[str] = field(default_factory=list)
+    dump_weights_dir_for_validation: str | None = None
+    nnodes: int | None = None
+    node_rank: int | None = None
+    use_mindspeed: bool = False
 
     def with_version(self, version: int) -> "WeightUpdateMeta":
         """Return a copy of this meta with versioned path.
@@ -255,6 +272,44 @@ class WeightUpdateMeta:
             lora_name=lora_name,
             lora_int_id=lora_int_id,
             base_model_name=base_model_name,
+        )
+
+    @classmethod
+    def from_awex(
+        cls,
+        meta_server_addr: str,
+        comm_backend: str = "file",
+        weights_exchange_ipc_backend: str = "cuda",
+        weights_comm_nccl_group_size: int = 1,
+        enable_debug_mode: bool = False,
+        debug_mode_config: dict | None = None,
+        disable_weights_exchange_pipeline: bool = False,
+        enable_colocate_mode: bool = False,
+        weights_validation_steps: int = 0,
+        validate_weights_every_n_steps: int = 1,
+        dump_weights_list_for_validation: list[str] | None = None,
+        dump_weights_dir_for_validation: str | None = None,
+        nnodes: int | None = None,
+        node_rank: int | None = None,
+        use_mindspeed: bool = False,
+    ) -> "WeightUpdateMeta":
+        return cls(
+            type="awex",
+            meta_server_addr=meta_server_addr,
+            comm_backend=comm_backend,
+            weights_exchange_ipc_backend=weights_exchange_ipc_backend,
+            weights_comm_nccl_group_size=weights_comm_nccl_group_size,
+            enable_debug_mode=enable_debug_mode,
+            debug_mode_config=debug_mode_config or {},
+            disable_weights_exchange_pipeline=disable_weights_exchange_pipeline,
+            enable_colocate_mode=enable_colocate_mode,
+            weights_validation_steps=weights_validation_steps,
+            validate_weights_every_n_steps=validate_weights_every_n_steps,
+            dump_weights_list_for_validation=dump_weights_list_for_validation or [],
+            dump_weights_dir_for_validation=dump_weights_dir_for_validation,
+            nnodes=nnodes,
+            node_rank=node_rank,
+            use_mindspeed=use_mindspeed,
         )
 
 

--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import numpy as np
+import ray
 import torch
 import torch.distributed as dist
 from PIL.Image import Image as ImageObject
@@ -172,6 +173,8 @@ class WeightUpdateMeta:
     nccl_group_name: str | None = None
     weight_chunked_mem_mb: int = 1024
 
+    backend: str | None = None
+
     use_lora: bool = False
     lora_name: str = ""
     lora_int_id: int = 0
@@ -252,6 +255,7 @@ class WeightUpdateMeta:
             type="xccl",
             alloc_mode=allocation_mode,
             weight_chunked_mem_mb=weight_chunked_mem_mb,
+            backend=current_platform.communication_backend,
         )
 
     @classmethod
@@ -272,6 +276,7 @@ class WeightUpdateMeta:
             lora_name=lora_name,
             lora_int_id=lora_int_id,
             base_model_name=base_model_name,
+            backend=current_platform.communication_backend,
         )
 
     @classmethod
@@ -384,7 +389,25 @@ class LocalInfServerInfo:
 
     host: str
     port: int
-    process: subprocess.Popen
+    process: subprocess.Popen | None = None
+    # need to store actors in the case where launch server has actor refs so we can call destructor later
+    actors: list[ray.actor.ActorHandle[Any]] = field(default_factory=list)
+
+    @property
+    def is_ray(self) -> bool:
+        return bool(self.actors)
+
+    @property
+    def is_popen(self) -> bool:
+        return self.process is not None
+
+    @classmethod
+    def from_launch_result(cls, host: str, port: int, ret):
+        if isinstance(ret, subprocess.Popen):
+            return cls(host=host, port=port, process=ret)
+
+        # Must be list[ActorHandle]
+        return cls(host=host, port=port, actors=ret)
 
 
 @dataclass

--- a/areal/engine/__init__.py
+++ b/areal/engine/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "MegatronLMEngine",
     "RemoteSGLangEngine",
     "RemotevLLMEngine",
+    "RayRemotevLLMEngine",
 ]
 
 _LAZY_IMPORTS = {
@@ -24,6 +25,7 @@ _LAZY_IMPORTS = {
     "MegatronLMEngine": "areal.engine.megatron_engine",
     "RemoteSGLangEngine": "areal.engine.sglang_remote",
     "RemotevLLMEngine": "areal.engine.vllm_remote",
+    "RayRemotevLLMEngine": "areal.engine.ray_vllm_remote",
 }
 
 

--- a/areal/engine/awex_writer.py
+++ b/areal/engine/awex_writer.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+from areal.utils import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AwexMegatronWriterAdapter:
+    """Adapter that exposes AReaL MegatronEngine to Awex writer API."""
+
+    def __init__(self, engine, meta):
+        if getattr(meta, "use_mindspeed", False) or (meta.comm_backend == "hccl"):
+            # Ensure MindSpeed patches are enabled before Awex imports Megatron.
+            os.environ.setdefault("AWEX_USE_MINDSPEED", "1")
+        try:
+            from awex.writer.weights_writer import get_weights_exchange_writer
+        except Exception as exc:  # pragma: no cover - import guard
+            raise RuntimeError(
+                "Awex is not available. Install awex or ensure it is on PYTHONPATH."
+            ) from exc
+
+        self._engine = engine
+        self._get_writer = get_weights_exchange_writer
+        self.weights_exchange_writer = None
+
+        self.hf_config = engine.hf_config
+        self.model = engine.model
+        self.engine_name = "mcore"
+        self.global_step = -1
+
+        self.meta_server_addr = meta.meta_server_addr or ""
+        self.comm_backend = meta.comm_backend or "file"
+        self.enable_debug_mode = meta.enable_debug_mode
+        self.enable_colocate_mode = meta.enable_colocate_mode
+
+        self.config = {
+            "weights_validation_steps": meta.weights_validation_steps,
+            "validate_weights_every_n_steps": meta.validate_weights_every_n_steps,
+            "dump_weights_list_for_validation": meta.dump_weights_list_for_validation,
+            "dump_weights_dir_for_validation": meta.dump_weights_dir_for_validation,
+            "disable_weights_exchange_pipeline": meta.disable_weights_exchange_pipeline,
+            "debug_mode_config": meta.debug_mode_config,
+        }
+
+        self._export_meta_server_env(self.meta_server_addr)
+
+    def _export_meta_server_env(self, meta_server_addr: str) -> None:
+        os.environ["AWEX_META_SERVER_ADDR"] = meta_server_addr or ""
+        ip, port = (meta_server_addr or ":").split(":")
+        os.environ["AWEX_META_SERVER_IP"] = ip
+        os.environ["AWEX_META_SERVER_PORT"] = port
+
+    def initialize(self) -> None:
+        if self.weights_exchange_writer is not None:
+            return
+        self.weights_exchange_writer = self._get_writer(self)
+        self.weights_exchange_writer.initialize()
+        if self.enable_colocate_mode:
+            self.release_memory_occupation()
+
+    def set_global_step(self, global_step: int) -> None:
+        # Awex writer uses this for logging and synchronization metadata.
+        self.global_step = global_step
+
+    def write_weights(self, **kwargs) -> None:
+        if self.weights_exchange_writer is None:
+            raise RuntimeError("Awex writer not initialized.")
+        self.weights_exchange_writer.write_weights(step_id=self.global_step, **kwargs)
+        if self.enable_colocate_mode:
+            self.release_memory_occupation()
+
+    def save_hf_checkpoint(self, path: str) -> None:
+        self._engine._save_model_to_hf(path)
+
+    def release_memory_occupation(self, tags: Optional[list[str]] = None) -> None:
+        if self.enable_colocate_mode:
+            logger.warning(
+                "Awex colocate mode requested, but MegatronEngine does not "
+                "support fine-grained memory release. No-op."
+            )
+
+    def resume_memory_occupation(self, tags: Optional[list[str]] = None) -> None:
+        if self.enable_colocate_mode:
+            logger.warning(
+                "Awex colocate mode requested, but MegatronEngine does not "
+                "support fine-grained memory resume. No-op."
+            )
+
+    def release_grad_memory(self, empty_cache: bool = True) -> None:
+        # Placeholder to satisfy Awex TrainingEngine API.
+        return None

--- a/areal/engine/core/model.py
+++ b/areal/engine/core/model.py
@@ -90,7 +90,45 @@ def get_model_update_meta(config: BaseExperimentConfig) -> WeightUpdateMeta:
         return WeightUpdateMeta.from_disk(
             config.experiment_name, config.trial_name, config.cluster.fileroot
         )
-    else:
-        return WeightUpdateMeta.from_fsdp_xccl(
-            AllocationMode.from_str(config.allocation_mode)
+    if weight_update_mode == "awex":
+        awex_cfg = getattr(config, "awex", None)
+        if awex_cfg is None:
+            raise ValueError("Awex config is required when weight_update_mode is 'awex'.")
+        if not awex_cfg.meta_server_addr:
+            raise ValueError("awex.meta_server_addr must be set when using awex.")
+        comm_backend = awex_cfg.comm_backend
+        ipc_backend = awex_cfg.weights_exchange_ipc_backend
+        use_mindspeed = awex_cfg.use_mindspeed or awex_cfg.device_backend == "npu"
+        if awex_cfg.device_backend == "npu":
+            # Default to HCCL for NPU when NCCL is requested.
+            if comm_backend == "nccl":
+                comm_backend = "hccl"
+            # CUDA IPC is not available on NPU; fall back to CPU.
+            if ipc_backend == "cuda":
+                ipc_backend = "cpu"
+        meta = WeightUpdateMeta.from_awex(
+            meta_server_addr=awex_cfg.meta_server_addr,
+            comm_backend=comm_backend,
+            weights_exchange_ipc_backend=ipc_backend,
+            weights_comm_nccl_group_size=awex_cfg.weights_comm_nccl_group_size,
+            enable_debug_mode=awex_cfg.enable_debug_mode,
+            debug_mode_config=awex_cfg.debug_mode_config,
+            disable_weights_exchange_pipeline=awex_cfg.disable_weights_exchange_pipeline,
+            enable_colocate_mode=awex_cfg.enable_colocate_mode,
+            weights_validation_steps=awex_cfg.weights_validation_steps,
+            validate_weights_every_n_steps=awex_cfg.validate_weights_every_n_steps,
+            dump_weights_list_for_validation=awex_cfg.dump_weights_list_for_validation,
+            dump_weights_dir_for_validation=awex_cfg.dump_weights_dir_for_validation,
+            nnodes=awex_cfg.nnodes,
+            node_rank=awex_cfg.node_rank,
+            use_mindspeed=use_mindspeed,
         )
+        if awex_cfg.comm_backend == "file":
+            disk_meta = WeightUpdateMeta.from_disk(
+                config.experiment_name, config.trial_name, config.cluster.fileroot
+            )
+            meta.path = disk_meta.path
+        return meta
+    return WeightUpdateMeta.from_fsdp_xccl(
+        AllocationMode.from_str(config.allocation_mode)
+    )

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -1140,9 +1140,9 @@ class FSDPEngine(TrainEngine):
 
     @trace_perf("fsdp_engine.update_weights_from_disk", category="io")
     def _update_weights_from_disk(self, meta: WeightUpdateMeta):
-        fut = Future()
-
+        
         if dist.get_rank() == 0:
+            self.rollout_engine.pause_generation()
             fut = self.rollout_engine.update_weights_from_disk(meta)
 
         assert meta.path is not None
@@ -1160,6 +1160,7 @@ class FSDPEngine(TrainEngine):
             )
 
             fut.result()
+            self.rollout_engine.continue_generation()
 
         current_platform.synchronize()
         dist.barrier(group=self.cpu_group)

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -42,6 +42,7 @@ from areal.api import (
 )
 from areal.api.cli_args import MicroBatchSpec, PerfTracerConfig, TrainEngineConfig
 from areal.api.io_struct import DeviceRuntimeInfo
+from areal.engine.awex_writer import AwexMegatronWriterAdapter
 from areal.engine.core import (
     aggregate_eval_losses,
     compute_total_loss_weight,
@@ -167,6 +168,7 @@ class MegatronEngine(TrainEngine):
             self.fp8_config.direct_convert if self.enable_fp8 else False
         )
         self.quantization_config: dict[str, int | str | list[str]] | None = None
+        self.awex_writer: AwexMegatronWriterAdapter | None = None
 
     def create_process_group(self, parallel_strategy: ParallelStrategy | None = None):
         if parallel_strategy is None:
@@ -282,8 +284,11 @@ class MegatronEngine(TrainEngine):
 
         self.model = _MegatronModelList(models)
 
-        with self.device:
-            self._load_model_from_hf(self.config.path)
+        if self.config.init_from_scratch:
+            self.logger.info("init_from_scratch=True; skipping HF weight loading.")
+        else:
+            with self.device:
+                self._load_model_from_hf(self.config.path)
 
         # NOTE: Clear high_precision_init_val for FP8 parameters.
         #
@@ -443,6 +448,13 @@ class MegatronEngine(TrainEngine):
             rollout_engine=engine, train_engine=self
         )
 
+        if meta.type == "awex":
+            if not meta.meta_server_addr:
+                raise ValueError("meta_server_addr must be set for awex weight update.")
+            if self.awex_writer is None:
+                self.awex_writer = AwexMegatronWriterAdapter(self, meta)
+                self.awex_writer.initialize()
+
         if meta.type == "xccl" and not self.weight_update_group_initialized:
             self._init_weight_update_from_distributed(meta)
             self.weight_update_group_initialized = True
@@ -496,6 +508,8 @@ class MegatronEngine(TrainEngine):
             )
             with tms_context:
                 self._update_weights_from_distributed(meta)
+        elif meta.type == "awex":
+            self._update_weights_from_awex(meta)
         elif meta.type == "disk":
             self._update_weights_from_disk(meta)
         else:
@@ -1315,6 +1329,49 @@ class MegatronEngine(TrainEngine):
         dist.barrier(group=self.cpu_group)
 
         if dist.get_rank() == 0:
+            self.rollout_engine.continue_generation()
+
+        current_platform.synchronize()
+        dist.barrier(group=self.cpu_group)
+
+    @trace_perf("megatron_engine.update_weights_from_awex", category="comm")
+    def _update_weights_from_awex(self, meta: WeightUpdateMeta) -> None:
+        if self.awex_writer is None:
+            raise RuntimeError("Awex writer is not initialized. Call connect_engine().")
+
+        step_id = self.get_version()
+        self.awex_writer.set_global_step(step_id)
+
+        if dist.get_rank() == 0:
+            self.rollout_engine.pause_generation()
+
+        dist.barrier(group=self.cpu_group)
+
+        comm_backend = meta.comm_backend or "file"
+        fut = None
+        if comm_backend == "file":
+            if not meta.path:
+                raise ValueError("meta.path must be set for awex file backend.")
+            self.awex_writer.write_weights(path=meta.path)
+            if dist.get_rank() == 0:
+                fut = self.rollout_engine.update_weights_from_awex(
+                    meta, step_id=step_id, kwargs={"path": meta.path}
+                )
+        else:
+            if dist.get_rank() == 0:
+                fut = self.rollout_engine.update_weights_from_awex(
+                    meta, step_id=step_id, kwargs=None
+                )
+            # Give the reader a head start before writer sends.
+            dist.barrier(group=self.cpu_group)
+            self.awex_writer.write_weights()
+
+        dist.barrier(group=self.cpu_group)
+
+        if dist.get_rank() == 0 and fut is not None:
+            fut.result()
+            self.rollout_engine.continue_generation()
+        elif dist.get_rank() == 0:
             self.rollout_engine.continue_generation()
 
         current_platform.synchronize()

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -10,8 +10,8 @@ from concurrent.futures import Future
 from contextlib import nullcontext
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
-import mindspeed.megatron_adaptor
 
+import mindspeed.megatron_adaptor  # noqa: F401, isort: skip
 import mbridge
 import torch
 import torch.distributed as dist
@@ -408,6 +408,11 @@ class MegatronEngine(TrainEngine):
         assert self.process_group_initialized
         return mpu.get_data_parallel_group()
 
+    @property
+    def data_parallel_group_gloo(self) -> dist.ProcessGroup:
+        assert self.process_group_initialized
+        return mpu.get_data_parallel_group_gloo()
+
     def current_data_parallel_head(self) -> int:
         """Get the rank of the head of the current data parallel group."""
         assert self.process_group_initialized
@@ -793,7 +798,10 @@ class MegatronEngine(TrainEngine):
         return res
 
     def export_stats(self) -> dict[str, float]:
-        data = stats_tracker.export_all(reduce_group=self.data_parallel_group)
+        data = stats_tracker.export_all(
+            reduce_group=self.data_parallel_group,
+            gloo_group=self.data_parallel_group_gloo,
+        )
         if mpu.get_pipeline_model_parallel_world_size() > 1:
             # Some log info only exist in last pipeline rank
             data_list = [data]

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1410,9 +1410,9 @@ class MegatronEngine(TrainEngine):
 
     @trace_perf("megatron_engine.update_weights_from_disk", category="io")
     def _update_weights_from_disk(self, meta: WeightUpdateMeta) -> None:
-        fut = Future()
-
+        
         if dist.get_rank() == 0:
+            self.rollout_engine.pause_generation()
             fut = self.rollout_engine.update_weights_from_disk(meta)
 
         self._save_model_to_hf(meta.path, self.tokenizer, None)
@@ -1429,6 +1429,7 @@ class MegatronEngine(TrainEngine):
             )
 
             fut.result()
+            self.rollout_engine.pause_generation()
 
         current_platform.synchronize()
         dist.barrier(group=self.cpu_group)

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1429,7 +1429,7 @@ class MegatronEngine(TrainEngine):
             )
 
             fut.result()
-            self.rollout_engine.pause_generation()
+            self.rollout_engine.continue_generation()
 
         current_platform.synchronize()
         dist.barrier(group=self.cpu_group)

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -10,6 +10,7 @@ from concurrent.futures import Future
 from contextlib import nullcontext
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
+import mindspeed.megatron_adaptor
 
 import mbridge
 import torch
@@ -138,6 +139,7 @@ class MegatronEngine(TrainEngine):
         self.device = None
         self.optimizer_config = config.optimizer
         self.mcore_config = config.megatron
+        self.mindspeed_config = config.mindspeed
         self.parallel_strategy = None
         self.optimizer = None
         self.lr_scheduler = None
@@ -174,6 +176,9 @@ class MegatronEngine(TrainEngine):
         if parallel_strategy is None:
             parallel_strategy = ParallelStrategy()
         self.parallel_strategy = self._make_parallel_strategy(parallel_strategy)
+        # need to patch mindspeed here as it needs access to parallel strategy to init various internal groups
+        # as well as patch depending on parallelism sizes
+        self._patch_mindspeed(parallel_strategy)
         backend = current_platform.communication_backend
         if not dist.is_initialized():
             # NOTE: device_id **SHOULD NOT** be passed into init_process_group,
@@ -260,9 +265,30 @@ class MegatronEngine(TrainEngine):
             self.hf_config, self.tf_config = make_hf_and_mcore_config(
                 self.config.path, dtype=self.dtype, bridge=self.bridge
             )
-            self.tf_config = configure_pipeline_layer_splits(
-                self.parallel_strategy, self.hf_config, self.tf_config
-            )
+
+            if (
+                self.mcore_config.num_layers_in_first_pipeline_stage
+                or self.mcore_config.num_layers_in_last_pipeline_stage
+                or self.mcore_config.account_for_embedding_in_pipeline_split
+                or self.mcore_config.account_for_loss_in_pipeline_split
+            ):
+                self.bridge.config.num_layers_in_first_pipeline_stage = (
+                    self.mcore_config.num_layers_in_first_pipeline_stage
+                )
+                self.bridge.config.num_layers_in_last_pipeline_stage = (
+                    self.mcore_config.num_layers_in_last_pipeline_stage
+                )
+                self.bridge.config.account_for_embedding_in_pipeline_split = (
+                    self.mcore_config.account_for_embedding_in_pipeline_split
+                )
+                self.bridge.config.account_for_loss_in_pipeline_split = (
+                    self.mcore_config.account_for_loss_in_pipeline_split
+                )
+
+            else:
+                self.tf_config = configure_pipeline_layer_splits(
+                    self.parallel_strategy, self.hf_config, self.tf_config
+                )
 
             # Get quantization_config from hf_config if available (for FP8 weight updates)
             self.quantization_config = getattr(
@@ -621,9 +647,7 @@ class MegatronEngine(TrainEngine):
                 return loss, {}
 
             model_vp_stage = getattr(model, "vp_stage", 0)
-            if mpu.is_pipeline_last_stage(
-                ignore_virtual=False, vp_stage=model_vp_stage
-            ):
+            if mpu.is_pipeline_last_stage(ignore_virtual=False):
                 output = unpad_logits(
                     output,
                     padding_length=mb_input.padding_length,
@@ -972,7 +996,6 @@ class MegatronEngine(TrainEngine):
             use_distributed_optimizer=self.mcore_config.ddp.use_distributed_optimizer,
             params_dtype=self.dtype,
             clip_grad=self.optimizer_config.gradient_clipping,
-            fp8_recipe=(self.fp8_config.recipe if self.enable_fp8 else None),
         )
         mcore_opt_config.overlap_param_gather_with_optimizer_step = (
             self.mcore_config.overlap_param_gather_with_optimizer_step
@@ -1401,6 +1424,29 @@ class MegatronEngine(TrainEngine):
 
         current_platform.synchronize()
         dist.barrier(group=self.cpu_group)
+
+    def _patch_mindspeed(self, parallel_strategy: ParallelStrategy):
+        from mindspeed.megatron_adaptor import repatch
+
+        config = self.mindspeed_config.as_dict()
+        megatron_config = self.mcore_config
+        config_overrides = {
+            "context_parallel_size": getattr(
+                parallel_strategy, "context_parallel_size", 1
+            ),
+            "expert_model_parallel_size": getattr(
+                parallel_strategy, "expert_model_parallel_size", 1
+            ),
+            "tensor_model_parallel_size": getattr(
+                parallel_strategy, "tensor_parallel_size", 1
+            ),
+            "recompute_method": megatron_config.recompute_method,
+            "recompute_granularity": megatron_config.recompute_granularity,
+            "recompute_num_layers": megatron_config.recompute_num_layers,
+        }
+
+        config.update(config_overrides)
+        repatch(config)
 
     def _save_model_to_hf(
         self,

--- a/areal/engine/megatron_utils/megatron.py
+++ b/areal/engine/megatron_utils/megatron.py
@@ -36,7 +36,11 @@ def _all_gather_and_concat(
 
     # this is bug in megatron's grouped moe.
     partition_dim = (
-        1 if "linear_fc2.weight" in name and partition_dim == 0 else partition_dim
+        0
+        if "linear_fc1.weight" in name
+        else 1
+        if "linear_fc2.weight" in name and partition_dim == 0
+        else partition_dim
     )
 
     return torch.cat(partitions, dim=partition_dim)
@@ -609,7 +613,7 @@ def get_named_parameters(model_module, num_experts):
             except AssertionError:
                 vp_stage = None
 
-        layer_offset = get_transformer_layer_offset(config, vp_stage=vp_stage)
+        layer_offset = get_transformer_layer_offset(config)
         for name, param in single_module.named_parameters():
             # for model without ddp wrap
             if not name.startswith("module.module."):

--- a/areal/engine/megatron_utils/packed_context_parallel.py
+++ b/areal/engine/megatron_utils/packed_context_parallel.py
@@ -164,9 +164,7 @@ def packed_context_parallel_forward(
         ) from e
 
     model_vp_stage = getattr(model, "vp_stage", None)
-    is_pipeline_last_stage = mpu.is_pipeline_last_stage(
-        ignore_virtual=False, vp_stage=model_vp_stage
-    )
+    is_pipeline_last_stage = mpu.is_pipeline_last_stage(ignore_virtual=False)
     output = postprocess_packed_seqs_context_parallel(
         output, cu_seqlens, is_pipeline_last_stage
     )

--- a/areal/engine/megatron_utils/pipeline_parallel.py
+++ b/areal/engine/megatron_utils/pipeline_parallel.py
@@ -1,15 +1,127 @@
+# Copyright (c) 2019-2025, NVIDIA CORPORATION. All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import copy
+import enum
 import math
 
 from megatron.core.transformer import TransformerConfig
-from megatron.core.transformer.pipeline_parallel_layer_layout import (
-    PipelineParallelLayerLayout,
-)
 from transformers import PretrainedConfig
 
 from areal.api import MegatronParallelStrategy
 from areal.utils import logging
 
-logger = logging.getLogger("MCoreParallel")
+logger = logging.getLogger("MCore PipelineParallel")
+
+
+class LayerType(enum.Enum):
+    """Layer type
+    embedding: embedding layer
+    loss: loss layer
+    encoder: encoder layer, not implemented yet, expect to be used in MLLM models
+    decoder: decoder layer
+    mtp: multi-token prediction layer, not implemented yet
+    """
+
+    embedding = 1
+    loss = 2
+    encoder = 3
+    decoder = 4
+    mtp = 5
+
+
+class PipelineParallelLayerLayout:
+    """Configuration of custom pipeline parallel layer partitioning."""
+
+    def __repr__(self):
+        return self.input_data
+
+    def __init__(self, layout: str | list, pipeline_model_parallel_size: int):
+        """Initialize PipelineParallelLayerLayout from a list or a str.
+        Format validation will be done here.
+        """
+
+        self.input_data = layout
+        if isinstance(layout, str):
+            layout = PipelineParallelLayerLayout.parse_str_to_list(layout)
+        else:
+            layout = copy.deepcopy(layout)
+        assert all(isinstance(row, list) for row in layout), (
+            f"pipeline_model_parallel_layout must be a list of lists, but got"
+            f" {[type(row) for row in layout]=}"
+        )
+
+        # Check PP size and get VPP size
+        assert len(layout) % pipeline_model_parallel_size == 0, (
+            f"pipeline_model_parallel_layout must be divisible"
+            f" by pipeline_model_parallel_size ({len(layout)=},"
+            f" {pipeline_model_parallel_size=})"
+        )
+        virtual_pipeline_model_parallel_size = (
+            len(layout) // pipeline_model_parallel_size
+        )
+
+        # Convert 1D layout to 2D layout
+        layout = [
+            [
+                layout[vpp_rank * pipeline_model_parallel_size + pp_rank]
+                for vpp_rank in range(virtual_pipeline_model_parallel_size)
+            ]
+            for pp_rank in range(pipeline_model_parallel_size)
+        ]
+
+        # Convert all strings in pipeline_model_parallel_layout to LayerType
+        for pp_rank in range(pipeline_model_parallel_size):
+            for vpp_rank in range(virtual_pipeline_model_parallel_size):
+                transferred_layout = []
+                for layer_type in layout[pp_rank][vpp_rank]:
+                    assert isinstance(layer_type, LayerType) or isinstance(
+                        layer_type, str
+                    ), (
+                        f"elements in pipeline_model_parallel_layout must be LayerType or str,"
+                        f" but got {type(layer_type)}."
+                    )
+                    if isinstance(layer_type, str):
+                        layer_type = layer_type.strip().lower()
+                        assert layer_type in LayerType.__members__, (
+                            f"{layer_type} is not a valid LayerType"
+                        )
+                        layer_type = LayerType[layer_type]
+                    transferred_layout.append(layer_type)
+                layout[pp_rank][vpp_rank] = transferred_layout
+
+        # Flatten the pipeline layout in layer id order.
+        flatten_layout = []
+        for vpp_rank in range(virtual_pipeline_model_parallel_size):
+            for row in layout:
+                flatten_layout.extend(row[vpp_rank])
+
+        self.pipeline_model_parallel_size = pipeline_model_parallel_size
+        self.virtual_pipeline_model_parallel_size = virtual_pipeline_model_parallel_size
+        self.layout = layout
+        self.flatten_layout = flatten_layout
 
 
 def configure_pipeline_layer_splits(

--- a/areal/engine/ray_vllm_remote.py
+++ b/areal/engine/ray_vllm_remote.py
@@ -1,0 +1,165 @@
+import subprocess
+import sys
+import uuid
+from typing import Any
+
+import ray
+from ray.runtime_env import RuntimeEnv
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+from areal.api.cli_args import InferenceEngineConfig, vLLMConfig
+from areal.engine.vllm_remote import RemotevLLMEngine, VLLMBackend, _copy_environ
+from areal.infra import RemoteInfEngine
+from areal.infra.utils.proc import kill_process_tree
+from areal.infra.utils.ray import (
+    create_resource_spec,
+    get_placement_group_master_ip_and_port,
+)
+from areal.utils import logging
+
+logger = logging.getLogger("RayVLLMRemote")
+
+
+def _get_gpu(bundle):
+    if "NPU" in bundle:
+        return "NPU"
+    elif "GPU" in bundle:
+        return "GPU"
+
+    return ""
+
+
+def _get_resource_spec_and_n_gpu(bundle):
+    cpu = bundle["CPU"]
+    # already in bytes since it's from the bundle
+    memory = bundle["memory"]
+
+    # cannot be autodetected since this launcher is launched with 0 gpus
+    # must read from bundle
+    n_gpu = 0
+    device = "CPU"
+    if device := _get_gpu(bundle):
+        n_gpu = bundle[device]
+
+    return create_resource_spec(device, cpu, n_gpu, memory), n_gpu
+
+
+@ray.remote
+class vLLMMultinodeLauncher:
+    def __init__(self):
+        self.process = None
+
+    def launch_server(self, server_args: dict[str, Any], headless):
+        if headless:
+            cmd = vLLMConfig.build_cmd_from_args_headless(server_args)
+        else:
+            cmd = vLLMConfig.build_cmd_from_args(server_args)
+
+        _env = _copy_environ()
+
+        self.process = subprocess.Popen(
+            cmd, env=_env, stdout=sys.stdout, stderr=sys.stdout
+        )
+
+    def shutdown(self):
+        logger.info("Received termination, killing vllm server process")
+        if self.process and self.process.poll() is None:
+            kill_process_tree(self.process.pid, graceful=True)
+
+    def __ray_shutdown__(self):
+        self.shutdown()
+
+
+class RayVLLMBackend(VLLMBackend):
+    """
+    Same as VLLMBackend except uses Ray to launch the servers
+    """
+
+    def __init__(self):
+        super().__init__()
+        # save actors as strings instead of actor ref as actor ref is not serializable in ProcessPoolExecutor
+        self.actor_names: list[str] = []
+        # for dp
+        self.dp_ip = ""
+        self.dp_port = 0
+
+    def launch_server(
+        self, server_args: dict[str, Any]
+    ) -> list[ray.actor.ActorHandle[vLLMMultinodeLauncher]]:
+        pg = ray.util.get_current_placement_group()
+        tp_size = server_args["tensor_parallel_size"]
+        pp_size = server_args["pipeline_parallel_size"]
+        dp_group_world_size = tp_size * pp_size
+        dp_offset = 0
+        is_head = True
+
+        actors = []
+
+        for i, bundle in enumerate(pg.bundle_specs):
+            options, n_gpu = _get_resource_spec_and_n_gpu(bundle)
+            current_args = server_args.copy()
+            if is_head:
+                self.dp_ip, self.dp_port = get_placement_group_master_ip_and_port(pg, i)
+            logger.info(f"Launching actor {i}")
+
+            # remove VISIBLE DEVICE envs as ray head had already set them
+            # without removing them, vLLM cannot access devices
+            # similarly with ray inherited env vars as they can cause scheduling issues
+            _env = _copy_environ()
+            new_env = {}
+            for k, v in _env.items():
+                if "VISIBLE_DEVICE" in k:
+                    continue
+                if "VISIBLE_CORE" in k:
+                    continue
+                if "RAY_" in k:
+                    continue
+                new_env[k] = v
+
+            actor_name = str(uuid.uuid4())
+            actor = vLLMMultinodeLauncher.options(
+                **options,
+                name=actor_name,
+                lifetime="detached",
+                runtime_env=RuntimeEnv(env_vars=new_env),
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg,
+                    placement_group_capture_child_tasks=True,
+                    placement_group_bundle_index=i,
+                ),
+            ).remote()
+
+            # cast to int as the args require integer values
+            n_gpu = int(n_gpu)
+            dp_local = n_gpu // dp_group_world_size
+            current_args["data_parallel_size_local"] = dp_local
+            current_args["data_parallel_address"] = self.dp_ip
+            current_args["data_parallel_rpc_port"] = self.dp_port
+            logger.info(f"Launching server {i}")
+            if is_head:
+                current_args["api_server_count"] = int(bundle["CPU"])
+                actor.launch_server.remote(current_args, False)
+                is_head = False
+            else:
+                current_args["data_parallel_start_rank"] = dp_offset
+                actor.launch_server.remote(current_args, True)
+
+            dp_offset += dp_local
+
+            self.actor_names.append(actor_name)
+            actors.append(actor)
+
+        return actors
+
+
+class RayRemotevLLMEngine(RemotevLLMEngine):
+    """
+    Same as RemotevLLMEngine except uses RayVLLMBackend for composition
+    """
+
+    def __init__(self, config: InferenceEngineConfig):
+        self.config = config
+        # Pure composition - create internal engine with vLLM backend
+        self._engine = RemoteInfEngine(config, RayVLLMBackend())
+        # lora already initialized when use_lora=true during init, by design, for vLLM
+        self._engine.lora_initialized = config.use_lora

--- a/areal/engine/sglang_remote.py
+++ b/areal/engine/sglang_remote.py
@@ -202,6 +202,16 @@ class SGLangBackend:
         }
         return HttpRequest(endpoint="/init_weights_update_group", payload=payload)
 
+    def build_awex_init_request(
+        self, meta: WeightUpdateMeta, engine_rank: int, num_engines: int
+    ) -> HttpRequest:
+        raise NotImplementedError("Awex is not supported for SGLang backend.")
+
+    def build_awex_update_request(
+        self, meta: WeightUpdateMeta, step_id: int, kwargs: dict | None
+    ) -> HttpRequest:
+        raise NotImplementedError("Awex is not supported for SGLang backend.")
+
     def get_pause_request(self) -> HttpRequest:
         """Get SGLang pause request."""
         return HttpRequest(endpoint="/pause_generation", payload={})
@@ -266,9 +276,17 @@ class RemoteSGLangEngine(InferenceEngine):
         engine_id: str | None = None,
         addr: str | list[str] | None = None,
         train_data_parallel_size: int | None = None,
+        engine_rank: int | None = None,
+        num_engines: int | None = None,
     ):
         """Initialize the engine by discovering and connecting to servers."""
-        return self._engine.initialize(engine_id, addr, train_data_parallel_size)
+        return self._engine.initialize(
+            engine_id,
+            addr,
+            train_data_parallel_size,
+            engine_rank=engine_rank,
+            num_engines=num_engines,
+        )
 
     def destroy(self):
         """Destroy the engine and clean up resources."""
@@ -315,6 +333,15 @@ class RemoteSGLangEngine(InferenceEngine):
     def update_weights_from_disk(self, meta: WeightUpdateMeta) -> Future[None]:
         """Update weights from disk."""
         return self._engine.update_weights_from_disk(meta)
+
+    def update_weights_from_awex(
+        self,
+        meta: WeightUpdateMeta,
+        step_id: int | None = None,
+        kwargs: dict | None = None,
+    ) -> Future[None]:
+        """Update weights via Awex."""
+        raise NotImplementedError("Awex is not supported for SGLang backend.")
 
     def submit(
         self,

--- a/areal/engine/vllm_ext/areal_vllm_server.py
+++ b/areal/engine/vllm_ext/areal_vllm_server.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from http import HTTPStatus
-from typing import TYPE_CHECKING
 
 import uvloop
 from fastapi import Depends, Request
@@ -23,13 +22,6 @@ from vllm.entrypoints.openai.protocol import (
 from vllm.entrypoints.utils import cli_env_setup, load_aware_call, with_cancellation
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
-from vllm.v1.engine import EngineCoreOutput, EngineCoreOutputs, FinishReason
-from vllm.v1.engine.core import EngineCore
-from vllm.v1.metrics.stats import LoRARequestStates
-from vllm.v1.request import RequestStatus
-
-if TYPE_CHECKING:
-    from vllm.v1.engine.output_processor import RequestState
 
 logger = init_logger("areal_vllm_server")
 logger.setLevel(logging.INFO)
@@ -118,9 +110,12 @@ def build_response(ret_list):
 async def update_weight(request: UpdateWeightsRequest, raw_request: Request):
     logger.info(f"API server starts update_weight, {request.model_path}")
     llm = raw_request.app.state.engine_client
-    ret_list = await llm.engine_core.call_utility_async(
-        "areal_injected_update_weight",
-        request.model_path,
+
+    # Pause + abort inflight + clear caches
+    await llm.pause_generation(wait_for_inflight_requests=False, clear_cache=True)
+    ret_list = await llm.collective_rpc(
+        "update_weights",
+        args=(request.model_path,),
     )
     return build_response(ret_list)
 
@@ -128,15 +123,24 @@ async def update_weight(request: UpdateWeightsRequest, raw_request: Request):
 @router.post("/areal_update_weights_lora")
 async def update_weight_lora(request: UpdateWeightsRequestLora, raw_request: Request):
     logger.info(
-        f"API server starts update_weight_lora, lora_model_path-{request.lora_model_path}, lora_name-{request.lora_name}, lora_int_id-{request.lora_int_id}, base_model_name-{request.base_model_name}"
+        "API server starts update_weight_lora, "
+        f"lora_model_path-{request.lora_model_path}, "
+        f"lora_name-{request.lora_name}, "
+        f"lora_int_id-{request.lora_int_id}, "
+        f"base_model_name-{request.base_model_name}"
     )
     llm = raw_request.app.state.engine_client
-    ret_list = await llm.engine_core.call_utility_async(
-        "areal_injected_update_weight_lora",
-        request.lora_model_path,
-        request.lora_name,
-        request.lora_int_id,
-        request.base_model_name,
+    # Pause + abort inflight + clear caches
+    await llm.pause_generation(wait_for_inflight_requests=False, clear_cache=True)
+
+    ret_list = await llm.collective_rpc(
+        "update_weights_lora",
+        args=(
+            request.lora_model_path,
+            request.lora_name,
+            request.lora_int_id,
+            request.base_model_name,
+        ),
     )
     return build_response(ret_list)
 
@@ -145,9 +149,9 @@ async def update_weight_lora(request: UpdateWeightsRequestLora, raw_request: Req
 async def update_weight_xccl(raw_request: Request):
     logger.info("API server starts update_weight")
     llm = raw_request.app.state.engine_client
-    ret_list = await llm.engine_core.call_utility_async(
-        "areal_injected_update_weight_xccl",
-    )
+    # Pause + abort inflight + clear caches
+    await llm.pause_generation(wait_for_inflight_requests=False, clear_cache=True)
+    ret_list = await llm.collective_rpc("update_weight_xccl")
     return build_response(ret_list)
 
 
@@ -155,9 +159,10 @@ async def update_weight_xccl(raw_request: Request):
 async def update_weight_lora_xccl(raw_request: Request):
     logger.info("API server starts update_weight_lora via XCCL")
     llm = raw_request.app.state.engine_client
-    ret_list = await llm.engine_core.call_utility_async(
-        "areal_injected_update_weight_lora_xccl",
-    )
+    # Pause + abort inflight + clear caches
+    await llm.pause_generation(wait_for_inflight_requests=False, clear_cache=True)
+
+    ret_list = await llm.collective_rpc("update_weight_lora_xccl")
     return build_response(ret_list)
 
 
@@ -227,17 +232,31 @@ async def set_weight_meta_xccl_lora(
 @router.post("/areal_pause_generation")
 async def pause_generation(raw_request: Request):
     logger.info("API server starts pause_generation and aborts all requests")
+
     llm = raw_request.app.state.engine_client
-    # Abort all running and waiting requests
+
+    # 1) Pause vLLM generation
     _generation_run_event.clear()
-    await llm.engine_core.call_utility_async("abort_all_reqs")
+    await llm.pause_generation(
+        wait_for_inflight_requests=False,
+        clear_cache=True,
+    )
+
     return to_json_response(True, "Generation paused and all requests aborted")
 
 
 @router.post("/areal_continue_generation")
 async def continue_generation(raw_request: Request):
     logger.info("API server starts continue_generation")
+
+    llm = raw_request.app.state.engine_client
+
+    # resume engine
+    await llm.resume_generation()
+
+    # resume submission loop
     _generation_run_event.set()
+
     return to_json_response(True, "Generation continued")
 
 
@@ -268,122 +287,6 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     response = await original_create_completion(request, raw_request)
 
     return response
-
-
-# engine core related hook functions
-def abort_all_reqs(self):
-    """Abort all running and waiting requests and clean up resources."""
-    scheduler = self.scheduler
-    abort_lists = list(scheduler.running) + list(scheduler.waiting)
-
-    if not abort_lists:
-        # No requests to abort
-        success = scheduler.reset_prefix_cache()
-        if not success:
-            raise RuntimeError(
-                f"Prefix cache must be reset to prevent kv cache pollution! Reset: {success}"
-            )
-        return
-
-    client_outputs = {}
-    for req in abort_lists:
-        engine_output = EngineCoreOutput(
-            request_id=req.request_id,
-            new_token_ids=[],
-            finish_reason=FinishReason.ABORT,
-            new_logprobs=None,
-            new_prompt_logprobs_tensors=None,
-            stop_reason=None,
-        )
-        if req.client_index not in client_outputs:
-            client_outputs[req.client_index] = []
-        client_outputs[req.client_index].append(engine_output)
-
-    request_ids = [req.request_id for req in abort_lists]
-    scheduler.finish_requests(request_ids, RequestStatus.FINISHED_ABORTED)
-
-    for client_index, outputs in client_outputs.items():
-        engine_core_outputs = EngineCoreOutputs(outputs=outputs)
-        self.output_queue.put_nowait((client_index, engine_core_outputs))
-
-    success = scheduler.reset_prefix_cache()
-    if not success:
-        raise RuntimeError(
-            f"Prefix cache must be reset to prevent kv cache pollution! Reset: {success}"
-        )
-
-
-def areal_injected_update_weight(self, path):
-    self.abort_all_reqs()
-    return self.collective_rpc("update_weights", args=(path,))
-
-
-def areal_injected_update_weight_lora(
-    self, lora_model_path, lora_name, lora_int_id, base_model_name
-):
-    self.abort_all_reqs()
-    return self.collective_rpc(
-        "update_weights_lora",
-        args=(
-            lora_model_path,
-            lora_name,
-            lora_int_id,
-            base_model_name,
-        ),
-    )
-
-
-def areal_injected_update_weight_xccl(self):
-    self.abort_all_reqs()
-    return self.collective_rpc("update_weight_xccl")
-
-
-def areal_injected_update_weight_lora_xccl(self):
-    self.abort_all_reqs()
-    return self.collective_rpc("update_weight_lora_xccl")
-
-
-def finish_request(self, req_state: "RequestState"):
-    if req_state.lora_name is None:
-        return
-    lora_stats = self.lora_name_to_stats[req_state.lora_name]
-    # Simply added this if-condition
-    if req_state.request_id in lora_stats.running_requests:
-        lora_stats.running_requests.remove(req_state.request_id)
-
-
-def hook():
-    setattr(EngineCore, "abort_all_reqs", abort_all_reqs)
-    setattr(EngineCore, "areal_injected_update_weight", areal_injected_update_weight)
-    setattr(
-        EngineCore,
-        "areal_injected_update_weight_lora",
-        areal_injected_update_weight_lora,
-    )
-    setattr(
-        EngineCore,
-        "areal_injected_update_weight_xccl",
-        areal_injected_update_weight_xccl,
-    )
-    setattr(
-        EngineCore,
-        "areal_injected_update_weight_lora_xccl",
-        areal_injected_update_weight_lora_xccl,
-    )
-
-    # Patch for LoRARequestStates management in vllm < v0.11.0
-    # This may be removed with vllm >= 0.12.x
-    from areal.utils import pkg_version
-
-    if not pkg_version.is_version_greater_or_equal("vllm", "0.12.0"):
-        setattr(
-            LoRARequestStates,
-            "finish_request",
-            finish_request,
-        )
-
-
-hook()
 
 
 if __name__ == "__main__":

--- a/areal/engine/vllm_ext/vllm_worker_extension.py
+++ b/areal/engine/vllm_ext/vllm_worker_extension.py
@@ -2,17 +2,54 @@ import traceback
 
 import torch
 import torch.distributed as dist
+from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import init_logger
 from vllm.lora.lora_model import LoRAModel
 from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.model_loader import get_model_loader
+from vllm.model_executor.model_loader.utils import process_weights_after_loading
 
 from areal.engine.core.distributed import init_custom_process_group
 from areal.infra.platforms import current_platform
 from areal.utils.constants import DIST_GROUP_DEFAULT_TIMEOUT
 
 logger = init_logger("vllm_worker_extension")
+
+
+def undo_moe_postprocess_for_reload(model):
+    if getattr(current_platform, "device_type", None) != "npu":
+        return
+
+    for name, p in model.named_parameters():
+        if "mlp.experts.w13_weight" in name:
+            p.data = p.data.transpose(1, 2).contiguous()
+
+        elif "mlp.experts.w2_weight" in name:
+            p.data = p.data.transpose(1, 2).contiguous()
+
+
+def _apply_ascend_patch_once():
+    try:
+        from vllm_ascend.ops.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod
+    except Exception:
+        return
+
+    if getattr(AscendUnquantizedFusedMoEMethod, "_areal_patched", False):
+        return
+
+    original = AscendUnquantizedFusedMoEMethod.process_weights_after_loading
+
+    def patched(self_method, layer):
+        original(self_method, layer)
+        layer.w13_weight.weight_loader = layer.weight_loader
+        layer.w2_weight.weight_loader = layer.weight_loader
+
+    AscendUnquantizedFusedMoEMethod.process_weights_after_loading = patched
+    AscendUnquantizedFusedMoEMethod._areal_patched = True
+
+
+_apply_ascend_patch_once()
 
 
 class VLLMWorkerExtension:
@@ -28,12 +65,19 @@ class VLLMWorkerExtension:
         logger.info(f"start update weights, {model_path}", flush=True)
         try:
             # load weight
+            undo_moe_postprocess_for_reload(self.model_runner.model)
             self.model_runner.model_config.model = model_path
             model_loader = get_model_loader(self.model_runner.vllm_config.load_config)
             logger.info("Reloading weights inplace...")
             model_loader.load_weights(
                 self.model_runner.model, model_config=self.model_runner.model_config
             )
+            if getattr(current_platform, "device_type", None) == "npu":
+                process_weights_after_loading(
+                    self.model_runner.model,
+                    self.model_runner.model_config,
+                    self.model_runner.device,
+                )
             self.sync()
 
             return True, "Success"
@@ -118,6 +162,7 @@ class VLLMWorkerExtension:
 
     def update_weight_xccl(self):
         logger.info("start update weights by nccl or hccl", flush=True)
+        undo_moe_postprocess_for_reload(self.model_runner.model)
         names = self.areal_weight_meta_names
         dtypes = self.areal_weight_meta_dtypes
         shapes = self.areal_weight_meta_shapes
@@ -142,6 +187,12 @@ class VLLMWorkerExtension:
                     async_op=False,
                 )
                 self.model_runner.model.load_weights(weights=[(name, tensor)])
+            if getattr(current_platform, "device_type", None) == "npu":
+                process_weights_after_loading(
+                    self.model_runner.model,
+                    self.model_runner.model_config,
+                    self.model_runner.device,
+                )
             self.sync()
             return True, "Success"
         except Exception as e:
@@ -276,7 +327,7 @@ class VLLMWorkerExtension:
                 backend=backend,
                 world_size=world_size,
                 init_method=f"tcp://{master_address}:{master_port}",
-                rank=self.rank + rank_offset,
+                rank=get_world_group().rank + rank_offset,
                 group_name=group_name,
                 timeout=DIST_GROUP_DEFAULT_TIMEOUT,
             )

--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -33,6 +33,18 @@ from areal.utils import logging, perf_tracer, stats_tracker
 logger = logging.getLogger("vLLMEngine")
 
 
+def _copy_environ():
+    _env = os.environ.copy()
+    triton_cache_path = _env.get("TRITON_CACHE_PATH", TRITON_CACHE_PATH)
+    _env["TRITON_CACHE_PATH"] = os.path.join(triton_cache_path, str(uuid.uuid4()))
+
+    vllm_cache_path = _env.get("VLLM_CACHE_ROOT")
+    if vllm_cache_path:
+        _env["VLLM_CACHE_ROOT"] = os.path.join(vllm_cache_path, str(uuid.uuid4()))
+    _env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
+    return _env
+
+
 class VLLMBackend:
     """vLLM-specific backend implementation for remote inference."""
 
@@ -203,7 +215,9 @@ class VLLMBackend:
             "master_port": str(meta.nccl_master_port),
             "rank_offset": rank_offset,
             "world_size": meta.alloc_mode.gen.world_size + 1,
-            "backend": current_platform.communication_backend,
+            "backend": meta.backend
+            if meta.backend is not None
+            else current_platform.communication_backend,
             "group_name": meta.nccl_group_name,
         }
         return HttpRequest(endpoint="/areal_init_weights_update_group", payload=payload)
@@ -289,15 +303,7 @@ class VLLMBackend:
     def launch_server(self, server_args: dict[str, Any]) -> subprocess.Popen:
         """Launch vLLM server subprocess."""
         cmd = vLLMConfig.build_cmd_from_args(server_args)
-
-        _env = os.environ.copy()
-        triton_cache_path = _env.get("TRITON_CACHE_PATH", TRITON_CACHE_PATH)
-        _env["TRITON_CACHE_PATH"] = os.path.join(triton_cache_path, str(uuid.uuid4()))
-
-        vllm_cache_path = _env.get("VLLM_CACHE_ROOT")
-        if vllm_cache_path:
-            _env["VLLM_CACHE_ROOT"] = os.path.join(vllm_cache_path, str(uuid.uuid4()))
-        _env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
+        _env = _copy_environ()
 
         logger.info(f"Launching vLLM server with command: {' '.join(cmd)}")
         return subprocess.Popen(
@@ -396,7 +402,9 @@ class RemotevLLMEngine(InferenceEngine):
         kwargs: dict | None = None,
     ) -> Future[None]:
         """Update weights via Awex."""
-        return self._engine.update_weights_from_awex(meta, step_id=step_id, kwargs=kwargs)
+        return self._engine.update_weights_from_awex(
+            meta, step_id=step_id, kwargs=kwargs
+        )
 
     def submit(
         self,

--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -208,6 +208,45 @@ class VLLMBackend:
         }
         return HttpRequest(endpoint="/areal_init_weights_update_group", payload=payload)
 
+    def build_awex_init_request(
+        self, meta: WeightUpdateMeta, engine_rank: int, num_engines: int
+    ) -> HttpRequest:
+        """Build vLLM Awex init request."""
+        payload = {
+            "meta_server_addr": meta.meta_server_addr,
+            "engine_rank": engine_rank,
+            "num_engines": num_engines,
+            "comm_backend": meta.comm_backend or "file",
+            "enable_debug_mode": meta.enable_debug_mode,
+            "debug_mode_config": meta.debug_mode_config or {},
+            "disable_weights_exchange_pipeline": meta.disable_weights_exchange_pipeline,
+            "enable_colocate_mode": meta.enable_colocate_mode,
+            "weights_exchange_ipc_backend": meta.weights_exchange_ipc_backend or "cuda",
+            "weights_comm_nccl_group_size": meta.weights_comm_nccl_group_size,
+            "weights_validation_steps": meta.weights_validation_steps,
+            "validate_weights_every_n_steps": meta.validate_weights_every_n_steps,
+        }
+        if meta.dump_weights_list_for_validation:
+            payload["dump_weights_list_for_validation"] = (
+                meta.dump_weights_list_for_validation
+            )
+        if meta.dump_weights_dir_for_validation:
+            payload["dump_weights_dir_for_validation"] = (
+                meta.dump_weights_dir_for_validation
+            )
+        if meta.nnodes is not None:
+            payload["nnodes"] = meta.nnodes
+        if meta.node_rank is not None:
+            payload["node_rank"] = meta.node_rank
+        return HttpRequest(endpoint="/areal_awex_init", payload=payload)
+
+    def build_awex_update_request(
+        self, meta: WeightUpdateMeta, step_id: int, kwargs: dict | None
+    ) -> HttpRequest:
+        """Build vLLM Awex update request."""
+        payload = {"step_id": step_id, "kwargs": kwargs or {}}
+        return HttpRequest(endpoint="/areal_awex_update", payload=payload)
+
     def get_pause_request(self) -> HttpRequest:
         """Get vLLM pause request."""
         return HttpRequest(endpoint="/areal_pause_generation", payload={})
@@ -292,9 +331,17 @@ class RemotevLLMEngine(InferenceEngine):
         engine_id: str | None = None,
         addr: str | list[str] | None = None,
         train_data_parallel_size: int | None = None,
+        engine_rank: int | None = None,
+        num_engines: int | None = None,
     ):
         """Initialize the engine by discovering and connecting to servers."""
-        return self._engine.initialize(engine_id, addr, train_data_parallel_size)
+        return self._engine.initialize(
+            engine_id,
+            addr,
+            train_data_parallel_size,
+            engine_rank=engine_rank,
+            num_engines=num_engines,
+        )
 
     def destroy(self):
         """Destroy the engine and clean up resources."""
@@ -341,6 +388,15 @@ class RemotevLLMEngine(InferenceEngine):
     def update_weights_from_disk(self, meta: WeightUpdateMeta) -> Future[None]:
         """Update weights from disk."""
         return self._engine.update_weights_from_disk(meta)
+
+    def update_weights_from_awex(
+        self,
+        meta: WeightUpdateMeta,
+        step_id: int | None = None,
+        kwargs: dict | None = None,
+    ) -> Future[None]:
+        """Update weights via Awex."""
+        return self._engine.update_weights_from_awex(meta, step_id=step_id, kwargs=kwargs)
 
     def submit(
         self,

--- a/areal/infra/controller/rollout_callback.py
+++ b/areal/infra/controller/rollout_callback.py
@@ -165,6 +165,23 @@ class RolloutCallback:
         payload = {"meta": serialize_value(meta)}
         return self._post_nowait_void("/callback/update_weights_disk", payload)
 
+    def update_weights_from_awex(
+        self,
+        meta: WeightUpdateMeta,
+        step_id: int | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> Future[None]:
+        """Callback to controller to load weights via Awex on inference side.
+
+        This method is NON-BLOCKING to allow weight exchange coordination.
+        """
+        payload = {
+            "meta": serialize_value(meta),
+            "step_id": step_id,
+            "kwargs": serialize_value(kwargs),
+        }
+        return self._post_nowait_void("/callback/update_weights_awex", payload)
+
     def pause_generation(self) -> None:
         """Callback to controller to pause inference generation.
 

--- a/areal/infra/controller/rollout_controller.py
+++ b/areal/infra/controller/rollout_controller.py
@@ -273,6 +273,8 @@ class RolloutController:
                     # args in `engine_api`
                     engine_id=str(rank),
                     addr=f"{info.host}:{info.port}",
+                    engine_rank=rank,
+                    num_engines=len(self.workers),
                     *args,
                     **kwargs,
                 )
@@ -292,6 +294,8 @@ class RolloutController:
                     engine_name=self._engine_name(rank),
                     # args in `engine_api`
                     engine_id=str(rank),
+                    engine_rank=rank,
+                    num_engines=len(self.workers),
                     *args,
                     **kwargs,
                 )
@@ -561,6 +565,17 @@ class RolloutController:
             payload = request.get_json() or {}
             meta = deserialize_value(payload.get("meta"))
             self._callback_loop.run_until_complete(self.update_weights_from_disk(meta))
+            return jsonify({"status": "ok"})
+
+        @app.route("/callback/update_weights_awex", methods=["POST"])
+        def update_weights_awex():
+            payload = request.get_json() or {}
+            meta = deserialize_value(payload.get("meta"))
+            step_id = payload.get("step_id")
+            kwargs = deserialize_value(payload.get("kwargs"))
+            self._callback_loop.run_until_complete(
+                self.update_weights_from_awex(meta, step_id=step_id, kwargs=kwargs)
+            )
             return jsonify({"status": "ok"})
 
         @app.route("/callback/pause_generation", methods=["POST"])
@@ -1021,6 +1036,16 @@ class RolloutController:
         meta.clear_checkpoint_after_load = False
         await self._collective_rpc_async("update_weights_from_disk", meta=meta)
         shutil.rmtree(meta.path, ignore_errors=True)
+
+    async def update_weights_from_awex(
+        self,
+        meta: WeightUpdateMeta,
+        step_id: int | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ):
+        await self._collective_rpc_async(
+            "update_weights_from_awex", meta=meta, step_id=step_id, kwargs=kwargs
+        )
 
     async def pause_generation(self):
         await self._collective_rpc_async("pause_generation")

--- a/areal/infra/platforms/__init__.py
+++ b/areal/infra/platforms/__init__.py
@@ -21,13 +21,16 @@ def _init_platform() -> Platform:
     """
     Detect and initialize the appropriate platform based on available devices.
     Priority:
-    1. CUDA (NVIDIA)
-    2. TODO: NPU (if torch_npu is installed)
+    1. NPU (if torch_npu is installed)
+    2. CUDA (NVIDIA)
     3. CPU (fallback)
     Returns:
         An instance of a subclass of Platform corresponding to the detected hardware.
     """
-    if torch.cuda.is_available():
+    if is_npu_available:
+        logger.info("Initializing NPU platform (NPU).")
+        return NPUPlatform()
+    elif torch.cuda.is_available():
         device_name = torch.cuda.get_device_name().upper()
         logger.info(f"Detected CUDA device: {device_name}")
         if "NVIDIA" in device_name:
@@ -35,9 +38,6 @@ def _init_platform() -> Platform:
             return CudaPlatform()
         logger.warning("Unrecognized CUDA device. Falling back to UnknownPlatform.")
         return UnknownPlatform()
-    elif is_npu_available:
-        logger.info("Initializing NPU platform (NPU).")
-        return NPUPlatform()
     else:
         logger.info("No supported accelerator detected. Initializing CPU platform.")
         return CpuPlatform()

--- a/areal/infra/platforms/platform.py
+++ b/areal/infra/platforms/platform.py
@@ -50,7 +50,7 @@ class Platform:
     # .e.g. CUDA_VISIBLE_DEVICES for CUDA.
     # hint: search for "get_visible_accelerator_ids_env_var" in
     # https://github.com/ray-project/ray/tree/master/python/ray/_private/accelerators # noqa
-    # Examples: "CUDA_VISIBLE_DEVICES", "ASCEND_VISIBLE_DEVICES"
+    # Examples: "CUDA_VISIBLE_DEVICES", "ASCEND_RT_VISIBLE_DEVICES"
     device_control_env_var: str
 
     # Optional Ray experimental config

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -226,6 +226,18 @@ class RemoteInfBackendProtocol(Protocol):
         """
         ...
 
+    def build_awex_init_request(
+        self, meta: WeightUpdateMeta, engine_rank: int, num_engines: int
+    ) -> HttpRequest:
+        """Build request to initialize Awex on the inference server."""
+        ...
+
+    def build_awex_update_request(
+        self, meta: WeightUpdateMeta, step_id: int, kwargs: dict | None
+    ) -> HttpRequest:
+        """Build request to update weights via Awex."""
+        ...
+
     def get_pause_request(self) -> HttpRequest:
         """Get request to pause generation.
 
@@ -351,6 +363,12 @@ class RemoteInfEngine(InferenceEngine):
         self._version = 0
 
         self.lock = Lock()
+        # Serialize Awex init so concurrent updates do not double-init the remote engine.
+        self._awex_lock = Lock()
+        self._awex_initialized = False
+        # Optional Awex engine identity overrides (set by controller).
+        self._awex_engine_rank: int | None = None
+        self._awex_num_engines: int | None = None
 
         self._workflow_executor: WorkflowExecutor | None = None
         self._initialized = False
@@ -384,6 +402,8 @@ class RemoteInfEngine(InferenceEngine):
         engine_id: str | None = None,
         addr: str | list[str] | None = None,
         train_data_parallel_size: int | None = None,
+        engine_rank: int | None = None,
+        num_engines: int | None = None,
     ):
         """Initialize the engine by discovering and connecting to servers.
 
@@ -402,6 +422,10 @@ class RemoteInfEngine(InferenceEngine):
             else:
                 engine_id = uuid.uuid4().hex
         self.engine_id = engine_id
+        if engine_rank is not None:
+            self._awex_engine_rank = int(engine_rank)
+        if num_engines is not None:
+            self._awex_num_engines = int(num_engines)
         self.logger = logging.getLogger(f"[RemoteInfEngine Rank {engine_id}]")
 
         if addr:
@@ -991,6 +1015,44 @@ class RemoteInfEngine(InferenceEngine):
         fut.add_done_callback(callback)
         return fut
 
+    def update_weights_from_awex(
+        self,
+        meta: WeightUpdateMeta,
+        step_id: int | None = None,
+        kwargs: dict | None = None,
+    ) -> Future[None]:
+        """Update weights in the inference engine via Awex."""
+        assert meta.type == "awex"
+        if not meta.meta_server_addr:
+            raise ValueError("meta_server_addr must be set for awex updates.")
+        if step_id is None:
+            step_id = self.get_version()
+        with self._awex_lock:
+            if not self._awex_initialized:
+                init_fut = get_executor().submit(
+                    _init_awex_remote,
+                    self.backend,
+                    meta,
+                    self.addresses,
+                    self._awex_engine_rank,
+                    self._awex_num_engines,
+                    self.config.request_timeout,
+                    self.config.request_retries,
+                )
+                init_fut.result()
+                self._awex_initialized = True
+
+        return get_executor().submit(
+            _update_weights_from_awex,
+            self.backend,
+            meta,
+            step_id,
+            kwargs,
+            self.addresses,
+            self.config.request_timeout,
+            self.config.request_retries,
+        )
+
     def submit(
         self,
         data: dict[str, Any],
@@ -1412,5 +1474,106 @@ def _update_weights_from_distributed(
                     for addr in addresses
                 ]
                 await asyncio.gather(*jobs)
+
+    return uvloop.run(_fn())
+
+
+def _init_awex_remote(
+    backend: RemoteInfBackendProtocol,
+    meta: WeightUpdateMeta,
+    addresses: list[str],
+    engine_rank_override: int | None = None,
+    num_engines_override: int | None = None,
+    request_timeout: float | None = None,
+    request_retries: int | None = None,
+):
+    """Helper to initialize Awex on remote inference servers."""
+    if request_timeout is None and request_retries is None:
+        # Backward compatibility: old signature passed (timeout, retries) in place of overrides.
+        request_timeout = float(engine_rank_override) if engine_rank_override is not None else None
+        request_retries = int(num_engines_override) if num_engines_override is not None else None
+        engine_rank_override = None
+        num_engines_override = None
+    if request_timeout is None or request_retries is None:
+        raise ValueError("request_timeout and request_retries must be provided.")
+
+    async def _fn():
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=request_timeout),
+            read_bufsize=1024 * 1024 * 10,
+            connector=get_default_connector(),
+        ) as session:
+            jobs = []
+            if engine_rank_override is not None and num_engines_override is not None:
+                for addr in addresses:
+                    http_req = backend.build_awex_init_request(
+                        meta,
+                        engine_rank=engine_rank_override,
+                        num_engines=num_engines_override,
+                    )
+                    jobs.append(
+                        arequest_with_retry(
+                            session=session,
+                            addr=addr,
+                            endpoint=http_req.endpoint,
+                            payload=http_req.payload,
+                            method=http_req.method,
+                            max_retries=request_retries,
+                            timeout=request_timeout,
+                        )
+                    )
+            else:
+                num_engines = len(addresses)
+                for engine_rank, addr in enumerate(addresses):
+                    http_req = backend.build_awex_init_request(
+                        meta, engine_rank=engine_rank, num_engines=num_engines
+                    )
+                    jobs.append(
+                        arequest_with_retry(
+                            session=session,
+                            addr=addr,
+                            endpoint=http_req.endpoint,
+                            payload=http_req.payload,
+                            method=http_req.method,
+                            max_retries=request_retries,
+                            timeout=request_timeout,
+                        )
+                    )
+            await asyncio.gather(*jobs)
+
+    return uvloop.run(_fn())
+
+
+def _update_weights_from_awex(
+    backend: RemoteInfBackendProtocol,
+    meta: WeightUpdateMeta,
+    step_id: int,
+    kwargs: dict | None,
+    addresses: list[str],
+    request_timeout: float,
+    request_retries: int,
+):
+    """Helper to update weights via Awex in a separate process."""
+
+    async def _fn():
+        http_req = backend.build_awex_update_request(meta, step_id, kwargs)
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=request_timeout),
+            read_bufsize=1024 * 1024 * 10,
+            connector=get_default_connector(),
+        ) as session:
+            jobs = [
+                arequest_with_retry(
+                    session=session,
+                    addr=addr,
+                    endpoint=http_req.endpoint,
+                    payload=http_req.payload,
+                    method=http_req.method,
+                    max_retries=request_retries,
+                    timeout=request_timeout,
+                )
+                for addr in addresses
+            ]
+            await asyncio.gather(*jobs)
 
     return uvloop.run(_fn())

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -39,7 +39,6 @@ from areal.api.io_struct import (
     WeightUpdateRequests,
 )
 from areal.infra import workflow_context
-from areal.infra.platforms import current_platform
 from areal.infra.utils.concurrent import get_executor
 from areal.infra.utils.http import arequest_with_retry, get_default_connector
 from areal.infra.utils.launcher import wait_llm_server_addrs
@@ -930,7 +929,7 @@ class RemoteInfEngine(InferenceEngine):
 
         def callback(fut):
             self.logger.info(
-                f"Initialized {current_platform.communication_backend.upper()} group "
+                f"Initialized {meta.backend} group "
                 f"for distributed weight update for {meta.nccl_group_name}."
             )
 
@@ -1298,12 +1297,13 @@ class RemoteInfEngine(InferenceEngine):
         """Launch a local inference server."""
         server_args["host"] = gethostip()
         server_args["port"] = find_free_ports(1)[0]
-        process = self.backend.launch_server(server_args)
+        launch_reference = self.backend.launch_server(server_args)
+
         address = f"{server_args['host']}:{server_args['port']}"
-        server_info = LocalInfServerInfo(
+        server_info = LocalInfServerInfo.from_launch_result(
             host=server_args["host"],
             port=server_args["port"],
-            process=process,
+            ret=launch_reference,
         )
         try:
             self._wait_for_server(address)
@@ -1327,9 +1327,15 @@ class RemoteInfEngine(InferenceEngine):
         addr = f"{server_info.host}:{server_info.port}"
         if addr in self.addresses:
             self.addresses.remove(addr)
-        if server_info.process.poll() is not None:
-            return
-        kill_process_tree(server_info.process.pid, graceful=True)
+        if server_info.is_popen:
+            if server_info.process.poll() is not None:
+                return
+            kill_process_tree(server_info.process.pid, graceful=True)
+        elif server_info.is_ray:
+            for actor in server_info.actors:
+                logger.info(f"Shutting down actor {actor}")
+                # manual graceful termination
+                actor.__ray_terminate__.remote()
 
     def teardown_server(self):
         """Teardown all locally launched servers."""
@@ -1490,8 +1496,12 @@ def _init_awex_remote(
     """Helper to initialize Awex on remote inference servers."""
     if request_timeout is None and request_retries is None:
         # Backward compatibility: old signature passed (timeout, retries) in place of overrides.
-        request_timeout = float(engine_rank_override) if engine_rank_override is not None else None
-        request_retries = int(num_engines_override) if num_engines_override is not None else None
+        request_timeout = (
+            float(engine_rank_override) if engine_rank_override is not None else None
+        )
+        request_retries = (
+            int(num_engines_override) if num_engines_override is not None else None
+        )
         engine_rank_override = None
         num_engines_override = None
     if request_timeout is None or request_retries is None:

--- a/areal/infra/rpc/ray_rpc_server.py
+++ b/areal/infra/rpc/ray_rpc_server.py
@@ -190,3 +190,7 @@ class RayRPCServer:
         self._engines.clear()
         self._default_engine_name = None
         ray.actor.exit_actor()
+
+
+def __ray_shutdown__(self):
+    self.destroy()

--- a/areal/infra/rpc/ray_rpc_server.py
+++ b/areal/infra/rpc/ray_rpc_server.py
@@ -1,13 +1,21 @@
+import abc
 import os
+import shlex
+import subprocess
+import sys
+import time
 import traceback
 from concurrent.futures import Future
 from typing import Any
 
 import ray
+import requests
 
 from areal.api import InferenceEngine, TrainEngine
 from areal.api.cli_args import BaseExperimentConfig
 from areal.infra.rpc.rtensor import RTensor
+from areal.infra.rpc.serialization import deserialize_value, serialize_value
+from areal.infra.utils.proc import kill_process_tree
 from areal.utils import logging, name_resolve, seeding
 from areal.utils.data import (
     broadcast_tensor_container,
@@ -17,25 +25,16 @@ from areal.utils.dynamic_import import import_from_string
 from areal.utils.network import find_free_ports
 
 
-@ray.remote
-class RayRPCServer:
+class RayServer(abc.ABC):
     """
-    Ray engine container. Represents either:
-    - one training world rank, or
-    - one rollout instance
-
-    Supports multiple named engines per worker for colocation scenarios.
-
-    Placement group scheduling is controlled by the scheduler.
-    The actor is only responsible for the engine lifecycle and method calls
-    within this process.
+    Ray actor base class that all Ray actors under RayScheduler should inherit from
     """
 
-    def __init__(self):
+    def __init__(self, config: BaseExperimentConfig, **kwargs):
         self._engines: dict[str, TrainEngine | InferenceEngine] = {}
         self._default_engine_name: str | None = None  # For backward compatibility
         self._allocated_port = set()
-        self.logger = logging.getLogger("RayRPCServer")
+        self.config: BaseExperimentConfig = config
 
     def _get_device(self):
         # lazy resolve the device inside worker process
@@ -63,6 +62,51 @@ class RayRPCServer:
     def set_env(self, env: dict[str, str]) -> None:
         for k, v in env.items():
             os.environ[str(k)] = str(v)
+
+    def post_init(self, **kwargs) -> Any:
+        # the HTTPLauncher needs this, but keeping this here for interface compatibility
+        # launched after the actor has been deployed
+        pass
+
+    @abc.abstractmethod
+    def create_engine(
+        self,
+        engine: str,
+        *init_args,
+        engine_name: str | None = None,
+        **init_kwargs,
+    ) -> None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def call(self, method: str, *args, engine_name: str | None = None, **kwargs) -> Any:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def destroy(self) -> None:
+        raise NotImplementedError()
+
+    def __ray_shutdown__(self):
+        self.destroy()
+
+
+@ray.remote
+class RayRPCServer(RayServer):
+    """
+    Ray engine container. Represents either:
+    - one training world rank, or
+    - one rollout instance
+
+    Supports multiple named engines per worker for colocation scenarios.
+
+    Placement group scheduling is controlled by the scheduler.
+    The actor is only responsible for the engine lifecycle and method calls
+    within this process.
+    """
+
+    def __init__(self, config: BaseExperimentConfig, **kwargs):
+        super().__init__(config, **kwargs)
+        self.logger = logging.getLogger("RayRPCServer")
 
     def create_engine(
         self,
@@ -192,5 +236,169 @@ class RayRPCServer:
         ray.actor.exit_actor()
 
 
-def __ray_shutdown__(self):
-    self.destroy()
+@ray.remote
+class RayHTTPLauncher(RayServer):
+    """
+    Ray implementation of a launcher to launch proxy servers and any HTTP servers
+    """
+
+    REQUIRED_ARGS = ("command", "worker_index", "role")
+
+    def __init__(self, config: BaseExperimentConfig, **kwargs):
+        super().__init__(config, **kwargs)
+        self.logger = logging.getLogger("RayHTTPLauncher")
+
+        missing = [k for k in self.REQUIRED_ARGS if k not in kwargs]
+        if missing:
+            raise TypeError(f"Missing required kwargs: {missing}")
+
+        self.command = kwargs["command"]
+        self.worker_index = kwargs["worker_index"]
+        self.role = kwargs["role"]
+        self.worker_ip = ray.util.get_node_ip_address()
+        self.worker_port = None
+        self.worker_process: subprocess.Popen | None = None
+
+    def post_init(self, **kwargs):
+        self.worker_port = kwargs.get("port", self.alloc_ports(1)[0])
+        self.worker_process = self.launch_server(port=self.worker_port)
+
+    def create_engine(
+        self,
+        engine: str,
+        *init_args,
+        engine_name: str | None = None,
+        **init_kwargs,
+    ) -> None:
+        self.logger.debug(f"Initializing engine {engine}")
+        payload = {
+            "engine": engine,
+            "engine_name": engine_name,
+            "init_args": serialize_value(list(init_args)),
+            "init_kwargs": serialize_value(init_kwargs),
+        }
+        return self._post_request("create_engine", payload)
+
+    def call(self, method: str, *args, engine_name: str | None = None, **kwargs) -> Any:
+        self.logger.debug(
+            f"Calling {method} on engine '{engine_name}' with arguments {args=} {kwargs=}"
+        )
+
+        payload = {
+            "method": method,
+            "engine_name": engine_name,
+            "args": serialize_value(list(args)),
+            "kwargs": serialize_value(kwargs),
+        }
+        return self._post_request("call", payload)
+
+    def destroy(self) -> None:
+        if self.worker_process and self.worker_process.poll() is None:
+            kill_process_tree(self.worker_process.pid, timeout=3, graceful=True)
+
+        # Destroy all engines
+        for engine_name, engine in list(self._engines.items()):
+            try:
+                engine.destroy()
+                self.logger.info(f"RayRPCServer Engine '{engine_name}' destroyed")
+            except Exception as e:
+                self.logger.error(
+                    f"RayRPCServer error destroying engine '{engine_name}': {e}"
+                )
+        self._engines.clear()
+        self._default_engine_name = None
+        ray.actor.exit_actor()
+
+    def launch_server(self, port):
+        # keeping this as a separate function to support Awex server launches later
+        if not self.command:
+            raise RuntimeError(
+                f"Command was not given to {self.__class__.__name__}.launch_server. Cannot launch without command."
+            )
+
+        cmd = [sys.executable, "-m"]
+        cmd.extend(shlex.split(self.command))
+        cmd.extend(["--port", str(port)])
+
+        cmd.extend(["--experiment-name", self.config.experiment_name])
+        cmd.extend(["--trial-name", self.config.trial_name])
+        cmd.extend(["--role", self.role])
+        cmd.extend(["--worker-index", str(self.worker_index)])
+
+        cluster_config = self.config.cluster
+        name_resolve = self.config.cluster.name_resolve
+
+        cmd.extend(["--name-resolve-type", name_resolve.type])
+        cmd.extend(["--nfs-record-root", name_resolve.nfs_record_root])
+        cmd.extend(["--etcd3-addr", name_resolve.etcd3_addr])
+        cmd.extend(["--fileroot", str(cluster_config.fileroot)])
+
+        _env = os.environ.copy()
+        self.worker_process = subprocess.Popen(
+            cmd, env=_env, stdout=sys.stdout, stderr=subprocess.STDOUT
+        )
+
+        try:
+            self._check_health()
+        except Exception as e:
+            self.logger.error(e)
+            kill_process_tree(self.worker_process.pid, timeout=3, graceful=True)
+            raise RuntimeError(f"Could not launch server with command {cmd}")
+
+        return self.worker_process
+
+    def _post_request(
+        self,
+        endpoint,
+        payload,
+        http_timeout: float = 7200.0,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+    ):
+        url = f"{self.url}/{endpoint}"
+        # adapted from local scheduler
+        for attempt in range(1, max_retries + 1):
+            if self.worker_process and self.worker_process.poll() is not None:
+                raise RuntimeError("Worker has terminated")
+
+            response = requests.post(url, json=payload, timeout=http_timeout)
+
+            if response.status_code == 200:
+                result = response.json().get("result")
+                deserialized_result = deserialize_value(result)
+                return deserialized_result
+            elif response.status_code in [400, 500]:
+                error_detail = response.json().get("detail", "unknown error")
+                return error_detail
+
+            # otherwise retry
+            if attempt < max_retries:
+                delay = retry_delay * (2 ** (attempt - 1))
+                self.logger.warning(
+                    f"Calling url {url} failed on actor '{ray.runtime_context.get_runtime_context().current_actor}' "
+                    f"(attempt {attempt}/{max_retries}): {response.json()}. "
+                    f"Retrying in {delay:.1f}s..."
+                )
+                time.sleep(delay)
+
+    @property
+    def url(self):
+        return f"http://{self.worker_ip}:{self.worker_port}"
+
+    def _check_health(self, timeout: float = 60.0):
+        url = f"{self.url}/health"
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.worker_process and self.worker_process.poll() is not None:
+                raise RuntimeError("Server process exited before becoming healthy")
+
+            try:
+                r = requests.get(url, timeout=2.0)
+                if r.status_code == 200:
+                    return
+            except requests.RequestException:
+                # expected during startup
+                pass
+            time.sleep(1)
+
+        raise RuntimeError(f"Health check timed out for {url}")

--- a/areal/infra/scheduler/ray.py
+++ b/areal/infra/scheduler/ray.py
@@ -19,7 +19,7 @@ from areal.api.cli_args import (
     SchedulingSpec,
     SchedulingStrategyType,
 )
-from areal.infra.rpc.ray_rpc_server import RayRPCServer
+from areal.infra.rpc.ray_rpc_server import RayHTTPLauncher, RayRPCServer
 from areal.infra.scheduler.exceptions import (
     EngineCallError,
     WorkerCreationError,
@@ -182,7 +182,7 @@ class RayScheduler(Scheduler):
                 name=worker_id,
                 runtime_env=RuntimeEnv(env_vars=env),
                 scheduling_strategy=pg_scheduling_strategy,
-            ).remote()
+            ).remote(config=self.exp_config)
 
             # 0 needed to pad the list as the trainer takes index 1 for ports
             worker_ports = ["0", str(master_port)]
@@ -209,7 +209,8 @@ class RayScheduler(Scheduler):
         role: str,
         target_role: str,
         target_workers: list[RayWorkerInfo],
-        schedulings,
+        schedulings: list[SchedulingSpec],
+        command: str | None = None,
     ) -> list[str]:
         """Create forked workers on same placement groups as target workers.
 
@@ -238,9 +239,11 @@ class RayScheduler(Scheduler):
 
         worker_info_list: list[RayWorkerInfo] = []
         worker_ids: list[str] = []
+        post_init_tasks: list[ray.ObjectRef] = []
 
         for idx, (target_wi, spec) in enumerate(zip(target_workers, schedulings)):
-            worker_id = f"{role}/{idx}"
+            # include parent in ray name since role and iteration idx alone can cause name collision if forking multiple times
+            worker_id = f"{target_role}/{role}/{idx}"
 
             # Reuse placement group from target worker
             pg = target_wi.placement_group
@@ -266,13 +269,23 @@ class RayScheduler(Scheduler):
                     additional_options = dict(num_gpus=0.01)
                 else:
                     additional_options = {"resources": {device: 0.01}}
-            actor = RayRPCServer.options(
+            if command and "rpc.rpc_server" not in command:
+                actor_cls = RayHTTPLauncher
+            else:
+                actor_cls = RayRPCServer
+            actor = actor_cls.options(
                 **additional_options,
                 num_cpus=0,  # Minimal CPU allocation for forked actor
                 name=worker_id,
                 runtime_env=RuntimeEnv(env_vars=target_wi.env_vars),
                 scheduling_strategy=PlacementGroupSchedulingStrategy(**strategy_kwargs),
-            ).remote()
+            ).remote(
+                config=self.exp_config,
+                # needed for RayHTTPLauncher
+                command=command,
+                worker_index=idx,
+                role=role,
+            )
 
             # Build Worker object with same IP/ports as target
             worker_ports = ray.get(
@@ -280,6 +293,8 @@ class RayScheduler(Scheduler):
                     count=len(target_wi.worker.worker_ports)
                 )
             )
+            # run any post inits needed
+            post_init_tasks.append(actor.post_init.remote(port=worker_ports[0]))
 
             worker = Worker(
                 id=worker_id,
@@ -300,8 +315,9 @@ class RayScheduler(Scheduler):
             worker_info_list.append(wi)
             worker_ids.append(worker_id)
 
+        ray.get(post_init_tasks)
         # Register forked workers
-        self._workers[role] = worker_info_list
+        self._workers.setdefault(role, []).extend(worker_info_list)
         for wi in worker_info_list:
             self._worker_info_by_id[wi.worker.id] = wi
 
@@ -562,11 +578,6 @@ class RayScheduler(Scheduler):
         list[str]
             List of worker IDs created (e.g., ["proxy/0", "proxy/1"])
         """
-        if command is not None:
-            logger.warning(
-                f"RayScheduler.fork_workers: 'command' parameter is ignored. "
-                f"Ray actors always use RayRPCServer. Got command='{command}'"
-            )
 
         if target_role not in self._workers:
             raise WorkerNotFoundError(f"Target role '{target_role}' not found for fork")
@@ -575,10 +586,12 @@ class RayScheduler(Scheduler):
         schedulings = []
         for target_wi in target_workers:
             # Use minimal resources for forked workers
-            schedulings.append(SchedulingSpec(cpu=0, mem=0, gpu=1, port_count=1))
+            # use 0 gpu to prevent any scheduling issues since forks so far only use cpu
+            # future forks that require gpu should change fork implementation to accept a scheduling spec
+            schedulings.append(SchedulingSpec(cpu=0, mem=0, gpu=0, port_count=1))
 
-        worker_ids = self._create_forked_workers(
-            role, target_role, target_workers, schedulings
+        worker_ids = self._create_forked_workers_internal(
+            role, target_role, target_workers, schedulings, command
         )
         self._colocated_roles[role] = target_role
         return worker_ids

--- a/areal/infra/scheduler/ray.py
+++ b/areal/infra/scheduler/ray.py
@@ -55,7 +55,7 @@ class RayWorkerInfo:
 class RayScheduler(Scheduler):
     def __init__(
         self,
-        startup_timeout: float = 30.0,
+        startup_timeout: float = 300.0,
         *,
         exp_config: BaseExperimentConfig | None = None,
     ):
@@ -162,19 +162,18 @@ class RayScheduler(Scheduler):
         worker_ids: list[str] = []
 
         placement_strategy = self._get_placement_strategy(schedulings)
-        placement_groups = placement_strategy.create_placement_group(
+        placement_strategy.create_placement_group(
             role,
             schedulings,
             self.exp_config.cluster.n_gpus_per_node,
             timeout=self.startup_timeout,
         )
 
-        master_ip, master_port = get_placement_group_master_ip_and_port(
-            placement_groups[0], placement_group_bundle_index=0
-        )
-
         for idx, spec in enumerate(schedulings):
             options, pg_scheduling_strategy = placement_strategy.actor_resources(spec)
+            master_ip, master_port = get_placement_group_master_ip_and_port(
+                pg_scheduling_strategy.placement_group, placement_group_bundle_index=0
+            )
             worker_id = f"{role}/{idx}"
             env = self._build_env_vars(spec)
             actor = RayRPCServer.options(

--- a/areal/infra/utils/ray.py
+++ b/areal/infra/utils/ray.py
@@ -13,10 +13,11 @@ def get_placement_group_master_ip_and_port(
         port = find_free_ports(1, (10000, 60000))[0]
         return host_ip, port
 
+    # 0 resources as task cannot be scheduled in certain scenarios
     future = ray.remote(
-        num_cpus=1,
+        num_cpus=0,
         num_gpus=0,
-        memory=10 * 1024 * 1024,  # Convert MB to bytes
+        memory=0,
         scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=placement_group,
             placement_group_bundle_index=placement_group_bundle_index,

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -991,24 +991,6 @@ def _log_proximal_approximation_stats(
                     logprobs=logprobs,
                     prox_logp_gt=prox_logp_gt,
                 )
-        if logprobs is not None:
-            # Log KL divergence estimators to check for policy drift between the
-            # training-time policy (logprobs) and the inference-time policy (old_logp).
-            log_ratio = (logprobs.float() - old_logp.float()).detach()
-            
-            # Implementation of different estimators for KL divergence.
-            # See: https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/#true-on-policy-rl
-            kl_div_estimator_direct = -log_ratio
-            kl_div_estimator_taylor = log_ratio**2 / 2.0
-            kl_div_estimator_dual = log_ratio.exp() - 1 - log_ratio
-
-            # Register these to TensorBoard
-            stats_tracker.stat(
-                kl_div_direct=kl_div_estimator_direct,
-                kl_div_taylor=kl_div_estimator_taylor,
-                kl_div_dual=kl_div_estimator_dual,
-                denominator="n_valid_tokens",
-            )
 
 
 def _log_version_staleness_stats(

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -991,6 +991,24 @@ def _log_proximal_approximation_stats(
                     logprobs=logprobs,
                     prox_logp_gt=prox_logp_gt,
                 )
+        if logprobs is not None:
+            # Log KL divergence estimators to check for policy drift between the
+            # training-time policy (logprobs) and the inference-time policy (old_logp).
+            log_ratio = (logprobs.float() - old_logp.float()).detach()
+            
+            # Implementation of different estimators for KL divergence.
+            # See: https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/#true-on-policy-rl
+            kl_div_estimator_direct = -log_ratio
+            kl_div_estimator_taylor = log_ratio**2 / 2.0
+            kl_div_estimator_dual = log_ratio.exp() - 1 - log_ratio
+
+            # Register these to TensorBoard
+            stats_tracker.stat(
+                kl_div_direct=kl_div_estimator_direct,
+                kl_div_taylor=kl_div_estimator_taylor,
+                kl_div_dual=kl_div_estimator_dual,
+                denominator="n_valid_tokens",
+            )
 
 
 def _log_version_staleness_stats(

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -34,6 +34,8 @@ from areal.api.cli_args import (
     vLLMConfig,
 )
 from areal.engine import RemoteSGLangEngine, RemotevLLMEngine
+from areal.engine.core.model import get_model_update_meta
+from areal.utils.awex_runtime import prepare_awex_runtime
 from areal.infra import (
     LocalScheduler,
     RayScheduler,
@@ -105,6 +107,7 @@ class PPOTrainer:
             logging.setup_file_logging(StatsLogger.get_log_path(config.stats_logger))
 
         self.config = config
+        self._awex_runtime = prepare_awex_runtime(config)
         self.processor, self.tokenizer = load_hf_processor_and_tokenizer(
             config.tokenizer_path
         )
@@ -262,6 +265,8 @@ class PPOTrainer:
                         }
                     )
                 self.weight_update_meta = WeightUpdateMeta.from_fsdp_xccl(**xccl_kwargs)
+        elif self.config.actor.weight_update_mode == "awex":
+            self.weight_update_meta = get_model_update_meta(config)
         else:
             raise ValueError(
                 f"Invalid weight update mode: {self.config.actor.weight_update_mode}"
@@ -549,6 +554,7 @@ class PPOTrainer:
             self.critic.destroy()
         self.actor.destroy()
         perf_tracer.save(force=True)
+        self._awex_runtime.close()
 
     def _config_perf_tracer(self):
         rank = int(os.getenv("RANK", "0"))

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -1003,9 +1003,6 @@ class PPOTrainer:
         if not is_single_controller():
             raise NotImplementedError("Proxy workers not supported in SPMD mode")
 
-        if self.config.scheduler.type == "ray":
-            raise NotImplementedError("Proxy workers not supported with RayScheduler")
-
         assert isinstance(self.rollout, RolloutController)
 
         logger.info("Initializing proxy workers for AgentWorkflow support")

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -33,9 +33,8 @@ from areal.api.cli_args import (
     ValidDatasetConfig,
     vLLMConfig,
 )
-from areal.engine import RemoteSGLangEngine, RemotevLLMEngine
+from areal.engine import RayRemotevLLMEngine, RemoteSGLangEngine, RemotevLLMEngine
 from areal.engine.core.model import get_model_update_meta
-from areal.utils.awex_runtime import prepare_awex_runtime
 from areal.infra import (
     LocalScheduler,
     RayScheduler,
@@ -44,6 +43,7 @@ from areal.infra import (
     current_platform,
 )
 from areal.utils import logging, perf_tracer, seeding, stats_tracker
+from areal.utils.awex_runtime import prepare_awex_runtime
 from areal.utils.dataloader import create_dataloader
 from areal.utils.environ import is_single_controller
 from areal.utils.evaluator import Evaluator
@@ -750,7 +750,14 @@ class PPOTrainer:
                 self.config.vllm.lora_modules = [
                     f"{self.config.gconfig.lora_name}-v0={lora_path}"
                 ]
-            engine_cls = RemotevLLMEngine
+            if (
+                self.allocation_mode.gen_instance_size
+                > self.config.cluster.n_gpus_per_node
+            ):
+                # gen instance spans more than 1 node
+                engine_cls = RayRemotevLLMEngine
+            else:
+                engine_cls = RemotevLLMEngine
             server_args = vLLMConfig.build_args(
                 vllm_config=self.config.vllm,
                 tp_size=self.allocation_mode.gen.tp_size,

--- a/areal/utils/awex_runtime.py
+++ b/areal/utils/awex_runtime.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+import weakref
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+from areal.api.cli_args import BaseExperimentConfig
+from areal.utils.environ import is_single_controller
+
+if TYPE_CHECKING:
+    from areal.api.cli_args import AwexConfig
+
+
+@dataclass
+class AwexRuntimeHandle:
+    meta_server_addr: str | None = None
+    owns_meta_server: bool = False
+    _stop_fn: Callable[[], bool] | None = None
+    _finalizer: weakref.finalize | None = None
+
+    def close(self) -> None:
+        if (
+            self.owns_meta_server
+            and self._finalizer is not None
+            and self._finalizer.alive
+        ):
+            self._finalizer()
+
+
+def _get_weight_update_engine_config(config: BaseExperimentConfig):
+    if hasattr(config, "actor"):
+        return config.actor
+    if hasattr(config, "model"):
+        return config.model
+    raise ValueError(
+        f"Config {type(config).__name__} must have either 'actor' or 'model' attribute"
+    )
+
+
+def _resolve_meta_server_override() -> str | None:
+    for key in ("AREAL_AWEX_META_SERVER_ADDR", "AWEX_META_SERVER_ADDR"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+    return None
+
+
+def _import_meta_server_fns():
+    try:
+        from awex.meta.meta_server import start_meta_server, stop_meta_server
+    except ImportError as exc:
+        raise RuntimeError(
+            "Awex runtime bootstrap requires the awex package to be installed."
+        ) from exc
+    return start_meta_server, stop_meta_server
+
+
+def _safe_stop_meta_server(stop_fn: Callable[[], bool]) -> None:
+    stop_fn()
+
+
+def prepare_awex_runtime(config: BaseExperimentConfig) -> AwexRuntimeHandle:
+    engine_config = _get_weight_update_engine_config(config)
+    if engine_config.weight_update_mode != "awex":
+        return AwexRuntimeHandle()
+
+    awex_cfg: AwexConfig | None = getattr(config, "awex", None)
+    if awex_cfg is None:
+        raise ValueError("Awex config is required when weight_update_mode is 'awex'.")
+
+    meta_server_addr = _resolve_meta_server_override() or awex_cfg.meta_server_addr
+    if meta_server_addr and meta_server_addr.lower() != "auto":
+        awex_cfg.meta_server_addr = meta_server_addr
+        return AwexRuntimeHandle(meta_server_addr=meta_server_addr)
+
+    if not is_single_controller():
+        raise ValueError(
+            "AWEX auto-start is supported only in single-controller mode. "
+            "Set awex.meta_server_addr explicitly when running in SPMD mode."
+        )
+
+    start_meta_server, stop_meta_server = _import_meta_server_fns()
+    meta_ip, meta_port = start_meta_server()
+    resolved_addr = f"{meta_ip}:{meta_port}"
+    handle = AwexRuntimeHandle(
+        meta_server_addr=resolved_addr,
+        owns_meta_server=True,
+        _stop_fn=stop_meta_server,
+    )
+    handle._finalizer = weakref.finalize(
+        handle, _safe_stop_meta_server, stop_meta_server
+    )
+    awex_cfg.meta_server_addr = resolved_addr
+    return handle

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -261,13 +261,22 @@ def allocate_balanced_mbs_synced(
     group_indices = allocate_balanced_mbs(mb_spec, lens)
     if not dist.is_initialized():
         return group_indices
-    all_n_mbs = [None for _ in range(dist.get_world_size(group))]
-    dist.all_gather_object(all_n_mbs, len(group_indices), group=group)
+    all_n_mbs = all_gather_int(len(group_indices), group=group)
     if all(mbs == len(group_indices) for mbs in all_n_mbs):
         return group_indices
     return allocate_balanced_mbs_synced(
         MicroBatchSpec.new(mb_spec, n_mbs=max(all_n_mbs)), lens, group=group
     )
+
+
+def all_gather_int(value: int, group):
+    world_size = dist.get_world_size(group=group)
+    x = torch.tensor(
+        [value], dtype=torch.int64, device=current_platform.current_device()
+    )
+    out = [torch.empty_like(x) for _ in range(world_size)]
+    dist.all_gather(out, x, group=group)
+    return [int(t.item()) for t in out]
 
 
 def pack_tensor_dict(data: dict[str, Any]) -> dict[str, Any]:

--- a/areal/utils/stats_tracker.py
+++ b/areal/utils/stats_tracker.py
@@ -147,7 +147,9 @@ class DistributedStatsTracker:
             raise ValueError("reduce_type must be a ReduceType enum")
         self.reduce_types[key] = reduce_type
 
-    def export(self, key=None, reduce_group=None, reset=True) -> dict[str, float]:
+    def export(
+        self, key=None, reduce_group=None, reset=True, gloo_group=None
+    ) -> dict[str, float]:
         """Get aggregated statistics"""
         with self.lock:
             if key is not None:
@@ -165,7 +167,7 @@ class DistributedStatsTracker:
             keys = list(self.stats.keys())
             if reduce_group is not None:
                 all_keys = [None for _ in range(dist.get_world_size(reduce_group))]
-                dist.all_gather_object(all_keys, keys, group=reduce_group)
+                dist.all_gather_object(all_keys, keys, group=gloo_group or reduce_group)
                 # Should ensure that the orders are the same
                 keys = sorted(list(set(flat2d(all_keys))))
             results = {}
@@ -310,17 +312,21 @@ def get(name: str = ""):
         return TRACKERS[name]
 
 
-def export_all(reduce_group=None, reset=True) -> dict[str, float]:
+def export_all(reduce_group=None, reset=True, gloo_group=None) -> dict[str, float]:
     stat = {}
     duplicate_keys = set()
     tracker_keys = list(TRACKERS.keys())
-    if reduce_group is not None:
+    if reduce_group is not None or gloo_group is not None:
         all_trackers = [None for _ in range(dist.get_world_size(reduce_group))]
-        dist.all_gather_object(all_trackers, list(TRACKERS.keys()), group=reduce_group)
+        dist.all_gather_object(
+            all_trackers, list(TRACKERS.keys()), group=gloo_group or reduce_group
+        )
         tracker_keys = sorted(list(set(flat2d(all_trackers))))
     for tracker_key in tracker_keys:
         tracker = get(tracker_key)
-        x = tracker.export(reduce_group=reduce_group, reset=reset)
+        x = tracker.export(
+            reduce_group=reduce_group, reset=reset, gloo_group=gloo_group
+        )
         for k in x.keys():
             if k in stat:
                 duplicate_keys.add(k)

--- a/examples/experimental/awex/README.md
+++ b/examples/experimental/awex/README.md
@@ -1,0 +1,70 @@
+# Experimental Awex GSM8K Example
+
+This folder provides a minimal AWEX config for GSM8K GRPO in single-controller
+mode.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `gsm8k_grpo_awex_sample.yaml` | Minimal config for local validation on 2 GPUs. |
+| `gsm8k_grpo_awex_npu_sample.yaml` | Minimal config for local validation on 2 NPUs. |
+
+## Install Awex
+
+Install Awex before running the sample.
+
+```bash
+git clone https://github.com/inclusionAI/asystem-awex.git
+cd asystem-awex
+pip install -e .
+```
+
+After installation, AReaL can use AWEX directly. The vLLM-side AWEX integration
+is discovered through the installed package, so no extra `VLLM_PLUGINS`
+configuration is needed in the normal AReaL workflow.
+
+## Quickstart
+
+Run from repo root (`AReaL/`).
+
+```bash
+python examples/math/gsm8k_rl.py \
+  --config examples/experimental/awex/gsm8k_grpo_awex_sample.yaml
+```
+
+NPU sample:
+
+```bash
+python examples/math/gsm8k_rl.py \
+  --config examples/experimental/awex/gsm8k_grpo_awex_npu_sample.yaml
+```
+
+## Runtime behavior
+
+- If Awex is enabled and `awex.meta_server_addr` is empty or `auto`,
+  `PPOTrainer` starts a local Awex meta server automatically before rollout
+  initialization in single-controller mode.
+- In SPMD mode, set `awex.meta_server_addr` explicitly instead of relying on
+  auto-start.
+
+## Environment variables
+
+| Env var | Meaning |
+| --- | --- |
+| `AREAL_AWEX_META_SERVER_ADDR` | Preferred external meta server addr (`ip:port`). If unset, the trainer follows `awex.meta_server_addr`. |
+| `AWEX_META_SERVER_ADDR` | Generic external meta server addr override. |
+
+## Notes
+
+- Use `actor.path`, `ref.path`, `tokenizer_path`, and `vllm.model` in the yaml
+  to point to the model you want to validate.
+- `gsm8k_grpo_awex_sample.yaml` targets a small local GPU validation setup.
+- `gsm8k_grpo_awex_npu_sample.yaml` targets a small local NPU validation setup.
+
+## Adapting the sample for NPU
+
+Use `gsm8k_grpo_awex_npu_sample.yaml` directly for the single-controller NPU
+path. If you need a larger NPU training config, start from
+`examples/math/gsm8k_grpo_npu.yaml` and copy the AWEX settings from the NPU
+sample here.

--- a/examples/experimental/awex/gsm8k_grpo_awex_npu_sample.yaml
+++ b/examples/experimental/awex/gsm8k_grpo_awex_npu_sample.yaml
@@ -1,0 +1,184 @@
+experiment_name: gsm8k-grpo-awex-npu-sample
+trial_name: trial0
+
+seed: 1
+enable_offload: false
+total_train_epochs: 1
+total_train_steps: 5
+tokenizer_path: ${actor.path}
+
+cluster:
+  n_nodes: 1
+  n_gpus_per_node: 2
+  fileroot: /tmp/areal/experiments
+  name_resolve:
+    type: nfs
+    nfs_record_root: /tmp/areal/name_resolve
+
+allocation_mode: vllm:d1p1t1+megatron:d1p1t1
+
+scheduler:
+  type: local
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 256
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 2
+  enable_rollout_tracing: false
+  scheduling_spec: ${actor.scheduling_spec}
+
+gconfig:
+  n_samples: 1
+  min_new_tokens: 0
+  max_new_tokens: 1024
+  greedy: false
+  temperature: 1.0
+
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen3-0.6B
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: false
+  dtype: bfloat16
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer:
+    type: adam
+    lr: 2.0e-5
+    weight_decay: 0.01
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.0
+  eps_clip: 0.4
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  behave_imp_weight_cap: 5.0
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  weight_update_mode: awex
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_spec:
+    - task_type: worker
+      port_count: 2
+      gpu: 1
+      cpu: 4
+      mem: 32
+      cmd: python3 -m areal.infra.rpc.rpc_server
+      env_vars:
+        VLLM_USE_V1: "1"
+        VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+        TASK_QUEUE_ENABLE: "2"
+        HCCL_EXEC_TIMEOUT: "14400"
+        HCCL_OP_EXPANSION_MODE: "HOST"
+        ACL_DEVICE_SYNC_TIMEOUT: "14400"
+        HCCL_EVENT_TIMEOUT: "14500"
+        HCCL_ASYNC_ERROR_HANDLING: "0"
+        ACL_STREAM_TIMEOUT: "14500000"
+        HCCL_CONNECT_TIMEOUT: "7200"
+        PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+
+ref:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  init_from_scratch: false
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  mb_spec:
+    max_tokens_per_mb: 1024
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+vllm:
+  model: ${actor.path}
+  seed: ${seed}
+  skip_tokenizer_init: false
+  dtype: ${actor.dtype}
+  max_model_len: 2048
+  gpu_memory_utilization: 0.7
+  enforce_eager: true
+
+awex:
+  meta_server_addr: auto
+  comm_backend: hccl
+  weights_exchange_ipc_backend: cpu
+  weights_comm_nccl_group_size: 1
+  weights_validation_steps: 0
+  validate_weights_every_n_steps: 1
+
+train_dataset:
+  batch_size: 256
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+  max_length: 512
+
+valid_dataset:
+  batch_size: 256
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: disabled
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: 3600
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: disabled
+
+perf_tracer:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  enabled: false
+  session_tracer:
+    enabled: false

--- a/examples/experimental/awex/gsm8k_grpo_awex_sample.yaml
+++ b/examples/experimental/awex/gsm8k_grpo_awex_sample.yaml
@@ -1,0 +1,174 @@
+experiment_name: gsm8k-grpo-awex-sample
+trial_name: trial0
+
+seed: 1
+enable_offload: false
+total_train_epochs: 1
+total_train_steps: 5
+tokenizer_path: ${actor.path}
+
+cluster:
+  n_nodes: 1
+  n_gpus_per_node: 2
+  fileroot: /tmp/areal/experiments
+  name_resolve:
+    type: nfs
+    nfs_record_root: /tmp/areal/name_resolve
+
+allocation_mode: vllm:d1p1t1+megatron:d1p1t1
+
+scheduler:
+  type: local
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 2
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 2
+  enable_rollout_tracing: false
+  scheduling_spec: ${actor.scheduling_spec}
+
+gconfig:
+  n_samples: 1
+  min_new_tokens: 0
+  max_new_tokens: 1024
+  greedy: false
+  temperature: 1.0
+
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen3-0.6B
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: false
+  dtype: bfloat16
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer:
+    type: adam
+    lr: 2.0e-5
+    weight_decay: 0.01
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.0
+  eps_clip: 0.4
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  behave_imp_weight_cap: 5.0
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  weight_update_mode: awex
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_spec:
+    - task_type: worker
+      port_count: 2
+      gpu: 1
+      cpu: 4
+      mem: 32
+      cmd: python3 -m areal.infra.rpc.rpc_server
+      env_vars: {}
+
+ref:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  init_from_scratch: false
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  mb_spec:
+    max_tokens_per_mb: 1024
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+vllm:
+  model: ${actor.path}
+  seed: ${seed}
+  skip_tokenizer_init: false
+  dtype: ${actor.dtype}
+  max_model_len: 2048
+  gpu_memory_utilization: 0.7
+
+awex:
+  meta_server_addr: auto
+  comm_backend: nccl
+  weights_exchange_ipc_backend: cuda
+  weights_comm_nccl_group_size: 1
+  weights_validation_steps: 0
+  validate_weights_every_n_steps: 1
+
+# datasets
+train_dataset:
+  batch_size: 256
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+  max_length: 512
+
+valid_dataset:
+  batch_size: 256
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+
+# Utilities
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: disabled
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: 3600
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: disabled
+
+perf_tracer:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  enabled: false
+  session_tracer:
+    enabled: false

--- a/examples/math/README.md
+++ b/examples/math/README.md
@@ -22,3 +22,16 @@ are free to try out more of the hyperparameters listed below!
 - Max_new_tokens: 1024
 - Max_head_offpolicyness: 2
 - Training Time: ~35 minutes (batchsize 4), ~65 minutes (batchsize 8)
+
+## Awex Example Location
+
+Awex-specific GSM8K sample scripts were moved to:
+
+- `examples/experimental/awex/README.md`
+- `examples/experimental/awex/gsm8k_grpo_awex_sample.yaml`
+
+Awex meta server bootstrap is now handled by `PPOTrainer` when
+`actor.weight_update_mode=awex`; the standard `examples/math/gsm8k_rl.py`
+entrypoint can be used directly with the AWEX sample yaml. Auto-start is only
+available in single-controller mode; SPMD runs must provide an explicit
+`awex.meta_server_addr`.

--- a/examples/math/boba_grpo_megatron_npu.yaml
+++ b/examples/math/boba_grpo_megatron_npu.yaml
@@ -1,0 +1,185 @@
+experiment_name: boba_grpo
+trial_name: trial0
+
+seed: 1
+enable_offload: false
+total_train_epochs: 10
+tokenizer_path: ${actor.path}
+
+cluster:
+  n_nodes: 4
+  n_gpus_per_node: 16
+  fileroot: /tmp/areal/experiments
+  name_resolve:
+    type: nfs
+    nfs_record_root: /tmp/areal/name_resolve
+
+allocation_mode: vllm:d4p1t8+megatron:(attn:d4p4t2c1|ffn:d1p4t1e8)
+
+scheduler:
+  type: ray
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 400
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 4
+  pause_grace_period: 30
+  enable_rollout_tracing: true
+  scheduling_spec: ${actor.scheduling_spec}
+  fileroot: ${cluster.fileroot}
+  tokenizer_path: ${tokenizer_path}
+  dump_to_file: true
+
+gconfig:
+  n_samples: 16
+  min_new_tokens: 0
+  max_new_tokens: 8192
+  greedy: false
+  temperature: 1.0
+
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen3-30B-A3B
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: true
+  dtype: bfloat16
+  mb_spec:
+    max_tokens_per_mb: 16384
+  optimizer:
+    type: adam
+    lr: 1e-6
+    weight_decay: 0.1
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+  eps_clip: 0.4
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.0
+  ppo_n_minibatches: 4
+  recompute_logprob: true
+  use_decoupled_loss: true
+  behave_imp_weight_cap: 5.0
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  weight_update_mode: xccl
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_spec:
+    - task_type: worker
+      port_count: 2
+      gpu: 1
+      mem: 32
+      cmd: python3 -m areal.scheduler.rpc.rpc_server
+      env_vars:
+        VLLM_USE_V1: "1"
+        VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+        TASK_QUEUE_ENABLE: "2"
+        HCCL_EXEC_TIMEOUT: "14400"
+        HCCL_OP_EXPANSION_MODE: "HOST"
+        ACL_DEVICE_SYNC_TIMEOUT: "14400"
+        HCCL_EVENT_TIMEOUT: "14500"
+        HCCL_ASYNC_ERROR_HANDLING: "0"
+        ACL_STREAM_TIMEOUT: "14500000"
+        HCCL_CONNECT_TIMEOUT: "7200"
+        PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+        TORCH_COMPILE_DISABLE: "1"
+        HCCL_BUFFSIZE : "512"
+
+ref:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  init_from_scratch: false
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  mb_spec:
+    max_tokens_per_mb: 16384
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+sglang:
+  model_path: ${actor.path}
+  random_seed: ${seed}
+  skip_tokenizer_init: true
+  dtype: ${actor.dtype}
+  max_running_requests: null
+  context_length: 32768
+  mem_fraction_static: 0.8
+
+vllm:
+  model: ${actor.path}
+  seed: ${seed}
+  skip_tokenizer_init: false
+  dtype: ${actor.dtype}
+  max_model_len: 32768
+  gpu_memory_utilization: 0.8
+  data_parallel_size: 2
+  tensor_parallel_size: 4
+  enable_expert_parallel: true
+  enforce_eager: true
+
+# datasets
+train_dataset:
+  path: inclusionAI/AReaL-boba-Data
+  batch_size: 128
+  pin_memory: true
+  type: rl
+
+# Utilities
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: disabled
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: 3600
+  retries: 0
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: null
+  freq_steps: null
+  freq_secs: null
+
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: disabled
+
+perf_tracer:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  enabled: false
+  session_tracer:
+    enabled: false

--- a/examples/tau2/README_NPU.md
+++ b/examples/tau2/README_NPU.md
@@ -1,0 +1,203 @@
+# Running tau2-airline on Ascend NPU
+
+This guide explains how to set up and run **tau2-airline** training on an **Ascend NPU**
+(Atlas A3) environment. For a general explanation about the training pipeline, see
+[this](README.md).
+
+______________________________________________________________________
+
+# 1. Environment Setup
+
+## 1.1 Create the Container
+
+Create a container using the following image:
+
+`swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a3`
+
+You can use the following commands to create the container:
+
+```bash
+WORK_DIR=<your_workspace>
+CONTAINER_WORK_DIR=<your_container_workspace>
+
+IMAGE=swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a3
+CONTAINER_NAME=areal_npu
+
+cd "${WORK_DIR}"
+
+docker pull "${IMAGE}"
+
+docker run -itd \
+  --cap-add=SYS_PTRACE \
+  --net=host \
+  --device=/dev/davinci0 \
+  --device=/dev/davinci1 \
+  --device=/dev/davinci2 \
+  --device=/dev/davinci3 \
+  --device=/dev/davinci4 \
+  --device=/dev/davinci5 \
+  --device=/dev/davinci6 \
+  --device=/dev/davinci7 \
+  --device=/dev/davinci8 \
+  --device=/dev/davinci9 \
+  --device=/dev/davinci10 \
+  --device=/dev/davinci11 \
+  --device=/dev/davinci12 \
+  --device=/dev/davinci13 \
+  --device=/dev/davinci14 \
+  --device=/dev/davinci15 \
+  --device=/dev/davinci_manager \
+  --device=/dev/devmm_svm \
+  --device=/dev/hisi_hdc \
+  --shm-size=1200g \
+  -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /etc/ascend_install.info:/etc/ascend_install.info \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+  -v /var/log/npu/:/usr/slog \
+  -v "${WORK_DIR}:${CONTAINER_WORK_DIR}" \
+  --privileged=true \
+  --name "${CONTAINER_NAME}" \
+  "${IMAGE}" \
+  /bin/bash
+```
+
+______________________________________________________________________
+
+# 2. Install tau2-bench
+
+Clone the following repository and install the benchmark:
+
+```bash
+git clone https://github.com/dhh1995/tau2-bench.git
+cd tau2-bench
+git checkout dhh/async-and-custom-completion
+pip install -e .
+cd ..
+```
+
+______________________________________________________________________
+
+# 3. Install AReaL
+
+Clone the **AReaL** repository and check out the `ascend-v1.0.1` branch:
+
+```bash
+git clone https://github.com/inclusionAI/AReaL
+cd AReal
+git checkout ascend-v1.0.1
+pip install -e . --no-deps
+```
+
+______________________________________________________________________
+
+# 4. Prepare tau2 Training
+
+Once the setup is complete, follow the steps below.
+
+______________________________________________________________________
+
+# 4.1 Launch the User Simulator
+
+Start the **vLLM OpenAI-compatible API server** on one of your nodes.
+
+Make sure the file `qwen3_nonthinking.jinja` is available. Adjust the port accordingly.
+
+```bash
+python3 -m vllm.entrypoints.openai.api_server \
+  --model /path/to/Qwen3-30B-A3B \
+  --served-model-name Qwen3-30B-A3B \
+  --host 0.0.0.0 \
+  --port 30000 \
+  --enforce-eager \
+  --data-parallel-size 4 \
+  --tensor-parallel-size 4 \
+  --enable-auto-tool-choice \
+  --tool-call-parser hermes \
+  --chat-template ./qwen3_nonthinking.jinja
+```
+
+______________________________________________________________________
+
+# 4.2 Initialize Ray
+
+Ensure **Ray is initialized on all nodes** and that the same codebase is available on
+each node.
+
+### Start the Ray Head (first node)
+
+```bash
+cd AReal
+ray start --head
+```
+
+### Start Ray Workers (other nodes)
+
+```bash
+cd AReal
+
+# Replace with the actual IP address of the head node
+RAY_HEAD_IP=xxx.xxx.xxx.xxx
+
+ray start --address="${RAY_HEAD_IP}:6379"
+```
+
+You can verify the cluster by running:
+
+```bash
+ray status
+```
+
+______________________________________________________________________
+
+# 4.3 Run tau2-airline on 4 nodes
+
+Use the provided YAML file for NPU: `config_30b_moe_airline_npu.yaml`.
+
+For a **4-node setup**:
+
+- Allocate **1 node for the user simulator**.
+- Use the following allocation mode:
+
+```yaml
+allocation_mode: vllm:d4t4+megatron:(attn:d2p4t4|ffn:d1p4e8)
+```
+
+______________________________________________________________________
+
+# 5. Configuration Notes
+
+Before running the benchmark:
+
+1. Update the YAML configuration file `config_30b_moe_airline_npu.yaml` with the correct
+   paths.
+1. Set `user_llm_base_url` to the **IP address and port of the node running the user
+   simulator** and `user_llm` to the model name.
+1. Ensure the **vLLM server is started with `--enforce-eager`**.
+1. In the YAML configuration, make sure you have:
+
+```yaml
+actor:
+  enable_tree_training: false
+
+vllm:
+  enforce_eager: true
+
+rollout:
+  pause_grace_period: 30
+```
+
+______________________________________________________________________
+
+# 6. Launch Training
+
+Run the following command:
+
+```bash
+python3 examples/tau2/train.py \
+  --config examples/tau2/config_30b_moe_airline_npu.yaml
+```
+
+Additionally, you can increase the `timeout` of `workflow_kwargs` in `train.py` if you
+have observed too many timeouts.

--- a/examples/tau2/config_30b_moe_airline_npu.yaml
+++ b/examples/tau2/config_30b_moe_airline_npu.yaml
@@ -1,0 +1,267 @@
+experiment_name: tau2-grpo-30b
+trial_name: trial0
+
+seed: 1
+enable_offload: false
+total_train_epochs: 200
+total_train_steps: 500
+tokenizer_path: ${actor.path}
+
+cluster:
+  n_nodes: 3
+  n_gpus_per_node: 16
+  fileroot: /tmp/experiments
+  name_resolve:
+    type: nfs
+    nfs_record_root: /tmp/name_resolve
+
+allocation_mode: vllm:d1t16+megatron:(attn:d2p4t4|ffn:d1p4e8)
+
+scheduler:
+  type: ray
+
+gconfig:
+  n_samples: 8
+  min_new_tokens: 0
+  max_new_tokens: 8192
+  max_tokens: 30000
+  greedy: false
+  temperature: 1.0
+  top_p: 1.0
+  top_k: 100000000
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 128
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 2
+  pause_grace_period: 30
+  enable_rollout_tracing: false
+  scheduling_spec:
+    - task_type: worker
+      port_count: 2
+      cpu: 1
+      gpu: 1
+      mem: 1
+      cmd: python3 -m areal.infra.rpc.rpc_server
+      env_vars: ${actor.scheduling_spec[0].env_vars}
+  fileroot: ${cluster.fileroot}
+  tokenizer_path: ${tokenizer_path}
+  dump_to_file: true
+  setup_timeout: 3000.0
+  request_timeout: 14400
+  request_retries: 3
+  openai:
+    mode: inline
+    tool_call_parser: qwen25
+    reasoning_parser: qwen3
+    chat_template_type: hf
+    engine_max_tokens: ${gconfig.max_tokens}
+    export_style: individual
+    turn_discount: 1.0
+    subproc_max_workers: 4
+    session_timeout_seconds: 36000
+
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen3-30B-A3B
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: true
+  dtype: bfloat16
+  grad_reduce_dtype: float32
+  mb_spec:
+    n_mbs: 1
+    granularity: 1
+    max_tokens_per_mb: 32768
+    n_mbs_divisor: 1
+  pad_to_maximum: true
+  optimizer:
+    type: adam
+    lr: 5e-6
+    weight_decay: 0.005
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1.0e-08
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+    min_loss_scale: 1.0
+    loss_scale_window: 5.0
+    hysteresis: 2
+  mindspeed:
+    swap_optimizer: true
+    use_fused_rotary_pos_emb: true
+    use_fused_swiglu: true
+    moe_alltoall_overlap_comm: true
+    moe_grouped_gemm: true
+    moe_zero_memory: "level 1"
+    moe_permute_fusion: true
+    gemm_gradient_accumulation_fusion: true
+    position_embedding_type: "rope"
+  archon:
+    attn_type: varlen
+    offload_params: false
+    enable_compile: true
+    ac_mode: full
+    ac_preserve_rng_state: true
+  eps_clip: 0.4
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  reward_clip: 20.0
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  behave_imp_weight_cap: 5.0
+  discount: 1.0
+  gae_lambda: 1.0
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+    std_unbiased: true
+    eps: 1.0e-05
+  max_new_tokens: ${gconfig.max_new_tokens}
+  enable_tree_training: false
+  scheduling_spec:
+    - task_type: worker
+      port_count: 2
+      gpu: 1
+      cpu: 1
+      mem: 1
+      cmd: python3 -m areal.infra.rpc.rpc_server
+      # image: /path/to/container.sif  # Optional: specify container image for Slurm
+      env_vars:
+        VLLM_USE_V1: "1"
+        TASK_QUEUE_ENABLE: "2"
+        HCCL_EXEC_TIMEOUT: "14400"
+        ACL_DEVICE_SYNC_TIMEOUT: "14400"
+        HCCL_EVENT_TIMEOUT: "14500"
+        HCCL_ASYNC_ERROR_HANDLING: "0"
+        ACL_STREAM_TIMEOUT: "14500000"
+        HCCL_CONNECT_TIMEOUT: "7200"
+        PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+        TORCH_COMPILE_DISABLE: "1"
+        HCCL_BUFFSIZE : "512"
+        HCCL_IF_BASE_PORT: "50000"
+      additional_bash_cmds:
+        # install tau2-bench with async generation
+        - uv pip install git+https://github.com/dhh1995/tau2-bench.git@dhh/async-and-custom-completion
+
+ref:
+  experiment_name: ${experiment_name}
+  scheduling_spec: ${actor.scheduling_spec}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  init_from_scratch: false
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  mb_spec:
+    n_mbs: 1
+    granularity: 1
+    max_tokens_per_mb: 32768
+    n_mbs_divisor: 1
+  optimizer: null
+  enable_tree_training: false
+
+# Tau2 environment configuration
+econfig:
+  domain: airline
+  max_steps: 50
+  add_thinking_tool: false
+  solo_mode: false
+  user_llm_base_url: http://localhost:8000/v1/  # Replace with your user LLM endpoint
+  user_llm: openai/qwen      # Replace with your user model name
+  user_llm_args:
+    temperature: 0.0
+    max_completion_tokens: 2048
+  turn_discount: 1.0
+  invalid_format_penalty: 0.1
+
+# SGLang inference server configuration
+sglang:
+  model_path: ${actor.path}
+  random_seed: ${seed}
+  skip_tokenizer_init: true
+  dtype: ${actor.dtype}
+  context_length: 32768
+  mem_fraction_static: 0.8
+  max_prefill_tokens: 32768
+  schedule_policy: lpm
+  attention_backend: fa3
+  log_level: warning
+
+vllm:
+  model: ${actor.path}
+  seed: ${seed}
+  skip_tokenizer_init: false
+  dtype: ${actor.dtype}
+  max_model_len: 32768
+  gpu_memory_utilization: 0.8
+  tensor_parallel_size: 4
+  enable_expert_parallel: true
+  enforce_eager: true
+
+# Datasets
+train_dataset:
+  batch_size: 16
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  drop_last: true
+  path: tau2/train
+  type: rl
+  max_length: 1024
+
+valid_dataset:
+  batch_size: 16
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  drop_last: false
+  path: tau2/test
+  type: rl
+
+# Utilities
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: null #change it to 1 if you want to save checkpoints
+
+recover:
+  mode: disabled
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_secs: 3600
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: null
+  freq_steps: null
+  freq_secs: null
+
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: disabled
+
+perf_tracer:
+  enabled: false
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  save_interval: 1
+  session_tracer:
+    enabled: true
+    flush_threshold: 100

--- a/examples/tau2/train.py
+++ b/examples/tau2/train.py
@@ -1,5 +1,6 @@
 """Training script for Tau2 benchmark with AReaL proxy mode."""
 
+import os
 import sys
 import warnings
 from typing import Any
@@ -14,6 +15,20 @@ from areal.api.cli_args import load_expr_config
 from areal.utils import logging
 
 logger = logging.getLogger("Tau2Train")
+
+
+def _ensure_awex_runtime(config) -> None:
+    if config.actor.weight_update_mode != "awex":
+        return
+    meta_addr = os.environ.get("AREAL_GSM8K_AWEX_META_SERVER")
+    if not meta_addr:
+        meta_addr = config.awex.meta_server_addr
+    if not meta_addr or meta_addr.lower() == "auto":
+        from awex.meta.meta_server import start_meta_server
+
+        meta_ip, meta_port = start_meta_server()
+        meta_addr = f"{meta_ip}:{meta_port}"
+    config.awex.meta_server_addr = meta_addr
 
 
 def get_tau2_dataset(
@@ -68,6 +83,7 @@ def main(args):
     warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
 
     config, _ = load_expr_config(args, Tau2PPOConfig)
+    _ensure_awex_runtime(config)
     econfig = config.econfig
     domain = econfig.domain
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,6 @@ classifiers = [
 
 dependencies = [
     # Core ML/AI libraries
-    "torch>=2.9.1,<2.10",
-    "torchao==0.15.0",
-    "torchaudio",
-    "torchvision",
-    "torchdata",
     "huggingface_hub",
     "datasets>=3.0.0",
     "transformers==4.57.1",
@@ -133,6 +128,21 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Platform-dependent PyTorch libraries
+pytorch-cuda = [
+    "torch>=2.9.1,<2.10; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "torchao==0.15.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "torchaudio; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "torchvision; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "torchdata; sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
+pytorch-npu = [
+    "torch==2.9.0; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "torch-npu==2.9.0; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "torchaudio; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "torchvision; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "torchdata; sys_platform == 'linux' and platform_machine == 'aarch64'",
+]
 # CUDA-dependent extras - these packages only have Linux x86_64 wheels
 # Platform markers ensure they're skipped on unsupported platforms
 sglang = [
@@ -153,11 +163,15 @@ megatron = [
 ]
 # Convenience extra for all CUDA packages (requires Linux x86_64 with CUDA)
 cuda = [
+    "areal[pytorch-cuda]",
     "areal[vllm]",
     "areal[sglang]",
     "areal[tms]",
     "areal[megatron]",
     "areal[flash-attn]",
+]
+npu = [
+    "areal[pytorch-npu]",
 ]
 # 'all' extra - kept for compatibility, CUDA packages skipped on non-Linux via markers
 all = [
@@ -209,13 +223,41 @@ environments = [
 override-dependencies = [
     "torchao==0.15.0",
     "openai>2.6.1",
-    "soundfile>=0.12.1,<0.13.0",
+    "soundfile==0.13.1",
     "outlines-core==0.1.26",
     "grpcio>=1.76.0",
     "grpcio-reflection>=1.76.0",
     "xgrammar == 0.1.29; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 's390x' or platform_machine == 'ppc64le'",
     "llguidance >= 1.3.0, < 1.4.0; platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64' or platform_machine == 's390x' or platform_machine == 'ppc64le'",
 ]
+conflicts = [
+    [{ extra = "npu" }, { extra = "cuda" }],
+    [{ extra = "npu" }, { extra = "all" }],
+]
+
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cu129", extra = "pytorch-cuda", marker = "sys_platform == 'linux'" },
+    { index = "pytorch-cpu", extra = "pytorch-npu", marker = "sys_platform == 'linux'" },
+]
+torchvision = [
+    { index = "pytorch-cu129", extra = "pytorch-cuda", marker = "sys_platform == 'linux'" },
+    { index = "pytorch-cpu", extra = "pytorch-npu", marker = "sys_platform == 'linux'" },
+]
+torchaudio = [
+    { index = "pytorch-cu129", extra = "pytorch-cuda", marker = "sys_platform == 'linux'" },
+    { index = "pytorch-cpu", extra = "pytorch-npu", marker = "sys_platform == 'linux'" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu129"
+url = "https://download.pytorch.org/whl/cu129"
+explicit = true
 
 [tool.uv.extra-build-dependencies]
 flash-attn = ["torch>=2.9.1,<2.10"]

--- a/tests/experimental/awex/README.md
+++ b/tests/experimental/awex/README.md
@@ -1,0 +1,132 @@
+# Awex Experimental Test Scripts
+
+This folder contains practical scripts for validating and benchmarking Awex
+weight exchange between Megatron and vLLM.
+
+## What each script is for
+
+| Script | Use case | Output |
+| --- | --- | --- |
+| `build_reduced_qwen3_moe.py` | Build a smaller MoE checkpoint for local validation. Supports both slicing from local full weights and generating a config-only dummy checkpoint from HF. | A local HF checkpoint (`config.json` + `*.safetensors` + index). |
+| `test_awex_megatron_vllm_integration.py` | End-to-end integration test: Megatron writes weights and vLLM receives/loads via Awex. | `pytest` pass/fail. |
+| `bench_weight_transfer.py` | Latency micro-benchmark for weight update path (`awex_nccl` / `awex_file` / `xccl`). | JSON timing summary on stdout (optional `--out`). |
+
+## Prerequisites
+
+- Run commands from repo root (`AReaL/`).
+- Install runtime dependencies needed by your path:
+  - `vllm`
+  - `awex` (plugin path available)
+  - CUDA or NPU runtime (NPU is experimental)
+- For default single-rank runs, prepare at least 2 visible devices:
+  - 1 for Megatron
+  - 1 for vLLM
+
+## 1) Build reduced checkpoints
+
+### 1.1 Slice mode (from local full checkpoint)
+
+Use when you already have full model weights and want realistic reduced weights.
+
+```bash
+python tests/experimental/awex/build_reduced_qwen3_moe.py \
+  --input /home/model/Qwen3-30B-A3B-Instruct-2507 \
+  --output /home/model/Qwen3-30B-A3B-Instruct-2507-reduced-l2-e8 \
+  --num-layers 2 \
+  --num-experts 8 \
+  --num-experts-per-tok 2 \
+  --force
+```
+
+### 1.2 Dummy mode (config-only from Hugging Face)
+
+Use when you do not want to pre-download full weights.
+
+```bash
+python tests/experimental/awex/build_reduced_qwen3_moe.py \
+  --hf-model Qwen/Qwen3-30B-A3B \
+  --output /home/model/Qwen3-30B-A3B-dummy-reduced-l2-e8 \
+  --num-layers 2 \
+  --num-experts 8 \
+  --num-experts-per-tok 2 \
+  --dtype bfloat16 \
+  --max-shard-size-gb 2 \
+  --force
+```
+
+Common options:
+- `--no-tokenizer`: skip tokenizer/processor download in dummy mode.
+- `--seed`: control deterministic random init in dummy mode.
+- `--no-trust-remote-code`: disable `trust_remote_code`.
+
+## 2) Run integration test
+
+Script: `tests/experimental/awex/test_awex_megatron_vllm_integration.py`
+
+Dense path:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 \
+AREAL_AWEX_DEVICE_BACKEND=cuda \
+AREAL_AWEX_MODEL=dense \
+AREAL_AWEX_DENSE_MODEL_PATH=/home/model/Qwen3-0.6B \
+pytest tests/experimental/awex/test_awex_megatron_vllm_integration.py -k awex -v
+```
+
+MoE path:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 \
+AREAL_AWEX_DEVICE_BACKEND=cuda \
+AREAL_AWEX_MODEL=moe \
+AREAL_AWEX_MOE_MODEL_PATH=/home/model/Qwen3-30B-A3B-Instruct-2507-reduced-l2-e8 \
+pytest tests/experimental/awex/test_awex_megatron_vllm_integration.py -k awex -v
+```
+
+Helpful env vars:
+- `AREAL_AWEX_MODEL`: `dense` or `moe`.
+- `AREAL_AWEX_DENSE_MODEL_PATH`: local dense model path.
+- `AREAL_AWEX_MOE_MODEL_PATH`: local reduced MoE path.
+- `AREAL_AWEX_ALLOW_HF_DOWNLOAD=1`: allow dense model download fallback.
+- `AREAL_AWEX_COMM_BACKEND`: `nccl` (default) or `file`.
+- `AREAL_AWEX_DEVICE_BACKEND`: `cuda`, `npu`, `cpu`, `auto`.
+
+## 3) Run weight update benchmark
+
+Script: `tests/experimental/awex/bench_weight_transfer.py`
+
+Dense benchmark:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 \
+AREAL_AWEX_DENSE_MODEL_PATH=/home/model/Qwen3-0.6B \
+python tests/experimental/awex/bench_weight_transfer.py \
+  --device-backend cuda \
+  --modes awex_nccl,awex_file,xccl \
+  --iters 4 \
+  --warmup 1 \
+  --model-kind dense
+```
+
+MoE benchmark:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 \
+AREAL_AWEX_MOE_MODEL_PATH=/home/model/Qwen3-30B-A3B-Instruct-2507-reduced-l2-e8 \
+python tests/experimental/awex/bench_weight_transfer.py \
+  --device-backend cuda \
+  --modes awex_nccl,awex_file,xccl \
+  --iters 4 \
+  --warmup 1 \
+  --model-kind moe
+```
+
+Optional:
+- `--out /tmp/awex_bench.json` to save benchmark JSON.
+
+## NPU note (experimental)
+
+- Use `ASCEND_RT_VISIBLE_DEVICES` instead of `CUDA_VISIBLE_DEVICES`.
+- Set `AREAL_AWEX_DEVICE_BACKEND=npu`.
+- Prefer `AREAL_AWEX_COMM_BACKEND=hccl` for integration path.
+- Awex NPU path typically uses `weights_exchange_ipc_backend=cpu`.

--- a/tests/experimental/awex/bench_weight_transfer.py
+++ b/tests/experimental/awex/bench_weight_transfer.py
@@ -1,0 +1,339 @@
+"""Benchmark weight update latency across Awex (nccl/file) and XCCL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
+
+import torch
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+if _REPO_ROOT not in os.sys.path:
+    os.sys.path.insert(0, _REPO_ROOT)
+
+from areal.api.alloc_mode import AllocationMode
+from areal.api.cli_args import (
+    InferenceEngineConfig,
+    MegatronEngineConfig,
+    TrainEngineConfig,
+    vLLMConfig,
+)
+from areal.api.io_struct import FinetuneSpec, WeightUpdateMeta
+from areal.engine.megatron_engine import MegatronEngine
+from areal.engine.vllm_remote import RemotevLLMEngine
+from areal.utils import network
+
+DEFAULT_DENSE_PATH = "/home/model/Qwen3-0.6B"
+DEFAULT_MOE_PATH = "/home/model/Qwen3-30B-A3B-Instruct-2507-reduced-l2-e8"
+
+
+def _detect_device_backend(requested: str) -> str:
+    if requested and requested != "auto":
+        return requested
+    if getattr(torch, "npu", None) is not None and torch.npu.is_available():
+        return "npu"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+def _visible_env_name(device_backend: str) -> str:
+    if device_backend == "npu":
+        return "ASCEND_RT_VISIBLE_DEVICES"
+    return "CUDA_VISIBLE_DEVICES"
+
+
+def _device_count(device_backend: str) -> int:
+    if device_backend == "npu":
+        return 0 if getattr(torch, "npu", None) is None else torch.npu.device_count()
+    if device_backend == "cuda":
+        return torch.cuda.device_count()
+    return 0
+
+
+def _select_devices(tp_size: int = 1, device_backend: str = "cuda"):
+    visible_env = os.environ.get(_visible_env_name(device_backend), "").strip()
+    if visible_env:
+        visible_devices = [int(x) for x in visible_env.split(",") if x.strip()]
+    else:
+        visible_devices = list(range(_device_count(device_backend)))
+
+    need = 1 + tp_size
+    if len(visible_devices) < need:
+        raise RuntimeError(
+            f"Need at least {need} devices (1 for Megatron + {tp_size} for vLLM). "
+            f"Found {len(visible_devices)}."
+        )
+
+    megatron_device = visible_devices[0]
+    vllm_devices = visible_devices[1 : 1 + tp_size]
+    return megatron_device, vllm_devices
+
+
+@contextmanager
+def _temp_env(overrides: dict[str, str]):
+    old = {key: os.environ.get(key) for key in overrides}
+    os.environ.update(overrides)
+    try:
+        yield
+    finally:
+        for key, value in old.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _resolve_model_path(model_kind: str) -> str:
+    if model_kind == "dense":
+        return (
+            os.environ.get("AREAL_AWEX_DENSE_MODEL_PATH")
+            or os.environ.get("AREAL_BENCH_DENSE_MODEL_PATH")
+            or DEFAULT_DENSE_PATH
+        )
+    return (
+        os.environ.get("AREAL_AWEX_MOE_MODEL_PATH")
+        or os.environ.get("AREAL_BENCH_MOE_MODEL_PATH")
+        or DEFAULT_MOE_PATH
+    )
+
+
+def _build_vllm_args(model_path: str) -> dict:
+    vllm_cfg = vLLMConfig(
+        skip_tokenizer_init=False,
+        model=model_path,
+        gpu_memory_utilization=0.7,
+        max_num_seqs=1,
+        max_model_len=2048,
+        enforce_eager=True,
+    )
+    if hasattr(vllm_cfg, "load_format"):
+        vllm_cfg.load_format = os.environ.get(
+            "AREAL_AWEX_VLLM_LOAD_FORMAT",
+            os.environ.get("AREAL_BENCH_VLLM_LOAD_FORMAT", "auto"),
+        )
+    return vLLMConfig.build_args(vllm_cfg, tp_size=1, pp_size=1)
+
+
+def _setup_megatron_env(device_backend: str):
+    dist_port = network.find_free_ports(1)[0]
+    os.environ.update(
+        {
+            "WORLD_SIZE": "1",
+            "RANK": "0",
+            "LOCAL_RANK": "0",
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": str(dist_port),
+        }
+    )
+    if device_backend == "npu":
+        if getattr(torch, "npu", None) is None:
+            raise RuntimeError("torch.npu is not available for NPU backend.")
+        torch.npu.set_device(0)
+    else:
+        torch.cuda.set_device(0)
+
+
+def _safe_destroy(fn, name: str, timeout: int = 10) -> None:
+    done = threading.Event()
+
+    def _run():
+        try:
+            fn()
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    if not done.wait(timeout):
+        print(f"[bench] {name} timed out after {timeout}s; continuing.", flush=True)
+
+
+def _run_mode(
+    mode: str,
+    model_kind: str,
+    iters: int,
+    warmup: int,
+    device_backend: str,
+) -> dict:
+    from awex.meta.meta_server import start_meta_server, stop_meta_server
+
+    megatron_device, vllm_devices = _select_devices(tp_size=1, device_backend=device_backend)
+    model_path = _resolve_model_path(model_kind)
+
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(f"Model path not found: {model_path}")
+
+    vllm_env = {
+        _visible_env_name(device_backend): ",".join(map(str, vllm_devices)),
+        "AWEX_DEVICE_TYPE": device_backend,
+    }
+    if mode.startswith("awex"):
+        vllm_env["VLLM_PLUGINS"] = "awex_adapter"
+
+    inf_engine = None
+    train_engine = None
+    meta_server_addr = None
+    tmpdir = None
+
+    timings: list[float] = []
+
+    try:
+        if mode.startswith("awex"):
+            meta_ip, meta_port = start_meta_server()
+            meta_server_addr = f"{meta_ip}:{meta_port}"
+
+        vllm_args = _build_vllm_args(model_path)
+        inf_engine = RemotevLLMEngine(
+            InferenceEngineConfig(
+                experiment_name="awex_bench",
+                trial_name=f"{mode}_{model_kind}",
+                setup_timeout=360,
+                request_timeout=60,
+            )
+        )
+        with _temp_env(vllm_env):
+            inf_engine.launch_server(vllm_args)
+        inf_engine.initialize()
+        inf_engine.set_version(1)
+
+        _setup_megatron_env(device_backend)
+
+        train_config = TrainEngineConfig(
+            experiment_name="awex_bench",
+            trial_name=f"{mode}_{model_kind}",
+            path=model_path,
+            init_from_scratch=False,
+            optimizer=None,
+            megatron=MegatronEngineConfig(),
+        )
+        train_engine = MegatronEngine(train_config)
+        alloc_mode = AllocationMode.from_str("vllm:d1p1t1+megatron:d1p1t1")
+        train_engine.create_process_group(alloc_mode.train)
+        ft_spec = FinetuneSpec(total_train_epochs=1, dataset_size=16, train_batch_size=2)
+        train_engine.initialize(addr=None, ft_spec=ft_spec)
+        train_engine.set_version(1)
+
+        if mode == "xccl":
+            meta = WeightUpdateMeta.from_megatron_xccl(alloc_mode)
+        elif mode == "awex_nccl":
+            if meta_server_addr is None:
+                raise RuntimeError("Meta server addr missing for awex_nccl")
+            meta = WeightUpdateMeta.from_awex(
+                meta_server_addr=meta_server_addr,
+                comm_backend="hccl" if device_backend == "npu" else "nccl",
+            )
+        elif mode == "awex_file":
+            if meta_server_addr is None:
+                raise RuntimeError("Meta server addr missing for awex_file")
+            tmpdir = tempfile.TemporaryDirectory()
+            meta = WeightUpdateMeta.from_awex(
+                meta_server_addr=meta_server_addr,
+                comm_backend="file",
+            )
+            meta.path = tmpdir.name
+        else:
+            raise ValueError(f"Unknown mode: {mode}")
+        if device_backend == "npu" and meta.type == "awex":
+            meta.weights_exchange_ipc_backend = "cpu"
+
+        train_engine.connect_engine(inf_engine, meta)
+
+        for i in range(warmup):
+            train_engine.set_version(i + 1)
+            train_engine.update_weights(meta)
+
+        for i in range(iters):
+            train_engine.set_version(warmup + i + 1)
+            start = time.perf_counter()
+            train_engine.update_weights(meta)
+            timings.append(time.perf_counter() - start)
+
+        print(f"[bench] {mode} updates complete, entering cleanup.", flush=True)
+    finally:
+        print(f"[bench] cleanup start for {mode}.", flush=True)
+        if train_engine is not None:
+            print(f"[bench] destroying train engine for {mode}.", flush=True)
+            _safe_destroy(train_engine.destroy, "train_engine.destroy", timeout=10)
+        if inf_engine is not None:
+            print(f"[bench] destroying inference engine for {mode}.", flush=True)
+            _safe_destroy(inf_engine.destroy, "inf_engine.destroy", timeout=10)
+        if tmpdir is not None:
+            tmpdir.cleanup()
+        if mode.startswith("awex"):
+            print(f"[bench] stopping meta server for {mode}.", flush=True)
+            stop_meta_server()
+        print(f"[bench] cleanup done for {mode}.", flush=True)
+
+    return {
+        "mode": mode,
+        "iterations": iters,
+        "warmup": warmup,
+        "timings_sec": timings,
+        "mean_sec": statistics.mean(timings) if timings else None,
+        "p50_sec": statistics.median(timings) if timings else None,
+        "min_sec": min(timings) if timings else None,
+        "max_sec": max(timings) if timings else None,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--modes",
+        default="awex_nccl,awex_file,xccl",
+        help="Comma-separated modes: awex_nccl, awex_file, xccl",
+    )
+    parser.add_argument("--iters", type=int, default=3)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--model-kind", choices=["dense", "moe"], default="dense")
+    parser.add_argument("--out", default="")
+    parser.add_argument(
+        "--device-backend",
+        choices=["auto", "cuda", "npu", "cpu"],
+        default="auto",
+        help="Device backend to use (auto/cuda/npu/cpu).",
+    )
+    args = parser.parse_args()
+    device_backend = _detect_device_backend(args.device_backend)
+    if device_backend != "auto":
+        os.environ["AWEX_DEVICE_TYPE"] = device_backend
+        if device_backend == "npu":
+            os.environ.setdefault("AWEX_USE_MINDSPEED", "1")
+
+    results = []
+    for mode in [m.strip() for m in args.modes.split(",") if m.strip()]:
+        try:
+            res = _run_mode(
+                mode,
+                args.model_kind,
+                args.iters,
+                args.warmup,
+                device_backend,
+            )
+            results.append(res)
+        except Exception as exc:  # pylint: disable=broad-except
+            results.append({"mode": mode, "error": repr(exc)})
+
+    payload = {
+        "model_kind": args.model_kind,
+        "iters": args.iters,
+        "warmup": args.warmup,
+        "results": results,
+    }
+    print(json.dumps(payload, indent=2))
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/experimental/awex/build_reduced_qwen3_moe.py
+++ b/tests/experimental/awex/build_reduced_qwen3_moe.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Build a reduced HF checkpoint by slicing or synthetic initialization.
+
+Two modes are supported:
+1) Slice mode (`--input`): keep the first N layers and first K experts from
+   an existing local checkpoint.
+2) Dummy mode (`--hf-model`): fetch HF config only, reduce it locally, then
+   initialize random weights from config and save as a local checkpoint.
+
+This is intended for Awex integration tests that need real weight loading
+on limited GPU memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+from pathlib import Path
+from typing import Any, Iterable
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+LAYER_RE = re.compile(r"^model\.layers\.(\d+)\.")
+EXPERT_RE = re.compile(r"\.mlp\.experts\.(\d+)\.")
+GATE_SUFFIX = ".mlp.gate.weight"
+
+DTYPE_SIZES = {
+    "F16": 2,
+    "BF16": 2,
+    "F32": 4,
+    "F64": 8,
+    "I64": 8,
+    "I32": 4,
+    "I16": 2,
+    "I8": 1,
+    "U8": 1,
+    "BOOL": 1,
+}
+
+
+def _dtype_from_name(name: str) -> torch.dtype:
+    normalized = name.lower()
+    mapping = {
+        "float32": torch.float32,
+        "fp32": torch.float32,
+        "float16": torch.float16,
+        "fp16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+    }
+    if normalized not in mapping:
+        raise ValueError(f"Unsupported dtype: {name}")
+    return mapping[normalized]
+
+
+def _update_config_dict(
+    cfg: dict[str, Any],
+    num_layers: int,
+    num_experts: int,
+    num_experts_per_tok: int,
+) -> dict[str, Any]:
+    if "num_hidden_layers" in cfg:
+        cfg["num_hidden_layers"] = num_layers
+    if "layer_types" in cfg and isinstance(cfg["layer_types"], list):
+        cfg["layer_types"] = cfg["layer_types"][:num_layers]
+    if "num_experts" in cfg:
+        cfg["num_experts"] = num_experts
+    if "num_local_experts" in cfg:
+        cfg["num_local_experts"] = num_experts
+    if "num_experts_per_tok" in cfg:
+        cfg["num_experts_per_tok"] = min(num_experts_per_tok, num_experts)
+    if "moe_top_k" in cfg:
+        cfg["moe_top_k"] = min(num_experts_per_tok, num_experts)
+    if "max_window_layers" in cfg:
+        cfg["max_window_layers"] = num_layers
+    if "mlp_only_layers" in cfg and isinstance(cfg["mlp_only_layers"], list):
+        cfg["mlp_only_layers"] = [i for i in cfg["mlp_only_layers"] if i < num_layers]
+    return cfg
+
+
+def _parse_layer(key: str) -> int | None:
+    match = LAYER_RE.match(key)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _parse_expert(key: str) -> int | None:
+    match = EXPERT_RE.search(key)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _should_keep(key: str, num_layers: int, num_experts: int) -> bool:
+    layer = _parse_layer(key)
+    if layer is None:
+        return True
+    if layer >= num_layers:
+        return False
+    expert = _parse_expert(key)
+    if expert is not None and expert >= num_experts:
+        return False
+    return True
+
+
+def _tensor_nbytes(shape: Iterable[int], dtype: str) -> int:
+    size = DTYPE_SIZES.get(dtype)
+    if size is None:
+        raise ValueError(f"Unsupported dtype {dtype}")
+    numel = 1
+    for dim in shape:
+        numel *= dim
+    return numel * size
+
+
+def _plan_shards(
+    keys: list[str],
+    weight_map: dict[str, str],
+    num_experts: int,
+    max_shard_bytes: int,
+) -> list[list[str]]:
+    sizes: dict[str, int] = {}
+    keys_by_file: dict[str, list[str]] = {}
+    for key in keys:
+        keys_by_file.setdefault(weight_map[key], []).append(key)
+
+    for filename, file_keys in keys_by_file.items():
+        with safe_open(filename, framework="pt", device="cpu") as handle:
+            for key in file_keys:
+                sl = handle.get_slice(key)
+                shape = list(sl.get_shape())
+                dtype = sl.get_dtype()
+                if key.endswith(GATE_SUFFIX):
+                    shape[0] = min(shape[0], num_experts)
+                sizes[key] = _tensor_nbytes(shape, dtype)
+
+    shards: list[list[str]] = []
+    current: list[str] = []
+    current_bytes = 0
+    for key in keys:
+        size = sizes[key]
+        if current and current_bytes + size > max_shard_bytes:
+            shards.append(current)
+            current = []
+            current_bytes = 0
+        current.append(key)
+        current_bytes += size
+    if current:
+        shards.append(current)
+    return shards
+
+
+def _copy_support_files(src_dir: Path, dst_dir: Path) -> None:
+    for item in src_dir.iterdir():
+        if item.name.startswith("model-") or item.name == "model.safetensors.index.json":
+            continue
+        if item.is_dir():
+            if item.name.startswith("."):
+                continue
+            shutil.copytree(item, dst_dir / item.name, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, dst_dir / item.name)
+
+
+def _update_config(path: Path, num_layers: int, num_experts: int, num_experts_per_tok: int) -> None:
+    cfg = json.loads(path.read_text())
+    cfg = _update_config_dict(cfg, num_layers, num_experts, num_experts_per_tok)
+    path.write_text(json.dumps(cfg, indent=2) + "\n")
+
+
+def _prepare_output_dir(
+    output: str | None,
+    default_name: str,
+    force: bool,
+) -> Path:
+    output_dir = Path(output if output else default_name).resolve()
+    if output_dir.exists():
+        if not force:
+            raise FileExistsError(
+                f"Output directory exists: {output_dir}. Use --force to overwrite."
+            )
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def _ensure_single_file_index(weights_dir: Path) -> None:
+    index_path = weights_dir / "model.safetensors.index.json"
+    if index_path.exists():
+        return
+    single_file = weights_dir / "model.safetensors"
+    if not single_file.exists():
+        return
+    weight_map: dict[str, str] = {}
+    total_size = 0
+    with safe_open(str(single_file), framework="pt", device="cpu") as f:
+        for key in f.keys():
+            sl = f.get_slice(key)
+            shape = list(sl.get_shape())
+            dtype = sl.get_dtype()
+            total_size += _tensor_nbytes(shape, dtype)
+            weight_map[key] = single_file.name
+    index = {
+        "metadata": {"total_size": total_size},
+        "weight_map": weight_map,
+    }
+    index_path.write_text(json.dumps(index, indent=2) + "\n")
+
+
+def _save_tokenizer_and_processor(
+    hf_model: str,
+    output_dir: Path,
+    trust_remote_code: bool,
+) -> None:
+    try:
+        from transformers import AutoProcessor, AutoTokenizer
+    except ImportError:
+        return
+
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(
+            hf_model,
+            trust_remote_code=trust_remote_code,
+        )
+        tokenizer.save_pretrained(output_dir)
+        print("[dummy] Saved tokenizer files.")
+    except Exception as exc:
+        print(f"[dummy] Skip tokenizer save: {exc}")
+
+    try:
+        processor = AutoProcessor.from_pretrained(
+            hf_model,
+            trust_remote_code=trust_remote_code,
+        )
+        processor.save_pretrained(output_dir)
+        print("[dummy] Saved processor files.")
+    except Exception:
+        # Most text-only models do not provide a processor; this is expected.
+        pass
+
+
+def _build_dummy_checkpoint(
+    hf_model: str,
+    output_dir: Path,
+    num_layers: int,
+    num_experts: int,
+    num_experts_per_tok: int,
+    max_shard_size_gb: float,
+    dtype: torch.dtype,
+    trust_remote_code: bool,
+    seed: int | None,
+    save_tokenizer: bool,
+) -> None:
+    try:
+        from transformers import AutoConfig, AutoModelForCausalLM
+    except ImportError as e:
+        raise RuntimeError(
+            "transformers is required for --hf-model dummy mode. "
+            "Install with: pip install transformers"
+        ) from e
+
+    print(f"[dummy] Loading config from Hugging Face: {hf_model}")
+    cfg = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
+    cfg_dict = _update_config_dict(
+        cfg.to_dict(),
+        num_layers=num_layers,
+        num_experts=num_experts,
+        num_experts_per_tok=num_experts_per_tok,
+    )
+    cfg = cfg.__class__.from_dict(cfg_dict)
+
+    if seed is not None:
+        torch.manual_seed(seed)
+        print(f"[dummy] Using torch seed={seed}")
+
+    max_shard_bytes = int(max_shard_size_gb * (1 << 30))
+    print(
+        f"[dummy] Initializing reduced model from config (dtype={dtype}, "
+        f"layers={cfg_dict.get('num_hidden_layers')}, "
+        f"experts={cfg_dict.get('num_experts', cfg_dict.get('num_local_experts'))})."
+    )
+    model = AutoModelForCausalLM.from_config(
+        cfg,
+        trust_remote_code=trust_remote_code,
+        dtype=dtype,
+    )
+    model.save_pretrained(
+        output_dir,
+        safe_serialization=True,
+        max_shard_size=max_shard_bytes,
+    )
+    _ensure_single_file_index(output_dir)
+
+    if save_tokenizer:
+        _save_tokenizer_and_processor(
+            hf_model=hf_model,
+            output_dir=output_dir,
+            trust_remote_code=trust_remote_code,
+        )
+
+    print(f"[dummy] Reduced dummy checkpoint written to: {output_dir}")
+
+
+def _reduce_existing_checkpoint(
+    src_dir: Path,
+    output_dir: Path,
+    num_layers: int,
+    num_experts: int,
+    num_experts_per_tok: int,
+    max_shard_size_gb: float,
+) -> None:
+    index_path = src_dir / "model.safetensors.index.json"
+    if not index_path.exists():
+        raise FileNotFoundError(f"Missing index file: {index_path}")
+    index = json.loads(index_path.read_text())
+    weight_map: dict[str, str] = index["weight_map"]
+
+    selected_keys = [
+        k
+        for k in sorted(weight_map.keys())
+        if _should_keep(k, num_layers, num_experts)
+    ]
+    if not selected_keys:
+        raise RuntimeError("No tensors selected. Check num_layers/num_experts.")
+
+    max_shard_bytes = int(max_shard_size_gb * (1 << 30))
+    shard_plan = _plan_shards(
+        selected_keys,
+        {k: str(src_dir / v) for k, v in weight_map.items()},
+        num_experts,
+        max_shard_bytes,
+    )
+    num_shards = len(shard_plan)
+    print(
+        f"[reduce] Selected {len(selected_keys)} tensors into {num_shards} shard(s)."
+    )
+
+    weight_map_out: dict[str, str] = {}
+    total_size = 0
+    file_handles: dict[str, safe_open] = {}
+
+    try:
+        for shard_idx, keys in enumerate(shard_plan, start=1):
+            shard_name = f"model-{shard_idx:05d}-of-{num_shards:05d}.safetensors"
+            shard_path = output_dir / shard_name
+            tensors: dict[str, torch.Tensor] = {}
+            for key in keys:
+                filename = str(src_dir / weight_map[key])
+                if filename not in file_handles:
+                    file_handles[filename] = safe_open(
+                        filename, framework="pt", device="cpu"
+                    )
+                tensor = file_handles[filename].get_tensor(key)
+                if key.endswith(GATE_SUFFIX):
+                    tensor = tensor[:num_experts].contiguous()
+                tensors[key] = tensor
+                weight_map_out[key] = shard_name
+                total_size += tensor.numel() * tensor.element_size()
+            save_file(tensors, shard_path)
+            print(f"[reduce] Wrote {shard_path} with {len(tensors)} tensors.")
+    finally:
+        for handle in file_handles.values():
+            handle.__exit__(None, None, None)
+
+    index_out = {
+        "metadata": {"total_size": total_size},
+        "weight_map": weight_map_out,
+    }
+    (output_dir / "model.safetensors.index.json").write_text(
+        json.dumps(index_out, indent=2) + "\n"
+    )
+
+    _copy_support_files(src_dir, output_dir)
+    for cfg_name in ("config.json", "config_1m.json"):
+        cfg_path = output_dir / cfg_name
+        if cfg_path.exists():
+            _update_config(cfg_path, num_layers, num_experts, num_experts_per_tok)
+    print(f"[reduce] Reduced checkpoint written to: {output_dir}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source_group = parser.add_mutually_exclusive_group(required=True)
+    source_group.add_argument(
+        "--input",
+        help="Path to source local HF model directory (slice mode).",
+    )
+    source_group.add_argument(
+        "--hf-model",
+        help="Hugging Face model id/path for config-only download (dummy mode).",
+    )
+    parser.add_argument("--output", help="Output directory for reduced checkpoint.")
+    parser.add_argument("--num-layers", type=int, default=2, help="Number of layers to keep.")
+    parser.add_argument("--num-experts", type=int, default=8, help="Number of experts to keep.")
+    parser.add_argument(
+        "--num-experts-per-tok",
+        type=int,
+        default=2,
+        help="Number of experts per token (will be clipped to num_experts).",
+    )
+    parser.add_argument(
+        "--max-shard-size-gb",
+        type=float,
+        default=2.0,
+        help="Max shard size in GB for output safetensors.",
+    )
+    parser.add_argument(
+        "--dtype",
+        default="bfloat16",
+        choices=["bfloat16", "bf16", "float16", "fp16", "float32", "fp32"],
+        help="Weight dtype for --hf-model dummy mode.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=1,
+        help="Random seed for --hf-model dummy mode initialization.",
+    )
+    parser.add_argument(
+        "--no-trust-remote-code",
+        action="store_true",
+        help="Disable trust_remote_code when loading HF config/model/tokenizer.",
+    )
+    parser.add_argument(
+        "--no-tokenizer",
+        action="store_true",
+        help="Do not download/save tokenizer/processor files in --hf-model mode.",
+    )
+    parser.add_argument("--force", action="store_true", help="Overwrite output directory.")
+    args = parser.parse_args()
+
+    if args.input:
+        src_dir = Path(args.input).resolve()
+        if not src_dir.exists():
+            raise FileNotFoundError(f"Input model path not found: {src_dir}")
+        output_dir = _prepare_output_dir(
+            args.output,
+            f"{src_dir}-reduced-l{args.num_layers}-e{args.num_experts}",
+            args.force,
+        )
+        _reduce_existing_checkpoint(
+            src_dir=src_dir,
+            output_dir=output_dir,
+            num_layers=args.num_layers,
+            num_experts=args.num_experts,
+            num_experts_per_tok=args.num_experts_per_tok,
+            max_shard_size_gb=args.max_shard_size_gb,
+        )
+        return
+
+    model_id = args.hf_model
+    default_name = (
+        model_id.replace("/", "__")
+        + f"-dummy-reduced-l{args.num_layers}-e{args.num_experts}"
+    )
+    output_dir = _prepare_output_dir(args.output, default_name, args.force)
+    _build_dummy_checkpoint(
+        hf_model=model_id,
+        output_dir=output_dir,
+        num_layers=args.num_layers,
+        num_experts=args.num_experts,
+        num_experts_per_tok=args.num_experts_per_tok,
+        max_shard_size_gb=args.max_shard_size_gb,
+        dtype=_dtype_from_name(args.dtype),
+        trust_remote_code=not args.no_trust_remote_code,
+        seed=args.seed,
+        save_tokenizer=not args.no_tokenizer,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/experimental/awex/test_awex_megatron_vllm_integration.py
+++ b/tests/experimental/awex/test_awex_megatron_vllm_integration.py
@@ -1,0 +1,851 @@
+"""Integration test for Awex weight exchange between Megatron and vLLM."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import queue
+import threading
+import tempfile
+import time
+import json
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from areal.api.alloc_mode import ParallelStrategy
+from areal.api.cli_args import (
+    InferenceEngineConfig,
+    MegatronEngineConfig,
+    TrainEngineConfig,
+    vLLMConfig,
+)
+from areal.api.io_struct import FinetuneSpec, WeightUpdateMeta
+from areal.engine.megatron_engine import MegatronEngine
+from areal.engine.vllm_remote import RemotevLLMEngine
+from areal.tests.utils import get_model_path
+from areal.utils import network
+from areal.utils.pkg_version import is_available
+from areal.utils.proc import kill_process_tree
+
+IS_VLLM_INSTALLED = is_available("vllm")
+IS_AWEX_INSTALLED = is_available("awex")
+
+DENSE_HF_ID = "Qwen/Qwen3-0.6B"
+DENSE_LOCAL_PATH = "/home/model/Qwen3-0.6B/"
+MOE_LOCAL_PATH = "/home/model/Qwen3-30B-A3B-Instruct-2507-reduced-l2-e8"
+
+# Avoid MindSpeed transformer_config_init_wrapper get sys args which might translate to ''
+import sys
+sys.argv = [sys.argv[0]]
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.environ.get(name, str(default)))
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_float(name: str, default: float) -> float:
+    return float(os.environ.get(name, str(default)))
+
+
+def _env_csv(name: str) -> list[str]:
+    raw = os.environ.get(name, "")
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+# === Parallel configuration (edit to test multi-GPU) ===
+# Training-side parallelism (Megatron).
+TRAIN_TP_SIZE = _env_int("AREAL_AWEX_TRAIN_TP_SIZE", 1)
+TRAIN_PP_SIZE = _env_int("AREAL_AWEX_TRAIN_PP_SIZE", 1)
+TRAIN_DP_SIZE = _env_int("AREAL_AWEX_TRAIN_DP_SIZE", 1)
+TRAIN_CP_SIZE = _env_int("AREAL_AWEX_TRAIN_CP_SIZE", 1)
+TRAIN_EP_SIZE = _env_int("AREAL_AWEX_TRAIN_EP_SIZE", 1)
+TRAIN_ETP_SIZE = _env_int("AREAL_AWEX_TRAIN_ETP_SIZE", 1)
+
+# Inference-side parallelism (vLLM).
+VLLM_TP_SIZE = _env_int("AREAL_AWEX_VLLM_TP_SIZE", 1)
+VLLM_PP_SIZE = _env_int("AREAL_AWEX_VLLM_PP_SIZE", 1)
+# Optional vLLM data/expert parallel settings (internal DP on a single server).
+VLLM_DATA_PARALLEL_SIZE = _env_int("AREAL_AWEX_VLLM_DP_SIZE", 1)
+VLLM_ENABLE_EXPERT_PARALLEL = _env_bool("AREAL_AWEX_VLLM_ENABLE_EP", False)
+VLLM_ENABLE_EPLB = _env_bool("AREAL_AWEX_VLLM_ENABLE_EPLB", False)
+VLLM_EXPERT_PLACEMENT_STRATEGY = os.environ.get(
+    "AREAL_AWEX_VLLM_EXPERT_PLACEMENT_STRATEGY", ""
+).strip()
+VLLM_EPLB_WINDOW_SIZE = _env_int("AREAL_AWEX_VLLM_EPLB_WINDOW_SIZE", 8)
+VLLM_EPLB_STEP_INTERVAL = _env_int("AREAL_AWEX_VLLM_EPLB_STEP_INTERVAL", 4)
+VLLM_EPLB_NUM_REDUNDANT_EXPERTS = _env_int(
+    "AREAL_AWEX_VLLM_EPLB_NUM_REDUNDANT_EXPERTS", 0
+)
+VLLM_EPLB_LOG_BALANCEDNESS = _env_bool(
+    "AREAL_AWEX_VLLM_EPLB_LOG_BALANCEDNESS", True
+)
+# NPU(vllm-ascend) EPLB knobs. Keep GPU-style knobs above for CUDA vLLM.
+VLLM_EPLB_DYNAMIC = _env_bool("AREAL_AWEX_VLLM_EPLB_DYNAMIC", True)
+VLLM_EPLB_EXPERT_HEAT_COLLECTION_INTERVAL = _env_int(
+    "AREAL_AWEX_VLLM_EPLB_EXPERT_HEAT_COLLECTION_INTERVAL",
+    VLLM_EPLB_WINDOW_SIZE,
+)
+VLLM_EPLB_ALGORITHM_EXECUTION_INTERVAL = _env_int(
+    "AREAL_AWEX_VLLM_EPLB_ALGORITHM_EXECUTION_INTERVAL",
+    VLLM_EPLB_STEP_INTERVAL,
+)
+VLLM_EPLB_EXPERT_MAP_PATH = (
+    os.environ.get("AREAL_AWEX_VLLM_EPLB_EXPERT_MAP_PATH", "").strip() or None
+)
+VLLM_EPLB_EXPERT_MAP_RECORD_PATH = (
+    os.environ.get("AREAL_AWEX_VLLM_EPLB_EXPERT_MAP_RECORD_PATH", "").strip() or None
+)
+VLLM_EPLB_POLICY_TYPE = _env_int("AREAL_AWEX_VLLM_EPLB_POLICY_TYPE", 1)
+VLLM_NUM_ENGINES = _env_int("AREAL_AWEX_VLLM_NUM_ENGINES", 1)
+NUM_UPDATES = _env_int("AREAL_AWEX_NUM_UPDATES", 1)
+VALIDATION_STEPS = _env_int("AREAL_AWEX_VALIDATION_STEPS", -1)
+VALIDATE_EVERY_N_STEPS = _env_int("AREAL_AWEX_VALIDATE_EVERY_N_STEPS", 1)
+REQUESTS_PER_UPDATE = _env_int("AREAL_AWEX_REQUESTS_PER_UPDATE", 0)
+REQUEST_TIMEOUT_S = _env_int("AREAL_AWEX_REQUEST_TIMEOUT_S", 30)
+REQUEST_RETRIES = _env_int("AREAL_AWEX_REQUEST_RETRIES", 3)
+STRICT_REQUEST_TRAFFIC = _env_bool("AREAL_AWEX_STRICT_REQUEST_TRAFFIC", False)
+ENGINE_REQUEST_TIMEOUT_S = _env_int("AREAL_AWEX_ENGINE_REQUEST_TIMEOUT_S", 60)
+ENGINE_SETUP_TIMEOUT_S = _env_int("AREAL_AWEX_ENGINE_SETUP_TIMEOUT_S", 360)
+VLLM_GPU_MEMORY_UTILIZATION = _env_float(
+    "AREAL_AWEX_VLLM_GPU_MEMORY_UTILIZATION", 0.6
+)
+VLLM_MAX_NUM_SEQS = _env_int("AREAL_AWEX_VLLM_MAX_NUM_SEQS", 1)
+VLLM_MAX_MODEL_LEN = _env_int("AREAL_AWEX_VLLM_MAX_MODEL_LEN", 128)
+TRAIN_CLUSTER_ID = os.environ.get("AREAL_AWEX_TRAIN_CLUSTER_ID", "").strip() or None
+VLLM_CLUSTER_IDS = _env_csv("AREAL_AWEX_VLLM_CLUSTER_IDS")
+
+# vLLM instances to launch (edit for multi-engine setups).
+# Each instance can define its own tp/pp sizes and device list (IDs in visible list).
+# For internal vLLM DP+EP, set data_parallel_size on the instance. We keep
+# a single server instance and let vLLM manage DP ranks internally.
+# Optional "engine_rank" controls ordering (default: list order). If provided, it
+# must be unique and contiguous starting from 0.
+# If all devices are None, they will be auto-assigned after training devices.
+if VLLM_NUM_ENGINES < 1:
+    raise RuntimeError("AREAL_AWEX_VLLM_NUM_ENGINES must be >= 1.")
+if VLLM_CLUSTER_IDS and len(VLLM_CLUSTER_IDS) != VLLM_NUM_ENGINES:
+    raise RuntimeError(
+        "AREAL_AWEX_VLLM_CLUSTER_IDS must have exactly "
+        f"{VLLM_NUM_ENGINES} items, got {len(VLLM_CLUSTER_IDS)}."
+    )
+
+VLLM_INSTANCES: list[dict] = []
+for engine_idx in range(VLLM_NUM_ENGINES):
+    VLLM_INSTANCES.append(
+        {
+            "tp_size": VLLM_TP_SIZE,
+            "pp_size": VLLM_PP_SIZE,
+            "devices": None,
+            "engine_rank": engine_idx,
+            "data_parallel_size": VLLM_DATA_PARALLEL_SIZE,
+            "enable_expert_parallel": VLLM_ENABLE_EXPERT_PARALLEL,
+            "enable_eplb": VLLM_ENABLE_EPLB,
+            "expert_placement_strategy": VLLM_EXPERT_PLACEMENT_STRATEGY or None,
+            "awex_cluster_id": (
+                VLLM_CLUSTER_IDS[engine_idx] if VLLM_CLUSTER_IDS else None
+            ),
+            "eplb_config": {
+                "window_size": VLLM_EPLB_WINDOW_SIZE,
+                "step_interval": VLLM_EPLB_STEP_INTERVAL,
+                "num_redundant_experts": VLLM_EPLB_NUM_REDUNDANT_EXPERTS,
+                "log_balancedness": VLLM_EPLB_LOG_BALANCEDNESS,
+            },
+        }
+    )
+
+
+def _detect_device_backend() -> str:
+    requested = os.environ.get("AREAL_AWEX_DEVICE_BACKEND", "auto").lower()
+    if requested and requested != "auto":
+        return requested
+    if getattr(torch, "npu", None) is not None and torch.npu.is_available():
+        return "npu"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+def _visible_env_name(device_backend: str) -> str:
+    if device_backend == "npu":
+        return "ASCEND_RT_VISIBLE_DEVICES"
+    return "CUDA_VISIBLE_DEVICES"
+
+
+def _device_count(device_backend: str) -> int:
+    if device_backend == "npu":
+        return 0 if getattr(torch, "npu", None) is None else torch.npu.device_count()
+    if device_backend == "cuda":
+        return torch.cuda.device_count()
+    return 0
+
+
+def _select_devices(
+    train_world_size: int,
+    vllm_world_size: int,
+    device_backend: str = "cuda",
+    vllm_device_ids: list[int] | None = None,
+):
+    visible_env = os.environ.get(_visible_env_name(device_backend), "").strip()
+    if visible_env:
+        visible_devices = [int(x) for x in visible_env.split(",") if x.strip()]
+    else:
+        visible_devices = list(range(_device_count(device_backend)))
+
+    if vllm_device_ids is not None:
+        for device_id in vllm_device_ids:
+            if device_id not in visible_devices:
+                raise RuntimeError(
+                    f"vLLM device id {device_id} is not visible. "
+                    f"Visible devices: {visible_devices}"
+                )
+        vllm_devices = vllm_device_ids
+        train_devices = [d for d in visible_devices if d not in vllm_devices][
+            :train_world_size
+        ]
+    else:
+        train_devices = visible_devices[:train_world_size]
+        vllm_devices = visible_devices[
+            train_world_size : train_world_size + vllm_world_size
+        ]
+
+    need = train_world_size + vllm_world_size
+    if len(visible_devices) < need or len(train_devices) < train_world_size or len(vllm_devices) < vllm_world_size:
+        pytest.skip(
+            f"Need at least {need} devices (train={train_world_size}, vLLM={vllm_world_size}). "
+            f"Found {len(visible_devices)}."
+        )
+
+    return train_devices, vllm_devices
+
+
+def _train_world_size() -> int:
+    return TRAIN_TP_SIZE * TRAIN_PP_SIZE * TRAIN_DP_SIZE * TRAIN_CP_SIZE
+
+
+def _build_ascend_eplb_config(base_config: dict | None) -> dict:
+    cfg = {
+        "dynamic_eplb": VLLM_EPLB_DYNAMIC,
+        "expert_heat_collection_interval": VLLM_EPLB_EXPERT_HEAT_COLLECTION_INTERVAL,
+        "algorithm_execution_interval": VLLM_EPLB_ALGORITHM_EXECUTION_INTERVAL,
+        "num_redundant_experts": VLLM_EPLB_NUM_REDUNDANT_EXPERTS,
+        "eplb_policy_type": VLLM_EPLB_POLICY_TYPE,
+    }
+    if VLLM_EPLB_EXPERT_MAP_PATH:
+        cfg["expert_map_path"] = VLLM_EPLB_EXPERT_MAP_PATH
+    if VLLM_EPLB_EXPERT_MAP_RECORD_PATH:
+        cfg["expert_map_record_path"] = VLLM_EPLB_EXPERT_MAP_RECORD_PATH
+    raw = base_config or {}
+    if "dynamic_eplb" in raw:
+        cfg["dynamic_eplb"] = bool(raw["dynamic_eplb"])
+    if "expert_heat_collection_interval" in raw:
+        cfg["expert_heat_collection_interval"] = int(
+            raw["expert_heat_collection_interval"]
+        )
+    if "algorithm_execution_interval" in raw:
+        cfg["algorithm_execution_interval"] = int(
+            raw["algorithm_execution_interval"]
+        )
+    # Backward-compatible mapping from GPU EPLB keys.
+    if (
+        "window_size" in raw
+        and "expert_heat_collection_interval" not in raw
+    ):
+        cfg["expert_heat_collection_interval"] = int(raw["window_size"])
+    if (
+        "step_interval" in raw
+        and "algorithm_execution_interval" not in raw
+    ):
+        cfg["algorithm_execution_interval"] = int(raw["step_interval"])
+    if "num_redundant_experts" in raw:
+        cfg["num_redundant_experts"] = int(raw["num_redundant_experts"])
+    if "expert_map_path" in raw and raw["expert_map_path"]:
+        cfg["expert_map_path"] = str(raw["expert_map_path"])
+    if "expert_map_record_path" in raw and raw["expert_map_record_path"]:
+        cfg["expert_map_record_path"] = str(raw["expert_map_record_path"])
+    if "eplb_policy_type" in raw:
+        cfg["eplb_policy_type"] = int(raw["eplb_policy_type"])
+    return cfg
+
+
+def _build_vllm_instances() -> list[dict]:
+    if not VLLM_INSTANCES:
+        raise RuntimeError("VLLM_INSTANCES is empty; configure at least one vLLM instance.")
+    instances = []
+    for idx, inst in enumerate(VLLM_INSTANCES):
+        tp_size = int(inst.get("tp_size", VLLM_TP_SIZE))
+        pp_size = int(inst.get("pp_size", VLLM_PP_SIZE))
+        devices = inst.get("devices")
+        engine_rank = int(inst.get("engine_rank", idx))
+        data_parallel_size = int(
+            inst.get("data_parallel_size", VLLM_DATA_PARALLEL_SIZE) or 1
+        )
+        enable_expert_parallel = bool(
+            inst.get("enable_expert_parallel", VLLM_ENABLE_EXPERT_PARALLEL)
+        )
+        enable_eplb = bool(inst.get("enable_eplb", VLLM_ENABLE_EPLB))
+        expert_placement_strategy = (
+            (inst.get("expert_placement_strategy") or VLLM_EXPERT_PLACEMENT_STRATEGY)
+            or None
+        )
+        awex_cluster_id = str(inst.get("awex_cluster_id", "") or "").strip() or None
+        eplb_config = inst.get("eplb_config")
+        if eplb_config is None:
+            eplb_config = {
+                "window_size": VLLM_EPLB_WINDOW_SIZE,
+                "step_interval": VLLM_EPLB_STEP_INTERVAL,
+                "num_redundant_experts": VLLM_EPLB_NUM_REDUNDANT_EXPERTS,
+                "log_balancedness": VLLM_EPLB_LOG_BALANCEDNESS,
+            }
+        if data_parallel_size < 1:
+            raise RuntimeError("data_parallel_size must be >= 1.")
+        if enable_eplb and tp_size == 1 and data_parallel_size == 1:
+            raise RuntimeError(
+                "EPLB requires vLLM TP>1 or DP>1. "
+                f"Got tp_size={tp_size}, data_parallel_size={data_parallel_size}."
+            )
+        world_size = tp_size * pp_size * data_parallel_size
+        if devices is not None and len(devices) != world_size:
+            raise RuntimeError(
+                f"vLLM instance {idx} expects {world_size} devices "
+                f"but got {len(devices)}."
+            )
+        instances.append(
+            {
+                "tp_size": tp_size,
+                "pp_size": pp_size,
+                "devices": devices,
+                "engine_rank": engine_rank,
+                "data_parallel_size": data_parallel_size,
+                "enable_expert_parallel": enable_expert_parallel,
+                "enable_eplb": enable_eplb,
+                "expert_placement_strategy": expert_placement_strategy,
+                "awex_cluster_id": awex_cluster_id,
+                "eplb_config": eplb_config,
+                "world_size": world_size,
+            }
+        )
+    engine_ranks = [inst["engine_rank"] for inst in instances]
+    if len(set(engine_ranks)) != len(engine_ranks):
+        raise RuntimeError(f"Duplicate engine_rank values found: {engine_ranks}")
+    instances.sort(key=lambda x: x["engine_rank"])
+    expected = list(range(len(instances)))
+    if engine_ranks != expected and [i["engine_rank"] for i in instances] != expected:
+        raise RuntimeError(
+            "engine_rank must be contiguous starting from 0 (e.g. 0,1,2...)."
+        )
+    return instances
+
+
+@contextmanager
+def _temp_env(overrides: dict[str, str]):
+    old = {key: os.environ.get(key) for key in overrides}
+    os.environ.update(overrides)
+    try:
+        yield
+    finally:
+        for key, value in old.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _http_get_json(url: str, timeout_s: int) -> dict:
+    request = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout_s) as response:
+        body = response.read().decode("utf-8")
+    return json.loads(body) if body else {}
+
+
+def _http_post_json(url: str, payload: dict, timeout_s: int) -> dict:
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout_s) as response:
+        raw = response.read().decode("utf-8")
+    return json.loads(raw) if raw else {}
+
+
+def _discover_model_id(server_addr: str, fallback_model: str, timeout_s: int) -> str:
+    try:
+        payload = _http_get_json(f"http://{server_addr}/v1/models", timeout_s)
+        models = payload.get("data") or []
+        if models and isinstance(models[0], dict):
+            model_id = models[0].get("id")
+            if model_id:
+                return str(model_id)
+    except Exception as exc:
+        print(
+            f"[awex-test] failed to discover model id on {server_addr}: {exc}. "
+            f"fallback to {fallback_model}",
+            flush=True,
+        )
+    return fallback_model
+
+
+def _drive_completion_traffic(
+    *,
+    server_addrs: list[str],
+    fallback_model: str,
+    requests_per_update: int,
+    timeout_s: int,
+    retries: int,
+    strict: bool,
+) -> None:
+    if requests_per_update <= 0:
+        return
+    model_ids = {
+        addr: _discover_model_id(addr, fallback_model=fallback_model, timeout_s=timeout_s)
+        for addr in server_addrs
+    }
+    for server_addr in server_addrs:
+        model_id = model_ids[server_addr]
+        for req_idx in range(requests_per_update):
+            payload = {
+                "model": model_id,
+                "prompt": f"awex eplb trigger request {req_idx}",
+                "max_tokens": 8,
+                "temperature": 0.0,
+            }
+            last_error = None
+            for attempt in range(1, max(1, retries) + 1):
+                try:
+                    _http_post_json(
+                        f"http://{server_addr}/v1/completions",
+                        payload=payload,
+                        timeout_s=timeout_s,
+                    )
+                    last_error = None
+                    break
+                except (
+                    TimeoutError,
+                    urllib.error.HTTPError,
+                    urllib.error.URLError,
+                    json.JSONDecodeError,
+                    RuntimeError,
+                ) as exc:
+                    last_error = exc
+                    time.sleep(min(1.0 * attempt, 3.0))
+            if last_error is not None:
+                message = (
+                    f"[awex-test] completion traffic failed on {server_addr} after "
+                    f"{max(1, retries)} attempts: {last_error}"
+                )
+                if strict:
+                    raise RuntimeError(message) from last_error
+                print(message, flush=True)
+                return
+
+
+def _run_awex_integration(result_queue, model_path: str):
+    def _safe_destroy(fn, name: str, timeout: int = 10) -> None:
+        done = threading.Event()
+
+        def _run():
+            try:
+                fn()
+            finally:
+                done.set()
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        if not done.wait(timeout):
+            print(f"[awex-test] {name} timed out after {timeout}s.", flush=True)
+
+    rank = 0
+    world_size = 1
+    try:
+        device_backend = _detect_device_backend()
+        os.environ.setdefault("AWEX_DEVICE_TYPE", device_backend)
+        if device_backend == "npu":
+            os.environ.setdefault("AWEX_USE_MINDSPEED", "1")
+        os.environ.setdefault("AWEX_MASTER_ADDR", "127.0.0.1")
+        train_world_size = _train_world_size()
+        world_size = int(os.environ.get("WORLD_SIZE", "1"))
+        rank = int(os.environ.get("RANK", "0"))
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        if train_world_size > 1 and world_size == 1:
+            raise RuntimeError(
+                f"TRAIN_* sizes require WORLD_SIZE={train_world_size}. "
+                "Launch with torchrun to enable multi-rank training."
+            )
+        if world_size > 1 and world_size != train_world_size:
+            raise RuntimeError(
+                f"WORLD_SIZE ({world_size}) does not match TRAIN_* world size ({train_world_size})."
+            )
+
+        vllm_instances = _build_vllm_instances()
+        vllm_world_size = sum(inst["world_size"] for inst in vllm_instances)
+        explicit_devices = [inst["devices"] for inst in vllm_instances if inst["devices"] is not None]
+        if explicit_devices and len(explicit_devices) != len(vllm_instances):
+            raise RuntimeError(
+                "VLLM_INSTANCES must either specify devices for all instances or none."
+            )
+        if explicit_devices:
+            flat_vllm_devices = [d for inst in vllm_instances for d in inst["devices"]]
+            if len(flat_vllm_devices) != vllm_world_size:
+                raise RuntimeError(
+                    f"Explicit vLLM devices ({len(flat_vllm_devices)}) do not match "
+                    f"expected world size ({vllm_world_size})."
+                )
+            train_devices, _ = _select_devices(
+                train_world_size=train_world_size,
+                vllm_world_size=len(flat_vllm_devices),
+                device_backend=device_backend,
+                vllm_device_ids=flat_vllm_devices,
+            )
+        else:
+            train_devices, flat_vllm_devices = _select_devices(
+                train_world_size=train_world_size,
+                vllm_world_size=vllm_world_size,
+                device_backend=device_backend,
+                vllm_device_ids=None,
+            )
+            offset = 0
+            for inst in vllm_instances:
+                size = inst["world_size"]
+                inst["devices"] = flat_vllm_devices[offset : offset + size]
+                offset += size
+
+        train_device = train_devices[local_rank]
+
+        # Start Awex meta server
+        from awex.meta.meta_server import start_meta_server, stop_meta_server
+
+        meta_server_addr = None
+
+        # Launch vLLM server with Awex plugin enabled (real weights + validation).
+        enable_validation = True
+        comm_backend = os.environ.get("AREAL_AWEX_COMM_BACKEND", "nccl").lower()
+
+        vllm_config = vLLMConfig(
+            skip_tokenizer_init=False,
+            model=model_path,
+            gpu_memory_utilization=VLLM_GPU_MEMORY_UTILIZATION,
+            max_num_seqs=VLLM_MAX_NUM_SEQS,
+            max_model_len=VLLM_MAX_MODEL_LEN,
+            enforce_eager=True,
+            # load_format="auto",
+        )
+
+        vllm_env_base = {
+            "AWEX_DEVICE_TYPE": device_backend,
+        }
+
+        inf_engine = None
+        train_engine = None
+        tmpdir = None
+
+        try:
+            temp_config = InferenceEngineConfig(
+                experiment_name="test_awex_megatron_vllm",
+                trial_name="trial_0",
+                setup_timeout=ENGINE_SETUP_TIMEOUT_S,
+                request_timeout=ENGINE_REQUEST_TIMEOUT_S,
+            )
+            inf_engine = RemotevLLMEngine(temp_config)
+
+            # Initialize Megatron engine
+            if world_size == 1:
+                dist_port = network.find_free_ports(1)[0]
+                os.environ.update(
+                    {
+                        "WORLD_SIZE": "1",
+                        "RANK": "0",
+                        "LOCAL_RANK": "0",
+                        "MASTER_ADDR": "localhost",
+                        "MASTER_PORT": str(dist_port),
+                    }
+                )
+
+            # Pin Megatron to the first visible GPU
+            if device_backend == "npu":
+                if getattr(torch, "npu", None) is None:
+                    raise RuntimeError("torch.npu is not available for NPU backend.")
+                torch.npu.set_device(train_device)
+            else:
+                torch.cuda.set_device(train_device)
+
+            train_config = TrainEngineConfig(
+                experiment_name="test_awex_megatron_vllm",
+                trial_name="trial_0",
+                path=model_path,
+                init_from_scratch=False,
+                optimizer=None,
+                megatron=MegatronEngineConfig(),
+            )
+            train_engine = MegatronEngine(train_config)
+            train_parallel = ParallelStrategy(
+                tensor_parallel_size=TRAIN_TP_SIZE,
+                pipeline_parallel_size=TRAIN_PP_SIZE,
+                data_parallel_size=TRAIN_DP_SIZE,
+                context_parallel_size=TRAIN_CP_SIZE,
+                expert_parallel_size=TRAIN_EP_SIZE,
+                expert_tensor_parallel_size=TRAIN_ETP_SIZE,
+            )
+            train_engine.create_process_group(train_parallel)
+            ft_spec = FinetuneSpec(total_train_epochs=1, dataset_size=128, train_batch_size=2)
+            train_engine.initialize(addr=None, ft_spec=ft_spec)
+            train_engine.set_version(1)
+            if TRAIN_CLUSTER_ID:
+                os.environ["AWEX_CLUSTER_ID"] = TRAIN_CLUSTER_ID
+
+            if rank == 0:
+                meta_ip, meta_port = start_meta_server()
+                meta_server_addr = f"{meta_ip}:{meta_port}"
+            if dist.is_initialized():
+                obj_list = [meta_server_addr]
+                dist.broadcast_object_list(obj_list, src=0)
+                meta_server_addr = obj_list[0]
+
+            server_addrs = None
+            if rank == 0:
+                server_infos = []
+                for inst in vllm_instances:
+                    vllm_args = vLLMConfig.build_args(
+                        vllm_config=vllm_config,
+                        tp_size=inst["tp_size"],
+                        pp_size=inst["pp_size"],
+                    )
+                    vllm_extra_args = {
+                        "data_parallel_size": inst.get("data_parallel_size"),
+                        "enable_expert_parallel": inst.get("enable_expert_parallel"),
+                    }
+                    vllm_env = {
+                        _visible_env_name(device_backend): ",".join(
+                            map(str, inst["devices"])
+                        ),
+                        **vllm_env_base,
+                    }
+                    if inst.get("enable_eplb"):
+                        if device_backend == "npu":
+                            ascend_eplb_config = _build_ascend_eplb_config(
+                                inst.get("eplb_config")
+                            )
+                            vllm_extra_args["additional_config"] = json.dumps(
+                                {"eplb_config": ascend_eplb_config}
+                            )
+                            if (
+                                ascend_eplb_config.get("dynamic_eplb")
+                                or ascend_eplb_config.get(
+                                    "expert_map_record_path"
+                                )
+                            ):
+                                vllm_env["DYNAMIC_EPLB"] = "true"
+                            if ascend_eplb_config.get("expert_map_record_path"):
+                                vllm_env["EXPERT_MAP_RECORD"] = "true"
+                        else:
+                            vllm_extra_args["enable_eplb"] = True
+                            vllm_extra_args["eplb_config"] = json.dumps(
+                                inst.get("eplb_config") or {}
+                            )
+                    placement = inst.get("expert_placement_strategy")
+                    if placement and not (
+                        device_backend == "npu" and inst.get("enable_eplb")
+                    ):
+                        vllm_extra_args["expert_placement_strategy"] = placement
+                    vllm_args.update(vllm_extra_args)
+                    cluster_id = inst.get("awex_cluster_id")
+                    if cluster_id:
+                        vllm_env["AWEX_CLUSTER_ID"] = str(cluster_id)
+                    with _temp_env(vllm_env):
+                        server_infos.append(inf_engine.launch_server(vllm_args))
+                # RemoteInfEngine assigns engine_rank by the order of server_addrs.
+                server_addrs = [f"{s.host}:{s.port}" for s in server_infos]
+            if dist.is_initialized():
+                obj_list = [server_addrs]
+                dist.broadcast_object_list(obj_list, src=0)
+                server_addrs = obj_list[0]
+            inf_engine.initialize(addr=server_addrs)
+            inf_engine.set_version(1)
+
+            if enable_validation:
+                # This integration test should validate every configured update by default.
+                # If the env explicitly requests more validation steps, honor the larger value.
+                validation_steps = max(
+                    max(1, NUM_UPDATES),
+                    VALIDATION_STEPS if VALIDATION_STEPS >= 0 else 0,
+                )
+                validate_every_n_steps = 1
+                print(
+                    "[awex-test] validation config: "
+                    f"num_updates={NUM_UPDATES}, "
+                    f"validation_steps={validation_steps}, "
+                    f"validate_every_n_steps={validate_every_n_steps}",
+                    flush=True,
+                )
+            else:
+                validation_steps = 0
+                validate_every_n_steps = max(1, VALIDATE_EVERY_N_STEPS)
+
+            update_meta = WeightUpdateMeta.from_awex(
+                meta_server_addr=meta_server_addr,
+                comm_backend=(
+                    "hccl"
+                    if device_backend == "npu"
+                    else ("file" if comm_backend == "file" else "nccl")
+                ),
+                # Force-disable MindSpeed for GPU runs; keep it enabled for NPU.
+                use_mindspeed=(device_backend == "npu"),
+                weights_validation_steps=validation_steps,
+                validate_weights_every_n_steps=validate_every_n_steps,
+                enable_debug_mode=enable_validation,
+                debug_mode_config=(
+                    {"raise_on_validation_fail": True} if enable_validation else {}
+                ),
+            )
+            if device_backend == "npu":
+                update_meta.weights_exchange_ipc_backend = "cpu"
+            if comm_backend == "file":
+                if rank == 0:
+                    tmpdir = tempfile.TemporaryDirectory()
+                    update_meta.path = tmpdir.name
+                if dist.is_initialized():
+                    obj_list = [update_meta.path]
+                    dist.broadcast_object_list(obj_list, src=0)
+                    update_meta.path = obj_list[0]
+
+            train_engine.connect_engine(inf_engine, update_meta)
+            for step in range(1, max(1, NUM_UPDATES) + 1):
+                train_engine.set_version(step)
+                inf_engine.set_version(step)
+                if dist.is_initialized():
+                    dist.barrier()
+                train_engine.update_weights(update_meta)
+                if dist.is_initialized():
+                    dist.barrier()
+                if (
+                    rank == 0
+                    and REQUESTS_PER_UPDATE > 0
+                    and step < max(1, NUM_UPDATES)
+                ):
+                    _drive_completion_traffic(
+                        server_addrs=server_addrs,
+                        fallback_model=model_path,
+                        requests_per_update=REQUESTS_PER_UPDATE,
+                        timeout_s=max(1, REQUEST_TIMEOUT_S),
+                        retries=max(1, REQUEST_RETRIES),
+                        strict=STRICT_REQUEST_TRAFFIC,
+                    )
+
+            if result_queue is not None and rank == 0:
+                result_queue.put(("ok", None))
+        finally:
+            if train_engine is not None:
+                _safe_destroy(train_engine.destroy, "train_engine.destroy")
+            if inf_engine is not None:
+                _safe_destroy(inf_engine.destroy, "inf_engine.destroy")
+            if tmpdir is not None:
+                tmpdir.cleanup()
+            if rank == 0 and meta_server_addr is not None:
+                stop_meta_server()
+            # Ensure any leftover subprocesses are cleaned up before returning.
+            if rank == 0 and world_size == 1:
+                kill_process_tree(os.getpid(), include_parent=False, graceful=False)
+            if dist.is_initialized():
+                dist.barrier()
+    except Exception as exc:
+        if result_queue is not None and rank == 0:
+            result_queue.put(("error", repr(exc)))
+        raise
+
+
+def _resolve_moe_model_path() -> str:
+    env_path = os.environ.get("AREAL_AWEX_MOE_MODEL_PATH")
+    if env_path:
+        if not os.path.exists(env_path):
+            pytest.skip(
+                f"AREAL_AWEX_MOE_MODEL_PATH not found: {env_path}. "
+                "Set it to a reduced MoE checkpoint path."
+            )
+        return env_path
+    if os.path.exists(MOE_LOCAL_PATH):
+        return MOE_LOCAL_PATH
+    pytest.skip(
+        "Reduced MoE model not found locally. Build it with "
+        "`tests/experimental/awex/build_reduced_qwen3_moe.py` and set "
+        "AREAL_AWEX_MOE_MODEL_PATH."
+    )
+
+
+def _resolve_dense_model_path() -> str:
+    env_path = os.environ.get("AREAL_AWEX_DENSE_MODEL_PATH")
+    if env_path:
+        if not os.path.exists(env_path):
+            pytest.skip(
+                f"AREAL_AWEX_DENSE_MODEL_PATH not found: {env_path}. "
+                "Set it to a valid local path or enable download."
+            )
+        return env_path
+    if os.path.exists(DENSE_LOCAL_PATH):
+        return DENSE_LOCAL_PATH
+    if os.environ.get("AREAL_AWEX_ALLOW_HF_DOWNLOAD") == "1":
+        return get_model_path(DENSE_LOCAL_PATH, DENSE_HF_ID)
+    pytest.skip(
+        "Dense model not found locally. Set AREAL_AWEX_DENSE_MODEL_PATH or "
+        "AREAL_AWEX_ALLOW_HF_DOWNLOAD=1 to download."
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.multi_gpu
+def test_awex_megatron_to_vllm_nccl(tmp_path_factory):
+    if not IS_VLLM_INSTALLED:
+        pytest.skip("vLLM is not installed")
+    if not IS_AWEX_INSTALLED:
+        pytest.skip("awex is not installed")
+
+    timeout_seconds = int(os.environ.get("AREAL_AWEX_TEST_TIMEOUT_S", "600"))
+    model_kind = os.environ.get("AREAL_AWEX_MODEL", "dense").lower()
+    if model_kind == "moe":
+        model_path = _resolve_moe_model_path()
+    elif model_kind == "dense":
+        model_path = _resolve_dense_model_path()
+    else:
+        raise ValueError(
+            f"Unknown AREAL_AWEX_MODEL value: {model_kind}. Use 'dense' or 'moe'."
+        )
+    if int(os.environ.get("WORLD_SIZE", "1")) > 1:
+        _run_awex_integration(None, model_path)
+        return
+
+    ctx = mp.get_context("spawn")
+    result_queue = ctx.Queue()
+    proc = ctx.Process(
+        target=_run_awex_integration,
+        args=(result_queue, model_path),
+    )
+    proc.start()
+    proc.join(timeout_seconds)
+
+    if proc.is_alive():
+        kill_process_tree(proc.pid, graceful=False)
+        proc.join(5)
+        pytest.fail(f"Awex integration test exceeded {timeout_seconds}s timeout.")
+
+    status = None
+    detail = None
+    try:
+        status, detail = result_queue.get_nowait()
+    except queue.Empty:
+        status, detail = ("error", f"Worker exited with code {proc.exitcode}.")
+
+    if status != "ok":
+        pytest.fail(f"Awex integration test failed: {detail}")

--- a/tests/test_awex_runtime.py
+++ b/tests/test_awex_runtime.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from areal.api.cli_args import (
+    ClusterSpecConfig,
+    PPOActorConfig,
+    PPOConfig,
+    PPOCriticConfig,
+)
+from areal.utils.awex_runtime import prepare_awex_runtime
+
+
+def _create_ppo_config(weight_update_mode: str = "disk") -> PPOConfig:
+    config = PPOConfig()
+    config.experiment_name = "test_experiment"
+    config.trial_name = "test_trial"
+    config.allocation_mode = "vllm:d4p1t2+d8p1t1"
+    config.cluster = ClusterSpecConfig()
+    config.cluster.fileroot = "/tmp/areal_test"
+    config.actor = PPOActorConfig()
+    config.actor.weight_update_mode = weight_update_mode
+    config.critic = PPOCriticConfig()
+    return config
+
+
+def test_prepare_awex_runtime_noop_for_non_awex():
+    config = _create_ppo_config(weight_update_mode="disk")
+
+    handle = prepare_awex_runtime(config)
+
+    assert handle.meta_server_addr is None
+    assert handle.owns_meta_server is False
+    assert config.awex.meta_server_addr == ""
+
+
+def test_prepare_awex_runtime_reuses_explicit_config_addr(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = _create_ppo_config(weight_update_mode="awex")
+    config.awex.meta_server_addr = "127.0.0.1:23456"
+
+    def _unexpected_import() -> tuple[Callable[..., object], Callable[..., object]]:
+        raise AssertionError("meta server should not be started for explicit addr")
+
+    monkeypatch.setattr(
+        "areal.utils.awex_runtime._import_meta_server_fns", _unexpected_import
+    )
+
+    handle = prepare_awex_runtime(config)
+
+    assert handle.meta_server_addr == "127.0.0.1:23456"
+    assert handle.owns_meta_server is False
+    assert config.awex.meta_server_addr == "127.0.0.1:23456"
+
+
+def test_prepare_awex_runtime_starts_local_server_for_auto(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = _create_ppo_config(weight_update_mode="awex")
+    config.awex.meta_server_addr = "auto"
+    state = {"stopped": False}
+
+    def _fake_start():
+        return "127.0.0.1", 34567
+
+    def _fake_stop():
+        state["stopped"] = True
+        return True
+
+    monkeypatch.setattr(
+        "areal.utils.awex_runtime._import_meta_server_fns",
+        lambda: (_fake_start, _fake_stop),
+    )
+    monkeypatch.setattr(
+        "areal.utils.awex_runtime.is_single_controller",
+        lambda: True,
+    )
+
+    handle = prepare_awex_runtime(config)
+
+    assert handle.meta_server_addr == "127.0.0.1:34567"
+    assert handle.owns_meta_server is True
+    assert config.awex.meta_server_addr == "127.0.0.1:34567"
+
+    handle.close()
+
+    assert state["stopped"] is True
+
+
+def test_prepare_awex_runtime_prefers_env_override(monkeypatch: pytest.MonkeyPatch):
+    config = _create_ppo_config(weight_update_mode="awex")
+    config.awex.meta_server_addr = "auto"
+    monkeypatch.setenv("AREAL_AWEX_META_SERVER_ADDR", "127.0.0.1:45678")
+
+    def _unexpected_import() -> tuple[Callable[..., object], Callable[..., object]]:
+        raise AssertionError(
+            "meta server should not be started when env override exists"
+        )
+
+    monkeypatch.setattr(
+        "areal.utils.awex_runtime._import_meta_server_fns", _unexpected_import
+    )
+
+    handle = prepare_awex_runtime(config)
+
+    assert handle.meta_server_addr == "127.0.0.1:45678"
+    assert handle.owns_meta_server is False
+    assert config.awex.meta_server_addr == "127.0.0.1:45678"
+
+
+def test_prepare_awex_runtime_requires_explicit_addr_in_spmd(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = _create_ppo_config(weight_update_mode="awex")
+    config.awex.meta_server_addr = "auto"
+    monkeypatch.setattr(
+        "areal.utils.awex_runtime.is_single_controller",
+        lambda: False,
+    )
+
+    with pytest.raises(ValueError, match="single-controller mode"):
+        prepare_awex_runtime(config)

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -118,6 +118,10 @@ class TestGetModelUpdateMeta:
             (create_ppo_config, "fsdp_xccl", "xccl"),
             (create_sft_config, "fsdp_xccl", "xccl"),
             (create_rw_config, "fsdp_xccl", "xccl"),
+            (create_grpo_config, "awex", "awex"),
+            (create_ppo_config, "awex", "awex"),
+            (create_sft_config, "awex", "awex"),
+            (create_rw_config, "awex", "awex"),
         ],
         ids=[
             "GRPO-disk",
@@ -128,6 +132,10 @@ class TestGetModelUpdateMeta:
             "PPO-fsdp_xccl",
             "SFT-fsdp_xccl",
             "RW-fsdp_xccl",
+            "GRPO-awex",
+            "PPO-awex",
+            "SFT-awex",
+            "RW-awex",
         ],
     )
     def test_get_model_update_meta_modes(
@@ -135,6 +143,8 @@ class TestGetModelUpdateMeta:
     ):
         """Test get_model_update_meta with various configs and modes."""
         config = config_factory(weight_update_mode=weight_update_mode)
+        if weight_update_mode == "awex":
+            config.awex.meta_server_addr = "127.0.0.1:12345"
 
         result = get_model_update_meta(config)
 
@@ -145,6 +155,14 @@ class TestGetModelUpdateMeta:
             assert config.cluster.fileroot in result.path
             assert config.experiment_name in result.path
             assert config.trial_name in result.path
+        if expected_type == "awex":
+            assert result.meta_server_addr == config.awex.meta_server_addr
+
+    def test_awex_requires_meta_server_addr(self):
+        """Test that awex mode requires meta_server_addr."""
+        config = create_grpo_config(weight_update_mode="awex")
+        with pytest.raises(ValueError, match="meta_server_addr"):
+            get_model_update_meta(config)
 
     def test_invalid_config_type(self):
         """Test that passing TrainEngineConfig directly raises TypeError."""


### PR DESCRIPTION
## Description

 This fix ensures that after updating weights from disk in FSDPEngine, continue_generation() is called on the vLLM rollout engine. Previously, vLLM remained paused after the first weight update, causing all subsequent rollout requests to hang. Training stuck forever. Same modification is applied for Megatron_engine.py .

Fixes #(1160)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
