### PR TITLE
feat(service): add external model API support for inference service

### DIFF
--- a/areal/experimental/inference_service/controller/config.py
+++ b/areal/experimental/inference_service/controller/config.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from areal.api.cli_args import OpenAIProxyConfig
-
 
 @dataclass
 class GatewayControllerConfig:
@@ -20,6 +18,7 @@ class GatewayControllerConfig:
     # -- Model / tokenizer -------------------------------------------------
     tokenizer_path: str = ""
     model_path: str = ""
+    model: str = ""
 
     # -- Routing -----------------------------------------------------------
     routing_strategy: str = "round_robin"
@@ -53,5 +52,15 @@ class GatewayControllerConfig:
     pause_grace_period: float = 0.5
     n_gpus_per_node: int | None = None  # GPUs per physical node; None = single-node
 
-    # -- OpenAI proxy configuration (for agent-like workflows) ---------------
-    openai: OpenAIProxyConfig = field(default_factory=lambda: OpenAIProxyConfig())
+    # -- Admin / workflow --------------------------------------------------
+    admin_api_key: str | None = None
+    turn_discount: float = 1.0
+    export_style: str = "individual"
+    tool_call_parser: str = "qwen"
+    reasoning_parser: str = "qwen3"
+    engine_max_tokens: int | None = None
+    chat_template_type: str = "hf"
+
+    # -- External model API ------------------------------------------------
+    api_url: str | None = None
+    provider_api_key: str | None = None

--- a/areal/experimental/inference_service/controller/config.py
+++ b/areal/experimental/inference_service/controller/config.py
@@ -18,7 +18,7 @@ class GatewayControllerConfig:
     # -- Model / tokenizer -------------------------------------------------
     tokenizer_path: str = ""
     model_path: str = ""
-    model: str = ""
+    model: str = "default"
 
     # -- Routing -----------------------------------------------------------
     routing_strategy: str = "round_robin"

--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -82,30 +82,43 @@ class GatewayInferenceController:
         config: GatewayControllerConfig,
         scheduler: Scheduler,
     ) -> None:
-        from areal.api.alloc_mode import ModelAllocation
-
+        if config.admin_api_key is None:
+            raise ValueError(
+                "GatewayControllerConfig.admin_api_key must be set (not None)"
+            )
         self.config = config
         self.scheduler = scheduler
 
-        # Parse allocation from config.backend
-        self.rollout_alloc = ModelAllocation.from_str(config.backend)
+        if config.api_url is not None:
+            self.rollout_alloc = None
+        else:
+            from areal.api.alloc_mode import ModelAllocation
 
-        # Multi-node: derive nnodes_per_instance from n_gpus_per_node
-        total_gpus = (
-            self.rollout_alloc.parallel.tp_size * self.rollout_alloc.parallel.pp_size
-        )
-        n_gpus_per_node = config.n_gpus_per_node
-        if n_gpus_per_node is None:
+            self.rollout_alloc = ModelAllocation.from_str(config.backend)
+
+        # Multi-node: derive nnodes_per_instance from n_gpus_per_node.
+        # External mode has no local inference servers, so always single-node.
+        if self.rollout_alloc is None:
             nnodes_per_instance = 1
         else:
-            if n_gpus_per_node < 1:
-                raise ValueError(f"n_gpus_per_node must be >= 1, got {n_gpus_per_node}")
-            if total_gpus % n_gpus_per_node != 0:
-                raise ValueError(
-                    f"tp_size * pp_size ({total_gpus}) must be divisible "
-                    f"by n_gpus_per_node ({n_gpus_per_node})"
-                )
-            nnodes_per_instance = total_gpus // n_gpus_per_node
+            total_gpus = (
+                self.rollout_alloc.parallel.tp_size
+                * self.rollout_alloc.parallel.pp_size
+            )
+            n_gpus_per_node = config.n_gpus_per_node
+            if n_gpus_per_node is None:
+                nnodes_per_instance = 1
+            else:
+                if n_gpus_per_node < 1:
+                    raise ValueError(
+                        f"n_gpus_per_node must be >= 1, got {n_gpus_per_node}"
+                    )
+                if total_gpus % n_gpus_per_node != 0:
+                    raise ValueError(
+                        f"tp_size * pp_size ({total_gpus}) must be divisible "
+                        f"by n_gpus_per_node ({n_gpus_per_node})"
+                    )
+                nnodes_per_instance = total_gpus // n_gpus_per_node
         self._nnodes_per_instance = nnodes_per_instance
 
         # Worker management
@@ -209,6 +222,19 @@ class GatewayInferenceController:
 
         logger.info("GatewayInferenceController initialized (role=%s)", role)
 
