### PR TITLE
fix: keep versioned vllm lora routes valid during runtime updates

### DIFF
--- a/areal/engine/vllm_ext/areal_vllm_server.py
+++ b/areal/engine/vllm_ext/areal_vllm_server.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import logging
+import re
+from collections import OrderedDict
 from http import HTTPStatus
 
 import uvloop
@@ -31,6 +33,7 @@ logger.setLevel(logging.INFO)
 # Global event to control generation resume/pause
 _generation_run_event = asyncio.Event()
 _generation_run_event.set()  # Initially not paused
+_LORA_VERSION_PATTERN = re.compile(r"^(?P<base>.+)-v(?P<version>\d+)$")
 
 
 class UpdateWeightsRequest(OpenAIBaseModel):
@@ -48,7 +51,7 @@ class UpdateWeightsRequestLora(OpenAIBaseModel):
     # The name of lora adaptor
     lora_name: str
     # The id of the lora adaptor in vllm
-    lora_int_id: int
+    lora_int_id: int | None = None
     # The name of the base model for lora adaptors
     base_model_name: str
     # The format to load the weights
@@ -78,7 +81,7 @@ class UpdateWeightsFromXcclRequestLora(OpenAIBaseModel):
     dtypes: list[str]
     shapes: list[list[int]]
     lora_name: str
-    lora_int_id: int
+    lora_int_id: int | None = None
     lora_target_modules: list[str] | str
     lora_rank: int
     lora_alpha: int
@@ -122,12 +125,95 @@ def _infer_runtime_lora_path(serving_models, lora_name: str, lora_int_id: int) -
     return f"xccl://{lora_name}"
 
 
+def _split_versioned_lora_name(lora_name: str) -> tuple[str, int | None]:
+    match = _LORA_VERSION_PATTERN.fullmatch(lora_name)
+    if match is None:
+        return lora_name, None
+    return match.group("base"), int(match.group("version"))
+
+
+def _get_runtime_lora_capacity(app) -> int:
+    max_loras = getattr(getattr(app.state, "args", None), "max_loras", 1)
+    return max(1, int(max_loras))
+
+
+def _get_runtime_lora_state(
+    app,
+) -> tuple[OrderedDict[str, int], dict[str, tuple[int, str | None]]]:
+    if not hasattr(app.state, "_areal_runtime_lora_slots"):
+        serving_models = getattr(app.state, "openai_serving_models", None)
+        loaded = OrderedDict()
+        if serving_models is not None:
+            for name, request in serving_models.lora_requests.items():
+                loaded[name] = request.lora_int_id
+        app.state._areal_runtime_lora_slots = loaded
+        app.state._areal_runtime_lora_pending_slots = {}
+    return (
+        app.state._areal_runtime_lora_slots,
+        app.state._areal_runtime_lora_pending_slots,
+    )
+
+
+def _choose_eviction_candidate(
+    slots: OrderedDict[str, int], incoming_lora_name: str
+) -> tuple[str, int]:
+    incoming_base, _ = _split_versioned_lora_name(incoming_lora_name)
+    for name, slot in slots.items():
+        base, _ = _split_versioned_lora_name(name)
+        if base == incoming_base:
+            return name, slot
+    return next(iter(slots.items()))
+
+
+def _reserve_runtime_lora_slot(app, lora_name: str) -> tuple[int, str | None]:
+    slots, pending = _get_runtime_lora_state(app)
+    if lora_name in pending:
+        return pending[lora_name]
+    if lora_name in slots:
+        slots.move_to_end(lora_name)
+        reservation = (slots[lora_name], None)
+        pending[lora_name] = reservation
+        return reservation
+
+    capacity = _get_runtime_lora_capacity(app)
+    used_slots = set(slots.values())
+    free_slots = [slot for slot in range(1, capacity + 1) if slot not in used_slots]
+    if free_slots:
+        reservation = (free_slots[0], None)
+    else:
+        evicted_name, evicted_slot = _choose_eviction_candidate(slots, lora_name)
+        reservation = (evicted_slot, evicted_name)
+    pending[lora_name] = reservation
+    return reservation
+
+
+def _finalize_runtime_lora_slot(
+    app,
+    *,
+    lora_name: str,
+    lora_int_id: int,
+    replaced_lora_name: str | None,
+) -> None:
+    slots, pending = _get_runtime_lora_state(app)
+    pending.pop(lora_name, None)
+    if replaced_lora_name is not None and replaced_lora_name != lora_name:
+        slots.pop(replaced_lora_name, None)
+    slots[lora_name] = lora_int_id
+    slots.move_to_end(lora_name)
+
+
+def _clear_runtime_lora_reservation(app, lora_name: str) -> None:
+    _, pending = _get_runtime_lora_state(app)
+    pending.pop(lora_name, None)
+
+
 def _register_runtime_lora_name(
     app,
     *,
     lora_name: str,
     lora_int_id: int,
     base_model_name: str | None,
+    replaced_lora_name: str | None = None,
 ) -> None:
     serving_models = getattr(app.state, "openai_serving_models", None)
     if serving_models is None:
