### PR TITLE
fix(infra): move data service seed to worker-level config

### DIFF
--- a/areal/infra/data_service/controller/config.py
+++ b/areal/infra/data_service/controller/config.py
@@ -27,14 +27,16 @@ class DataServiceConfig:
     )
     setup_timeout: float = 120.0
     dataloader_num_workers: int = 4
+    seed: int = 42
 
     @staticmethod
-    def from_dataset_config(dataset_config) -> DataServiceConfig:
+    def from_dataset_config(dataset_config, seed: int = 42) -> DataServiceConfig:
         """Build from a ``_DatasetConfig`` instance."""
         return DataServiceConfig(
             num_workers=max(dataset_config.num_dataset_workers, 1),
             scheduling_spec=dataset_config.scheduling_spec,
             dataloader_num_workers=max(dataset_config.num_workers, 0),
+            seed=seed,
         )
 
 

--- a/areal/infra/data_service/controller/controller.py
+++ b/areal/infra/data_service/controller/controller.py
@@ -141,6 +141,8 @@ class DataController:
                             str(num_dataset_workers),
                             "--dataloader-num-workers",
                             str(cfg.dataloader_num_workers),
+                            "--seed",
+                            str(cfg.seed),
                         ],
                     )
                     for rank in range(num_dataset_workers)
@@ -241,7 +243,6 @@ class DataController:
         dataset_kwargs: dict[str, Any] | None = None,
         tokenizer_or_processor_path: str = "",
         split: str = "train",
-        seed: int = 42,
         shuffle: bool = True,
         drop_last: bool = True,
         max_length: int | None = None,
@@ -257,7 +258,6 @@ class DataController:
             "dataset_type": dataset_type,
             "split": split,
             "tokenizer_or_processor_path": tokenizer_or_processor_path,
-            "seed": seed,
             "max_length": max_length,
             "shuffle": shuffle,
             "drop_last": drop_last,

--- a/areal/infra/data_service/rdataset.py
+++ b/areal/infra/data_service/rdataset.py
@@ -203,7 +203,6 @@ class RDataset:
         controller: DataController,
         dataset_id: str,
         tokenizer_or_processor_path: str = "",
-        seed: int = 42,
         shuffle: bool = True,
         drop_last: bool = True,
         prefetch_chunk_size: int = 64,
@@ -226,7 +225,6 @@ class RDataset:
             max_length=self._max_length,
             dataset_kwargs=self._dataset_kwargs,
             tokenizer_or_processor_path=tokenizer_or_processor_path,
-            seed=seed,
             shuffle=shuffle,
             drop_last=drop_last,
         )

--- a/areal/infra/data_service/types.py
+++ b/areal/infra/data_service/types.py
@@ -14,7 +14,6 @@ class WorkerLoadDatasetRequest(BaseModel):
     dataset_type: str
     split: str = "train"
     tokenizer_or_processor_path: str = ""
-    seed: int = 42
     max_length: int | None = None
     shuffle: bool = True
     drop_last: bool = True

--- a/areal/infra/data_service/worker/__main__.py
+++ b/areal/infra/data_service/worker/__main__.py
@@ -15,6 +15,7 @@ def main():
     parser.add_argument("--rank", type=int, default=0)
     parser.add_argument("--world-size", type=int, default=1)
     parser.add_argument("--dataloader-num-workers", type=int, default=4)
+    parser.add_argument("--seed", type=int, default=42)
     args, _ = parser.parse_known_args()
 
     app_module = importlib.import_module("areal.infra.data_service.worker.app")
@@ -28,6 +29,7 @@ def main():
         rank=args.rank,
         world_size=args.world_size,
         dataloader_num_workers=args.dataloader_num_workers,
+        seed=args.seed,
     )
     uvicorn = importlib.import_module("uvicorn")
 

--- a/areal/infra/data_service/worker/app.py
+++ b/areal/infra/data_service/worker/app.py
@@ -45,11 +45,21 @@ class _DatasetState:
     sampler: DistributedSampler | None
     epoch: int
     exhausted: bool