+        if self.config.model:
+            self.register_model(
+                model=self.config.model,
+                url=self.config.api_url or "",
+                api_key=self.config.provider_api_key,
+            )
+        if self.external_mode:
+            logger.info(
+                "External model mode: url=%s, model=%s",
+                self.config.api_url,
+                self.config.model,
+            )
+
     async def _async_initialize(
         self,
         server_args: dict[str, Any] | None,
@@ -226,6 +252,8 @@ class GatewayInferenceController:
         * **server_infos is not None** — SGLang servers already exist so
           we only fork data proxy on every worker; fork router + gateway
           on worker 0.
+        * **external_mode** — skip inference servers entirely; data proxies
+          start with an empty ``--backend-addr``.
         """
         from dataclasses import asdict
 
@@ -234,35 +262,49 @@ class GatewayInferenceController:
         from areal.api.cli_args import SchedulingSpec, SchedulingStrategy
         from areal.api.scheduler_api import Job
 
-        alloc = self.rollout_alloc
-        dp_size = alloc.parallel.dp_size
         cfg = self.config
-        admin_api_key = self.config.openai.admin_api_key
+        admin_api_key = self.config.admin_api_key
 
-        inf_backend = alloc.backend
+        if self.external_mode:
+            dp_size = 1
+            inf_backend = None
+        else:
+            alloc = self.rollout_alloc
+            dp_size = alloc.parallel.dp_size
+            inf_backend = alloc.backend
 
         # ==================================================================
         # Step 0: Create RPCGuard workers (dp_size × nnodes_per_instance)
         # ==================================================================
-        inf_spec = SchedulingSpec(**asdict(cfg.scheduling_spec[0]))
-        instance_size = alloc.parallel.tp_size * alloc.parallel.pp_size
-        nnodes_per_instance = self._nnodes_per_instance
-        gpus_per_worker = instance_size // nnodes_per_instance
-
-        if server_infos is not None:
-            # Pre-existing inference servers — only need dp_size workers
-            # for CPU services (data proxy, router, gateway), no GPUs.
+        if self.external_mode:
+            inf_spec = SchedulingSpec(
+                task_type="worker",
+                port_count=2,
+                gpu=0,
+                mem=8,
+                cmd="python -m areal.experimental.inference_service.guard",
+            )
             total_workers = dp_size
-            inf_spec.gpu = 0
         else:
-            total_workers = dp_size * nnodes_per_instance
-            inf_spec.cpu *= gpus_per_worker
-            inf_spec.mem *= gpus_per_worker
-            if inf_spec.gpu > 0:
-                inf_spec.gpu = gpus_per_worker
+            inf_spec = SchedulingSpec(**asdict(cfg.scheduling_spec[0]))
+            instance_size = alloc.parallel.tp_size * alloc.parallel.pp_size
+            nnodes_per_instance = self._nnodes_per_instance
+            gpus_per_worker = instance_size // nnodes_per_instance
 
-        # Override cmd to launch RPCGuard instead of RPC server
-        inf_spec.cmd = "python -m areal.experimental.inference_service.guard"
+            if server_infos is not None:
+                # Pre-existing inference servers — only need dp_size workers
+                # for CPU services (data proxy, router, gateway), no GPUs.
+                total_workers = dp_size
+                inf_spec.gpu = 0
+            else:
+                total_workers = dp_size * nnodes_per_instance
+                inf_spec.cpu *= gpus_per_worker
+                inf_spec.mem *= gpus_per_worker
+                if inf_spec.gpu > 0:
+                    inf_spec.gpu = gpus_per_worker
+
+            # Override cmd to launch RPCGuard instead of RPC server
+            inf_spec.cmd = "python -m areal.experimental.inference_service.guard"
 
         inf_role = f"{self._worker_role}{self._INF_SUFFIX}"
         inf_job = Job(
@@ -284,9 +326,11 @@ class GatewayInferenceController:
         logger.info("RPCGuard workers ready: %s", [w.id for w in inf_workers])
 
         # ==================================================================
-        # Step 1: Launch inference servers (skip when pre-existing)
+        # Step 1: Launch inference servers (skip in external mode or when pre-existing)
         # ==================================================================
-        if server_infos is not None:
+        if self.external_mode:
+            logger.info("External mode — skipping inference server launch")
+        elif server_infos is not None:
             # Pre-existing servers — just record their addresses
             self.server_infos = server_infos
             self._inf_addrs = [
@@ -536,22 +580,39 @@ class GatewayInferenceController:
             str(cfg.set_reward_finish_timeout),
             "--callback-server-addr",
             f"http://{self.callback_addr}",
+            "--tool-call-parser",
+            cfg.tool_call_parser,
+            "--reasoning-parser",
+            cfg.reasoning_parser,
+            "--chat-template-type",
+            cfg.chat_template_type,
         ]
+        if cfg.engine_max_tokens is not None:
+            data_proxy_base_cmd += [
+                "--engine-max-tokens",
+                str(cfg.engine_max_tokens),
+            ]
 
         for group_idx in range(dp_size):
-            head_worker = inf_workers[
-                group_idx
-                if server_infos is not None
-                else group_idx * nnodes_per_instance
-            ]
+            if self.external_mode:
+                head_worker = inf_workers[group_idx]
+            else:
+                head_worker = inf_workers[
+                    group_idx
+                    if server_infos is not None
+                    else group_idx * nnodes_per_instance
+                ]
             guard_addr = f"http://{format_hostport(head_worker.ip, int(head_worker.worker_ports[0]))}"
             # Each data proxy connects to its group's head inference server
-            data_proxy_cmd = data_proxy_base_cmd + [
-                "--backend-addr",
-                self._inf_addrs[group_idx],
-                "--backend-type",
-                inf_backend or "sglang",
-            ]
+            if self.external_mode:
+                data_proxy_cmd = data_proxy_base_cmd + ["--backend-addr", ""]
+            else:
+                data_proxy_cmd = data_proxy_base_cmd + [
+                    "--backend-addr",
+                    self._inf_addrs[group_idx],
+                    "--backend-type",
+                    inf_backend or "sglang",
+                ]
             data_proxy_host, data_proxy_port = self._fork_on_guard(
                 guard_addr=guard_addr,
                 role="data-proxy",
@@ -619,7 +680,7 @@ class GatewayInferenceController:
             resp = requests.post(
                 f"{self._router_addr}/register",
                 json={"worker_addr": data_proxy_addr},
-                headers={"Authorization": f"Bearer {self.config.openai.admin_api_key}"},
+                headers={"Authorization": f"Bearer {self.config.admin_api_key}"},
                 timeout=5,
             )
             resp.raise_for_status()
@@ -631,6 +692,34 @@ class GatewayInferenceController:
                 data_proxy_addr,
                 worker_id,
             )
+
+    def register_model(
+        self,
+        model: str,
+        url: str = "",
+        api_key: str | None = None,
+        data_proxy_addrs: list[str] | None = None,
+    ) -> None:
+        import requests
+
+        if data_proxy_addrs is None:
+            data_proxy_addrs = self._data_proxy_addrs
+        resp = requests.post(
+            f"{self._gateway_addr}/register_model",
+            json={
+                "model": model,
+                "url": url,
+                "api_key": api_key,
+                "data_proxy_addrs": data_proxy_addrs,
+            },
+            headers={"Authorization": f"Bearer {self.config.admin_api_key}"},
+            timeout=self.config.request_timeout,
+        )
+        resp.raise_for_status()
+
+    @property
+    def external_mode(self) -> bool:
+        return self.config.api_url is not None
 
     def _start_online_callback_server(self) -> None:
         """Start callback server used by the router to deliver ready trajectories."""
@@ -647,7 +736,7 @@ class GatewayInferenceController:
         @app.route("/callback/online_ready", methods=["POST"])
         def online_ready():
             if request.headers.get("Authorization") != (
-                f"Bearer {self.config.openai.admin_api_key}"
+                f"Bearer {self.config.admin_api_key}"
             ):
                 return jsonify({"error": "Invalid admin API key"}), 403
             payload = request.get_json() or {}
@@ -1089,11 +1178,19 @@ class GatewayInferenceController:
         if extra_body and isinstance(extra_body, dict):
             body.update(extra_body)
 
-        api_key = (
-            session_api_key
-            if session_api_key is not None
-            else self.config.openai.admin_api_key
-        )
+        if self.external_mode:
+            body["model"] = self.config.model
+            api_key = (
+                session_api_key
+                if session_api_key is not None
+                else self.config.admin_api_key
+            )
+        else:
+            api_key = (
+                session_api_key
+                if session_api_key is not None
+                else self.config.admin_api_key
+            )
         url = f"{self._gateway_addr}/chat/completions"
         headers = {
             "Content-Type": "application/json",
@@ -1261,7 +1358,7 @@ class GatewayInferenceController:
                 "Gateway address is unavailable; initialize the controller first"
             )
 
-        openai_cfg = self.config.openai
+        openai_cfg = self.config
         admin_api_key = openai_cfg.admin_api_key
         turn_discount = openai_cfg.turn_discount
         export_style = openai_cfg.export_style
@@ -1300,6 +1397,19 @@ class GatewayInferenceController:
         from areal.api.workflow_api import RolloutWorkflow
         from areal.utils.dynamic_import import import_from_string
 
+        # External mode only supports online mode (workflow=None)
+        if self.external_mode and workflow is not None:
+            raise ValueError(
+                "External model mode only supports online mode (workflow=None). "
+                "Agent-based workflows are not supported with external models."
+            )
+
+        if self.external_mode and group_size > 1:
+            raise ValueError(
+                "External model mode requires group_size=1, "
+                f"got group_size={group_size}."
+            )
+
         # (a) None → online mode: create InferenceServiceWorkflow without agent
         if workflow is None:
             from areal.experimental.inference_service.controller.workflow import (
@@ -1312,7 +1422,7 @@ class GatewayInferenceController:
                 controller=self,
                 agent=None,
                 gateway_addr=self._gateway_addr,
-                admin_api_key=self.config.openai.admin_api_key,
+                admin_api_key=self.config.admin_api_key,
                 **online_kwargs,
             )
 
@@ -1473,7 +1583,7 @@ class GatewayInferenceController:
             resp = requests.post(
                 url,
                 json=payload,
-                headers={"Authorization": f"Bearer {self.config.openai.admin_api_key}"},
+                headers={"Authorization": f"Bearer {self.config.admin_api_key}"},
                 timeout=self.config.request_timeout,
             )
             if resp.status_code >= 400:
@@ -1500,9 +1610,7 @@ class GatewayInferenceController:
                 resp = await client.post(
                     url,
                     json=payload,
-                    headers={
-                        "Authorization": f"Bearer {self.config.openai.admin_api_key}"
-                    },
+                    headers={"Authorization": f"Bearer {self.config.admin_api_key}"},
                 )
                 if resp.status_code >= 400:
                     raise RuntimeError(

--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -86,6 +86,8 @@ class GatewayInferenceController:
             raise ValueError(
                 "GatewayControllerConfig.admin_api_key must be set (not None)"
             )
+        if not config.model:
+            raise ValueError("GatewayControllerConfig.model must not be empty")
         self.config = config
         self.scheduler = scheduler
 
@@ -1178,19 +1180,12 @@ class GatewayInferenceController:
         if extra_body and isinstance(extra_body, dict):
             body.update(extra_body)
 
-        if self.external_mode:
-            body["model"] = self.config.model
-            api_key = (
-                session_api_key
-                if session_api_key is not None
-                else self.config.admin_api_key
-            )
-        else:
-            api_key = (
-                session_api_key
-                if session_api_key is not None
-                else self.config.admin_api_key
-            )
+        body["model"] = self.config.model
+        api_key = (
+            session_api_key
+            if session_api_key is not None
+            else self.config.admin_api_key
+        )
         url = f"{self._gateway_addr}/chat/completions"
         headers = {
             "Content-Type": "application/json",

--- a/areal/experimental/inference_service/controller/workflow.py
+++ b/areal/experimental/inference_service/controller/workflow.py
@@ -183,17 +183,15 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         if not export_request:
             return None
 
-        session_id = export_request["session_id"]
-        trajectory_id = export_request["trajectory_id"]
-
-        result = await self._export_interactions(
-            http_session, session_id, trajectory_id=trajectory_id
+        interactions = await self._export_interactions(
+            http_session,
+            export_request["session_id"],
+            trajectory_id=export_request["trajectory_id"],
         )
-
-        if not result:
+        if not interactions:
             return None
 
-        last_id = next(reversed(result))
-        last_reward = result[last_id].reward
+        last_id = next(reversed(interactions))
+        last_reward = interactions[last_id].reward
         stats_tracker.get(workflow_context.stat_scope()).scalar(reward=last_reward)
-        return result
+        return interactions

--- a/areal/experimental/inference_service/controller/workflow.py
+++ b/areal/experimental/inference_service/controller/workflow.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 import aiohttp
 
 from areal.api.workflow_api import RolloutWorkflow
+from areal.experimental.openai.proxy.server import deserialize_interactions
 from areal.infra import workflow_context
 from areal.utils import logging, stats_tracker
 
@@ -23,23 +24,6 @@ _GRANT_CAPACITY_PATHNAME = "grant_capacity"
 _RL_START_SESSION_PATHNAME = "rl/start_session"
 _RL_SET_REWARD_PATHNAME = "rl/set_reward"
 _EXPORT_TRAJECTORIES_PATHNAME = "export_trajectories"
-
-
-def _deserialize_interactions(
-    data: dict[str, Any],
-) -> dict[str, InteractionWithTokenLogpReward]:
-    from areal.experimental.openai.types import InteractionWithTokenLogpReward
-    from areal.infra.rpc.serialization import deserialize_value
-
-    data = deserialize_value(data)
-    result: dict[str, InteractionWithTokenLogpReward] = {}
-    for key, item in data.items():
-        interaction = InteractionWithTokenLogpReward()
-        interaction._cache = item["tensor_dict"]
-        interaction.reward = item["reward"]
-        interaction.interaction_id = item["interaction_id"]
-        result[key] = interaction
-    return result
 
 
 class InferenceServiceWorkflow(RolloutWorkflow):
@@ -110,7 +94,8 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         async with session.post(url, json=payload, headers=headers) as resp:
             resp.raise_for_status()
             data = await resp.json()
-        return _deserialize_interactions(data["interactions"])
+
+        return deserialize_interactions(data["interactions"])
 
     async def arun_episode(
         self,
@@ -198,15 +183,17 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         if not export_request:
             return None
 
-        interactions = await self._export_interactions(
-            http_session,
-            export_request["session_id"],
-            trajectory_id=export_request["trajectory_id"],
+        session_id = export_request["session_id"]
+        trajectory_id = export_request["trajectory_id"]
+
+        result = await self._export_interactions(
+            http_session, session_id, trajectory_id=trajectory_id
         )
-        if not interactions:
+
+        if not result:
             return None
 
-        last_id = next(reversed(interactions))
-        last_reward = interactions[last_id].reward
+        last_id = next(reversed(result))
+        last_reward = result[last_id].reward
         stats_tracker.get(workflow_context.stat_scope()).scalar(reward=last_reward)
-        return interactions
+        return result

--- a/areal/experimental/inference_service/data_proxy/__main__.py
+++ b/areal/experimental/inference_service/data_proxy/__main__.py
@@ -52,6 +52,24 @@ def main():
         "--callback-server-addr",
         default="",
     )
+    parser.add_argument(
+        "--tool-call-parser",
+        default="qwen",
+    )
+    parser.add_argument(
+        "--reasoning-parser",
+        default="qwen3",
+    )
+    parser.add_argument(
+        "--engine-max-tokens",
+        type=int,
+        default=None,
+    )
+    parser.add_argument(
+        "--chat-template-type",
+        default="hf",
+        choices=("hf", "concat"),
+    )
     args, _ = parser.parse_known_args()
 
     # Resolve the actual serving host (replace 0.0.0.0 with real IP)
@@ -73,6 +91,10 @@ def main():
         admin_api_key=args.admin_api_key,
         callback_server_addr=args.callback_server_addr,
         serving_addr=format_hostport(serving_host, args.port),
+        tool_call_parser=args.tool_call_parser,
+        reasoning_parser=args.reasoning_parser,
+        engine_max_tokens=args.engine_max_tokens,
+        chat_template_type=args.chat_template_type,
     )
     app = create_app(config)
     uvicorn.run(app, host=config.host, port=config.port, log_level=config.log_level)

--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import json
 from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+import orjson
+from fastapi import Body, FastAPI, HTTPException, Request
 from fastapi.middleware.wsgi import WSGIMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import Response as RawResponse
 from flask import Flask
-from openai.types.chat.completion_create_params import CompletionCreateParams
-from pydantic import BaseModel
 
 from areal.experimental.inference_service.data_proxy.backend import (
     SGLangBridgeBackend,
@@ -140,11 +141,16 @@ def _create_inf_bridge(
 def _create_areal_client(
     inf_bridge: InfBridge,
     tok: TokenizerProxy,
+    config: DataProxyConfig,
 ) -> ArealOpenAI:
     """Create an ArealOpenAI client backed by the given InfBridge."""
     return ArealOpenAI(
         engine=inf_bridge,
         tokenizer=tok._tok,
+        tool_call_parser=config.tool_call_parser,
+        reasoning_parser=config.reasoning_parser,
+        engine_max_tokens=config.engine_max_tokens,
+        chat_template_type=config.chat_template_type,
     )
 
 
@@ -228,19 +234,11 @@ def create_app(config: DataProxyConfig) -> FastAPI:
     async def lifespan(app: FastAPI):
         logger.info(
             "Data proxy starting — backend=%s, tokenizer=%s",
-            config.backend_addr,
+            config.backend_addr or "(none)",
             config.tokenizer_path,
         )
-        tok = TokenizerProxy(config.tokenizer_path)
+
         pause_state = PauseState()
-
-        # InfBridge + ArealOpenAI for /chat/completions
-        inf_bridge = _create_inf_bridge(config.backend_addr, pause_state, config)
-        areal_client = _create_areal_client(inf_bridge, tok)
-
-        app.state.tokenizer = tok
-        app.state.inf_bridge = inf_bridge
-        app.state.areal_client = areal_client
         app.state.pause_state = pause_state
         app.state.config = config
         app.state.session_store = SessionStore(
@@ -248,6 +246,19 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         )
         app.state.session_store.set_admin_key(config.admin_api_key)
         app.state.version = 0
+
+        if not config.backend_addr:
+            app.state.tokenizer = None
+            app.state.inf_bridge = None
+            app.state.areal_client = None
+        else:
+            tok = TokenizerProxy(config.tokenizer_path)
+            inf_bridge = _create_inf_bridge(config.backend_addr, pause_state, config)
+            areal_client = _create_areal_client(inf_bridge, tok, config)
+            app.state.tokenizer = tok
+            app.state.inf_bridge = inf_bridge
+            app.state.areal_client = areal_client
+
         ready_task = asyncio.create_task(_ready_trajectory_loop(app))
         try:
             yield
@@ -260,6 +271,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         logger.info("Data proxy shutting down")
 
     app = FastAPI(title="AReaL Data Proxy", lifespan=lifespan)
+    _registered_models: dict[str, dict[str, str | None]] = {}
 
     # =========================================================================
     # Health
@@ -287,13 +299,23 @@ def create_app(config: DataProxyConfig) -> FastAPI:
 
     @app.post("/pause_generation")
     async def pause_generation():
-        inf_bridge: InfBridge = app.state.inf_bridge
+        inf_bridge: InfBridge | None = app.state.inf_bridge
+        if inf_bridge is None:
+            raise HTTPException(
+                status_code=503,
+                detail="No inference backend configured (external model mode).",
+            )
         await inf_bridge.pause()
         return {"status": "ok", "paused": True}
 
     @app.post("/continue_generation")
     async def continue_generation():
-        inf_bridge: InfBridge = app.state.inf_bridge
+        inf_bridge: InfBridge | None = app.state.inf_bridge
+        if inf_bridge is None:
+            raise HTTPException(
+                status_code=503,
+                detail="No inference backend configured (external model mode).",
+            )
         await inf_bridge.resume()
         return {"status": "ok", "paused": False}
 
@@ -335,12 +357,23 @@ def create_app(config: DataProxyConfig) -> FastAPI:
     @app.post("/rl/set_reward")
     async def set_reward(body: SetRewardRequest, request: Request):
         store: SessionStore = app.state.session_store
-        token = _extract_bearer_token(request)
-        session = _resolve_session_from_token(token, store)
-        if session is None:
-            raise HTTPException(
-                status_code=401, detail="Invalid or expired session API key."
-            )
+
+        if body.model:
+            session = store.get_session(body.model)
+            if session is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Session for model '{body.model}' not found. "
+                    "Ensure the external model has been registered.",
+                )
+        else:
+            token = _extract_bearer_token(request)
+            session = _resolve_session_from_token(token, store)
+            if session is None:
+                raise HTTPException(
+                    status_code=401,
+                    detail="Invalid or expired session API key.",
+                )
 
         try:
             reward_result = session.set_reward(
@@ -368,8 +401,127 @@ def create_app(config: DataProxyConfig) -> FastAPI:
     # =========================================================================
 
     @app.post("/chat/completions")
-    async def chat_completions(body: CompletionCreateParams, request: Request):
+    async def chat_completions(request: Request):
+        raw_body = await request.body()
+        try:
+            body_json = json.loads(raw_body)
+        except (json.JSONDecodeError, AttributeError):
+            raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+        model_name = body_json.get("model")
         store: SessionStore = app.state.session_store
+
+        # -----------------------------------------------------------------
+        # External model path: model is a registered external model name
+        # -----------------------------------------------------------------
+        ext_info = _registered_models.get(model_name) if model_name else None
+        if ext_info is not None and ext_info.get("url"):
+            ext_url = (ext_info["url"] or "").rstrip("/")
+            ext_model = ext_info["model"]
+            provider_api_key = ext_info.get("api_key")
+
+            forward_body = dict(body_json)
+            if ext_model is not None:
+                forward_body["model"] = ext_model
+            else:
+                forward_body.pop("model", None)
+
+            _skip = {"host", "content-length", "transfer-encoding", "authorization"}
+            forward_headers = {
+                k: v for k, v in dict(request.headers).items() if k.lower() not in _skip
+            }
+            if provider_api_key:
+                forward_headers["authorization"] = f"Bearer {provider_api_key}"
+
+            is_streaming = forward_body.get("stream", False) or False
+            messages = body_json.get("messages", [])
+
+            if is_streaming:
+                collected_chunks: list[str] = []
+
+                async def _stream_and_cache():
+                    success = False
+                    try:
+                        async with httpx.AsyncClient(
+                            timeout=httpx.Timeout(config.request_timeout)
+                        ) as client:
+                            async with client.stream(
+                                "POST",
+                                f"{ext_url}/chat/completions",
+                                json=forward_body,
+                                headers=forward_headers,
+                            ) as resp:
+                                if resp.status_code != 200:
+                                    error_body = await resp.aread()
+                                    yield (
+                                        f"data: {json.dumps({'error': error_body.decode()})}\n\n".encode()
+                                    )
+                                    return
+                                async for chunk in resp.aiter_bytes():
+                                    decoded = chunk.decode("utf-8", errors="replace")
+                                    collected_chunks.append(decoded)
+                                    yield chunk
+                                success = True
+                    except Exception as exc:
+                        logger.error(
+                            "External stream error for %s: %s", model_name, exc
+                        )
+                        yield f"data: {json.dumps({'error': str(exc)})}\n\n".encode()
+                    finally:
+                        if success and collected_chunks:
+                            ext_session = store.get_session(model_name)
+                            if ext_session is not None and ext_session.is_external_api:
+                                ext_session.add_string_interaction(
+                                    messages,
+                                    "".join(collected_chunks),
+                                )
+
+                return StreamingResponse(
+                    _stream_and_cache(),
+                    media_type="text/event-stream",
+                    headers={
+                        "Cache-Control": "no-cache",
+                        "X-Accel-Buffering": "no",
+                    },
+                )
+
+            full_url = f"{ext_url}/chat/completions"
+            try:
+                async with httpx.AsyncClient(timeout=config.request_timeout) as client:
+                    resp = await client.post(
+                        full_url,
+                        json=forward_body,
+                        headers=forward_headers,
+                    )
+            except Exception as exc:
+                raise HTTPException(
+                    status_code=502, detail=f"External API error: {exc}"
+                )
+
+            if resp.status_code != 200:
+                logger.error(
+                    "External API returned %d for %s: %s",
+                    resp.status_code,
+                    full_url,
+                    resp.text[:500],
+                )
+
+            response_str = resp.text
+
+            if resp.status_code == 200:
+                ext_session = store.get_session(model_name)
+                if ext_session is not None and ext_session.is_external_api:
+                    ext_session.add_string_interaction(messages, response_str)
+
+            return RawResponse(
+                content=resp.content,
+                status_code=resp.status_code,
+                media_type=resp.headers.get("content-type"),
+            )
+
+        # -----------------------------------------------------------------
+        # Internal model path: use AReaL inference server
+        # -----------------------------------------------------------------
         areal_client: ArealOpenAI = app.state.areal_client
 
         token = _try_extract_bearer_token(request)
@@ -380,19 +532,11 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         else:
             areal_cache = None
 
-        # Build kwargs from request body
-        if isinstance(body, BaseModel):
-            kwargs = body.model_dump()
-        else:
-            kwargs = dict(body)
-
-        # Remove model (ArealOpenAI ignores it)
+        kwargs = dict(body_json)
         kwargs.pop("model", None)
 
-        # Determine streaming
         is_streaming = kwargs.get("stream", False) or False
 
-        # Apply defaults for temperature/top_p if not set
         if "temperature" not in kwargs:
             kwargs["temperature"] = 1.0
         if "top_p" not in kwargs:
@@ -411,7 +555,6 @@ def create_app(config: DataProxyConfig) -> FastAPI:
             raise HTTPException(status_code=500, detail=f"{type(e).__name__}: {e}")
 
         if is_streaming:
-            # result is an async generator of ChatCompletionChunk
 
             async def _sse_stream():
                 async for chunk in result:
@@ -429,6 +572,22 @@ def create_app(config: DataProxyConfig) -> FastAPI:
             )
 
         return result
+
+    @app.post("/register_model")
+    async def register_model(request: Request):
+        store: SessionStore = app.state.session_store
+        body = await request.json()
+        name = body.get("name") or body.get("model")
+        url = body.get("url", "")
+        model = body.get("model", name)
+        api_key = body.get("api_key")
+        if not name:
+            raise HTTPException(status_code=400, detail="model name is required")
+        _registered_models[name] = {"url": url, "model": model, "api_key": api_key}
+        if url:
+            store.register_external_model(name)
+        logger.info("Model registered: name=%s url=%s", name, url or "(internal)")
+        return {"status": "ok", "name": name}
 
     # =========================================================================
     # Trajectory export (admin key required)
@@ -461,16 +620,15 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         if body.remove_session:
             store.remove_session(body.session_id)
 
-        # Serialize for HTTP transport, storing tensors locally as RTensor shards
         from areal.infra.rpc.rtensor import RTensor
 
         for item in interactions.values():
-            # Set the internal cache
-            item.to_tensor_dict()
-            # Remotize the tensor dict cache
-            item._cache = RTensor.remotize(item._cache, node_addr=config.serving_addr)
+            if item.has_tensor_data:
+                item.to_tensor_dict()
+                item._cache = RTensor.remotize(
+                    item._cache, node_addr=config.serving_addr
+                )
 
-        # serialize RTensors
         serialized = serialize_interactions(interactions)
         return ExportTrajectoriesResponse(interactions=serialized)
 
@@ -501,7 +659,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
 
         # Recreate InfBridge + ArealOpenAI with new backend address
         new_inf_bridge = _create_inf_bridge(new_addr, pause_state, app.state.config)
-        new_areal_client = _create_areal_client(new_inf_bridge, tok)
+        new_areal_client = _create_areal_client(new_inf_bridge, tok, app.state.config)
 
         # Build updated config copy, then swap all three state fields.
         # Concurrent requests already hold their own references so they

--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -357,23 +357,12 @@ def create_app(config: DataProxyConfig) -> FastAPI:
     @app.post("/rl/set_reward")
     async def set_reward(body: SetRewardRequest, request: Request):
         store: SessionStore = app.state.session_store
-
-        if body.model:
-            session = store.get_session(body.model)
-            if session is None:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Session for model '{body.model}' not found. "
-                    "Ensure the external model has been registered.",
-                )
-        else:
-            token = _extract_bearer_token(request)
-            session = _resolve_session_from_token(token, store)
-            if session is None:
-                raise HTTPException(
-                    status_code=401,
-                    detail="Invalid or expired session API key.",
-                )
+        token = _extract_bearer_token(request)
+        session = _resolve_session_from_token(token, store)
+        if session is None:
+            raise HTTPException(
+                status_code=401, detail="Invalid or expired session API key."
+            )
 
         try:
             reward_result = session.set_reward(
@@ -410,6 +399,11 @@ def create_app(config: DataProxyConfig) -> FastAPI:
 
         model_name = body_json.get("model")
         store: SessionStore = app.state.session_store
+
+        token = _try_extract_bearer_token(request)
+        session = _resolve_session_from_token(token, store)
+        if session is not None:
+            session.update_last_access()
 
         # -----------------------------------------------------------------
         # External model path: model is a registered external model name
@@ -468,9 +462,8 @@ def create_app(config: DataProxyConfig) -> FastAPI:
                         )
                         yield f"data: {json.dumps({'error': str(exc)})}\n\n".encode()
                     finally:
-                        if success and collected_chunks:
-                            ext_session = store.get_or_create_session(model_name)
-                            ext_session.add_string_interaction(
+                        if success and collected_chunks and session is not None:
+                            session.add_string_interaction(
                                 messages,
                                 "".join(collected_chunks),
                             )
@@ -507,9 +500,8 @@ def create_app(config: DataProxyConfig) -> FastAPI:
 
             response_str = resp.text
 
-            if resp.status_code == 200:
-                ext_session = store.get_or_create_session(model_name)
-                ext_session.add_string_interaction(messages, response_str)
+            if resp.status_code == 200 and session is not None:
+                session.add_string_interaction(messages, response_str)
 
             return RawResponse(
                 content=resp.content,
@@ -522,19 +514,20 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         # -----------------------------------------------------------------
         areal_client: ArealOpenAI = app.state.areal_client
 
-        token = _try_extract_bearer_token(request)
-        session = _resolve_session_from_token(token, store)
         if session is not None:
-            session.update_last_access()
             areal_cache: Any = session.active_completions
         else:
             areal_cache = None
 
+        # Build kwargs from request body
         kwargs = dict(body_json)
+        # Remove model (ArealOpenAI ignores it)
         kwargs.pop("model", None)
 
+        # Determine streaming
         is_streaming = kwargs.get("stream", False) or False
 
+        # Apply defaults for temperature/top_p if not set
         if "temperature" not in kwargs:
             kwargs["temperature"] = 1.0
         if "top_p" not in kwargs:
@@ -553,6 +546,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
             raise HTTPException(status_code=500, detail=f"{type(e).__name__}: {e}")
 
         if is_streaming:
+            # result is an async generator of ChatCompletionChunk
 
             async def _sse_stream():
                 async for chunk in result:
@@ -616,15 +610,19 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         if body.remove_session:
             store.remove_session(body.session_id)
 
+        # Serialize for HTTP transport, storing tensors locally as RTensor shards
         from areal.infra.rpc.rtensor import RTensor
 
         for item in interactions.values():
             if item.has_tensor_data:
+                # Set the internal cache
                 item.to_tensor_dict()
+                # Remotize the tensor dict cache
                 item._cache = RTensor.remotize(
                     item._cache, node_addr=config.serving_addr
                 )
 
+        # serialize RTensors
         serialized = serialize_interactions(interactions)
         return ExportTrajectoriesResponse(interactions=serialized)
 

--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -469,12 +469,11 @@ def create_app(config: DataProxyConfig) -> FastAPI:
                         yield f"data: {json.dumps({'error': str(exc)})}\n\n".encode()
                     finally:
                         if success and collected_chunks:
-                            ext_session = store.get_session(model_name)
-                            if ext_session is not None and ext_session.is_external_api:
-                                ext_session.add_string_interaction(
-                                    messages,
-                                    "".join(collected_chunks),
-                                )
+                            ext_session = store.get_or_create_session(model_name)
+                            ext_session.add_string_interaction(
+                                messages,
+                                "".join(collected_chunks),
+                            )
 
                 return StreamingResponse(
                     _stream_and_cache(),
@@ -509,9 +508,8 @@ def create_app(config: DataProxyConfig) -> FastAPI:
             response_str = resp.text
 
             if resp.status_code == 200:
-                ext_session = store.get_session(model_name)
-                if ext_session is not None and ext_session.is_external_api:
-                    ext_session.add_string_interaction(messages, response_str)
+                ext_session = store.get_or_create_session(model_name)
+                ext_session.add_string_interaction(messages, response_str)
 
             return RawResponse(
                 content=resp.content,
@@ -584,8 +582,6 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         if not name:
             raise HTTPException(status_code=400, detail="model name is required")
         _registered_models[name] = {"url": url, "model": model, "api_key": api_key}
-        if url:
-            store.register_external_model(name)
         logger.info("Model registered: name=%s url=%s", name, url or "(internal)")
         return {"status": "ok", "name": name}
 

--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -9,11 +9,10 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
-import orjson
-from fastapi import Body, FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.wsgi import WSGIMiddleware
-from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.responses import Response as RawResponse
+from fastapi.responses import StreamingResponse
 from flask import Flask
 
 from areal.experimental.inference_service.data_proxy.backend import (
@@ -567,7 +566,6 @@ def create_app(config: DataProxyConfig) -> FastAPI:
 
     @app.post("/register_model")
     async def register_model(request: Request):
-        store: SessionStore = app.state.session_store
         body = await request.json()
         name = body.get("name") or body.get("model")
         url = body.get("url", "")

--- a/areal/experimental/inference_service/data_proxy/config.py
+++ b/areal/experimental/inference_service/data_proxy/config.py
@@ -20,3 +20,9 @@ class DataProxyConfig:
     # Resolved serving address (host:port) used as node_addr for RTensor shards.
     # Set at startup by __main__.py after the host is resolved.
     serving_addr: str = ""
+
+    # ArealOpenAI client parameters (forwarded from OpenAIProxyConfig)
+    tool_call_parser: str = "qwen"
+    reasoning_parser: str = "qwen3"
+    engine_max_tokens: int | None = None
+    chat_template_type: str = "hf"

--- a/areal/experimental/inference_service/data_proxy/session.py
+++ b/areal/experimental/inference_service/data_proxy/session.py
@@ -108,19 +108,14 @@ class SessionData:
       ``export_trajectory``.
     - **Online**: one persistent session → many reward-bounded trajectories
       via repeated ``set_reward`` → ``export_trajectory`` calls.
-    - **External API**: same lifecycle as online mode but interactions
-      store raw request/response strings instead of tokenised data.
-      Set ``is_external_api=True`` at construction time.
     """
 
     def __init__(
         self,
         session_id: str,
         set_reward_finish_timeout: float = 0.0,
-        is_external_api: bool = False,
     ):
         self.session_id = session_id
-        self.is_external_api = is_external_api
         self._set_reward_finish_timeout = set_reward_finish_timeout
         self._last_access_time = time.time()
         self._lock = threading.Lock()
@@ -188,7 +183,7 @@ class SessionData:
             interaction_id=resolved_interaction_id,
             completions=completions,
             created_at=now,
-            needs_online_callback=self.session_id == "__hitl__" or self.is_external_api,
+            needs_online_callback=True,
         )
         self._ready_trajectories[trajectory_id] = ready
         self._active_completions = InteractionCache()