@@ -140,8 +226,9 @@ def _register_runtime_lora_name(
     requests = serving_models.lora_requests
     runtime_lora_path = _infer_runtime_lora_path(serving_models, lora_name, lora_int_id)
 
-    # Keep at most one public name per adapter id so /v1/models and request
-    # routing reflect the current versioned adapter name.
+    if replaced_lora_name is not None and replaced_lora_name != lora_name:
+        requests.pop(replaced_lora_name, None)
+
     for name, request in list(requests.items()):
         if getattr(request, "lora_int_id", None) == lora_int_id and name != lora_name:
             del requests[name]
@@ -154,6 +241,12 @@ def _register_runtime_lora_name(
     if base_model_name is not None:
         lora_request.base_model_name = base_model_name
     requests[lora_name] = lora_request
+    _finalize_runtime_lora_slot(
+        app,
+        lora_name=lora_name,
+        lora_int_id=lora_int_id,
+        replaced_lora_name=replaced_lora_name,
+    )
     logger.info(
         "Registered runtime LoRA adapter name '%s' for adapter id %s",
         lora_name,
@@ -181,8 +274,11 @@ async def areal_update_weight(request: UpdateWeightsRequest, raw_request: Reques
 async def areal_update_weight_lora(
     request: UpdateWeightsRequestLora, raw_request: Request
 ):
+    lora_int_id, replaced_lora_name = _reserve_runtime_lora_slot(
+        raw_request.app, request.lora_name
+    )
     logger.info(
-        f"API server starts areal_update_weight_lora, lora_model_path-{request.lora_model_path}, lora_name-{request.lora_name}, lora_int_id-{request.lora_int_id}, base_model_name-{request.base_model_name}"
+        f"API server starts areal_update_weight_lora, lora_model_path-{request.lora_model_path}, lora_name-{request.lora_name}, lora_int_id-{lora_int_id}, base_model_name-{request.base_model_name}"
     )
     llm = raw_request.app.state.engine_client
     await llm.pause_generation(wait_for_inflight_requests=False, clear_cache=True)
@@ -194,10 +290,23 @@ async def areal_update_weight_lora(
             args=(
                 request.lora_model_path,
                 request.lora_name,
-                request.lora_int_id,
+                lora_int_id,
                 request.base_model_name,
             ),
         )
+        if all(success for success, _ in ret_list):
+            _register_runtime_lora_name(
+                raw_request.app,
+                lora_name=request.lora_name,
+                lora_int_id=lora_int_id,
+                base_model_name=request.base_model_name,
+                replaced_lora_name=replaced_lora_name,
+            )
+        else:
+            _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+    except Exception:
+        _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+        raise
     finally:
         await llm.resume_generation()
 
@@ -221,6 +330,9 @@ async def areal_update_weight_xccl(raw_request: Request):
 async def areal_update_weight_lora_xccl(
     request: UpdateWeightsFromXcclRequestLora, raw_request: Request
 ):
+    lora_int_id, replaced_lora_name = _reserve_runtime_lora_slot(
+        raw_request.app, request.lora_name
+    )
     logger.info("API server starts areal_update_weight_lora_xccl")
     llm = raw_request.app.state.engine_client
     await llm.pause_generation(wait_for_inflight_requests=False, clear_cache=True)
@@ -232,9 +344,15 @@ async def areal_update_weight_lora_xccl(
             _register_runtime_lora_name(
                 raw_request.app,
                 lora_name=request.lora_name,
-                lora_int_id=request.lora_int_id,
+                lora_int_id=lora_int_id,
                 base_model_name=request.base_model_name,
+                replaced_lora_name=replaced_lora_name,
             )
+        else:
+            _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+    except Exception:
+        _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+        raise
     finally:
         await llm.resume_generation()
 
@@ -283,8 +401,9 @@ async def areal_set_weight_meta_xccl(
 async def areal_set_weight_meta_xccl_lora(
     request: UpdateWeightsFromXcclRequestLora, raw_request: Request
 ):
+    lora_int_id, _ = _reserve_runtime_lora_slot(raw_request.app, request.lora_name)
     logger.info(
-        f"API server starts areal_set_update_weight_meta_lora for {request.lora_name} with id {request.lora_int_id}"
+        f"API server starts areal_set_update_weight_meta_lora for {request.lora_name} with id {lora_int_id}"
     )
     llm = raw_request.app.state.engine_client
     ret_list = await llm.collective_rpc(
@@ -295,7 +414,7 @@ async def areal_set_weight_meta_xccl_lora(
             request.shapes,
             request.group_name,
             request.lora_name,
-            request.lora_int_id,
+            lora_int_id,
             request.lora_target_modules,
             request.lora_rank,
             request.lora_alpha,

--- a/areal/engine/vllm_ext/vllm_worker_extension.py
+++ b/areal/engine/vllm_ext/vllm_worker_extension.py
@@ -57,12 +57,13 @@ class VLLMWorkerExtension:
         )
         try:
             # load lora weight
-            self.model_runner.lora_manager.remove_adapter(lora_int_id)
+            adapter_ids = self.model_runner.lora_manager.list_adapters()
             lora_request = LoRARequest(
                 lora_name=lora_name,
                 lora_int_id=lora_int_id,
                 lora_path=lora_model_path,
                 base_model_name=base_model_name,
+                load_inplace=lora_int_id in adapter_ids,
             )
             logger.info(f"Reloading lora weights with request {lora_request}")
             self.model_runner.add_lora(lora_request)
@@ -171,24 +172,17 @@ class VLLMWorkerExtension:
         lora_int_id = self.areal_lora_int_id
 
         try:
-            # Check if LoRA manager and adapter exist
+            # Check if LoRA manager is initialized.
             if self.model_runner.lora_manager is None:
                 raise RuntimeError("LoRA manager is not initialized")
 
-            # Check if the LoRA adapter exists
             adapter_ids = self.model_runner.lora_manager.list_adapters()
             if lora_int_id not in adapter_ids:
-                raise RuntimeError(
-                    f"LoRA adapter {lora_int_id} not found. Available: {adapter_ids}"
+                logger.info(
+                    "LoRA adapter %s not found. Available: %s. Creating a new adapter slot.",
+                    lora_int_id,
+                    adapter_ids,
                 )
-
-            # Get the currently registered LoRA model (used for diagnostics).
-            lora_model = (
-                self.model_runner.lora_manager._adapter_manager._registered_adapters[
-                    lora_int_id
-                ]
-            )
-            logger.info(f"Found LoRA model with {len(lora_model.loras)} LoRA modules")
 
             # Receive all weights via XCCL broadcast
             logger.info(f"Receiving {len(names)} LoRA parameters via XCCL")
@@ -267,7 +261,8 @@ class VLLMWorkerExtension:
                 ),
             )
 
-            self.model_runner.lora_manager.remove_adapter(lora_int_id)
+            if lora_int_id in adapter_ids:
+                self.model_runner.lora_manager.remove_adapter(lora_int_id)
 
             self.model_runner.lora_manager._adapter_manager._add_adapter(new_lora_model)
             self.model_runner.lora_manager._adapter_manager.activate_adapter(
@@ -277,11 +272,6 @@ class VLLMWorkerExtension:
                 f"Updated New LoRA model with {len(new_lora_model.loras)} LoRA modules "
                 f"from {len(merged_weights)} tensors across {len(self.weight_update_groups)} groups"
             )
-            if len(new_lora_model.loras) != len(lora_model.loras):
-                logger.warning(
-                    f"Number of modules in the new LoRA model ({len(new_lora_model.loras)}) "
-                    f"does not match the old LoRA model ({len(lora_model.loras)})."
-                )
 
             self.sync()
             return True, "Success"

--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -131,10 +131,11 @@ class VLLMBackend:
             if meta.version is None:
                 raise ValueError("Version is required for LoRA update.")
             lora_name = get_versioned_lora_name(meta.lora_name, meta.version)
-            endpoint = "/v1/load_lora_adapter"
+            endpoint = "/areal_update_weights_lora"
             payload = {
-                "lora_path": str(meta.path),
+                "lora_model_path": str(meta.path),
                 "lora_name": lora_name,
+                "base_model_name": meta.base_model_name,
             }
         else:
             endpoint = "/areal_update_weights"
@@ -165,7 +166,6 @@ class VLLMBackend:
             lora_name = get_versioned_lora_name(meta.lora_name, meta.version)
             lora_payload = {
                 "lora_name": lora_name,
-                "lora_int_id": meta.lora_int_id,
                 "lora_target_modules": meta.peft_config["target_modules"],
                 "lora_rank": meta.peft_config["r"],
                 "lora_alpha": meta.peft_config["lora_alpha"],


### PR DESCRIPTION
## Description

  This PR fixes a vLLM LoRA routing issue where runtime weight updates can invalidate versioned LoRA model routes while rollout requests are still in flight.

  The root cause is that AReaL previously reused a single vLLM adapter id for multiple LoRA versions. During a runtime update, the old adapter slot could be replaced by the new version, while some rollout requests were still targeting the older versioned route (for example `lora_name-
  vN`). That led to 404 failures on the OpenAI-compatible endpoint.

  This PR keeps versioned LoRA route names unchanged and makes the vLLM integration preserve one adapter slot per LoRA version during runtime updates.

  The main changes are:
  - assign a stable vLLM adapter id for each LoRA version in the vLLM backend
  - allow the worker update path to create a new adapter slot when the incoming version id is not loaded yet
  - keep the existing replace behavior only when the same adapter id already exists

  This keeps the fix scoped to the vLLM integration layer and avoids changing the public LoRA naming scheme.

  ## Related Issue

  Fixes #1193

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [ ] ⚡ Performance improvement
  - [ ] ✅ Test coverage improvement

  ## Checklist

  - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
  - [ ] Relevant tests pass; new tests added for new functionality
  - [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
  - [x] Branch is up to date with `main`
  - [ ] Self-reviewed via `/review-pr` command
  - [ ] This PR was created by a coding agent via `/create-pr`
  - [ ] This PR is a breaking change

  **Breaking Change Details (if applicable):**

  N/A

  ## Additional Context

  This issue is specific to the current vLLM integration path. The SGLang backend does not exhibit the same failure mode here because versioned LoRA adapters can coexist there, so loading a newer version does not immediately invalidate older versioned adapter names.