+    unloading: bool = False
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 def create_worker_app(config: DataWorkerConfig) -> FastAPI:
+    # --- Concurrency model ---
+    # datasets_lock : guards dict mutations (add/remove entries) and the
+    #                 _loading_ids reservation set.
+    # state.lock    : guards per-dataset state operations (epoch reset,
+    #                 state save/load).
+    # Lock ordering : datasets_lock → state.lock (never reverse).
+    # Seed is set once at startup in lifespan(); per-epoch determinism
+    # is handled by DistributedSampler.set_epoch(), not by re-seeding.
     datasets: dict[str, _DatasetState] = {}
+    _loading_ids: set[str] = set()
     datasets_lock = asyncio.Lock()
 
     @asynccontextmanager
@@ -71,6 +81,17 @@ def create_worker_app(config: DataWorkerConfig) -> FastAPI:
                 status_code=404, detail=f"Unknown dataset_id: {dataset_id}"
             )
         return state
+
+    @asynccontextmanager
+    async def _locked_active_state(dataset_id: str):
+        state = _require_dataset(dataset_id)
+        async with state.lock:
+            if state.unloading:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Dataset {dataset_id} is unloading",
+                )
+            yield state
 
     @app.get("/health")
     async def health():
@@ -121,15 +142,31 @@ def create_worker_app(config: DataWorkerConfig) -> FastAPI:
             )
             return _dataset, _sampler, _dataloader
 
+        # Phase 1: Reserve the dataset ID under lock (fast).
         async with datasets_lock:
             if body.dataset_id in datasets:
                 raise HTTPException(
                     status_code=409,
                     detail=f"Dataset {body.dataset_id} is already loaded",
                 )
+            if body.dataset_id in _loading_ids:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Dataset {body.dataset_id} is currently loading",
+                )
+            _loading_ids.add(body.dataset_id)
 
+        # Phase 2: Load dataset outside lock (slow I/O).
+        try:
             dataset, sampler, dataloader = await asyncio.to_thread(_load_sync)
+        except Exception:
+            async with datasets_lock:
+                _loading_ids.discard(body.dataset_id)
+            raise
 
+        # Phase 3: Store the result under lock (fast).
+        async with datasets_lock:
+            _loading_ids.discard(body.dataset_id)
             datasets[body.dataset_id] = _DatasetState(
                 dataset_id=body.dataset_id,
                 raw_dataset=dataset,
@@ -147,35 +184,54 @@ def create_worker_app(config: DataWorkerConfig) -> FastAPI:
 
     @app.post("/v1/samples/fetch")
     async def fetch_samples(body: FetchSamplesRequest):
-        state = _require_dataset(body.dataset_id)
-        samples = [serialize_value(state.raw_dataset[idx]) for idx in body.indices]
-        return {"samples": samples}
+        async with _locked_active_state(body.dataset_id) as state:
+            samples = [serialize_value(state.raw_dataset[idx]) for idx in body.indices]
+            return {"samples": samples}
 
     @app.post("/datasets/unload")
     async def unload_dataset(body: WorkerUnloadDatasetRequest):
+        # Phase 1: look up state under datasets_lock (fast).
         async with datasets_lock:
-            if body.dataset_id not in datasets:
+            if body.dataset_id in _loading_ids:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Dataset {body.dataset_id} is currently loading",
+                )
+            state = datasets.get(body.dataset_id)
+            if state is None:
                 raise HTTPException(
                     status_code=404,
                     detail=f"Unknown dataset_id: {body.dataset_id}",
                 )
-            del datasets[body.dataset_id]
+
+        # Phase 2: drain in-flight state ops via state.lock (may wait).
+        async with state.lock:
+            if state.unloading:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Dataset {body.dataset_id} is already unloading",
+                )
+            state.unloading = True
+
+        # Phase 3: remove from dict under datasets_lock (fast).
+        async with datasets_lock:
+            current = datasets.get(body.dataset_id)
+            if current is state:
+                del datasets[body.dataset_id]
         return {"status": "ok"}
 
     @app.post("/epoch/reset")
     async def reset_epoch(body: WorkerEpochResetRequest):
-        state = _require_dataset(body.dataset_id)
-        async with state.lock:
+        async with _locked_active_state(body.dataset_id) as state:
             state.epoch = body.epoch
             state.exhausted = False
             if state.sampler is not None:
                 state.sampler.set_epoch(body.epoch)
