### PR TITLE
fix _update_weights_from_disk function to prevent training to be stuck

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -1315,9 +1315,9 @@ class FSDPEngine(TrainEngine):
 
     @trace_perf("fsdp_engine.update_weights_from_disk", category="io")
     def _update_weights_from_disk(self, meta: WeightUpdateMeta):
-        fut = Future()
-
+        
         if dist.get_rank() == 0:
+            self.rollout_engine.pause_generation()
             fut = self.rollout_engine.update_weights_from_disk(meta)
 
         assert meta.path is not None
@@ -1335,7 +1335,7 @@ class FSDPEngine(TrainEngine):
             )
 
             fut.result()
-
+            self.rollout_engine.continue_generation()
         current_platform.synchronize()
         dist.barrier(group=self.cpu_group)
 

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -1315,7 +1315,8 @@ class FSDPEngine(TrainEngine):
 
     @trace_perf("fsdp_engine.update_weights_from_disk", category="io")
     def _update_weights_from_disk(self, meta: WeightUpdateMeta):
-        
+        fut = Future()
+
         if dist.get_rank() == 0:
             self.rollout_engine.pause_generation()
             fut = self.rollout_engine.update_weights_from_disk(meta)
@@ -1336,6 +1337,7 @@ class FSDPEngine(TrainEngine):
 
             fut.result()
             self.rollout_engine.continue_generation()
+
         current_platform.synchronize()
         dist.barrier(group=self.cpu_group)
 

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1511,7 +1511,8 @@ class MegatronEngine(TrainEngine):
 
     @trace_perf("megatron_engine.update_weights_from_disk", category="io")
     def _update_weights_from_disk(self, meta: WeightUpdateMeta) -> None:
-        
+        fut = Future()
+
         if dist.get_rank() == 0:
             self.rollout_engine.pause_generation()
             fut = self.rollout_engine.update_weights_from_disk(meta)

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1511,9 +1511,9 @@ class MegatronEngine(TrainEngine):
 
     @trace_perf("megatron_engine.update_weights_from_disk", category="io")
     def _update_weights_from_disk(self, meta: WeightUpdateMeta) -> None:
-        fut = Future()
-
+        
         if dist.get_rank() == 0:
+            self.rollout_engine.pause_generation()
             fut = self.rollout_engine.update_weights_from_disk(meta)
 
         self._save_model_to_hf(meta.path, self.tokenizer, None)
@@ -1530,7 +1530,7 @@ class MegatronEngine(TrainEngine):
             )
 
             fut.result()
-
+            self.rollout_engine.continue_generation()
         current_platform.synchronize()
         dist.barrier(group=self.cpu_group)
 

--- a/areal/experimental/engine/archon_weight_sync.py
+++ b/areal/experimental/engine/archon_weight_sync.py
@@ -221,6 +221,7 @@ def update_weights_from_disk(
     fut: Future | None = None
 
     if dist.get_rank() == 0:
+        engine.rollout_engine.pause_generation()
         fut = engine.rollout_engine.update_weights_from_disk(meta)
 
     assert meta.path is not None
@@ -238,6 +239,7 @@ def update_weights_from_disk(
 
         assert fut is not None
         fut.result()
+        engine.rollout_engine.continue_generation()
 
     current_platform.synchronize()
     dist.barrier(group=engine.cpu_group)


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does -->
This fix ensures that after updating weights from disk in FSDPEngine, continue_generation() is called on the vLLM rollout engine. Previously, vLLM remained paused after the first weight update, causing all subsequent rollout requests to hang. Training stuck forever. Same modification is applied for Megatron_engine.py .

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(1160)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
