### PR TITLE
docs: clarify backend field is required, no implicit inheritance

### DIFF
--- a/docs/en/reference/alloc_mode.md
+++ b/docs/en/reference/alloc_mode.md
@@ -30,17 +30,18 @@ rollout:
 actor:
   backend: "fsdp:d8"
 
-# Critic engine (falls back to actor.backend if empty)
+# Critic engine (use YAML interpolation to share actor's backend)
 critic:
-  backend: ""
+  backend: "${actor.backend}"
 
-# Ref engine (falls back to actor.backend if empty)
+# Ref engine (use YAML interpolation to share actor's backend)
 ref:
-  backend: ""
+  backend: "${actor.backend}"
 ```
 
-When `critic.backend` or `ref.backend` is empty, it automatically inherits from
-`actor.backend`.
+The `backend` field is required for all engines. To reuse the actor's backend
+configuration, use OmegaConf interpolation `${actor.backend}` as shown above.
+There is no implicit fallback—an empty or missing `backend` value will raise an error.
 
 > **Note:** The top-level `allocation_mode` config field is deprecated and only retained
 > for backward compatibility with legacy SPMD launchers (local/ray/slurm). It is ignored


### PR DESCRIPTION
## Summary

Clarify that `critic.backend` and `ref.backend` do not automatically inherit from `actor.backend`. The `backend` field has `default=MISSING` (required), and there is no code-level fallback. Users should use OmegaConf interpolation `${actor.backend}` to share the actor backend.

The previous docs showed `backend: ""` and claimed it would "automatically inherit", which would actually cause a runtime error since `MISSING` requires an explicit value.

## Verification

- Confirmed `TrainEngineConfig.backend` has `default=MISSING` at `cli_args.py:1131`
- All example YAMLs use explicit `${actor.backend}` interpolation (e.g., `gsm8k_ppo.yaml:85`)
- No `__post_init__` or resolver implements fallback logic

## Test plan

- [ ] `pre-commit run --all-files` passes
- [ ] `./docs/build_all.sh` builds without errors

Ref: #1165 (Finding #1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)