-        return {"status": "ok", "epoch": state.epoch}
+        return {"status": "ok", "epoch": body.epoch}
 
     @app.post("/state/save")
     async def save_state(body: WorkerStateSaveRequest):
-        state = _require_dataset(body.dataset_id)
-        async with state.lock:
+        async with _locked_active_state(body.dataset_id) as state:
             save_dir = Path(body.path)
             save_dir.mkdir(parents=True, exist_ok=True)
             save_path = save_dir / f"worker_{config.rank}.pkl"
@@ -187,8 +243,7 @@ def create_worker_app(config: DataWorkerConfig) -> FastAPI:
 
     @app.post("/state/load")
     async def load_state(body: WorkerStateLoadRequest):
-        state = _require_dataset(body.dataset_id)
-        async with state.lock:
+        async with _locked_active_state(body.dataset_id) as state:
             load_path = Path(body.path) / f"worker_{config.rank}.pkl"
             if not load_path.exists():
                 raise HTTPException(

--- a/areal/infra/data_service/worker/app.py
+++ b/areal/infra/data_service/worker/app.py
@@ -45,15 +45,16 @@ class _DatasetState:
     sampler: DistributedSampler | None
     epoch: int
     exhausted: bool
-    seed: int
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 def create_worker_app(config: DataWorkerConfig) -> FastAPI:
     datasets: dict[str, _DatasetState] = {}
+    datasets_lock = asyncio.Lock()
 
     @asynccontextmanager
     async def lifespan(app: Any):
+        seeding.set_random_seed(config.seed, key=f"data_worker_{config.rank}")
         app.state.config = config
         app.state.datasets = datasets
         try:
@@ -81,12 +82,6 @@ def create_worker_app(config: DataWorkerConfig) -> FastAPI:
 
     @app.post("/datasets/load")
     async def load_dataset(body: WorkerLoadDatasetRequest):
-        if body.dataset_id in datasets:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Dataset {body.dataset_id} is already loaded",
-            )
-
         def _load_sync():
             _tokenizer = None
             _processor = None
@@ -95,11 +90,6 @@ def create_worker_app(config: DataWorkerConfig) -> FastAPI:
                     body.tokenizer_or_processor_path
                 )
 
-            seeding.set_random_seed(body.seed, key=f"data_worker_{config.rank}")
-
-            # Workers must load real datasets, not RDataset proxies.
-            # Call _get_custom_dataset directly to bypass the is_single_controller()
-            # gate in get_custom_dataset() that would create an RDataset.
             _dataset = _get_custom_dataset(
                 path=body.dataset_path,
                 type=body.dataset_type,
@@ -131,17 +121,23 @@ def create_worker_app(config: DataWorkerConfig) -> FastAPI:
             )
             return _dataset, _sampler, _dataloader
 
-        dataset, sampler, dataloader = await asyncio.to_thread(_load_sync)
+        async with datasets_lock:
+            if body.dataset_id in datasets:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Dataset {body.dataset_id} is already loaded",
+                )
 
-        datasets[body.dataset_id] = _DatasetState(
-            dataset_id=body.dataset_id,
-            raw_dataset=dataset,
-            dataloader=dataloader,
-            sampler=sampler,
-            epoch=0,
-            exhausted=False,
-            seed=body.seed,
-        )
+            dataset, sampler, dataloader = await asyncio.to_thread(_load_sync)
+
+            datasets[body.dataset_id] = _DatasetState(
+                dataset_id=body.dataset_id,
+                raw_dataset=dataset,
+                dataloader=dataloader,
+                sampler=sampler,
+                epoch=0,
+                exhausted=False,
+            )
 
         return {
             "status": "ok",
@@ -157,8 +153,12 @@ def create_worker_app(config: DataWorkerConfig) -> FastAPI:
 
     @app.post("/datasets/unload")
     async def unload_dataset(body: WorkerUnloadDatasetRequest):
-        state = _require_dataset(body.dataset_id)
-        async with state.lock:
+        async with datasets_lock:
+            if body.dataset_id not in datasets:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Unknown dataset_id: {body.dataset_id}",
+                )
             del datasets[body.dataset_id]
         return {"status": "ok"}
 
@@ -166,7 +166,6 @@ def create_worker_app(config: DataWorkerConfig) -> FastAPI:
     async def reset_epoch(body: WorkerEpochResetRequest):
         state = _require_dataset(body.dataset_id)
         async with state.lock:
-            seeding.set_random_seed(state.seed, key=f"data_worker_{config.rank}")
             state.epoch = body.epoch
             state.exhausted = False
             if state.sampler is not None:

--- a/areal/infra/data_service/worker/config.py
+++ b/areal/infra/data_service/worker/config.py
@@ -12,3 +12,4 @@ class DataWorkerConfig:
     rank: int = 0
     world_size: int = 1
     dataloader_num_workers: int = 4
+    seed: int = 42

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -207,7 +207,9 @@ class PPOTrainer:
         else:
             assert train_dataset is not None
             if is_single_controller() and isinstance(train_dataset, RDataset):
-                ds_cfg = DataServiceConfig.from_dataset_config(config.train_dataset)
+                ds_cfg = DataServiceConfig.from_dataset_config(
+                    config.train_dataset, seed=config.seed
+                )
                 assert self.scheduler is not None
                 controller = DataController(ds_cfg, self.scheduler)
                 controller.initialize(
@@ -218,7 +220,6 @@ class PPOTrainer:
                     controller,
                     dataset_id=f"{config.experiment_name}_{config.trial_name}_train",
                     tokenizer_or_processor_path=config.tokenizer_path,
-                    seed=config.seed,
                     shuffle=config.train_dataset.shuffle,
                     drop_last=config.train_dataset.drop_last,
                 )
@@ -240,7 +241,6 @@ class PPOTrainer:
                     self.data_controller,
                     dataset_id=f"{config.experiment_name}_{config.trial_name}_valid",
                     tokenizer_or_processor_path=config.tokenizer_path,
-                    seed=config.seed,
                     shuffle=self.config.valid_dataset.shuffle,
                     drop_last=self.config.valid_dataset.drop_last,
                 )

--- a/areal/trainer/rw_trainer.py
+++ b/areal/trainer/rw_trainer.py
@@ -105,7 +105,9 @@ class RWTrainer:
         self.actor = self._create_actor(config.actor)
 
         if is_single_controller() and isinstance(train_dataset, RDataset):
-            ds_cfg = DataServiceConfig.from_dataset_config(config.train_dataset)
+            ds_cfg = DataServiceConfig.from_dataset_config(
+                config.train_dataset, seed=config.seed
+            )
             controller = DataController(ds_cfg, self.scheduler)
             controller.initialize(role="data", num_dataset_workers=ds_cfg.num_workers)
             self.data_controller = controller
@@ -114,7 +116,6 @@ class RWTrainer:
                 controller,
                 dataset_id=f"{config.experiment_name}_{config.trial_name}_train",
                 tokenizer_or_processor_path=config.tokenizer_path,
-                seed=config.seed,
                 shuffle=config.train_dataset.shuffle,
                 drop_last=config.train_dataset.drop_last,
             )
@@ -144,7 +145,6 @@ class RWTrainer:
                     self.data_controller,
                     dataset_id=f"{config.experiment_name}_{config.trial_name}_valid",
                     tokenizer_or_processor_path=config.tokenizer_path,
-                    seed=config.seed,
                     shuffle=config.valid_dataset.shuffle,
                     drop_last=config.valid_dataset.drop_last,
                 )

--- a/areal/trainer/sft_trainer.py
+++ b/areal/trainer/sft_trainer.py
@@ -80,7 +80,9 @@ class SFTTrainer:
         self.actor = self._create_actor(config.actor)
 
         if is_single_controller() and isinstance(train_dataset, RDataset):
-            ds_cfg = DataServiceConfig.from_dataset_config(config.train_dataset)
+            ds_cfg = DataServiceConfig.from_dataset_config(
+                config.train_dataset, seed=config.seed
+            )
             controller = DataController(ds_cfg, self.scheduler)
             controller.initialize(role="data", num_dataset_workers=ds_cfg.num_workers)
             self.data_controller = controller
@@ -89,7 +91,6 @@ class SFTTrainer:
                 controller,
                 dataset_id=f"{config.experiment_name}_{config.trial_name}_train",
                 tokenizer_or_processor_path=config.tokenizer_path,
-                seed=config.seed,
                 shuffle=config.train_dataset.shuffle,
                 drop_last=config.train_dataset.drop_last,
             )