@@ -412,17 +407,16 @@ class SessionStore:
                 self._sessions["__hitl__"] = session
             return session
 
-    def register_external_model(self, name: str) -> SessionData:
+    def get_or_create_session(self, session_id: str) -> SessionData:
+        """Return an existing session or create a new one with the given ID."""
         with self._lock:
-            existing = self._sessions.get(name)
-            if existing is not None and existing.is_external_api:
-                return existing
-            session = SessionData(
-                session_id=name,
-                set_reward_finish_timeout=self._set_reward_finish_timeout,
-                is_external_api=True,
-            )
-            self._sessions[name] = session
+            session = self._sessions.get(session_id)
+            if session is None:
+                session = SessionData(
+                    session_id=session_id,
+                    set_reward_finish_timeout=self._set_reward_finish_timeout,
+                )
+                self._sessions[session_id] = session
             return session
 
     def get_session(self, session_id: str) -> SessionData | None:

--- a/areal/experimental/inference_service/data_proxy/session.py
+++ b/areal/experimental/inference_service/data_proxy/session.py
@@ -294,6 +294,30 @@ class SessionData:
         style: str,
         trajectory_id: int | None = None,
     ) -> tuple[int, dict[str, InteractionWithTokenLogpReward]]:
+        """Export a ready trajectory.
+
+        Parameters
+        ----------
+        discount : float
+            Reward discount factor passed to
+            :pymethod:`InteractionCache.export_interactions`.
+        style : str
+            Export style (``"individual"`` or ``"concat"``).
+        trajectory_id : int | None
+            Specific trajectory to export.  When ``None``, the latest
+            ready trajectory is exported.
+
+        Returns
+        -------
+        tuple[int, dict[str, InteractionWithTokenLogpReward]]
+            ``(trajectory_id, interactions)``
+
+        Raises
+        ------
+        KeyError
+            If no ready trajectories exist, or the requested
+            ``trajectory_id`` is not found.
+        """
         with self._lock:
             if not self._ready_trajectories:
                 raise KeyError(f"No ready trajectories for session {self.session_id}")
@@ -405,18 +429,6 @@ class SessionStore:
                     set_reward_finish_timeout=self._set_reward_finish_timeout,
                 )
                 self._sessions["__hitl__"] = session
-            return session
-
-    def get_or_create_session(self, session_id: str) -> SessionData:
-        """Return an existing session or create a new one with the given ID."""
-        with self._lock:
-            session = self._sessions.get(session_id)
-            if session is None:
-                session = SessionData(
-                    session_id=session_id,
-                    set_reward_finish_timeout=self._set_reward_finish_timeout,
-                )
-                self._sessions[session_id] = session
             return session
 
     def get_session(self, session_id: str) -> SessionData | None:

--- a/areal/experimental/inference_service/data_proxy/session.py
+++ b/areal/experimental/inference_service/data_proxy/session.py
@@ -7,16 +7,15 @@ from __future__ import annotations
 import secrets
 import threading
 import time
+import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pydantic import BaseModel
 
 from areal.experimental.openai.cache import InteractionCache
-
-if TYPE_CHECKING:
-    from areal.experimental.openai.types import InteractionWithTokenLogpReward
+from areal.experimental.openai.types import InteractionWithTokenLogpReward
 
 # Session timeout for cleanup (1 hour)
 SESSION_TIMEOUT_SECONDS = 3600
@@ -46,6 +45,7 @@ class SetRewardRequest(BaseModel):
 
     interaction_id: str | None = None
     reward: float
+    model: str | None = None
 
 
 class ExportTrajectoriesRequest(BaseModel):
@@ -61,7 +61,7 @@ class ExportTrajectoriesRequest(BaseModel):
 class ExportTrajectoriesResponse(BaseModel):
     """Response containing serialized interactions."""
 
-    interactions: dict[str, Any]
+    interactions: Any
 
 
 @dataclass(frozen=True)
@@ -108,10 +108,19 @@ class SessionData:
       ``export_trajectory``.
     - **Online**: one persistent session → many reward-bounded trajectories
       via repeated ``set_reward`` → ``export_trajectory`` calls.
+    - **External API**: same lifecycle as online mode but interactions
+      store raw request/response strings instead of tokenised data.
+      Set ``is_external_api=True`` at construction time.
     """
 
-    def __init__(self, session_id: str, set_reward_finish_timeout: float = 0.0):
+    def __init__(
+        self,
+        session_id: str,
+        set_reward_finish_timeout: float = 0.0,
+        is_external_api: bool = False,
+    ):
         self.session_id = session_id
+        self.is_external_api = is_external_api
         self._set_reward_finish_timeout = set_reward_finish_timeout
         self._last_access_time = time.time()
         self._lock = threading.Lock()
@@ -179,7 +188,7 @@ class SessionData:
             interaction_id=resolved_interaction_id,
             completions=completions,
             created_at=now,
-            needs_online_callback=self.session_id == "__hitl__",
+            needs_online_callback=self.session_id == "__hitl__" or self.is_external_api,
         )
         self._ready_trajectories[trajectory_id] = ready
         self._active_completions = InteractionCache()
@@ -273,36 +282,23 @@ class SessionData:
             ready.callback_delivered = True
             return True
 
+    def add_string_interaction(self, messages: list[dict], response: str) -> str:
+        interaction_id = str(uuid.uuid4())
+        interaction = InteractionWithTokenLogpReward(
+            messages=messages,
+            output_message_list=[{"role": "assistant", "content": response}],
+        )
+        interaction._interaction_id = interaction_id
+        self._active_completions[interaction_id] = interaction
+        self.update_last_access()
+        return interaction_id
+
     def export_trajectory(
         self,
         discount: float,
         style: str,
         trajectory_id: int | None = None,
     ) -> tuple[int, dict[str, InteractionWithTokenLogpReward]]:
-        """Export a ready trajectory.
-
-        Parameters
-        ----------
-        discount : float
-            Reward discount factor passed to
-            :pymethod:`InteractionCache.export_interactions`.
-        style : str
-            Export style (``"individual"`` or ``"concat"``).
-        trajectory_id : int | None
-            Specific trajectory to export.  When ``None``, the latest
-            ready trajectory is exported.
-
-        Returns
-        -------
-        tuple[int, dict[str, InteractionWithTokenLogpReward]]
-            ``(trajectory_id, interactions)``
-
-        Raises
-        ------
-        KeyError
-            If no ready trajectories exist, or the requested
-            ``trajectory_id`` is not found.
-        """
         with self._lock:
             if not self._ready_trajectories:
                 raise KeyError(f"No ready trajectories for session {self.session_id}")
@@ -414,6 +410,19 @@ class SessionStore:
                     set_reward_finish_timeout=self._set_reward_finish_timeout,
                 )
                 self._sessions["__hitl__"] = session
+            return session
+
+    def register_external_model(self, name: str) -> SessionData:
+        with self._lock:
+            existing = self._sessions.get(name)
+            if existing is not None and existing.is_external_api:
+                return existing
+            session = SessionData(
+                session_id=name,
+                set_reward_finish_timeout=self._set_reward_finish_timeout,
+                is_external_api=True,
+            )
+            self._sessions[name] = session
             return session
 
     def get_session(self, session_id: str) -> SessionData | None:

--- a/areal/experimental/inference_service/gateway/app.py
+++ b/areal/experimental/inference_service/gateway/app.py
@@ -27,8 +27,11 @@ from areal.experimental.inference_service.gateway.streaming import (
     forward_request,
     forward_sse_stream,
     grant_capacity_in_router,
+    list_models_from_router,
     query_router,
+    register_model_in_router,
     register_session_in_router,
+    remove_model_from_router,
     resolve_worker_addr,
     revoke_session_in_router,
 )
@@ -67,6 +70,18 @@ def create_app(config: GatewayConfig) -> FastAPI:
     @app.post("/chat/completions")
     async def chat_completions(request: Request):
         token = extract_bearer_token(request)
+        body = await request.body()
+        headers = _forwarding_headers(dict(request.headers))
+
+        model_name = None
+        is_streaming = False
+        try:
+            body_json = json.loads(body)
+            model_name = body_json.get("model")
+            is_streaming = body_json.get("stream", False) or False
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
         try:
             worker_addr = await query_router(
                 config.router_addr,
@@ -74,20 +89,10 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 "/chat/completions",
                 config.router_timeout,
                 admin_api_key=config.admin_api_key,
+                model=model_name,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
-
-        body = await request.body()
-        headers = _forwarding_headers(dict(request.headers))
-
-        # Detect streaming from request body
-        is_streaming = False
-        try:
-            body_json = json.loads(body)
-            is_streaming = body_json.get("stream", False) or False
-        except (json.JSONDecodeError, AttributeError):
-            pass
 
         if is_streaming:
             return StreamingResponse(
@@ -109,6 +114,72 @@ def create_app(config: GatewayConfig) -> FastAPI:
             status_code=resp.status_code,
             media_type=resp.headers.get("content-type"),
         )
+
+    @app.post("/register_model")
+    async def register_model(request: Request):
+        require_admin_key(request, config.admin_api_key)
+        body = await request.json()
+        model = body.get("model")
+        url = body.get("url", "")
+        api_key = body.get("api_key")
+        data_proxy_addrs = body.get("data_proxy_addrs", [])
+        if not model:
+            return JSONResponse({"error": "model is required"}, status_code=400)
+        try:
+            result = await register_model_in_router(
+                config.router_addr,
+                model,
+                url,
+                api_key,
+                data_proxy_addrs,
+                config.admin_api_key,
+                config.router_timeout,
+            )
+        except (RouterUnreachableError, RouterKeyRejectedError) as exc:
+            return _router_error_response(exc)
+
+        resolved_addrs = result.get("data_proxy_addrs", data_proxy_addrs)
+        headers = _forwarding_headers(dict(request.headers))
+
+        for addr in resolved_addrs:
+            resp = await forward_request(
+                f"{addr}/register_model",
+                json.dumps(
+                    {
+                        "name": model,
+                        "url": url,
+                        "model": model,
+                        "api_key": api_key,
+                    }
+                ).encode(),
+                headers,
+                config.forward_timeout,
+            )
+            if resp.status_code != 200:
+                await remove_model_from_router(
+                    config.router_addr,
+                    model,
+                    config.admin_api_key,
+                    config.router_timeout,
+                )
+                return JSONResponse(
+                    {"error": f"Data proxy registration failed: {resp.text}"},
+                    status_code=502,
+                )
+        return result
+
+    @app.get("/models")
+    async def list_models(request: Request):
+        require_admin_key(request, config.admin_api_key)
+        try:
+            names = await list_models_from_router(
+                config.router_addr,
+                config.admin_api_key,
+                config.router_timeout,
+            )
+        except (RouterUnreachableError, RouterKeyRejectedError) as exc:
+            return _router_error_response(exc)
+        return {"models": names}
 
     # =========================================================================
     # POST /rl/start_session — admin key ONLY, intercept response
@@ -176,6 +247,16 @@ def create_app(config: GatewayConfig) -> FastAPI:
     @app.post("/rl/set_reward")
     async def set_reward(request: Request):
         token = extract_bearer_token(request)
+        body = await request.body()
+        headers = _forwarding_headers(dict(request.headers))
+
+        model = None
+        try:
+            body_json = json.loads(body)
+            model = body_json.get("model")
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
         try:
             worker_addr = await query_router(
                 config.router_addr,
@@ -183,16 +264,14 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 "/rl/set_reward",
                 config.router_timeout,
                 admin_api_key=config.admin_api_key,
+                model=model,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
 
-        body = await request.body()
-        headers = _forwarding_headers(dict(request.headers))
         resp = await forward_request(
             f"{worker_addr}/rl/set_reward", body, headers, config.forward_timeout
         )
-
         return Response(
             content=resp.content,
             status_code=resp.status_code,
@@ -248,24 +327,26 @@ def create_app(config: GatewayConfig) -> FastAPI:
         return {"results": results}
 
     # =========================================================================
-    # POST /export_trajectories — admin key ONLY, route by session_id
+    # POST /export_trajectories — admin key ONLY, route by session_id or model field
     # =========================================================================
 
     @app.post("/export_trajectories")
     async def export_trajectories(request: Request):
         require_admin_key(request, config.admin_api_key)
-
         body = await request.body()
 
-        # Parse body to extract session_id for routing
         try:
             body_json = json.loads(body)
-            session_id = body_json.get("session_id")
         except (json.JSONDecodeError, AttributeError):
-            return JSONResponse(
-                {"error": "Invalid JSON body or missing session_id"},
-                status_code=400,
-            )
+            return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+        model = body_json.get("model")
+        session_id = body_json.get("session_id")
+
+        if model and not session_id:
+            session_id = model
+            body_json["session_id"] = session_id
+            body = json.dumps(body_json).encode()
 
         if not session_id:
             return JSONResponse({"error": "session_id is required"}, status_code=400)
@@ -276,6 +357,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 timeout=config.router_timeout,
                 session_id=session_id,
                 admin_api_key=config.admin_api_key,
+                model=model,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -288,9 +370,6 @@ def create_app(config: GatewayConfig) -> FastAPI:
             config.forward_timeout,
         )
 
-        # Always ask the router to clean up after successful export.
-        # The router itself distinguishes offline one-shot sessions from
-        # persistent online sessions and will keep online bindings intact.
         if resp.status_code == 200:
             await revoke_session_in_router(
                 config.router_addr,
@@ -399,4 +478,19 @@ def create_app(config: GatewayConfig) -> FastAPI:
         continue_generation,
         methods=["POST"],
     )
+
+    # =========================================================================
+    # OpenAI / OpenRouter compatibility aliases — /v1/* prefixed routes
+    # =========================================================================
+    app.add_api_route(
+        "/v1/chat/completions",
+        chat_completions,
+        methods=["POST"],
+    )
+    app.add_api_route(
+        "/v1/models",
+        list_models,
+        methods=["GET"],
+    )
+
     return app

--- a/areal/experimental/inference_service/gateway/streaming.py
+++ b/areal/experimental/inference_service/gateway/streaming.py
@@ -38,6 +38,7 @@ async def query_router(
     *,
     session_id: str | None = None,
     admin_api_key: str | None = None,
+    model: str | None = None,
 ) -> str:
     """Ask the Router for a worker address.
 
