### PR TITLE
chore: add @CormickKneey as maintainer and agent_service codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 /areal/api/                 @garrett4wade
 /areal/engine/              @rchardx
 /areal/experimental/inference_service        @nuzant
+/areal/experimental/agent_service/          @CormickKneey
 /areal/infra/               @garrett4wade
 /areal/models/              @rchardx
 /areal/trainer/             @garrett4wade

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,6 +23,7 @@ project.
 | Zhiyu Mei    | AReaL Team, Ant Group     | @nuzant       |
 | Xujie Shen   | AReaL Team, Ant Group     | @fishcrap     |
 | Tongkai Yang | AReaL Team, Ant Group     | @fredy12      |
+| Han Jiang    | AReaL Team, Ant Group     | @CormickKneey |
 
 ### Lead Maintainer (BDFL)
 


### PR DESCRIPTION
## Description

Add Han Jiang (@CormickKneey) as a project maintainer and assign codeownership for `areal/experimental/agent_service/`.

**Key changes:**
- **GOVERNANCE.md**: Add Han Jiang (@CormickKneey, AReaL Team, Ant Group) to the maintainers table
- **.github/CODEOWNERS**: Add `/areal/experimental/agent_service/` owned by @CormickKneey

## Related Issue

N/A — governance update.

## Type of Change

- [x] ♻️ Refactoring

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

No code changes — governance and codeownership metadata only.