### PR TITLE
fix: handle integer device ids in ray rpc server

### DIFF
--- a/areal/infra/rpc/ray_rpc_server.py
+++ b/areal/infra/rpc/ray_rpc_server.py
@@ -45,6 +45,11 @@ class RayRPCServer:
 
         return current_platform.current_device()
 
+    def _get_device_type(self) -> str:
+        from areal.infra.platforms import current_platform
+
+        return current_platform.device_type
+
     def _should_broadcast_payload(
         self,
         engine: TrainEngine | InferenceEngine,
@@ -181,7 +186,7 @@ class RayRPCServer:
             if (
                 isinstance(engine, TrainEngine)
                 and engine.initialized
-                and self._get_device().type != "cpu"
+                and self._get_device_type() != "cpu"
             ):
                 from areal.infra.platforms import current_platform
 


### PR DESCRIPTION
## Description

  This PR fixes a RayRPCServer bug where device type detection can fail when `current_device()` returns an integer device id instead of an object with a `.type` attribute.

  The previous logic assumed that `self._get_device()` always returned a device-like object and accessed `.type` directly. In some execution paths this value is an integer, which caused:

  `AttributeError: 'int' object has no attribute 'type'`

  This PR makes device type detection robust for integer device ids and avoids the attribute access failure.

  ## Related Issue

  Fixes #1195

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [ ] ⚡ Performance improvement
  - [ ] ✅ Test coverage improvement

  ## Checklist

  - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
  - [ ] Relevant tests pass; new tests added for new functionality
  - [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
  - [x] Branch is up to date with `main`
  - [ ] Self-reviewed via `/review-pr` command
  - [ ] This PR was created by a coding agent via `/create-pr`
  - [ ] This PR is a breaking change

  **Breaking Change Details (if applicable):**

  N/A

  ## Additional Context

  This fixes failures such as:

  - `AttributeError: 'int' object has no attribute 'type'`