@@ -59,6 +60,8 @@ async def query_router(
         Router returned 404 (unknown key / session) or 503 (no healthy workers).
     """
     payload: dict[str, str] = {}
+    if model is not None:
+        payload["model"] = model
     if session_id is not None:
         payload["session_id"] = session_id
     else:
@@ -232,6 +235,96 @@ async def get_all_worker_addrs(
         return [w["addr"] for w in data.get("workers", [])]
     except Exception as exc:
         raise RouterUnreachableError(f"Failed to get workers: {exc}") from exc
+
+
+async def register_model_in_router(
+    router_addr: str,
+    model: str,
+    url: str,
+    api_key: str | None,
+    data_proxy_addrs: list[str],
+    admin_api_key: str,
+    timeout: float,
+) -> dict:
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                f"{router_addr}/register_model",
+                json={
+                    "model": model,
+                    "url": url,
+                    "api_key": api_key,
+                    "data_proxy_addrs": data_proxy_addrs,
+                },
+                headers={"Authorization": f"Bearer {admin_api_key}"},
+            )
+        if resp.status_code == 503:
+            raise RouterKeyRejectedError("No healthy workers", 503)
+        resp.raise_for_status()
+        return resp.json()
+    except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+        raise RouterUnreachableError(f"Router unreachable: {exc}") from exc
+
+
+async def route_external_model(
+    router_addr: str,
+    name: str,
+    admin_api_key: str,
+    timeout: float,
+) -> dict:
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                f"{router_addr}/route",
+                json={"model": name},
+                headers={"Authorization": f"Bearer {admin_api_key}"},
+            )
+        if resp.status_code == 404:
+            raise RouterKeyRejectedError(f"Model '{name}' not found", 404)
+        if resp.status_code == 503:
+            raise RouterKeyRejectedError(f"No healthy workers for model '{name}'", 503)
+        resp.raise_for_status()
+        return resp.json()
+    except RouterKeyRejectedError:
+        raise
+    except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+        raise RouterUnreachableError(f"Router unreachable: {exc}") from exc
+
+
+async def list_models_from_router(
+    router_addr: str,
+    admin_api_key: str,
+    timeout: float,
+) -> list[str]:
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(
+                f"{router_addr}/models",
+                headers={"Authorization": f"Bearer {admin_api_key}"},
+            )
+        resp.raise_for_status()
+        return resp.json().get("models", [])
+    except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+        raise RouterUnreachableError(f"Router unreachable: {exc}") from exc
+
+
+async def remove_model_from_router(
+    router_addr: str,
+    name: str,
+    admin_api_key: str,
+    timeout: float,
+) -> None:
+    """Remove an external model from the router registry (best-effort rollback)."""
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                f"{router_addr}/remove_model",
+                json={"name": name},
+                headers={"Authorization": f"Bearer {admin_api_key}"},
+            )
+        resp.raise_for_status()
+    except Exception:
+        pass  # Best-effort rollback; swallow errors
 
 
 async def resolve_worker_addr(

--- a/areal/experimental/inference_service/router/app.py
+++ b/areal/experimental/inference_service/router/app.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel
 from areal.experimental.inference_service.router.config import RouterConfig
 from areal.experimental.inference_service.router.state import (
     CapacityManager,
+    ModelRegistry,
     SessionRegistry,
     WorkerRegistry,
 )
@@ -75,6 +76,7 @@ class RouteRequest(BaseModel):
     api_key: str | None = None
     path: str | None = None
     session_id: str | None = None
+    model: str | None = None
 
 
 class RegisterSessionRequest(BaseModel):
@@ -87,6 +89,17 @@ class RemoveSessionRequest(BaseModel):
     session_id: str
 
 
+class RegisterModelRequest(BaseModel):
+    model: str
+    url: str = ""
+    api_key: str | None = None
+    data_proxy_addrs: list[str] = []
+
+
+class RemoveModelRequest(BaseModel):
+    name: str
+
+
 # =============================================================================
 # App factory
 # =============================================================================
@@ -97,6 +110,7 @@ def create_app(config: RouterConfig) -> FastAPI:
 
     worker_registry = WorkerRegistry()
     session_registry = SessionRegistry()
+    model_registry = ModelRegistry()
     capacity_manager = CapacityManager()
     strategy = get_strategy(config.routing_strategy)
 
@@ -127,6 +141,7 @@ def create_app(config: RouterConfig) -> FastAPI:
         poll_task = asyncio.create_task(_poll_workers())
         app.state.worker_registry = worker_registry
         app.state.session_registry = session_registry
+        app.state.model_registry = model_registry
         app.state.capacity_manager = capacity_manager
         app.state.strategy = strategy
         yield
@@ -142,6 +157,7 @@ def create_app(config: RouterConfig) -> FastAPI:
     # Expose registries on app.state for tests that bypass lifespan
     app.state.worker_registry = worker_registry
     app.state.session_registry = session_registry
+    app.state.model_registry = model_registry
     app.state.capacity_manager = capacity_manager
     app.state.strategy = strategy
 
@@ -218,12 +234,57 @@ def create_app(config: RouterConfig) -> FastAPI:
     @app.post("/route")
     async def route(body: RouteRequest, request: Request):
         _require_admin_key(request, config.admin_api_key)
-        # 0. session_id lookup takes precedence
+
+        # Step A: resolve model → candidate worker addrs
+        model_addrs: list[str] | None = None
+        if body.model is not None:
+            info = await model_registry.get(body.model)
+            if info is not None:
+                model_addrs = info.data_proxy_addrs
+        if model_addrs is None:
+            first = await model_registry.first()
+            if first is not None:
+                model_addrs = first.data_proxy_addrs
+
+        def _filter_healthy(workers: list, addrs: list[str] | None) -> list:
+            if addrs is None:
+                return workers
+            addr_set = set(addrs)
+            return [w for w in workers if w.worker_addr in addr_set]
+
+        # Step B: session_id lookup
         if body.session_id is not None:
             worker = await session_registry.lookup_by_id(body.session_id)
-            if worker is None:
+            if worker is not None:
+                return {"worker_addr": worker}
+            if model_addrs is None:
                 raise HTTPException(status_code=404, detail="Session not found")
-            return {"worker_addr": worker}
+
+        # Step C: model-only routing (no api_key/session_id)
+        if body.api_key is None and model_addrs is not None:
+            healthy = await worker_registry.get_healthy_workers()
+            addr_set = set(model_addrs)
+            healthy = [w for w in healthy if w.worker_addr in addr_set]
+            if not healthy:
+                raise HTTPException(status_code=503, detail="No healthy workers")
+            worker = strategy.pick(healthy)
+            if worker is None:
+                raise HTTPException(status_code=503, detail="No healthy workers")
+            info = (
+                await model_registry.get(body.model)
+                if body.model
+                else await model_registry.first()
+            )
+            return {
+                "worker_addr": worker.worker_addr,
+                "url": info.url if info else "",
+                "api_key": info.api_key if info else None,
+            }
+
+        if body.api_key is None and body.model is not None and model_addrs is None:
+            raise HTTPException(
+                status_code=404, detail=f"Model '{body.model}' not found"
+            )
 
         if body.api_key is None:
             raise HTTPException(
@@ -231,10 +292,9 @@ def create_app(config: RouterConfig) -> FastAPI:
                 detail="Either 'api_key' or 'session_id' must be provided",
             )
 
-        # 1. Session key → pinned worker (batch sessions)
+        # Step C: Session key → pinned worker
         pinned = await session_registry.lookup_by_key(body.api_key)
         if pinned is not None:
-            # Check if pinned worker is healthy
             all_workers = await worker_registry.get_all_workers()
             worker_map = {w.worker_addr: w for w in all_workers}
             w = worker_map.get(pinned)
@@ -242,9 +302,10 @@ def create_app(config: RouterConfig) -> FastAPI:
                 raise HTTPException(status_code=503, detail="Pinned worker unhealthy")
             return {"worker_addr": pinned}
 
-        # 2. Admin key → HITL routing (sticky session)
+        # Step D: Admin key → pick from model addrs
         if hmac.compare_digest(body.api_key, config.admin_api_key):
             healthy = await worker_registry.get_healthy_workers()
+            healthy = _filter_healthy(healthy, model_addrs)
             if not healthy:
                 raise HTTPException(status_code=503, detail="No healthy workers")
             worker = strategy.pick(healthy)
@@ -257,7 +318,7 @@ def create_app(config: RouterConfig) -> FastAPI:
             )
             return {"worker_addr": worker.worker_addr}
 
-        # 3. Unknown key
+        # Step E: Unknown key
         raise HTTPException(status_code=404, detail="Unknown API key")
 
     # =========================================================================
@@ -330,6 +391,51 @@ def create_app(config: RouterConfig) -> FastAPI:
                 for w in all_workers
             ]
         }
+
+    @app.post("/register_model")
+    async def register_model(body: RegisterModelRequest, request: Request):
+        _require_admin_key(request, config.admin_api_key)
+        addrs = body.data_proxy_addrs
+        if not addrs:
+            healthy = await worker_registry.get_healthy_workers()
+            if not healthy:
+                raise HTTPException(status_code=503, detail="No healthy workers")
+            addrs = [w.worker_addr for w in healthy]
+        await model_registry.register(
+            body.model,
+            body.url,
+            body.api_key,
+            addrs,
+        )
+        logger.info(
+            "Model registered: model=%s url=%s data_proxy_addrs=%s",
+            body.model,
+            body.url or "(internal)",
+            addrs,
+        )
+        return {
+            "status": "ok",
+            "model": body.model,
+            "data_proxy_addrs": addrs,
+        }
+
+    @app.get("/models")
+    async def list_models(request: Request):
+        _require_admin_key(request, config.admin_api_key)
+        names = await model_registry.list_names()
+        return {"models": names}
+
+    @app.post("/remove_model")
+    async def remove_model(body: RemoveModelRequest, request: Request):
+        _require_admin_key(request, config.admin_api_key)
+        removed = await model_registry.remove(body.name)
+        if not removed:
+            raise HTTPException(
+                status_code=404,
+                detail=f"External model '{body.name}' not found",
+            )
+        logger.info("External model removed: name=%s", body.name)
+        return {"status": "ok", "name": body.name}
 
     # =========================================================================
     # Worker resolution by ID (admin key required)

--- a/areal/experimental/inference_service/router/state.py
+++ b/areal/experimental/inference_service/router/state.py
@@ -207,3 +207,54 @@ class SessionRegistry:
         """Return the number of registered session keys."""
         async with self._lock:
             return len(self._key_to_worker)
+
+
+@dataclass
+class ModelInfo:
+    """A registered model (internal or external)."""
+
+    name: str
+    url: str  # empty string for internal models
+    api_key: str | None
+    data_proxy_addrs: list[str] = field(default_factory=list)
+
+
+class ModelRegistry:
+    """Thread-safe registry for model routing."""
+
+    def __init__(self) -> None:
+        self._models: dict[str, ModelInfo] = {}
+        self._lock = asyncio.Lock()
+
+    async def register(
+        self,
+        name: str,
+        url: str,
+        api_key: str | None,
+        data_proxy_addrs: list[str],
+    ) -> None:
+        async with self._lock:
+            self._models[name] = ModelInfo(
+                name=name,
+                url=url,
+                api_key=api_key,
+                data_proxy_addrs=data_proxy_addrs,
+            )
+
+    async def get(self, name: str) -> ModelInfo | None:
+        async with self._lock:
+            return self._models.get(name)
+
+    async def first(self) -> ModelInfo | None:
+        async with self._lock:
+            if not self._models:
+                return None
+            return next(iter(self._models.values()))
+
+    async def list_names(self) -> list[str]:
+        async with self._lock:
+            return list(self._models.keys())
+
+    async def remove(self, name: str) -> bool:
+        async with self._lock:
+            return self._models.pop(name, None) is not None

--- a/areal/experimental/openai/proxy/server.py
+++ b/areal/experimental/openai/proxy/server.py
@@ -134,11 +134,19 @@ def serialize_interactions(
 
     result = {}
     for key, interaction in interactions.items():
-        result[key] = {
-            "tensor_dict": interaction.to_tensor_dict(),
-            "reward": interaction.reward,
-            "interaction_id": interaction.interaction_id,
-        }
+        if interaction.has_tensor_data:
+            result[key] = {
+                "tensor_dict": interaction.to_tensor_dict(),
+                "reward": interaction.reward,
+                "interaction_id": interaction.interaction_id,
+            }
+        else:
+            result[key] = {
+                "messages": interaction.messages,
+                "output_message_list": interaction.output_message_list,
+                "reward": interaction.reward,
+                "interaction_id": interaction.interaction_id,
+            }
     return serialize_value(result)
 
 
@@ -152,9 +160,12 @@ def deserialize_interactions(
     data = deserialize_value(data)
     result = {}
     for key, item in data.items():
-        # Create a minimal InteractionWithTokenLogpReward with cached tensor dict
         interaction = InteractionWithTokenLogpReward()
-        interaction._cache = item["tensor_dict"]
+        if "tensor_dict" in item:
+            interaction._cache = item["tensor_dict"]
+        else:
+            interaction.messages = item["messages"]
+            interaction.output_message_list = item["output_message_list"]
         interaction.reward = item["reward"]
         interaction.interaction_id = item["interaction_id"]
         result[key] = interaction

--- a/areal/experimental/openai/types.py
+++ b/areal/experimental/openai/types.py
@@ -58,6 +58,10 @@ class InteractionWithTokenLogpReward:
     _interaction_id: str | None = None
 
     @property
+    def has_tensor_data(self) -> bool:
+        return self.model_response is not None or self._cache is not None
+
+    @property
     def is_completion(self) -> bool:
         return self.completion is not None
 
@@ -200,3 +204,28 @@ class InteractionWithTokenLogpReward:
         )
         self._cache = result
         return result
+
+
+def concat_string_interactions(
+    interactions: dict[str, InteractionWithTokenLogpReward],
+) -> dict[str, list[dict]]:
+    """Concat interactions that lack tensor data (e.g. external API mode).
+
+    Returns a dict with an ``"interactions"`` key containing a list of
+    ``{"request": ..., "response": ..., "reward": ...}`` dicts, one per
+    interaction.  This is the counterpart of
+    :func:`~areal.utils.data.concat_padded_tensors` for string-only
+    trajectories.
+    """
+    return {
+        "interactions": [
+            {
+                "request": v.messages,
+                "response": (
+                    v.output_message_list[0]["content"] if v.output_message_list else ""
+                ),
+                "reward": v.reward,
+            }
+            for v in interactions.values()
+        ]
+    }

--- a/areal/infra/workflow_executor.py
+++ b/areal/infra/workflow_executor.py
@@ -30,7 +30,10 @@ from .async_task_runner import (
 from .staleness_manager import StalenessManager
 from areal.infra import workflow_context
 from .workflow_context import WorkflowContext
-from areal.experimental.openai.types import InteractionWithTokenLogpReward
+from areal.experimental.openai.types import (
+    InteractionWithTokenLogpReward,
+    concat_string_interactions,
+)
 from areal.utils import logging, perf_tracer, stats_tracker
 from areal.infra.utils.concurrent import get_executor
 from areal.utils.data import concat_padded_tensors, cycle_dataloader
@@ -1067,13 +1070,19 @@ class WorkflowExecutor:
                                 self._expected_trajectory_keys,
                             )
 
-                # Convert InteractionWithTokenLogpReward to tensor dict if needed
+                # Convert InteractionWithTokenLogpReward to tensor dict if needed.
+                # External-API interactions have no tensor data; fall back to
+                # concat_string_interactions which produces a plain dict of
+                # request/response strings instead of padded tensors.
                 if isinstance(traj, dict) and all(
                     isinstance(v, InteractionWithTokenLogpReward) for v in traj.values()
                 ):
-                    traj = concat_padded_tensors(
-                        [v.to_tensor_dict() for v in traj.values()]
-                    )
+                    if all(v.has_tensor_data for v in traj.values()):
+                        traj = concat_padded_tensors(
+                            [v.to_tensor_dict() for v in traj.values()]
+                        )
+                    else:
+                        traj = concat_string_interactions(traj)
 
                 assert traj is None or isinstance(traj, dict), traj
 

--- a/examples/experimental/inference_service/README.md
+++ b/examples/experimental/inference_service/README.md
@@ -113,13 +113,16 @@ python3 examples/experimental/inference_service/human_in_the_loop_demo.py
 
 Key CLI arguments:
 
-| Argument            | Default               | Description                                                           |
-| ------------------- | --------------------- | --------------------------------------------------------------------- |
-| `--actor-path`      | `Qwen/Qwen3-0.6B`     | Path to the HuggingFace model weights                                 |
-| `--admin-key`       | `sk-test123456`       | Admin API key (must match `rollout.openai.admin_api_key` in the YAML) |
-| `--request-timeout` | `3600`                | Per-request timeout in seconds                                        |
-| `--gateway-wait`    | `600`                 | Seconds to wait for the gateway to become ready                       |
-| `--question`        | *strawberry question* | Question posed in every HITL round                                    |
+| Argument             | Default               | Description                                                           |
+| -------------------- | --------------------- | --------------------------------------------------------------------- |
+| `--actor-path`       | `Qwen/Qwen3-0.6B`     | Path to the HuggingFace model weights                                 |
+| `--admin-key`        | `sk-test123456`       | Admin API key (must match `rollout.openai.admin_api_key` in the YAML) |
+| `--request-timeout`  | `3600`                | Per-request timeout in seconds                                        |
+| `--gateway-wait`     | `600`                 | Seconds to wait for the gateway to become ready                       |
+| `--question`         | *strawberry question* | Question posed in every HITL round                                    |
+| `--external-url`     | `None`                | External API URL (enables external model mode)                        |
+| `--external-api-key` | `None`                | API key for the external provider                                     |
+| `--external-model`   | `None`                | Model name sent to the external API                                   |
 
 You can override the model path without editing the script:
 
@@ -127,6 +130,22 @@ You can override the model path without editing the script:
 python3 examples/experimental/inference_service/human_in_the_loop_demo.py \
     --actor-path /path/to/your/model
 ```
+
+### External Model Mode (optional)
+
+Example 2 can also run HITL with an external OpenAI-compatible provider instead of the
+local rollout model. Pass the external flags through `human_in_the_loop_demo.py`; they
+are forwarded to `online_rollout.py`:
+
+```bash
+python3 examples/experimental/inference_service/human_in_the_loop_demo.py \
+    --external-url https://api.openai.com/v1 \
+    --external-api-key sk-... \
+    --external-model gpt-4o
+```
+
+When `--external-url` is set, the controller enables external model mode and routes chat
+traffic through the unified `/chat/completions` + `/export_trajectories` external flow.
 
 ### Running a Manual HITL Session
 

--- a/examples/experimental/inference_service/human_in_the_loop_demo.py
+++ b/examples/experimental/inference_service/human_in_the_loop_demo.py
@@ -102,23 +102,15 @@ def _restore_zeroclaw_config(config_path: Path, backup: Path) -> None:
 # ── Reward submission ──────────────────────────────────────────────────────
 
 
-def _set_reward(
-    gateway_addr: str,
-    api_key: str,
-    reward: float,
-    model: str | None = None,
-) -> None:
+def _set_reward(gateway_addr: str, api_key: str, reward: float) -> None:
     print(f"    Setting reward={reward}")
-    payload = {"reward": reward}
-    if model:
-        payload["model"] = model
     resp = requests.post(
         f"{gateway_addr}/rl/set_reward",
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bearer {api_key}",
         },
-        json=payload,
+        json={"reward": reward},
         timeout=10,
     )
     resp.raise_for_status()
@@ -132,7 +124,6 @@ def _do_round(
     api_key: str,
     question: str,
     label: str,
-    model: str | None = None,
 ) -> None:
     session_file = tempfile.mktemp(suffix=".json", prefix="zeroclaw_session_")
 
@@ -163,7 +154,7 @@ def _do_round(
 
     if CORRECT_ANSWER_RE.search(resp_text):
         print("  ✔ Correct on first try.")
-        _set_reward(gateway_addr, api_key, 1.0, model=model)
+        _set_reward(gateway_addr, api_key, 1.0)
         Path(session_file).unlink(missing_ok=True)
         return
 
@@ -196,10 +187,10 @@ def _do_round(
 
     if CORRECT_ANSWER_RE.search(resp_text):
         print("  ✔ Correct on second try.")
-        _set_reward(gateway_addr, api_key, 1.0, model=model)
+        _set_reward(gateway_addr, api_key, 1.0)
     else:
         print("  ✘ Still wrong after two attempts — setting reward to 0.")
-        _set_reward(gateway_addr, api_key, 0.0, model=model)
+        _set_reward(gateway_addr, api_key, 0.0)
 
     Path(session_file).unlink(missing_ok=True)
 
@@ -237,19 +228,19 @@ def main() -> None:
         help="Inference backend used by online_rollout.py",
     )
     parser.add_argument(
-        "--external-url",
+        "--api-url",
         default=None,
         help="External API URL (enables external model mode)",
     )
     parser.add_argument(
-        "--external-api-key",
+        "--provider-api-key",
         default=None,
         help="API key for the external provider",
     )
     parser.add_argument(
-        "--external-model",
+        "--model",
         default=None,
-        help="Model name sent to the external API",
+        help="Model name for the gateway controller",
     )
     args = parser.parse_args()
 
@@ -295,13 +286,12 @@ def main() -> None:
             f"rollout.openai.admin_api_key={args.admin_key}",
             f"rollout.request_timeout={args.request_timeout}",
         ]
-        if args.external_url:
-            rollout_cmd.extend(["--external-url", args.external_url])
-        if args.external_api_key:
-            rollout_cmd.extend(["--external-api-key", args.external_api_key])
-        if args.external_model:
-            rollout_cmd.extend(["--external-model", args.external_model])
-
+        if args.api_url:
+            rollout_cmd.extend(["--api-url", args.api_url])
+        if args.provider_api_key:
+            rollout_cmd.extend(["--provider-api-key", args.provider_api_key])
+        if args.model:
+            rollout_cmd.extend(["--model", args.model])
         rollout_proc = subprocess.Popen(
             rollout_cmd,
             stdout=log_fh,
@@ -337,45 +327,20 @@ def main() -> None:
             sys.exit(1)
         print(f"  Gateway: {gateway_addr}")
 
-        is_external = args.external_url is not None
-        if is_external:
-            _print_header("External model mode")
-            print(f"  URL:   {args.external_url}")
-            print(f"  Model: {args.external_model}")
-
-        # The gateway always authenticates with the admin key, even in
-        # external mode.  The external provider API key is only used by
-        # online_rollout.py when forwarding requests to the external API.
-        gateway_api_key = args.admin_key
-
-        # Model name registered by online_rollout.py matches
-        # ``ext_args.external_model or ext_args.external_name``
-        # (--external-name defaults to "ext-model").
-        ext_model_name = (args.external_model or "ext-model") if is_external else None
-
         # ── Step 2: Patch zeroclaw config ──
         _print_header("Step 2: Update ~/.zeroclaw/config.toml")
         zeroclaw_backup = _patch_zeroclaw_config(
-            zeroclaw_config,
-            gateway_addr,
-            gateway_api_key,
-            model=ext_model_name,
+            zeroclaw_config, gateway_addr, args.admin_key, model=args.model
         )
         print("  Done.")
 
         # ── Steps 3–4: HITL rounds ──
         _print_header(f"Steps 3–4  ({BATCH_SIZE} HITL rounds)")
         for i in range(BATCH_SIZE):
-            _do_round(
-                gateway_addr,
-                gateway_api_key,
-                args.question,
-                f"Trajectory {i}",
-                model=ext_model_name,
-            )
+            _do_round(gateway_addr, args.admin_key, args.question, f"Trajectory {i}")
 
-        # ── Verify rollout completion ──
-        _print_header("Check online_rollout output")
+        # ── Step 5: Verify rollout completion ──
+        _print_header("Step 5: Check online_rollout output for databatch")
         print("  Waiting for rollout to process ...")
         wait_deadline = time.monotonic() + ROLLOUT_COMPLETE_WAIT_SECS
         found = False
@@ -395,13 +360,8 @@ def main() -> None:
         if found:
             for line in rollout_log.read_text().splitlines():
                 if "Rollout complete" in line:
-                    print(f"  ✔ Detected:\n  {line}")
+                    print(f"  ✔ Databatch detected:\n  {line}")
                     break
-            if is_external:
-                print()
-                for line in rollout_log.read_text().splitlines():
-                    if "request:" in line or "response:" in line:
-                        print(f"  {line.strip()}")
         else:
             print("  ✘ No 'Rollout complete' message found yet.")
             print("    The rollout may still be collecting trajectories.")

--- a/examples/experimental/inference_service/human_in_the_loop_demo.py
+++ b/examples/experimental/inference_service/human_in_the_loop_demo.py
@@ -54,7 +54,12 @@ def _print_header(title: str) -> None:
 # ── Zeroclaw config helpers ────────────────────────────────────────────────
 
 
-def _patch_zeroclaw_config(config_path: Path, gateway_addr: str, api_key: str) -> Path:
+def _patch_zeroclaw_config(
+    config_path: Path,
+    gateway_addr: str,
+    api_key: str,
+    model: str | None = None,
+) -> Path:
     backup = config_path.with_suffix(".demo_bak")
     shutil.copy2(config_path, backup)
 
@@ -75,6 +80,14 @@ def _patch_zeroclaw_config(config_path: Path, gateway_addr: str, api_key: str) -
     else:
         text = f'api_key = "{api_key}"\n' + text
 
+    if model is not None:
+        text = re.sub(
+            r'^default_model\s*=\s*".*"',
+            f'default_model = "{model}"',
+            text,
+            flags=re.MULTILINE,
+        )
+
     config_path.write_text(text)
     return backup
 
@@ -89,15 +102,23 @@ def _restore_zeroclaw_config(config_path: Path, backup: Path) -> None:
 # ── Reward submission ──────────────────────────────────────────────────────
 
 
-def _set_reward(gateway_addr: str, api_key: str, reward: float) -> None:
+def _set_reward(
+    gateway_addr: str,
+    api_key: str,
+    reward: float,
+    model: str | None = None,
+) -> None:
     print(f"    Setting reward={reward}")
+    payload = {"reward": reward}
+    if model:
+        payload["model"] = model
     resp = requests.post(
         f"{gateway_addr}/rl/set_reward",
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bearer {api_key}",
         },
-        json={"reward": reward},
+        json=payload,
         timeout=10,
     )
     resp.raise_for_status()
@@ -111,6 +132,7 @@ def _do_round(
     api_key: str,
     question: str,
     label: str,
+    model: str | None = None,
 ) -> None:
     session_file = tempfile.mktemp(suffix=".json", prefix="zeroclaw_session_")
 
@@ -141,7 +163,7 @@ def _do_round(
 
     if CORRECT_ANSWER_RE.search(resp_text):
         print("  ✔ Correct on first try.")
-        _set_reward(gateway_addr, api_key, 1.0)
+        _set_reward(gateway_addr, api_key, 1.0, model=model)
         Path(session_file).unlink(missing_ok=True)
         return
 
@@ -174,10 +196,10 @@ def _do_round(
 
     if CORRECT_ANSWER_RE.search(resp_text):
         print("  ✔ Correct on second try.")
-        _set_reward(gateway_addr, api_key, 1.0)
+        _set_reward(gateway_addr, api_key, 1.0, model=model)
     else:
         print("  ✘ Still wrong after two attempts — setting reward to 0.")
-        _set_reward(gateway_addr, api_key, 0.0)
+        _set_reward(gateway_addr, api_key, 0.0, model=model)
 
     Path(session_file).unlink(missing_ok=True)
 
@@ -214,6 +236,21 @@ def main() -> None:
         default=DEFAULT_INFERENCE_BACKEND,
         help="Inference backend used by online_rollout.py",
     )
+    parser.add_argument(
+        "--external-url",
+        default=None,
+        help="External API URL (enables external model mode)",
+    )
+    parser.add_argument(
+        "--external-api-key",
+        default=None,
+        help="API key for the external provider",
+    )
+    parser.add_argument(
+        "--external-model",
+        default=None,
+        help="Model name sent to the external API",
+    )
     args = parser.parse_args()
 
     online_rollout = (
@@ -248,17 +285,25 @@ def main() -> None:
         # ── Step 1: Launch online_rollout.py ──
         _print_header("Step 1: Launch online_rollout.py")
         log_fh = open(rollout_log, "w")
+        rollout_cmd = [
+            sys.executable,
+            str(online_rollout),
+            "--config",
+            str(config_yaml),
+            f"actor.path={args.actor_path}",
+            f"rollout.backend={args.inference_backend}:d1",
+            f"rollout.openai.admin_api_key={args.admin_key}",
+            f"rollout.request_timeout={args.request_timeout}",
+        ]
+        if args.external_url:
+            rollout_cmd.extend(["--external-url", args.external_url])
+        if args.external_api_key:
+            rollout_cmd.extend(["--external-api-key", args.external_api_key])
+        if args.external_model:
+            rollout_cmd.extend(["--external-model", args.external_model])
+
         rollout_proc = subprocess.Popen(
-            [
-                sys.executable,
-                str(online_rollout),
-                "--config",
-                str(config_yaml),
-                f"actor.path={args.actor_path}",
-                f"rollout.backend={args.inference_backend}:d1",
-                f"rollout.openai.admin_api_key={args.admin_key}",
-                f"rollout.request_timeout={args.request_timeout}",
-            ],
+            rollout_cmd,
             stdout=log_fh,
             stderr=subprocess.STDOUT,
             cwd=str(REPO_ROOT),
@@ -292,20 +337,45 @@ def main() -> None:
             sys.exit(1)
         print(f"  Gateway: {gateway_addr}")
 
+        is_external = args.external_url is not None
+        if is_external:
+            _print_header("External model mode")
+            print(f"  URL:   {args.external_url}")
+            print(f"  Model: {args.external_model}")
+
+        # The gateway always authenticates with the admin key, even in
+        # external mode.  The external provider API key is only used by
+        # online_rollout.py when forwarding requests to the external API.
+        gateway_api_key = args.admin_key
+
+        # Model name registered by online_rollout.py matches
+        # ``ext_args.external_model or ext_args.external_name``
+        # (--external-name defaults to "ext-model").
+        ext_model_name = (args.external_model or "ext-model") if is_external else None
+
         # ── Step 2: Patch zeroclaw config ──
         _print_header("Step 2: Update ~/.zeroclaw/config.toml")
         zeroclaw_backup = _patch_zeroclaw_config(
-            zeroclaw_config, gateway_addr, args.admin_key
+            zeroclaw_config,
+            gateway_addr,
+            gateway_api_key,
+            model=ext_model_name,
         )
         print("  Done.")
 
         # ── Steps 3–4: HITL rounds ──
         _print_header(f"Steps 3–4  ({BATCH_SIZE} HITL rounds)")
         for i in range(BATCH_SIZE):
-            _do_round(gateway_addr, args.admin_key, args.question, f"Trajectory {i}")
+            _do_round(
+                gateway_addr,
+                gateway_api_key,
+                args.question,
+                f"Trajectory {i}",
+                model=ext_model_name,
+            )
 
-        # ── Step 5: Verify rollout completion ──
-        _print_header("Step 5: Check online_rollout output for databatch")
+        # ── Verify rollout completion ──
+        _print_header("Check online_rollout output")
         print("  Waiting for rollout to process ...")
         wait_deadline = time.monotonic() + ROLLOUT_COMPLETE_WAIT_SECS
         found = False
@@ -325,8 +395,13 @@ def main() -> None:
         if found:
             for line in rollout_log.read_text().splitlines():
                 if "Rollout complete" in line:
-                    print(f"  ✔ Databatch detected:\n  {line}")
+                    print(f"  ✔ Detected:\n  {line}")
                     break
+            if is_external:
+                print()
+                for line in rollout_log.read_text().splitlines():
+                    if "request:" in line or "response:" in line:
+                        print(f"  {line.strip()}")
         else:
             print("  ✘ No 'Rollout complete' message found yet.")
             print("    The rollout may still be collecting trajectories.")

--- a/examples/experimental/inference_service/online_rollout.py
+++ b/examples/experimental/inference_service/online_rollout.py
@@ -14,10 +14,9 @@ def main(args: list[str]) -> None:
         sys.path.insert(0, str(repo_root))
 
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--external-url", default=None)
-    parser.add_argument("--external-api-key", default=None)
-    parser.add_argument("--external-model", default=None)
-    parser.add_argument("--external-name", default="ext-model")
+    parser.add_argument("--api-url", default=None)
+    parser.add_argument("--provider-api-key", default=None)
+    parser.add_argument("--model", default=None)
     ext_args, remaining = parser.parse_known_args(args)
 
     from areal.api.cli_args import PPOConfig, load_expr_config
@@ -53,7 +52,7 @@ def main(args: list[str]) -> None:
     else:
         raise NotImplementedError(f"Unknown scheduler type: {sched_type}")
 
-    is_external = ext_args.external_url is not None
+    is_external = ext_args.api_url is not None
 
     ctrl_config = GatewayControllerConfig(
         tokenizer_path=config.tokenizer_path,
@@ -75,10 +74,11 @@ def main(args: list[str]) -> None:
         turn_discount=openai_cfg.turn_discount,
         export_style=openai_cfg.export_style,
     )
+    if ext_args.model:
+        ctrl_config.model = ext_args.model
     if is_external:
-        ctrl_config.api_url = ext_args.external_url
-        ctrl_config.provider_api_key = ext_args.external_api_key
-        ctrl_config.model = ext_args.external_model or ext_args.external_name
+        ctrl_config.api_url = ext_args.api_url
+        ctrl_config.provider_api_key = ext_args.provider_api_key
         server_args = None
     else:
         from areal.api.alloc_mode import ModelAllocation
@@ -100,14 +100,9 @@ def main(args: list[str]) -> None:
 
         logger.info("Proxy gateway available at %s", ctrl.proxy_gateway_addr)
 
-        if is_external:
-            logger.info(
-                "External mode: url=%s model=%s name=%s",
-                ext_args.external_url,
-                ext_args.external_model,
-                ext_args.external_name,
-            )
-
+        # Online mode: pass None for both data and workflow so the
+        # controller creates empty-dict placeholders and uses the
+        # online InferenceServiceWorkflow (no agent).
         result = ctrl.rollout_batch(
             data=None,
             batch_size=config.train_dataset.batch_size,
@@ -117,20 +112,27 @@ def main(args: list[str]) -> None:
         if is_external:
             logger.info("Rollout complete (%d trajectories)", len(result))
             for i, traj in enumerate(result):
-                interactions = traj.get("interactions", [])
-                for j, interaction in enumerate(interactions):
+                for j, interaction in enumerate(traj.get("interactions", [])):
+                    request_msgs = interaction.get("request", [])
+                    request = (
+                        request_msgs[-1].get("content", "") if request_msgs else ""
+                    )
+                    response = interaction.get("response", "")
                     logger.info(
-                        "Trajectory %d, interaction %d:\n  request:  %s\n  response: %s",
+                        "Trajectory %d, interaction %d:\n"
+                        "  request:  %s\n  response: %s",
                         i,
                         j,
-                        interaction.get("request", "")[:300],
-                        interaction.get("response", "")[:300],
+                        request[:300],
+                        response[:300],
                     )
         else:
             import torch
 
             from areal.infra.rpc.rtensor import RTensor
 
+            # Localize RTensor references into real torch tensors so we
+            # can compute aggregate reward statistics.
             localized_rewards = [RTensor.localize(traj)["rewards"] for traj in result]
             all_rewards = torch.cat(localized_rewards, dim=0)
             logger.info(

--- a/examples/experimental/inference_service/online_rollout.py
+++ b/examples/experimental/inference_service/online_rollout.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
 from dataclasses import asdict
 from pathlib import Path
-
-import torch
 
 
 def main(args: list[str]) -> None:
@@ -14,7 +13,13 @@ def main(args: list[str]) -> None:
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
 
-    from areal.api.alloc_mode import ModelAllocation
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--external-url", default=None)
+    parser.add_argument("--external-api-key", default=None)
+    parser.add_argument("--external-model", default=None)
+    parser.add_argument("--external-name", default="ext-model")
+    ext_args, remaining = parser.parse_known_args(args)
+
     from areal.api.cli_args import PPOConfig, load_expr_config
     from areal.experimental.inference_service.controller.config import (
         GatewayControllerConfig,
@@ -22,13 +27,12 @@ def main(args: list[str]) -> None:
     from areal.experimental.inference_service.controller.controller import (
         GatewayInferenceController,
     )
-    from areal.infra.rpc.rtensor import RTensor
     from areal.utils import logging
     from areal.utils.environ import is_single_controller
 
     logger = logging.getLogger("InferenceServiceOnlineTrain")
 
-    config, _ = load_expr_config(args, PPOConfig)
+    config, _ = load_expr_config(remaining, PPOConfig)
     openai_cfg = config.rollout.openai
     if openai_cfg is None or openai_cfg.mode != "online":
         raise ValueError(
@@ -49,6 +53,8 @@ def main(args: list[str]) -> None:
     else:
         raise NotImplementedError(f"Unknown scheduler type: {sched_type}")
 
+    is_external = ext_args.external_url is not None
+
     ctrl_config = GatewayControllerConfig(
         tokenizer_path=config.tokenizer_path,
         model_path=config.actor.path,
@@ -65,15 +71,25 @@ def main(args: list[str]) -> None:
         scheduling_spec=config.rollout.scheduling_spec,
         setup_timeout=config.rollout.setup_timeout,
         request_timeout=config.rollout.request_timeout,
-        openai=openai_cfg,
+        admin_api_key=openai_cfg.admin_api_key,
+        turn_discount=openai_cfg.turn_discount,
+        export_style=openai_cfg.export_style,
     )
-    rollout_alloc = ModelAllocation.from_str(config.rollout.backend, name="rollout")
-    if rollout_alloc.backend == "sglang":
-        server_args = asdict(config.sglang)
-    elif rollout_alloc.backend == "vllm":
-        server_args = asdict(config.vllm)
+    if is_external:
+        ctrl_config.api_url = ext_args.external_url
+        ctrl_config.provider_api_key = ext_args.external_api_key
+        ctrl_config.model = ext_args.external_model or ext_args.external_name
+        server_args = None
     else:
-        raise ValueError(f"Unsupported rollout backend: {rollout_alloc.backend}")
+        from areal.api.alloc_mode import ModelAllocation
+
+        rollout_alloc = ModelAllocation.from_str(config.rollout.backend, name="rollout")
+        if rollout_alloc.backend == "sglang":
+            server_args = asdict(config.sglang)
+        elif rollout_alloc.backend == "vllm":
+            server_args = asdict(config.vllm)
+        else:
+            raise ValueError(f"Unsupported rollout backend: {rollout_alloc.backend}")
 
     ctrl = GatewayInferenceController(config=ctrl_config, scheduler=scheduler)
     try:
@@ -84,24 +100,44 @@ def main(args: list[str]) -> None:
 
         logger.info("Proxy gateway available at %s", ctrl.proxy_gateway_addr)
 
-        # Online mode: pass None for both data and workflow so the
-        # controller creates empty-dict placeholders and uses the
-        # online InferenceServiceWorkflow (no agent).
+        if is_external:
+            logger.info(
+                "External mode: url=%s model=%s name=%s",
+                ext_args.external_url,
+                ext_args.external_model,
+                ext_args.external_name,
+            )
+
         result = ctrl.rollout_batch(
             data=None,
             batch_size=config.train_dataset.batch_size,
             workflow=None,
         )
 
-        # Localize RTensor references into real torch tensors so we
-        # can compute aggregate reward statistics.
-        localized_rewards = [RTensor.localize(traj)["rewards"] for traj in result]
-        all_rewards = torch.cat(localized_rewards, dim=0)
-        logger.info(
-            "Rollout complete (%d trajectories), avg_reward=%.4f",
-            len(result),
-            all_rewards.mean().item(),
-        )
+        if is_external:
+            logger.info("Rollout complete (%d trajectories)", len(result))
+            for i, traj in enumerate(result):
+                interactions = traj.get("interactions", [])
+                for j, interaction in enumerate(interactions):
+                    logger.info(
+                        "Trajectory %d, interaction %d:\n  request:  %s\n  response: %s",
+                        i,
+                        j,
+                        interaction.get("request", "")[:300],
+                        interaction.get("response", "")[:300],
+                    )
+        else:
+            import torch
+
+            from areal.infra.rpc.rtensor import RTensor
+
+            localized_rewards = [RTensor.localize(traj)["rewards"] for traj in result]
+            all_rewards = torch.cat(localized_rewards, dim=0)
+            logger.info(
+                "Rollout complete (%d trajectories), avg_reward=%.4f",
+                len(result),
+                all_rewards.mean().item(),
+            )
     finally:
         ctrl.destroy()
         scheduler.delete_workers(None)

--- a/tests/experimental/inference_service/test_controller.py
+++ b/tests/experimental/inference_service/test_controller.py
@@ -27,6 +27,7 @@ class TestGatewayControllerConfig:
     def test_defaults(self):
         cfg = GatewayControllerConfig()
         assert cfg.admin_api_key is None
+        assert cfg.model == "default"
         assert cfg.consumer_batch_size == 16
         assert cfg.max_concurrent_rollouts is None
         assert cfg.max_head_offpolicyness == 0
@@ -245,6 +246,11 @@ class TestGatewayInferenceControllerConstruction:
     def test_admin_api_key_none_raises(self):
         cfg = GatewayControllerConfig()
         with pytest.raises(ValueError, match="admin_api_key must be set"):
+            GatewayInferenceController(config=cfg, scheduler=MagicMock())
+
+    def test_model_empty_raises(self):
+        cfg = GatewayControllerConfig(admin_api_key="test-key", model="")
+        with pytest.raises(ValueError, match="model must not be empty"):
             GatewayInferenceController(config=cfg, scheduler=MagicMock())
 
     def test_constructor(self):

--- a/tests/experimental/inference_service/test_controller.py
+++ b/tests/experimental/inference_service/test_controller.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from areal.api.cli_args import OpenAIProxyConfig
 from areal.experimental.inference_service.controller.config import (
     GatewayControllerConfig,
 )
@@ -27,8 +26,7 @@ from areal.experimental.inference_service.controller.workflow import (
 class TestGatewayControllerConfig:
     def test_defaults(self):
         cfg = GatewayControllerConfig()
-        assert isinstance(cfg.openai, OpenAIProxyConfig)
-        assert cfg.openai.admin_api_key == "areal-admin-key"
+        assert cfg.admin_api_key is None
         assert cfg.consumer_batch_size == 16
         assert cfg.max_concurrent_rollouts is None
         assert cfg.max_head_offpolicyness == 0
@@ -37,14 +35,13 @@ class TestGatewayControllerConfig:
 
     def test_custom_values(self):
         cfg = GatewayControllerConfig(
-            openai=OpenAIProxyConfig(admin_api_key="custom-key"),
+            admin_api_key="custom-key",
             consumer_batch_size=32,
             max_concurrent_rollouts=64,
             max_head_offpolicyness=5,
             set_reward_finish_timeout=3.0,
         )
-        assert cfg.openai is not None
-        assert cfg.openai.admin_api_key == "custom-key"
+        assert cfg.admin_api_key == "custom-key"
         assert cfg.consumer_batch_size == 32
         assert cfg.max_concurrent_rollouts == 64
         assert cfg.max_head_offpolicyness == 5
@@ -71,7 +68,7 @@ class TestGatewayControllerConfig:
 class TestControllerWorkflowResolution:
     def test_resolve_workflow_with_instance(self):
         controller = GatewayInferenceController(
-            config=GatewayControllerConfig(),
+            config=GatewayControllerConfig(admin_api_key="test-key"),
             scheduler=MagicMock(),
         )
         with pytest.raises(TypeError, match=r"callable run\(\) method"):
@@ -79,7 +76,7 @@ class TestControllerWorkflowResolution:
 
     def test_resolve_workflow_none_creates_online_inference_service_workflow(self):
         cfg = GatewayControllerConfig(
-            openai=OpenAIProxyConfig(admin_api_key="test-admin-key")
+            admin_api_key="test-admin-key",
         )
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
@@ -97,7 +94,7 @@ class TestControllerWorkflowResolution:
 
     def test_resolve_workflow_agent_class_creates_offline_workflow(self):
         cfg = GatewayControllerConfig(
-            openai=OpenAIProxyConfig(admin_api_key="test-admin-key")
+            admin_api_key="test-admin-key",
         )
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
@@ -125,7 +122,7 @@ class TestControllerWorkflowResolution:
 
     def test_resolve_workflow_with_agent_class(self):
         """Test _resolve_workflow wraps agent-like classes in InferenceServiceWorkflow."""
-        cfg = GatewayControllerConfig()
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         controller._gateway_addr = "http://test:8080"
@@ -144,7 +141,7 @@ class TestControllerWorkflowResolution:
 
     def test_resolve_workflow_agent_class_without_gateway_raises(self):
         controller = GatewayInferenceController(
-            config=GatewayControllerConfig(),
+            config=GatewayControllerConfig(admin_api_key="test-key"),
             scheduler=MagicMock(),
         )
 
@@ -157,7 +154,7 @@ class TestControllerWorkflowResolution:
 
     def test_resolve_workflow_rollout_workflow_instance_raises(self):
         controller = GatewayInferenceController(
-            config=GatewayControllerConfig(),
+            config=GatewayControllerConfig(admin_api_key="test-key"),
             scheduler=MagicMock(),
         )
         controller._gateway_addr = "http://test:8080"
@@ -175,7 +172,7 @@ class TestControllerWorkflowResolution:
 
     def test_resolve_workflow_rollout_workflow_class_raises(self):
         controller = GatewayInferenceController(
-            config=GatewayControllerConfig(),
+            config=GatewayControllerConfig(admin_api_key="test-key"),
             scheduler=MagicMock(),
         )
         controller._gateway_addr = "http://test:8080"
@@ -245,8 +242,13 @@ class TestGatewayInferenceControllerAPISurface:
 
 
 class TestGatewayInferenceControllerConstruction:
-    def test_constructor(self):
+    def test_admin_api_key_none_raises(self):
         cfg = GatewayControllerConfig()
+        with pytest.raises(ValueError, match="admin_api_key must be set"):
+            GatewayInferenceController(config=cfg, scheduler=MagicMock())
+
+    def test_constructor(self):
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
 
@@ -259,15 +261,15 @@ class TestGatewayInferenceControllerConstruction:
         assert controller._worker_ids == {}
         assert controller.worker_ids == {}
 
-    def test_admin_api_key_defaults_from_openai_proxy_config(self):
-        cfg = GatewayControllerConfig()
+    def test_admin_api_key_defaults(self):
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
-        assert controller.config.openai.admin_api_key == "areal-admin-key"
+        assert controller.config.admin_api_key == "test-key"
 
     def test_version_management_without_services(self):
         """set_version / get_version work even without gateway services."""
-        cfg = GatewayControllerConfig()
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
 
@@ -276,14 +278,14 @@ class TestGatewayInferenceControllerConstruction:
         assert controller.get_version() == 42
 
     def test_export_stats_returns_dict(self):
-        cfg = GatewayControllerConfig()
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         stats = controller.export_stats()
         assert isinstance(stats, dict)
 
     def test_start_proxy_is_noop(self):
-        cfg = GatewayControllerConfig()
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         # Should not raise
@@ -291,14 +293,14 @@ class TestGatewayInferenceControllerConstruction:
         controller.start_proxy_gateway()
 
     def test_proxy_gateway_addr(self):
-        cfg = GatewayControllerConfig()
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         # Before initialize, proxy_gateway_addr returns the empty _gateway_addr
         assert controller.proxy_gateway_addr == ""
 
     def test_callback_addr_formats_ipv6_hostport(self):
-        cfg = GatewayControllerConfig()
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         controller._callback_host = "2001:db8::10"
@@ -307,14 +309,14 @@ class TestGatewayInferenceControllerConstruction:
         assert controller.callback_addr == "[2001:db8::10]:19000"
 
     def test_workflow_executor_raises_before_init(self):
-        cfg = GatewayControllerConfig()
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         with pytest.raises(RuntimeError, match="initialize"):
             _ = controller.workflow_executor
 
     def test_config_perf_tracer_is_noop(self):
-        cfg = GatewayControllerConfig()
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         # Should not raise
@@ -347,7 +349,7 @@ class TestGatewayInferenceControllerConstruction:
                     cmd="python -m areal.experimental.inference_service.guard",
                 ),
             ),
-            openai=OpenAIProxyConfig(admin_api_key="test-admin-key"),
+            admin_api_key="test-admin-key",
         )
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         controller._callback_host = "127.0.0.1"
@@ -383,10 +385,9 @@ class TestGatewayInferenceControllerConstruction:
 
 class TestGatewayInferenceControllerHTTP:
     def test_gateway_http_post_raises_on_failure(self):
-        cfg = GatewayControllerConfig()
+        cfg = GatewayControllerConfig(admin_api_key="test-key")
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
-        # _gateway_addr points to unreachable host — should raise RuntimeError
         controller._gateway_addr = "http://127.0.0.1:19999"
         with pytest.raises(RuntimeError, match="Failed to POST"):
             controller._gateway_http_post("/test", {"key": "value"})
@@ -398,7 +399,7 @@ class TestGatewayInferenceControllerHTTP:
         mock_post.return_value = mock_resp
 
         cfg = GatewayControllerConfig(
-            openai=OpenAIProxyConfig(admin_api_key="my-secret-key")
+            admin_api_key="my-secret-key",
         )
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
@@ -416,7 +417,7 @@ class TestOnlineCallbackFlow:
     @pytest.mark.asyncio
     async def test_online_callback_without_waiter_buffers_export_request(self):
         cfg = GatewayControllerConfig(
-            openai=OpenAIProxyConfig(admin_api_key="test-admin-key")
+            admin_api_key="test-admin-key",
         )
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
@@ -437,7 +438,7 @@ class TestOnlineCallbackFlow:
     @pytest.mark.asyncio
     async def test_online_callback_settles_waiter_once(self):
         cfg = GatewayControllerConfig(
-            openai=OpenAIProxyConfig(admin_api_key="test-admin-key")
+            admin_api_key="test-admin-key",
         )
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
@@ -464,7 +465,7 @@ class TestOnlineCallbackFlow:
     @pytest.mark.asyncio
     async def test_online_callback_invalid_payload_keeps_waiter_pending(self):
         cfg = GatewayControllerConfig(
-            openai=OpenAIProxyConfig(admin_api_key="test-admin-key")
+            admin_api_key="test-admin-key",
         )
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
@@ -491,7 +492,7 @@ class TestOnlineCallbackFlow:
     @pytest.mark.asyncio
     async def test_cancelled_waiter_buffers_completed_online_result(self):
         cfg = GatewayControllerConfig(
-            openai=OpenAIProxyConfig(admin_api_key="test-admin-key")
+            admin_api_key="test-admin-key",
         )
         scheduler = MagicMock()
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
@@ -537,9 +538,6 @@ class TestInferenceServiceWorkflow:
             timeout=3.0,
         )
         workflow._grant_capacity = AsyncMock()
-        workflow._export_interactions = AsyncMock(
-            return_value={"chatcmpl-1": mock_interaction}
-        )
 
         with (
             patch(
@@ -548,8 +546,27 @@ class TestInferenceServiceWorkflow:
             patch(
                 "areal.experimental.inference_service.controller.workflow.stats_tracker"
             ) as mock_st,
+            patch(
+                "areal.experimental.inference_service.controller.workflow.deserialize_interactions"
+            ) as mock_deserialize,
         ):
-            mock_http_session = AsyncMock()
+            mock_deserialize.return_value = {"chatcmpl-1": mock_interaction}
+
+            # _run_online uses ``async with http_session.post(...)`` directly,
+            # so the mock must support the async context-manager protocol.
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json = AsyncMock(
+                return_value={"interactions": {"chatcmpl-1": {}}}
+            )
+
+            mock_cm = MagicMock()
+            mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+            mock_http_session = MagicMock()
+            mock_http_session.post = MagicMock(return_value=mock_cm)
+
             mock_wf_ctx.get_aiohttp_session = AsyncMock(return_value=mock_http_session)
             mock_wf_ctx.stat_scope.return_value = "rollout"
             mock_st.get.return_value = MagicMock()
@@ -560,11 +577,8 @@ class TestInferenceServiceWorkflow:
         assert "chatcmpl-1" in result
         workflow._grant_capacity.assert_awaited_once()
         controller.wait_for_online_trajectory.assert_awaited_once_with(timeout=3.0)
-        workflow._export_interactions.assert_awaited_once_with(
-            mock_http_session,
-            "sess-1",
-            trajectory_id=7,
-        )
+        mock_http_session.post.assert_called_once()
+        mock_deserialize.assert_called_once_with({"chatcmpl-1": {}})
 
     @pytest.mark.asyncio
     async def test_offline_mode_runs_agent(self):
@@ -632,23 +646,29 @@ class TestMultiNodeConfig:
         assert cfg.n_gpus_per_node == 4
 
     def test_n_gpus_per_node_zero_raises(self):
-        cfg = GatewayControllerConfig(n_gpus_per_node=0, backend="sglang:d1t8")
+        cfg = GatewayControllerConfig(
+            n_gpus_per_node=0, backend="sglang:d1t8", admin_api_key="test-key"
+        )
         with pytest.raises(ValueError, match="n_gpus_per_node must be >= 1"):
             GatewayInferenceController(config=cfg, scheduler=MagicMock())
 
     def test_gpus_not_divisible_raises(self):
-        cfg = GatewayControllerConfig(n_gpus_per_node=3, backend="sglang:d1t8")
+        cfg = GatewayControllerConfig(
+            n_gpus_per_node=3, backend="sglang:d1t8", admin_api_key="test-key"
+        )
         with pytest.raises(ValueError, match="must be divisible by n_gpus_per_node"):
             GatewayInferenceController(config=cfg, scheduler=MagicMock())
 
     def test_single_node_backward_compat(self):
-        cfg = GatewayControllerConfig(backend="sglang:d2t4")
+        cfg = GatewayControllerConfig(backend="sglang:d2t4", admin_api_key="test-key")
         controller = GatewayInferenceController(config=cfg, scheduler=MagicMock())
         assert controller._nnodes_per_instance == 1
 
     def test_multi_node_valid_config(self):
         # tp=16, n_gpus_per_node=8 → nnodes_per_instance=2
-        cfg = GatewayControllerConfig(n_gpus_per_node=8, backend="sglang:d1t16")
+        cfg = GatewayControllerConfig(
+            n_gpus_per_node=8, backend="sglang:d1t16", admin_api_key="test-key"
+        )
         controller = GatewayInferenceController(config=cfg, scheduler=MagicMock())
         assert controller._nnodes_per_instance == 2
 
@@ -677,7 +697,7 @@ class TestMultiNodeConfig:
             backend="sglang:d1t8",
             n_gpus_per_node=4,
             scheduling_spec=(SchedulingSpec(gpu=1, cpu=1, mem=1, cmd="mock"),),
-            openai=OpenAIProxyConfig(admin_api_key="test-key"),
+            admin_api_key="test-key",
         )
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         controller._callback_host = "127.0.0.1"
@@ -735,7 +755,7 @@ class TestMultiNodeConfig:
             backend="sglang:d1t8",
             n_gpus_per_node=4,
             scheduling_spec=(SchedulingSpec(gpu=1, cpu=1, mem=1, cmd="mock"),),
-            openai=OpenAIProxyConfig(admin_api_key="test-key"),
+            admin_api_key="test-key",
         )
         controller = GatewayInferenceController(config=cfg, scheduler=scheduler)
         controller._callback_host = "127.0.0.1"

--- a/tests/experimental/inference_service/test_controller_integration.py
+++ b/tests/experimental/inference_service/test_controller_integration.py
@@ -121,14 +121,10 @@ def _make_gateway_controller_config(
     online_mode: bool = False,
     set_reward_finish_timeout: float = 0.0,
 ):
-    from areal.api.cli_args import OpenAIProxyConfig, SchedulingSpec
+    from areal.api.cli_args import SchedulingSpec
     from areal.experimental.inference_service.controller.config import (
         GatewayControllerConfig,
     )
-
-    openai_cfg = OpenAIProxyConfig(admin_api_key="test-admin")
-    if online_mode:
-        openai_cfg = OpenAIProxyConfig(mode="online", admin_api_key="test-admin")
 
     return GatewayControllerConfig(
         tokenizer_path=model_path,
@@ -145,7 +141,7 @@ def _make_gateway_controller_config(
         consumer_batch_size=8,
         max_head_offpolicyness=1024,
         setup_timeout=180.0,
-        openai=openai_cfg,
+        admin_api_key="test-admin",
     )
 
 
@@ -630,8 +626,8 @@ class TestControllerOnlineWorkflow:
         import requests
 
         gateway_url = gateway_controller_online.proxy_gateway_addr
-        assert gateway_controller_online.config.openai is not None
-        admin_key = gateway_controller_online.config.openai.admin_api_key
+        assert gateway_controller_online.config.admin_api_key is not None
+        admin_key = gateway_controller_online.config.admin_api_key
 
         task_id = gateway_controller_online.submit(
             data={},
@@ -687,8 +683,8 @@ class TestControllerOnlineWorkflow:
         self, gateway_controller_with_reward_timeout
     ):
         gateway_url = gateway_controller_with_reward_timeout.proxy_gateway_addr
-        assert gateway_controller_with_reward_timeout.config.openai is not None
-        admin_key = gateway_controller_with_reward_timeout.config.openai.admin_api_key
+        assert gateway_controller_with_reward_timeout.config.admin_api_key is not None
+        admin_key = gateway_controller_with_reward_timeout.config.admin_api_key
 
         grant_resp = httpx.post(
             f"{gateway_url}/grant_capacity",
@@ -790,7 +786,7 @@ def gateway_controller_full_init(model_path, tmp_path_factory):
     if not has_gpu():
         pytest.skip("GPU required")
 
-    from areal.api.cli_args import OpenAIProxyConfig, SchedulingSpec
+    from areal.api.cli_args import SchedulingSpec
     from areal.experimental.inference_service.controller.config import (
         GatewayControllerConfig,
     )
@@ -810,7 +806,7 @@ def gateway_controller_full_init(model_path, tmp_path_factory):
         consumer_batch_size=8,
         max_head_offpolicyness=1024,
         setup_timeout=300.0,
-        openai=OpenAIProxyConfig(admin_api_key="test-admin"),
+        admin_api_key="test-admin",
     )
 
     server_args = {
@@ -1079,7 +1075,7 @@ def gateway_controller_full_init_vllm(model_path, tmp_path_factory):
     if not has_gpu():
         pytest.skip("GPU required")
 
-    from areal.api.cli_args import OpenAIProxyConfig, SchedulingSpec
+    from areal.api.cli_args import SchedulingSpec
     from areal.experimental.inference_service.controller.config import (
         GatewayControllerConfig,
     )
@@ -1099,7 +1095,7 @@ def gateway_controller_full_init_vllm(model_path, tmp_path_factory):
         consumer_batch_size=8,
         max_head_offpolicyness=1024,
         setup_timeout=300.0,
-        openai=OpenAIProxyConfig(admin_api_key="test-admin"),
+        admin_api_key="test-admin",
     )
 
     server_args = {
@@ -1284,7 +1280,7 @@ def gateway_controller_full_init_vlm_sglang(vlm_model_path, tmp_path_factory):
     if not has_gpu():
         pytest.skip("GPU required")
 
-    from areal.api.cli_args import OpenAIProxyConfig, SchedulingSpec
+    from areal.api.cli_args import SchedulingSpec
     from areal.experimental.inference_service.controller.config import (
         GatewayControllerConfig,
     )
@@ -1304,7 +1300,7 @@ def gateway_controller_full_init_vlm_sglang(vlm_model_path, tmp_path_factory):
         consumer_batch_size=8,
         max_head_offpolicyness=1024,
         setup_timeout=300.0,
-        openai=OpenAIProxyConfig(admin_api_key="test-admin"),
+        admin_api_key="test-admin",
     )
 
     local_scheduler = _make_local_scheduler(
@@ -1328,7 +1324,7 @@ def gateway_controller_full_init_vlm_vllm(vlm_model_path, tmp_path_factory):
     if not has_gpu():
         pytest.skip("GPU required")
 
-    from areal.api.cli_args import OpenAIProxyConfig, SchedulingSpec
+    from areal.api.cli_args import SchedulingSpec
     from areal.experimental.inference_service.controller.config import (
         GatewayControllerConfig,
     )
@@ -1348,7 +1344,7 @@ def gateway_controller_full_init_vlm_vllm(vlm_model_path, tmp_path_factory):
         consumer_batch_size=8,
         max_head_offpolicyness=1024,
         setup_timeout=300.0,
-        openai=OpenAIProxyConfig(admin_api_key="test-admin"),
+        admin_api_key="test-admin",
     )
 
     local_scheduler = _make_local_scheduler(

--- a/tests/experimental/inference_service/test_controller_version.py
+++ b/tests/experimental/inference_service/test_controller_version.py
@@ -31,6 +31,7 @@ def _make_controller(
     Does NOT call initialize() — internal fields are set directly.
     """
     cfg = GatewayControllerConfig(
+        admin_api_key="test-key",
         scheduling_spec=(SchedulingSpec(),),
     )
     scheduler = MagicMock()

--- a/tests/experimental/inference_service/test_external_model.py
+++ b/tests/experimental/inference_service/test_external_model.py
@@ -484,27 +484,29 @@ class TestDataProxyExternalEndpoints:
         resp = await data_proxy_client.post(
             "/chat/completions",
             json={"model": "ext-1", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer areal-admin-key"},
         )
         assert resp.status_code == 200
         assert resp.json()["id"] == "ext-1-response"
 
         not_ready = await data_proxy_client.post(
             "/export_trajectories",
-            json={"session_id": "ext-1"},
+            json={"session_id": "__hitl__"},
             headers={"Authorization": "Bearer areal-admin-key"},
         )
         assert not_ready.status_code == 409
 
         set_reward = await data_proxy_client.post(
             "/rl/set_reward",
-            json={"reward": 1.0, "model": "ext-1"},
+            json={"reward": 1.0},
+            headers={"Authorization": "Bearer areal-admin-key"},
         )
         assert set_reward.status_code == 200
         assert set_reward.json()["trajectory_ready"] is True
 
         exported = await data_proxy_client.post(
             "/export_trajectories",
-            json={"session_id": "ext-1"},
+            json={"session_id": "__hitl__"},
             headers={"Authorization": "Bearer areal-admin-key"},
         )
         assert exported.status_code == 200
@@ -566,20 +568,22 @@ class TestDataProxyExternalEndpoints:
                 "messages": [{"role": "user", "content": "hi"}],
                 "stream": True,
             },
+            headers={"Authorization": "Bearer areal-admin-key"},
         )
         assert resp.status_code == 200
         assert "text/event-stream" in resp.headers["content-type"]
 
         set_reward = await data_proxy_client.post(
             "/rl/set_reward",
-            json={"reward": 1.0, "model": "ext-1"},
+            json={"reward": 1.0},
+            headers={"Authorization": "Bearer areal-admin-key"},
         )
         assert set_reward.status_code == 200
         assert set_reward.json()["trajectory_ready"] is True
 
         exported = await data_proxy_client.post(
             "/export_trajectories",
-            json={"session_id": "ext-1"},
+            json={"session_id": "__hitl__"},
             headers={"Authorization": "Bearer areal-admin-key"},
         )
         assert exported.status_code == 200
