### PR TITLE
docs: fix tree packing algorithm name and token alignment constraint

### DIFF
--- a/docs/en/reference/tree_training.md
+++ b/docs/en/reference/tree_training.md
@@ -50,8 +50,10 @@ actor:
 | `pad_to_maximum`            | bool | Yes      | Must be `true` for tree training   |
 | `mb_spec.max_tokens_per_mb` | int  | Yes      | Max tokens per tree (must be set)  |
 
-NOTE: When tree training is enabled `max_tokens_per_mb` must be a multiple of
-`BLOCK_SIZE` (128).
+NOTE: When tree training is enabled, `max_tokens_per_mb` must be a multiple of
+`lcm(BLOCK_SIZE, parallel_size)`, where `BLOCK_SIZE` is 128 and
+`parallel_size = tp_size × sp_size`. In most configurations where `parallel_size`
+divides 128, this simplifies to a multiple of 128.
 
 ## Implementation
 
@@ -72,7 +74,7 @@ Seq2: [A, G, H]                [B] [G]                  tokens can attend to
 The tree building process:
 
 1. **Extract sequences**: Parse input_ids using attention_mask to get actual tokens
-1. **Greedy packing**: Insert sequences into tries using first-fit decreasing strategy
+1. **Greedy packing**: Insert sequences into tries using a first-fit strategy
 1. **Trie compression**: Merge linear chains into single compressed nodes
 1. **Mask generation**: Build block masks for efficient FlexAttention computation
 


### PR DESCRIPTION
## Summary

Two corrections to the tree training reference documentation:

1. **Packing algorithm**: Change "first-fit decreasing" to "first-fit". The code in `_greedy_build_tries()` iterates sequences in original order without sorting by decreasing size. (A proper FFD implementation exists in `areal/utils/seqpack.py` for trajectory redistribution, but tree packing intentionally uses plain first-fit to preserve prefix locality.)

2. **Token alignment constraint**: Document the full constraint `lcm(BLOCK_SIZE, parallel_size)` instead of just `BLOCK_SIZE` (128). In most configurations where `parallel_size` divides 128 this equals 128, but the actual code at `tree.py:341` uses `math.lcm()` which can be stricter with unusual parallel configs.

## Verification

- Confirmed no sort step in `_greedy_build_tries()` at `tree.py:476-523`
- Confirmed `math.lcm(BLOCK_SIZE, parallel_size)` at `tree.py:341`
- Git history shows no sort step was ever present or removed

## Test plan

- [ ] `pre-commit run --all-files` passes
- [ ] `./docs/build_all.sh` builds without errors

Ref: #1165 (Findings #6, #7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)