### PR TITLE
fix: serialize ray object refs in rpc payloads

### DIFF
--- a/areal/infra/rpc/serialization.py
+++ b/areal/infra/rpc/serialization.py
@@ -29,6 +29,11 @@ import torch
 from pydantic import BaseModel, Field
 
 try:
+    import ray
+except ImportError:  # pragma: no cover - optional in non-ray setups
+    ray = None
+
+try:
     from PIL import Image
     from PIL.Image import Image as ImageObject
 except ImportError:  # pragma: no cover - optional dependency for non-VLM setups
@@ -246,6 +251,26 @@ class SerializedPILImage(BaseModel):
             image = image.convert(self.mode)
 
         return image
+
+
+class SerializedRayObjectRef(BaseModel):
+    """Pydantic model for serialized ray.ObjectRef handles."""
+
+    type: Literal["ray_object_ref"] = Field(default="ray_object_ref")
+    data: str
+
+    @classmethod
+    def from_object_ref(cls, ref: Any) -> "SerializedRayObjectRef":
+        if ray is None:
+            raise RuntimeError("ray is required to serialize ObjectRef")
+        payload = ray.cloudpickle.dumps(ref)
+        return cls(data=base64.b64encode(payload).decode("utf-8"))
+
+    def to_object_ref(self) -> Any:
+        if ray is None:
+            raise RuntimeError("ray is required to deserialize ObjectRef")
+        payload = base64.b64decode(self.data.encode("utf-8"))
+        return ray.cloudpickle.loads(payload)
 
 
 class SerializedDataclass(BaseModel):
@@ -569,6 +594,11 @@ def serialize_value(value: Any) -> Any:
     if ImageObject is not None and isinstance(value, ImageObject):
         return SerializedPILImage.from_image(value).model_dump()
 
+    # Handle Ray object references when HTTP RPC needs to carry RTensor shard
+    # handles across processes.
+    if ray is not None and isinstance(value, ray.ObjectRef):
+        return SerializedRayObjectRef.from_object_ref(value).model_dump()
+
     # Handle dataclass instances (check before dict, as dataclasses can be dict-like)
     # Note: is_dataclass returns True for both classes and instances, so check it's not a type
     if is_dataclass(value) and not isinstance(value, type):
@@ -696,6 +726,16 @@ def deserialize_value(value: Any) -> Any:
             except Exception as e:
                 logger.warning(
                     f"Failed to deserialize PIL image, treating as regular dict: {e}"
+                )
+
+        # Check for SerializedRayObjectRef marker
+        if value.get("type") == "ray_object_ref":
+            try:
+                serialized_ref = SerializedRayObjectRef.model_validate(value)
+                return serialized_ref.to_object_ref()
+            except Exception as e:
+                logger.warning(
+                    f"Failed to deserialize ray.ObjectRef, treating as regular dict: {e}"
                 )
 
         # Check for SerializedTensor marker

--- a/areal/infra/rpc/serialization.py
+++ b/areal/infra/rpc/serialization.py
@@ -29,11 +29,6 @@ import torch
 from pydantic import BaseModel, Field
 
 try:
-    import ray
-except ImportError:  # pragma: no cover - optional in non-ray setups
-    ray = None
-
-try:
     from PIL import Image
     from PIL.Image import Image as ImageObject
 except ImportError:  # pragma: no cover - optional dependency for non-VLM setups
@@ -261,14 +256,14 @@ class SerializedRayObjectRef(BaseModel):
 
     @classmethod
     def from_object_ref(cls, ref: Any) -> "SerializedRayObjectRef":
-        if ray is None:
-            raise RuntimeError("ray is required to serialize ObjectRef")
+        import ray.cloudpickle
+
         payload = ray.cloudpickle.dumps(ref)
         return cls(data=base64.b64encode(payload).decode("utf-8"))
 
     def to_object_ref(self) -> Any:
-        if ray is None:
-            raise RuntimeError("ray is required to deserialize ObjectRef")
+        import ray.cloudpickle
+
         payload = base64.b64decode(self.data.encode("utf-8"))
         return ray.cloudpickle.loads(payload)
 
@@ -596,7 +591,9 @@ def serialize_value(value: Any) -> Any:
 
     # Handle Ray object references when HTTP RPC needs to carry RTensor shard
     # handles across processes.
-    if ray is not None and isinstance(value, ray.ObjectRef):
+    import ray
+
+    if isinstance(value, ray.ObjectRef):
         return SerializedRayObjectRef.from_object_ref(value).model_dump()
 
     # Handle dataclass instances (check before dict, as dataclasses can be dict-like)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -13,6 +13,11 @@ from tests.utils import get_model_path
 
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
 
+try:
+    import ray
+except ImportError:  # pragma: no cover - optional in non-ray setups
+    ray = None
+
 
 @dataclass
 class SampleData:
@@ -175,6 +180,20 @@ class TestSerializationRoundTrip:
         assert deserialized["dataclass"].name == "nested"
         assert torch.equal(deserialized["list"][0], payload["list"][0])
         assert deserialized["meta"]["text"] == "value"
+
+    @pytest.mark.skipif(ray is None, reason="Ray not installed")
+    def test_ray_object_ref_roundtrip(self):
+        """Ray ObjectRef handles should round-trip through RPC serialization."""
+        ray.init(local_mode=True, ignore_reinit_error=True)
+        try:
+            original = ray.put({"value": 123})
+            serialized = serialize_value({"ref": original})
+            assert serialized["ref"]["type"] == "ray_object_ref"
+
+            deserialized = deserialize_value(serialized)
+            assert ray.get(deserialized["ref"]) == {"value": 123}
+        finally:
+            ray.shutdown()
 
     @pytest.mark.skipif(
         not hasattr(torch, "cuda") or not torch.cuda.is_available(),

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,6 +5,7 @@ from io import BytesIO
 
 import numpy as np
 import pytest
+import ray
 import torch
 from PIL import Image
 from transformers import AutoTokenizer
@@ -12,11 +13,6 @@ from transformers import AutoTokenizer
 from tests.utils import get_model_path
 
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
-
-try:
-    import ray
-except ImportError:  # pragma: no cover - optional in non-ray setups
-    ray = None
 
 
 @dataclass
@@ -181,7 +177,6 @@ class TestSerializationRoundTrip:
         assert torch.equal(deserialized["list"][0], payload["list"][0])
         assert deserialized["meta"]["text"] == "value"
 
-    @pytest.mark.skipif(ray is None, reason="Ray not installed")
     def test_ray_object_ref_roundtrip(self):
         """Ray ObjectRef handles should round-trip through RPC serialization."""
         ray.init(local_mode=True, ignore_reinit_error=True)


### PR DESCRIPTION
  ## Description

  This PR fixes an RPC serialization bug where workflow results containing `ray.ObjectRef` values can fail during JSON response encoding.

  The RPC payload serialization layer did not explicitly support `ray.ObjectRef`, so these values could reach the Flask JSON response path unchanged and trigger:

  `Object of type ObjectRef is not JSON serializable`

  This PR adds explicit serialization and deserialization support for `ray.ObjectRef` and includes a round-trip test.

  ## Related Issue

  Fixes #1194

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [ ] ⚡ Performance improvement
  - [x] ✅ Test coverage improvement

  ## Checklist

  - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
  - [ ] Relevant tests pass; new tests added for new functionality
  - [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
  - [x] Branch is up to date with `main`
  - [ ] Self-reviewed via `/review-pr` command
  - [ ] This PR was created by a coding agent via `/create-pr`
  - [ ] This PR is a breaking change

  **Breaking Change Details (if applicable):**

  N/A

  ## Additional Context

  This fixes failures such as:

  - `Object of type ObjectRef is not JSON serializable`
  - `Failed to call method 'wait_for_task' on worker 'rollout/0'`