@@ -119,7 +120,6 @@ class SFTTrainer:
                     self.data_controller,
                     dataset_id=f"{config.experiment_name}_{config.trial_name}_valid",
                     tokenizer_or_processor_path=config.tokenizer_path,
-                    seed=config.seed,
                     shuffle=config.valid_dataset.shuffle,
                     drop_last=config.valid_dataset.drop_last,
                 )

--- a/tests/infra/data_service/test_worker.py
+++ b/tests/infra/data_service/test_worker.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 # pyright: reportMissingImports=false
+import asyncio
+import inspect
+import threading
+from collections.abc import Mapping
 from pathlib import Path
 from unittest.mock import patch
 
@@ -40,11 +44,24 @@ def _load_payload(**overrides: object) -> dict[str, object]:
         "dataset_id": DATASET_ID,
         "dataset_path": "test/dataset",
         "dataset_type": "rl",
-        "seed": 42,
         "shuffle": False,
     }
     payload.update(overrides)
     return payload
+
+
+def _get_route_endpoint(app, path: str, method: str = "POST"):
+    for route in app.routes:
+        if getattr(route, "path", None) == path and method in getattr(
+            route, "methods", set()
+        ):
+            return route.endpoint
+    raise AssertionError(f"Route not found: {method} {path}")
+
+
+def _get_worker_nonlocals(app) -> Mapping[str, object]:
+    endpoint = _get_route_endpoint(app, "/datasets/unload")
+    return inspect.getclosurevars(endpoint).nonlocals
 
 
 @pytest_asyncio.fixture
@@ -73,6 +90,32 @@ async def loaded_client(config: DataWorkerConfig):
             resp = await c.post("/datasets/load", json=_load_payload())
             assert resp.status_code == 200
             yield c
+
+
+@pytest_asyncio.fixture
+async def loaded_worker(config: DataWorkerConfig):
+    with (
+        patch("areal.infra.data_service.worker.app._get_custom_dataset") as mock_get,
+        patch(
+            "areal.infra.data_service.worker.app.load_hf_processor_and_tokenizer"
+        ) as mock_load,
+    ):
+        ds = _make_mock_dataset(8)
+        mock_get.return_value = ds
+        mock_load.return_value = (None, None)
+
+        app = create_worker_app(config)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post("/datasets/load", json=_load_payload())
+            assert resp.status_code == 200
+            nonlocals = _get_worker_nonlocals(app)
+            yield {
+                "app": app,
+                "client": c,
+                "datasets": nonlocals["datasets"],
+                "datasets_lock": nonlocals["datasets_lock"],
+            }
 
 
 @pytest.mark.asyncio
@@ -161,6 +204,123 @@ class TestSampleFetch:
         samples = resp.json()["samples"]
         assert len(samples) == 3
         assert samples[0] != samples[1]
