### PR TITLE
fix(engine): use meta device for non-rank-0 in FSDP memory_efficient_load

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -866,7 +866,15 @@ class FSDPEngine(TrainEngine):
         dtype = getattr(torch, self.config.dtype)
 
         if self.config.fsdp.memory_efficient_load:
-            loading_device = "cpu"
+            # Only rank 0 loads on CPU; other ranks use meta device (zero memory)
+            # to avoid CPU OOM when multiple workers share a node.
+            # Weights are broadcast from rank 0 after FSDP sharding in initialize().
+            # Note: meta device optimization only applies to LLM (not VLM), because
+            # VLM uses from_pretrained() which doesn't support meta device context.
+            if not self.is_vision_model and dist.get_rank() != 0:
+                loading_device = "meta"
+            else:
+                loading_device = "cpu"
         else:
             loading_device = current_platform.device_type
 

--- a/areal/engine/fsdp_utils/__init__.py
+++ b/areal/engine/fsdp_utils/__init__.py
@@ -118,7 +118,16 @@ def fsdp2_load_full_state_dict(
     )
 
     device = current_platform.current_device()
-    model = model.to(device=device, non_blocking=True)
+    # Handle meta device models (from memory_efficient_load where non-rank-0
+    # processes use meta tensors). to_empty() materializes meta tensors without
+    # copying data; the actual weights come from set_model_state_dict broadcast.
+    has_meta = any(t.is_meta for t in model.parameters()) or any(
+        t.is_meta for t in model.buffers()
+    )
+    if has_meta:
+        model = model.to_empty(device=device)
+    else:
+        model = model.to(device=device, non_blocking=True)
     cpu_offload = cpu_offload is not None
     options = StateDictOptions(
         full_state_dict=True,

--- a/areal/utils/recover.py
+++ b/areal/utils/recover.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import dataclasses
 import json
@@ -7,7 +8,10 @@ import pickle
 from typing import TYPE_CHECKING, Any
 
 import torch.distributed as dist
-from transformers import AutoProcessor, PreTrainedTokenizerFast
+from transformers import PreTrainedTokenizerFast
+
+if TYPE_CHECKING:
+    from transformers import AutoProcessor
 
 from areal.api import (
     FinetuneSpec,
@@ -221,7 +225,7 @@ class RecoverHandler:
         step_info: StepInfo,
         saver: Saver,
         evaluator: Evaluator,
-        stats_logger: "StatsLogger",
+        stats_logger: StatsLogger,
         dataloader: Any,
         tokenizer: PreTrainedTokenizerFast | None = None,
         processor: AutoProcessor | None = None,
@@ -270,7 +274,7 @@ class RecoverHandler:
         engine: TrainEngine | dict[str, TrainEngine] | TrainController,
         saver: Saver,
         evaluator: Evaluator,
-        stats_logger: "StatsLogger",
+        stats_logger: StatsLogger,
         dataloader: Any,
         inference_engine: InferenceEngine | None = None,
         weight_update_meta: WeightUpdateMeta | None = None,

--- a/areal/utils/saver.py
+++ b/areal/utils/saver.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import getpass
 import os
+from typing import TYPE_CHECKING
 
-from transformers import AutoProcessor, PreTrainedTokenizerFast
+from transformers import PreTrainedTokenizerFast
+
+if TYPE_CHECKING:
+    from transformers import AutoProcessor
 
 from areal.api import FinetuneSpec, SaveLoadMeta, TrainEngine
 from areal.api.cli_args import SaverConfig


### PR DESCRIPTION
## Summary

Fix CPU OOM when using `fsdp.memory_efficient_load=True` with multiple workers per node. Non-rank-0 processes now use `meta` device instead of `cpu` during model creation, reducing per-node CPU memory from ~512 GiB to ~64 GiB for a 32B model.

## Problem

When `memory_efficient_load=True`, **all ranks** created the full model on CPU via `from_config()` with `torch.device("cpu")` context. For a 32B model (bf16, ~64 GiB) with 8 workers per node:

- Each worker allocates ~64 GiB CPU RAM for the full model parameters
- 8 workers × 64 GiB = **~512 GiB**, far exceeding typical node memory (256 GiB)
- Result: kernel OOM killer or Ray memory monitor kills workers before FSDP sharding begins

The original design intent was to avoid GPU OOM by loading on CPU first, then broadcasting sharded weights. However, it shifted the OOM problem from GPU to CPU.

## Root Cause

In `_create_device_model()`, the loading device was unconditionally set to `"cpu"` for all ranks:

```python
if self.config.fsdp.memory_efficient_load:
    loading_device = "cpu"  # All ranks allocate full model on CPU
```

Combined with `from_config()` (which creates real tensors, not meta tensors), every rank materialized the entire model in CPU RAM.

## Fix

- **`fsdp_engine.py`**: Only rank-0 loads on CPU; other ranks use `"meta"` device (zero memory cost). Weights are broadcast from rank-0 after FSDP sharding via `fsdp2_load_full_state_dict` with `broadcast_from_rank0=True`.
- **`fsdp_utils/__init__.py`**: Handle meta→device conversion using `to_empty()` instead of `.to()` (which fails on meta tensors).
- **`saver.py`, `recover.py`**: Move `AutoProcessor` import to `TYPE_CHECKING` block to avoid eagerly importing `torchvision`.

## Test Results

Verified with Qwen3-32B, FSDP `d4c8`, 4 nodes × 8 L20Y GPUs (80 GiB), `memory_efficient_load=True`:

| Metric | Before (all ranks CPU) | After (rank-0 CPU + others meta) |
|--------|:---:|:---:|
| Non-rank-0 model creation | ~60s | **0.19s** |
| Peak CPU RAM per node | ~512 GiB → OOM | **~64 GiB** (rank-0 only) |
| GPU memory after train step | N/A (crashed) | **42.32 / 79.33 GiB** |
| Training | ❌ CPU OOM | ✅ Completes successfully |

The `memory_efficient_load=False` path is unchanged.