### PR TITLE
fix: FSDP initialization for set-valued wrap class names

### DIFF
--- a/areal/engine/fsdp_utils/__init__.py
+++ b/areal/engine/fsdp_utils/__init__.py
@@ -65,15 +65,24 @@ def apply_fsdp2(model, fsdp_kwargs, wrap_policy):
         "PyTorch version >= 2.4 is required for using fully_shard API (FSDP2)"
     )
 
-    default_transformer_cls_names_to_wrap = getattr(model, "_no_split_modules", list())
+    def _normalize_wrap_class_names(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return list(value)
+
+    default_transformer_cls_names_to_wrap = _normalize_wrap_class_names(
+        getattr(model, "_no_split_modules", list())
+    )
     fsdp_transformer_layer_cls_to_wrap = (
         wrap_policy.transformer_layer_cls_to_wrap if wrap_policy is not None else list()
     )
+    fsdp_transformer_layer_cls_to_wrap = _normalize_wrap_class_names(
+        fsdp_transformer_layer_cls_to_wrap
+    )
     if not fsdp_transformer_layer_cls_to_wrap:
         fsdp_transformer_layer_cls_to_wrap = default_transformer_cls_names_to_wrap
-
-    if isinstance(fsdp_transformer_layer_cls_to_wrap, str):
-        fsdp_transformer_layer_cls_to_wrap = [fsdp_transformer_layer_cls_to_wrap]
 
     assert (
         len(fsdp_transformer_layer_cls_to_wrap) > 0

--- a/areal/engine/fsdp_utils/__init__.py
+++ b/areal/engine/fsdp_utils/__init__.py
@@ -70,7 +70,7 @@ def apply_fsdp2(model, fsdp_kwargs, wrap_policy):
             return []
         if isinstance(value, str):
             return [value]
-        return list(value)
+        return value if isinstance(value, list) else list(value)
 
     default_transformer_cls_names_to_wrap = _normalize_wrap_class_names(
         getattr(model, "_no_split_modules", list())


### PR DESCRIPTION
## Description

  Normalize FSDP transformer wrap class names before using them during
  initialization.

  In some cases, these names may be provided as a `set` rather than a `list` or
  `tuple`. The previous implementation assumed the value was indexable and could
  fail with:

  `TypeError: 'set' object is not subscriptable`

  This change normalizes the value before validation and wrapping logic.

  ## Related Issue

  Fixes #1186

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [ ] ⚡ Performance improvement
  - [ ] ✅ Test coverage improvement

  ## Checklist

  - [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
  - [ ] Relevant tests pass; new tests added for new functionality
  - [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
  - [ ] Branch is up to date with `main`
  - [ ] Self-reviewed via `/review-pr` command
  - [ ] This PR was created by a coding agent via `/create-pr`
  - [ ] This PR is a breaking change

  **Breaking Change Details (if applicable):**

  N/A

  ## Additional Context

  This is a minimal compatibility fix. It does not change behavior for existing
  `str` or `list` inputs.