@@ -588,7 +592,7 @@ class TestDataProxyExternalEndpoints:
 
         exported_again = await data_proxy_client.post(
             "/export_trajectories",
-            json={"session_id": "ext-1"},
+            json={"session_id": "__hitl__"},
             headers={"Authorization": "Bearer areal-admin-key"},
         )
         assert exported_again.status_code == 409

--- a/tests/experimental/inference_service/test_external_model.py
+++ b/tests/experimental/inference_service/test_external_model.py
@@ -1,0 +1,791 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from areal.experimental.inference_service.data_proxy.app import (
+    create_app as create_data_proxy_app,
+)
+from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
+from areal.experimental.inference_service.data_proxy.session import SessionStore
+from areal.experimental.inference_service.gateway.app import (
+    create_app as create_gateway_app,
+)
+from areal.experimental.inference_service.gateway.config import GatewayConfig
+from areal.experimental.inference_service.gateway.streaming import (
+    RouterKeyRejectedError,
+)
+from areal.experimental.inference_service.router.app import (
+    create_app as create_router_app,
+)
+from areal.experimental.inference_service.router.config import RouterConfig
+from areal.experimental.inference_service.router.state import ModelRegistry
+
+ADMIN_KEY = "test-admin-key"
+SESSION_KEY = "session-key-abc123"
+WORKER_ADDR = "http://worker-1:18082"
+ROUTER_MODULE = "areal.experimental.inference_service.gateway.app"
+
+
+def admin_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {ADMIN_KEY}"}
+
+
+def session_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {SESSION_KEY}"}
+
+
+@pytest.fixture
+def router_config() -> RouterConfig:
+    return RouterConfig(
+        host="127.0.0.1",
+        port=18081,
+        admin_api_key=ADMIN_KEY,
+        poll_interval=999,
+        routing_strategy="round_robin",
+    )
+
+
+@pytest_asyncio.fixture
+async def router_client(router_config: RouterConfig):
+    app = create_router_app(router_config)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+class TestModelRegistry:
+    @pytest.mark.asyncio
+    async def test_model_registry_register_get_list_remove(self):
+        reg = ModelRegistry()
+        await reg.register("ext-a", "http://api", None, [WORKER_ADDR])
+
+        info = await reg.get("ext-a")
+        assert info is not None
+        assert info.name == "ext-a"
+        assert info.url == "http://api"
+        assert info.data_proxy_addrs == [WORKER_ADDR]
+
+        names = await reg.list_names()
+        assert names == ["ext-a"]
+
+        removed = await reg.remove("ext-a")
+        assert removed is True
+        assert await reg.get("ext-a") is None
+
+
+class TestRouterExternalEndpoints:
+    @pytest.mark.asyncio
+    async def test_register_model_success(self, router_client):
+        await router_client.post(
+            "/register",
+            json={"worker_addr": WORKER_ADDR},
+            headers=admin_headers(),
+        )
+
+        resp = await router_client.post(
+            "/register_model",
+            json={
+                "model": "ext-1",
+                "url": "http://ext-api",
+                "data_proxy_addrs": [WORKER_ADDR],
+            },
+            headers=admin_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["model"] == "ext-1"
+        assert data["data_proxy_addrs"] == [WORKER_ADDR]
+
+    @pytest.mark.asyncio
+    async def test_register_model_no_workers_503(self, router_client):
+        resp = await router_client.post(
+            "/register_model",
+            json={"model": "ext-1", "url": "http://ext-api"},
+            headers=admin_headers(),
+        )
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_register_model_no_auth_401(self, router_client):
+        resp = await router_client.post(
+            "/register_model",
+            json={"model": "ext-1", "url": "http://ext-api"},
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_route_model_success(self, router_client):
+        await router_client.post(
+            "/register",
+            json={"worker_addr": WORKER_ADDR},
+            headers=admin_headers(),
+        )
+        await router_client.post(
+            "/register_model",
+            json={
+                "model": "ext-1",
+                "url": "http://ext-api",
+                "data_proxy_addrs": [WORKER_ADDR],
+            },
+            headers=admin_headers(),
+        )
+
+        resp = await router_client.post(
+            "/route",
+            json={"model": "ext-1"},
+            headers=admin_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["worker_addr"] == WORKER_ADDR
+        assert data["url"] == "http://ext-api"
+
+    @pytest.mark.asyncio
+    async def test_route_model_not_found_404(self, router_client):
+        resp = await router_client.post(
+            "/route",
+            json={"model": "nope"},
+            headers=admin_headers(),
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_list_models_empty(self, router_client):
+        resp = await router_client.get("/models", headers=admin_headers())
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_models_after_registration(self, router_client):
+        await router_client.post(
+            "/register",
+            json={"worker_addr": WORKER_ADDR},
+            headers=admin_headers(),
+        )
+        await router_client.post(
+            "/register_model",
+            json={
+                "model": "ext-1",
+                "url": "http://ext-api",
+                "data_proxy_addrs": [WORKER_ADDR],
+            },
+            headers=admin_headers(),
+        )
+
+        resp = await router_client.get("/models", headers=admin_headers())
+        assert resp.status_code == 200
+        assert resp.json()["models"] == ["ext-1"]
+
+
+@pytest.fixture
+def gateway_config() -> GatewayConfig:
+    return GatewayConfig(
+        host="127.0.0.1",
+        port=18080,
+        admin_api_key=ADMIN_KEY,
+        router_addr="http://mock-router:8081",
+        router_timeout=2.0,
+        forward_timeout=30.0,
+    )
+
+
+@pytest_asyncio.fixture
+async def gateway_client(gateway_config: GatewayConfig):
+    app = create_gateway_app(gateway_config)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+class TestGatewayExternalEndpoints:
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.forward_request", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.register_model_in_router", new_callable=AsyncMock)
+    async def test_register_model_gateway_full_flow(
+        self,
+        mock_register_model,
+        mock_forward,
+        gateway_client,
+    ):
+        mock_register_model.return_value = {
+            "status": "ok",
+            "model": "ext-1",
+            "data_proxy_addrs": [WORKER_ADDR],
+        }
+        mock_forward.return_value = httpx.Response(200, json={"status": "ok"})
+
+        resp = await gateway_client.post(
+            "/register_model",
+            json={"model": "ext-1", "url": "http://ext-api"},
+            headers=admin_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["data_proxy_addrs"] == [WORKER_ADDR]
+        mock_register_model.assert_called_once()
+        mock_forward.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.forward_request", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.query_router", new_callable=AsyncMock)
+    async def test_chat_completions_external_model(
+        self,
+        mock_query_router,
+        mock_forward,
+        gateway_client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+        mock_forward.return_value = httpx.Response(200, json={"id": "ext-chat-1"})
+
+        resp = await gateway_client.post(
+            "/chat/completions",
+            json={"model": "ext-1", "messages": [{"role": "user", "content": "hi"}]},
+            headers=admin_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "ext-chat-1"
+        assert "/chat/completions" in mock_forward.call_args.args[0]
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.forward_sse_stream")
+    @patch(f"{ROUTER_MODULE}.query_router", new_callable=AsyncMock)
+    async def test_chat_completions_external_model_streaming(
+        self,
+        mock_query_router,
+        mock_forward_sse,
+        gateway_client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+
+        async def _stream() -> AsyncGenerator[bytes, None]:
+            yield b"data: hello\n\n"
+            yield b"data: [DONE]\n\n"
+
+        mock_forward_sse.return_value = _stream()
+
+        resp = await gateway_client.post(
+            "/chat/completions",
+            json={
+                "model": "ext-1",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+            headers=admin_headers(),
+        )
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.forward_request", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.query_router", new_callable=AsyncMock)
+    async def test_chat_completions_unregistered_model_falls_back(
+        self,
+        mock_query_router,
+        mock_forward,
+        gateway_client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+        mock_forward.return_value = httpx.Response(200, json={"id": "internal-chat"})
+
+        resp = await gateway_client.post(
+            "/chat/completions",
+            json={
+                "model": "missing",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            headers=session_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "internal-chat"
+        assert "/chat/completions" in mock_forward.call_args.args[0]
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.forward_request", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.query_router", new_callable=AsyncMock)
+    async def test_chat_completions_no_model_internal_path(
+        self,
+        mock_query_router,
+        mock_forward,
+        gateway_client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+        mock_forward.return_value = httpx.Response(200, json={"id": "internal-chat"})
+
+        resp = await gateway_client.post(
+            "/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+            headers=session_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "internal-chat"
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.list_models_from_router", new_callable=AsyncMock)
+    async def test_list_models_gateway(self, mock_list_models, gateway_client):
+        mock_list_models.return_value = ["ext-1", "ext-2"]
+
+        resp = await gateway_client.get("/models", headers=admin_headers())
+        assert resp.status_code == 200
+        assert resp.json()["models"] == ["ext-1", "ext-2"]
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.forward_request", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.query_router", new_callable=AsyncMock)
+    async def test_export_trajectories_routes_external_by_session_id(
+        self,
+        mock_query_router,
+        mock_forward,
+        gateway_client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+        mock_forward.return_value = httpx.Response(
+            200,
+            json={
+                "interactions": {"id-1": {"messages": [], "reward": 0.0}},
+            },
+        )
+
+        resp = await gateway_client.post(
+            "/export_trajectories",
+            json={"session_id": "ext-1"},
+            headers=admin_headers(),
+        )
+        assert resp.status_code == 200
+        assert "/export_trajectories" in mock_forward.call_args.args[0]
+
+
+@pytest.fixture
+def data_proxy_config() -> DataProxyConfig:
+    return DataProxyConfig(
+        host="127.0.0.1",
+        port=18082,
+        backend_addr="http://mock-sglang:30000",
+        tokenizer_path="mock-tokenizer",
+        request_timeout=10.0,
+    )
+
+
+@pytest.fixture
+def mock_tokenizer():
+    tok = MagicMock()
+    tok._tok = MagicMock()
+    tok._tok.eos_token_id = 2
+    tok._tok.pad_token_id = 0
+    return tok
+
+
+@pytest.fixture
+def mock_areal_client():
+    from openai.types.chat import ChatCompletion, ChatCompletionMessage
+    from openai.types.chat.chat_completion import Choice
+    from openai.types.completion_usage import CompletionUsage
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(
+        return_value=ChatCompletion(
+            id="chatcmpl-mock",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    logprobs=None,
+                    message=ChatCompletionMessage(content="Hello!", role="assistant"),
+                )
+            ],
+            created=1234567890,
+            model="sglang",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=3, prompt_tokens=5, total_tokens=8),
+        )
+    )
+    return mock_client
+
+
+@pytest_asyncio.fixture
+async def data_proxy_client(data_proxy_config, mock_tokenizer, mock_areal_client):
+    from areal.experimental.inference_service.data_proxy.backend import (
+        SGLangBridgeBackend,
+    )
+    from areal.experimental.inference_service.data_proxy.inf_bridge import InfBridge
+    from areal.experimental.inference_service.data_proxy.pause import PauseState
+
+    app = create_data_proxy_app(data_proxy_config)
+    pause_state = PauseState()
+    inf_bridge = InfBridge(
+        backend=SGLangBridgeBackend(),
+        backend_addr=data_proxy_config.backend_addr,
+        pause_state=pause_state,
+        request_timeout=data_proxy_config.request_timeout,
+        max_resubmit_retries=5,
+        resubmit_wait=0.01,
+    )
+    app.state.tokenizer = mock_tokenizer
+    app.state.inf_bridge = inf_bridge
+    app.state.areal_client = mock_areal_client
+    app.state.pause_state = pause_state
+    app.state.config = data_proxy_config
+    store = SessionStore()
+    store.set_admin_key(data_proxy_config.admin_api_key)
+    app.state.session_store = store
+    app.state.version = 0
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+class TestDataProxyExternalEndpoints:
+    @pytest.mark.asyncio
+    async def test_register_external_model(self, data_proxy_client):
+        resp = await data_proxy_client.post(
+            "/register_model",
+            json={"name": "ext-1", "url": "http://ext-api", "model": "gpt-4o"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_external_chat_completions_non_streaming(
+        self,
+        data_proxy_client,
+        monkeypatch,
+    ):
+        await data_proxy_client.post(
+            "/register_model",
+            json={"name": "ext-1", "url": "http://ext-api", "model": "gpt-4o"},
+        )
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, url, json=None, headers=None):
+                assert url == "http://ext-api/chat/completions"
+                assert json["model"] == "gpt-4o"
+                return httpx.Response(200, json={"id": "ext-1-response"})
+
+        monkeypatch.setattr(
+            "areal.experimental.inference_service.data_proxy.app.httpx.AsyncClient",
+            _FakeClient,
+        )
+
+        resp = await data_proxy_client.post(
+            "/chat/completions",
+            json={"model": "ext-1", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "ext-1-response"
+
+        not_ready = await data_proxy_client.post(
+            "/export_trajectories",
+            json={"session_id": "ext-1"},
+            headers={"Authorization": "Bearer areal-admin-key"},
+        )
+        assert not_ready.status_code == 409
+
+        set_reward = await data_proxy_client.post(
+            "/rl/set_reward",
+            json={"reward": 1.0, "model": "ext-1"},
+        )
+        assert set_reward.status_code == 200
+        assert set_reward.json()["trajectory_ready"] is True
+
+        exported = await data_proxy_client.post(
+            "/export_trajectories",
+            json={"session_id": "ext-1"},
+            headers={"Authorization": "Bearer areal-admin-key"},
+        )
+        assert exported.status_code == 200
+        payload = exported.json()
+        assert len(payload["interactions"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_external_chat_completions_streaming(
+        self,
+        data_proxy_client,
+        monkeypatch,
+    ):
+        await data_proxy_client.post(
+            "/register_model",
+            json={"name": "ext-1", "url": "http://ext-api", "model": "gpt-4o"},
+        )
+
+        class _FakeStreamResponse:
+            status_code = 200
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def aread(self):
+                return b""
+
+            async def aiter_bytes(self):
+                yield b"data: chunk-1\n\n"
+                yield b"data: [DONE]\n\n"
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def stream(self, method, url, json=None, headers=None):
+                assert method == "POST"
+                assert url == "http://ext-api/chat/completions"
+                assert json["model"] == "gpt-4o"
+                return _FakeStreamResponse()
+
+        monkeypatch.setattr(
+            "areal.experimental.inference_service.data_proxy.app.httpx.AsyncClient",
+            _FakeClient,
+        )
+
+        resp = await data_proxy_client.post(
+            "/chat/completions",
+            json={
+                "model": "ext-1",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+        )
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+
+        set_reward = await data_proxy_client.post(
+            "/rl/set_reward",
+            json={"reward": 1.0, "model": "ext-1"},
+        )
+        assert set_reward.status_code == 200
+        assert set_reward.json()["trajectory_ready"] is True
+
+        exported = await data_proxy_client.post(
+            "/export_trajectories",
+            json={"session_id": "ext-1"},
+            headers={"Authorization": "Bearer areal-admin-key"},
+        )
+        assert exported.status_code == 200
+        payload = exported.json()
+        assert len(payload["interactions"]) == 1
+
+        exported_again = await data_proxy_client.post(
+            "/export_trajectories",
+            json={"session_id": "ext-1"},
+            headers={"Authorization": "Bearer areal-admin-key"},
+        )
+        assert exported_again.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_unregistered_model_falls_through_to_internal(
+        self, data_proxy_client
+    ):
+        resp = await data_proxy_client.post(
+            "/chat/completions",
+            json={
+                "model": "missing",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_external_chat_uses_stored_provider_api_key(
+        self,
+        data_proxy_client,
+        monkeypatch,
+    ):
+        await data_proxy_client.post(
+            "/register_model",
+            json={
+                "name": "ext-1",
+                "url": "http://ext-api",
+                "model": "gpt-4o",
+                "api_key": "sk-provider-key-99",
+            },
+        )
+
+        captured_headers: dict[str, str] = {}
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, url, json=None, headers=None):
+                if headers:
+                    captured_headers.update(headers)
+                return httpx.Response(200, json={"id": "ext-1-response"})
+
+        monkeypatch.setattr(
+            "areal.experimental.inference_service.data_proxy.app.httpx.AsyncClient",
+            _FakeClient,
+        )
+
+        resp = await data_proxy_client.post(
+            "/chat/completions",
+            json={"model": "ext-1", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer sk-session-key"},
+        )
+        assert resp.status_code == 200
+        assert captured_headers.get("authorization") == "Bearer sk-provider-key-99"
+
+
+@pytest.mark.asyncio
+async def test_external_model_end_to_end_register_then_chat(router_config):
+    router_app = create_router_app(router_config)
+    router_transport = httpx.ASGITransport(app=router_app)
+    async with httpx.AsyncClient(
+        transport=router_transport,
+        base_url="http://router",
+    ) as router_client:
+        await router_client.post(
+            "/register",
+            json={"worker_addr": WORKER_ADDR},
+            headers=admin_headers(),
+        )
+
+        gateway_config = GatewayConfig(
+            host="127.0.0.1",
+            port=18080,
+            admin_api_key=ADMIN_KEY,
+            router_addr="http://router",
+            router_timeout=2.0,
+            forward_timeout=30.0,
+        )
+        gateway_app = create_gateway_app(gateway_config)
+        gateway_transport = httpx.ASGITransport(app=gateway_app)
+
+        proxy_state: dict[str, dict[str, str | None]] = {}
+
+        async def _register_model_in_router(
+            router_addr: str,
+            model: str,
+            url: str,
+            api_key: str | None,
+            data_proxy_addrs: list[str],
+            admin_api_key: str,
+            timeout: float,
+        ) -> dict:
+            resp = await router_client.post(
+                "/register_model",
+                json={
+                    "model": model,
+                    "url": url,
+                    "api_key": api_key,
+                    "data_proxy_addrs": data_proxy_addrs,
+                },
+                headers=admin_headers(),
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+        async def _query_router(
+            router_addr: str,
+            api_key: str | None = None,
+            path: str | None = None,
+            timeout: float = 2.0,
+            *,
+            session_id: str | None = None,
+            admin_api_key: str | None = None,
+            model: str | None = None,
+        ) -> str:
+            if model is not None:
+                resp = await router_client.post(
+                    "/route",
+                    json={"model": model},
+                    headers=admin_headers(),
+                )
+                if resp.status_code == 404:
+                    raise RouterKeyRejectedError("not found", 404)
+                if resp.status_code == 503:
+                    raise RouterKeyRejectedError("no healthy workers", 503)
+                resp.raise_for_status()
+                return resp.json()["worker_addr"]
+            resp = await router_client.post(
+                "/route",
+                json={"api_key": api_key, "session_id": session_id},
+                headers=admin_headers(),
+            )
+            resp.raise_for_status()
+            return resp.json()["worker_addr"]
+
+        async def _forward_request(
+            upstream_url: str,
+            body: bytes,
+            headers: dict[str, str],
+            timeout: float,
+        ) -> httpx.Response:
+            if upstream_url == f"{WORKER_ADDR}/register_model":
+                data = json.loads(body)
+                proxy_state[data["name"]] = {
+                    "url": data["url"],
+                    "model": data.get("model"),
+                }
+                return httpx.Response(200, json={"status": "ok"})
+            if upstream_url == f"{WORKER_ADDR}/chat/completions":
+                data = json.loads(body)
+                assert data["model"] in proxy_state
+                return httpx.Response(200, json={"id": "ext-e2e"})
+            return httpx.Response(500, json={"error": "unexpected"})
+
+        with (
+            patch(
+                f"{ROUTER_MODULE}.register_model_in_router",
+                new=AsyncMock(side_effect=_register_model_in_router),
+            ),
+            patch(
+                f"{ROUTER_MODULE}.query_router",
+                new=AsyncMock(side_effect=_query_router),
+            ),
+            patch(
+                f"{ROUTER_MODULE}.forward_request",
+                new=AsyncMock(side_effect=_forward_request),
+            ),
+        ):
+            async with httpx.AsyncClient(
+                transport=gateway_transport,
+                base_url="http://gateway",
+            ) as gateway_client:
+                reg = await gateway_client.post(
+                    "/register_model",
+                    json={
+                        "model": "ext-1",
+                        "url": "http://ext-api",
+                    },
+                    headers=admin_headers(),
+                )
+                assert reg.status_code == 200
+
+                chat = await gateway_client.post(
+                    "/chat/completions",
+                    json={
+                        "model": "ext-1",
+                        "messages": [{"role": "user", "content": "hello"}],
+                    },
+                    headers=admin_headers(),
+                )
+                assert chat.status_code == 200
+                assert chat.json()["id"] == "ext-e2e"

--- a/tests/experimental/inference_service/test_external_model_integration.py
+++ b/tests/experimental/inference_service/test_external_model_integration.py
@@ -351,7 +351,7 @@ async def test_external_model_flow_end_to_end_gateway_router_data_proxy(router_c
 
             set_reward = await gateway_client.post(
                 "/rl/set_reward",
-                json={"reward": 1.0, "model": "ext-1"},
+                json={"reward": 1.0},
                 headers=admin_headers(),
             )
             assert set_reward.status_code == 200
@@ -359,7 +359,7 @@ async def test_external_model_flow_end_to_end_gateway_router_data_proxy(router_c
 
             exported = await gateway_client.post(
                 "/export_trajectories",
-                json={"model": "ext-1"},
+                json={"session_id": "__hitl__"},
                 headers=admin_headers(),
             )
             assert exported.status_code == 200

--- a/tests/experimental/inference_service/test_external_model_integration.py
+++ b/tests/experimental/inference_service/test_external_model_integration.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from areal.experimental.inference_service.data_proxy.app import (
+    create_app as create_data_proxy_app,
+)
+from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
+from areal.experimental.inference_service.data_proxy.session import SessionStore
+from areal.experimental.inference_service.gateway.app import (
+    create_app as create_gateway_app,
+)
+from areal.experimental.inference_service.gateway.config import GatewayConfig
+from areal.experimental.inference_service.gateway.streaming import (
+    RouterKeyRejectedError,
+)
+from areal.experimental.inference_service.router.app import (
+    create_app as create_router_app,
+)
+from areal.experimental.inference_service.router.config import RouterConfig
+
+ADMIN_KEY = "test-admin-key"
+WORKER_ADDR = "http://worker-1:18082"
+ROUTER_MODULE = "areal.experimental.inference_service.gateway.app"
+
+
+def admin_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {ADMIN_KEY}"}
+
+
+@pytest.fixture
+def router_config() -> RouterConfig:
+    return RouterConfig(
+        host="127.0.0.1",
+        port=18081,
+        admin_api_key=ADMIN_KEY,
+        poll_interval=999,
+        routing_strategy="round_robin",
+    )
+
+
+@pytest.fixture
+def gateway_config() -> GatewayConfig:
+    return GatewayConfig(
+        host="127.0.0.1",
+        port=18080,
+        admin_api_key=ADMIN_KEY,
+        router_addr="http://mock-router:8081",
+        router_timeout=2.0,
+        forward_timeout=30.0,
+    )
+
+
+@pytest_asyncio.fixture
+async def gateway_client(gateway_config: GatewayConfig):
+    app = create_gateway_app(gateway_config)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+class TestGatewayUnifiedExportTrajectories:
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.revoke_session_in_router", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.forward_request", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.query_router", new_callable=AsyncMock)
+    async def test_export_trajectories_with_session_id(
+        self,
+        mock_query_router,
+        mock_forward,
+        mock_revoke,
+        gateway_client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+        mock_forward.return_value = httpx.Response(
+            200,
+            json={
+                "interactions": {"id-1": {"messages": [], "reward": 0.0}},
+            },
+        )
+
+        resp = await gateway_client.post(
+            "/export_trajectories",
+            json={"session_id": "ext-1"},
+            headers=admin_headers(),
+        )
+
+        assert resp.status_code == 200
+        mock_query_router.assert_called_once()
+        assert "/export_trajectories" in mock_forward.call_args.args[0]
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.revoke_session_in_router", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.forward_request", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.query_router", new_callable=AsyncMock)
+    async def test_export_trajectories_internal_session(
+        self,
+        mock_query_router,
+        mock_forward,
+        mock_revoke,
+        gateway_client,
+    ):
+        mock_query_router.return_value = WORKER_ADDR
+        mock_forward.return_value = httpx.Response(200, json={"interactions": []})
+
+        resp = await gateway_client.post(
+            "/export_trajectories",
+            json={"session_id": "ses-1", "discount": 1.0, "style": "sft"},
+            headers=admin_headers(),
+        )
+
+        assert resp.status_code == 200
+        mock_query_router.assert_called_once()
+        mock_revoke.assert_called_once()
+        assert "/export_trajectories" in mock_forward.call_args.args[0]
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTER_MODULE}.revoke_session_in_router", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.forward_request", new_callable=AsyncMock)
+    @patch(f"{ROUTER_MODULE}.query_router", new_callable=AsyncMock)
+    async def test_export_trajectories_without_session_id_returns_400(
+        self,
+        mock_query_router,
+        mock_forward,
+        mock_revoke,
+        gateway_client,
+    ):
+        resp = await gateway_client.post(
+            "/export_trajectories",
+            json={"discount": 1.0},
+            headers=admin_headers(),
+        )
+
+        assert resp.status_code == 400
+        assert "session_id is required" in resp.json()["error"]
+        mock_query_router.assert_not_called()
+        mock_forward.assert_not_called()
+        mock_revoke.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_external_model_flow_end_to_end_gateway_router_data_proxy(router_config):
+    mock_external_app = FastAPI()
+
+    @mock_external_app.post("/chat/completions")
+    async def mock_chat(request: Request):
+        body = await request.json()
+        return JSONResponse(
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": 1234567890,
+                "model": body.get("model", "mock-model"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "Mock response"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            }
+        )
+
+    router_app = create_router_app(router_config)
+    data_proxy_app = create_data_proxy_app(
+        DataProxyConfig(
+            host="127.0.0.1",
+            port=18082,
+            backend_addr="http://mock-sglang:30000",
+            tokenizer_path="mock-tokenizer",
+            request_timeout=10.0,
+            admin_api_key=ADMIN_KEY,
+        )
+    )
+    data_proxy_app.state.config = DataProxyConfig(
+        host="127.0.0.1",
+        port=18082,
+        backend_addr="http://mock-sglang:30000",
+        tokenizer_path="mock-tokenizer",
+        request_timeout=10.0,
+        admin_api_key=ADMIN_KEY,
+    )
+    store = SessionStore()
+    store.set_admin_key(ADMIN_KEY)
+    data_proxy_app.state.session_store = store
+    data_proxy_app.state.version = 0
+    gateway_app = create_gateway_app(
+        GatewayConfig(
+            host="127.0.0.1",
+            port=18080,
+            admin_api_key=ADMIN_KEY,
+            router_addr="http://router",
+            router_timeout=2.0,
+            forward_timeout=30.0,
+        )
+    )
+
+    router_transport = httpx.ASGITransport(app=router_app)
+    proxy_transport = httpx.ASGITransport(app=data_proxy_app)
+    gateway_transport = httpx.ASGITransport(app=gateway_app)
+    external_transport = httpx.ASGITransport(app=mock_external_app)
+
+    async with (
+        httpx.AsyncClient(
+            transport=router_transport, base_url="http://router"
+        ) as router_client,
+        httpx.AsyncClient(
+            transport=proxy_transport, base_url="http://worker-1:18082"
+        ) as data_proxy_client,
+        httpx.AsyncClient(
+            transport=gateway_transport, base_url="http://gateway"
+        ) as gateway_client,
+        httpx.AsyncClient(
+            transport=external_transport, base_url="http://mock-external"
+        ) as external_client,
+    ):
+        await router_client.post(
+            "/register",
+            json={"worker_addr": WORKER_ADDR},
+            headers=admin_headers(),
+        )
+
+        async def _register_model_in_router(
+            router_addr: str,
+            model: str,
+            url: str,
+            api_key: str | None,
+            data_proxy_addrs: list[str],
+            admin_api_key: str,
+            timeout: float,
+        ) -> dict:
+            resp = await router_client.post(
+                "/register_model",
+                json={
+                    "model": model,
+                    "url": url,
+                    "api_key": api_key,
+                    "data_proxy_addrs": data_proxy_addrs,
+                },
+                headers=admin_headers(),
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+        async def _query_router(
+            router_addr: str,
+            api_key: str | None = None,
+            path: str | None = None,
+            timeout: float = 2.0,
+            *,
+            session_id: str | None = None,
+            admin_api_key: str | None = None,
+            model: str | None = None,
+        ) -> str:
+            payload: dict = {}
+            if model is not None:
+                payload["model"] = model
+            if session_id is not None:
+                payload["session_id"] = session_id
+            elif api_key is not None:
+                payload["api_key"] = api_key
+            resp = await router_client.post(
+                "/route",
+                json=payload,
+                headers=admin_headers(),
+            )
+            if resp.status_code in (404, 503):
+                raise RouterKeyRejectedError("routing failed", resp.status_code)
+            resp.raise_for_status()
+            return resp.json()["worker_addr"]
+
+        async def _forward_request(
+            upstream_url: str,
+            body: bytes,
+            headers: dict[str, str],
+            timeout: float,
+        ) -> httpx.Response:
+            if upstream_url.startswith(WORKER_ADDR):
+                path = upstream_url.removeprefix(WORKER_ADDR)
+                return await data_proxy_client.post(path, content=body, headers=headers)
+            return httpx.Response(500, json={"error": "unexpected upstream"})
+
+        class _ExternalClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, url, json=None, headers=None):
+                assert url == "http://mock-external/chat/completions"
+                return await external_client.post(
+                    "/chat/completions",
+                    json=json,
+                    headers=headers,
+                )
+
+        with (
+            patch(
+                f"{ROUTER_MODULE}.register_model_in_router",
+                new=AsyncMock(side_effect=_register_model_in_router),
+            ),
+            patch(
+                f"{ROUTER_MODULE}.query_router",
+                new=AsyncMock(side_effect=_query_router),
+            ),
+            patch(
+                f"{ROUTER_MODULE}.forward_request",
+                new=AsyncMock(side_effect=_forward_request),
+            ),
+            patch(
+                "areal.experimental.inference_service.data_proxy.app.httpx.AsyncClient",
+                _ExternalClient,
+            ),
+        ):
+            reg = await gateway_client.post(
+                "/register_model",
+                json={
+                    "model": "ext-1",
+                    "url": "http://mock-external",
+                },
+                headers=admin_headers(),
+            )
+            assert reg.status_code == 200
+
+            chat = await gateway_client.post(
+                "/chat/completions",
+                json={
+                    "model": "ext-1",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+                headers=admin_headers(),
+            )
+            assert chat.status_code == 200
+            assert chat.json()["id"] == "chatcmpl-mock"
+
+            set_reward = await gateway_client.post(
+                "/rl/set_reward",
+                json={"reward": 1.0, "model": "ext-1"},
+                headers=admin_headers(),
+            )
+            assert set_reward.status_code == 200
+            assert set_reward.json()["trajectory_ready"] is True
+
+            exported = await gateway_client.post(
+                "/export_trajectories",
+                json={"model": "ext-1"},
+                headers=admin_headers(),
+            )
+            assert exported.status_code == 200
+            payload = exported.json()
+            assert len(payload["interactions"]) == 1
+
+            interaction = next(iter(payload["interactions"].values()))
+            assert interaction["messages"][0]["content"] == "hello"
+            cached_response = json.loads(
+                interaction["output_message_list"][0]["content"]
+            )
+            assert (
+                cached_response["choices"][0]["message"]["content"] == "Mock response"
+            )

--- a/tests/experimental/inference_service/test_ipv6_entrypoints.py
+++ b/tests/experimental/inference_service/test_ipv6_entrypoints.py
@@ -20,6 +20,10 @@ def test_data_proxy_main_formats_ipv6_serving_addr():
         set_reward_finish_timeout=0.0,
         admin_api_key="admin-key",
         callback_server_addr="http://[::1]:19000",
+        tool_call_parser="qwen",
+        reasoning_parser="qwen3",
+        engine_max_tokens=None,
+        chat_template_type="hf",
     )
 
     with (

--- a/tests/experimental/inference_service/test_online_stack.py
+++ b/tests/experimental/inference_service/test_online_stack.py
@@ -176,6 +176,7 @@ async def online_stack(monkeypatch):
             *,
             session_id: str | None = None,
             admin_api_key: str | None = None,
+            model: str | None = None,
         ) -> str:
             del router_addr, timeout
             payload: dict[str, str] = {}


### PR DESCRIPTION
## Description

Add support for routing chat completions to external OpenAI-compatible APIs through the unified gateway/router/data-proxy stack. This enables interaction caching, reward assignment, and trajectory export for models from external providers.


### Details of Important API Changes

#### Registering an external model

Before sending chat requests to an external provider you must register it with the gateway. Registration tells the router which upstream URL to forward to and which provider-side model name to use:

```bash
curl -X POST http://127.0.0.1:<PORT>/register_model \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer <ADMIN_API_KEY>" \
    -d '{
      "name": "gpt-4o",
      "url": "https://api.openai.com/v1",
      "model": "gpt-4o-2024-08-06"
    }'
```

| Field   | Required | Description                                                                                                  |
| ------- | -------- | ------------------------------------------------------------------------------------------------------------ |
| `name`  | Yes      | A local alias used to route requests. This is the value you put in the `model` field of subsequent requests. |
| `url`   | Yes      | Base URL of the external OpenAI-compatible API (e.g. `https://api.openai.com/v1`).                           |
| `model` | No       | The model name sent to the external provider. If omitted, the `model` field is stripped from forwarded requests, letting the provider use its default. |

The gateway forwards the registration through the router (which picks a healthy data proxy worker) and then to the data proxy itself. If the data proxy registration fails the router entry is automatically rolled back.

You can list registered models with `GET /models` and remove one with `POST /remove_model` (both require the admin key).

#### Using the `model` field in requests

Once a model is registered, the `model` field in request bodies acts as the **routing key** that connects chat completions, reward assignment (which follows OpenRouter request standard), and trajectory export to the same external provider session.

**`POST /chat/completions`** (or `/v1/chat/completions`)

Include `"model": "<name>"` in the request body. The gateway checks whether `<name>` matches a registered external model. If it does, the request is proxied to the external API; otherwise it falls through to the normal session-based routing for local inference. Both streaming and non-streaming modes are supported. The `Authorization` header you provide is forwarded as-is to the external provider.

```bash
curl -X POST http://127.0.0.1:<PORT>/v1/chat/completions \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer <EXTERNAL_API_KEY>" \
    -d '{
      "model": "gpt-4o",
      "messages": [{"role": "user", "content": "Hello!"}]
    }'
```

**`POST /rl/set_reward`**

Include `"model": "<name>"` to attach a reward to the most recent interaction of that external model. When `model` is present the gateway routes by model name instead of the bearer token, so no session API key is needed.

```bash
curl -X POST http://127.0.0.1:<PORT>/rl/set_reward \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer <ADMIN_API_KEY>" \
    -d '{"model": "gpt-4o", "reward": 1.0}'
```

**`POST /export_trajectories`**

Use `"model": "<name>"` as a shorthand for `"session_id"`. The gateway translates `model` into the corresponding session ID and routes the export request to the correct data proxy:

```bash
curl -X POST http://127.0.0.1:<PORT>/export_trajectories \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer <ADMIN_API_KEY>" \
    -d '{"model": "gpt-4o"}'
```

The response includes `"external_api": true` and the raw request/response pairs (no token log-probs, since the external provider does not expose them).

## Related Issue

<!-- No linked issue found -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Key changes:
- External model registration flow: gateway -> router -> data proxy
- Proxy forwarding for streaming and non-streaming chat completions
- `ExternalSessionData` for interaction caching and trajectory export
- Controller `external_mode`: skip inference server launch, validate config
- Fail-fast on missing `external_api_key` to prevent admin key leakage
- Rollback router entry when data proxy registration fails
- Guard pause/continue against `None` `inf_bridge` in external mode
- Only cache successful external API responses
- Assert external mode requires `workflow=None` and `group_size=1`
- `/v1/chat/completions` and `/v1/models` OpenAI-compatible aliases
- HITL demo and online_rollout support for `--external-url` flags
- Comprehensive unit and integration tests (1150+ lines)

Files changed (16):
- `areal/experimental/inference_service/controller/config.py` — external model config fields
- `areal/experimental/inference_service/controller/controller.py` — external mode logic, model registration
- `areal/experimental/inference_service/controller/workflow.py` — external API trajectory passthrough
- `areal/experimental/inference_service/data_proxy/app.py` — external model endpoints, proxy forwarding
- `areal/experimental/inference_service/data_proxy/session.py` — `ExternalSessionData`, interaction cache
- `areal/experimental/inference_service/gateway/app.py` — model-based routing, /v1 aliases
- `areal/experimental/inference_service/gateway/streaming.py` — router helpers for external models
- `areal/experimental/inference_service/router/app.py` — model registry endpoints
- `areal/experimental/inference_service/router/state.py` — `ExternalModelRegistry`
- `examples/experimental/inference_service/README.md` — updated docs
- `examples/experimental/inference_service/human_in_the_loop_demo.py` — `--external-url` support
- `examples/experimental/inference_service/online_rollout.py` — `--external-url` support
- `tests/experimental/inference_service/test_controller.py` — updated controller tests
- `tests/experimental/inference_service/test_data_proxy_rtensor.py` — updated proxy tests
- `tests/experimental/inference_service/test_external_model.py` — new unit tests (755 lines)
- `tests/experimental/inference_service/test_external_model_integration.py` — new integration tests (402 lines)