+
+
+@pytest.mark.asyncio
+class TestWorkerConcurrency:
+    async def test_load_dataset_returns_409_when_same_id_currently_loading(
+        self, config: DataWorkerConfig
+    ):
+        load_started = threading.Event()
+        release_load = threading.Event()
+
+        def slow_get_dataset(*args, **kwargs):
+            del args, kwargs
+            load_started.set()
+            assert release_load.wait(timeout=2)
+            return _make_mock_dataset(8)
+
+        with (
+            patch(
+                "areal.infra.data_service.worker.app._get_custom_dataset",
+                side_effect=slow_get_dataset,
+            ),
+            patch(
+                "areal.infra.data_service.worker.app.load_hf_processor_and_tokenizer"
+            ) as mock_load,
+        ):
+            mock_load.return_value = (None, None)
+            app = create_worker_app(config)
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                first_load = asyncio.create_task(
+                    client.post("/datasets/load", json=_load_payload())
+                )
+                await asyncio.to_thread(load_started.wait, 1)
+
+                second_load = await client.post("/datasets/load", json=_load_payload())
+                assert second_load.status_code == 409
+                assert "currently loading" in second_load.json()["detail"].lower()
+
+                release_load.set()
+                first_response = await first_load
+                assert first_response.status_code == 200
+
+    async def test_unload_waits_for_in_flight_state_lock(self, loaded_worker):
+        client = loaded_worker["client"]
+        state = loaded_worker["datasets"][DATASET_ID]
+
+        await state.lock.acquire()
+        unload_task = asyncio.create_task(
+            client.post("/datasets/unload", json={"dataset_id": DATASET_ID})
+        )
+        await asyncio.sleep(0)
+        assert not unload_task.done()
+
+        state.lock.release()
+        unload_response = await asyncio.wait_for(unload_task, timeout=1)
+        assert unload_response.status_code == 200
+
+    async def test_fetch_returns_409_after_unload_starts(self, loaded_worker):
+        client = loaded_worker["client"]
+        state = loaded_worker["datasets"][DATASET_ID]
+        datasets_lock = loaded_worker["datasets_lock"]
+
+        await state.lock.acquire()
+        unload_task = asyncio.create_task(
+            client.post("/datasets/unload", json={"dataset_id": DATASET_ID})
+        )
+        await asyncio.sleep(0)
+
+        await datasets_lock.acquire()
+        state.lock.release()
+        await asyncio.sleep(0)
+
+        fetch_response = await client.post(
+            "/v1/samples/fetch",
+            json={"dataset_id": DATASET_ID, "indices": [0]},
+        )
+        assert fetch_response.status_code == 409
+        assert "unloading" in fetch_response.json()["detail"].lower()
+
+        datasets_lock.release()
+        unload_response = await asyncio.wait_for(unload_task, timeout=1)
+        assert unload_response.status_code == 200
+
+    async def test_unrelated_load_succeeds_while_unload_waits_on_state_lock(
+        self, loaded_worker
+    ):
+        client = loaded_worker["client"]
+        state = loaded_worker["datasets"][DATASET_ID]
+
+        await state.lock.acquire()
+        unload_task = asyncio.create_task(
+            client.post("/datasets/unload", json={"dataset_id": DATASET_ID})
+        )
+        await asyncio.sleep(0)
+
+        other_load = await asyncio.wait_for(
+            client.post(
+                "/datasets/load",
+                json=_load_payload(
+                    dataset_id="test-valid",
+                    dataset_path="test/other-dataset",
+                ),
+            ),
+            timeout=1,
+        )
+        assert other_load.status_code == 200
+        assert not unload_task.done()
+
+        state.lock.release()
+        unload_response = await asyncio.wait_for(unload_task, timeout=1)
+        assert unload_response.status_code == 200
+
+        health = await client.get("/health")
+        assert health.status_code == 200
+        assert health.json()["datasets"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Move the random seed from a per-request parameter (set on each `load_dataset` call and re-set on epoch reset) to a worker-level configuration set once at startup. This prevents repeated seed re-initialization from interfering with data shuffling correctness when multiple datasets are loaded on the same worker. Also adds a `datasets_lock` to eliminate race conditions on concurrent dataset load/unload operations.

## Related Issue

<!-- No tracked issue -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

**Key changes:**
- `DataServiceConfig` gains a `seed` field; `from_dataset_config()` now accepts seed from trainer config
- Seed passed as `--seed` CLI arg to worker subprocess, set once in `lifespan()` via `seeding.set_random_seed`
- Removed `seed` from `WorkerLoadDatasetRequest`, `_DatasetState`, and `RDataset.register()`
- Added `datasets_lock` (asyncio.Lock) for atomic dataset load/unload — prevents TOCTOU race on the datasets dict
- All trainers (`PPOTrainer`, `RWTrainer`, `SFTTrainer`) updated to pass seed through `DataServiceConfig` instead of per-dataset

**Files changed:**
- `areal/infra/data_service/controller/config.py` — add seed field + from_dataset_config param
- `areal/infra/data_service/controller/controller.py` — pass --seed arg, remove seed from load request
- `areal/infra/data_service/rdataset.py` — remove seed param from register()
- `areal/infra/data_service/types.py` — remove seed from WorkerLoadDatasetRequest
- `areal/infra/data_service/worker/__main__.py` — add --seed CLI arg
- `areal/infra/data_service/worker/app.py` — seed at startup, add datasets_lock
- `areal/infra/data_service/worker/config.py` — add seed field
- `areal/trainer/rl_trainer.py` — pass seed via DataServiceConfig
- `areal/trainer/rw_trainer.py` — pass seed via DataServiceConfig
- `areal/trainer/sft_trainer.py` — pass seed via DataServiceConfig