### PR TITLE
docs(community): add first biweekly meeting record and news entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ cost-effective** for a broad community of developers and researchers.
 
 ## 📰 News
 
+**\[2026/04/18\]** We are thrilled to announce that **AReaL's first Community Biweekly
+Meeting** was successfully held! Thank you to everyone who joined us. Meeting materials
+are now available
+[here](https://github.com/inclusionAI/AReaL/tree/main/assets/community). Our next
+meeting is scheduled for **2026/05/01** and will also be conducted in Chinese;
+English-language meetings will be scheduled in the future. We warmly welcome everyone to
+participate! See [Community](./assets/community/README.md) for more details.
+
 **\[2026/03/02\]** We provide [a complete example](./examples/openclaw/) to train your
 own 🦞 OpenClaw agent by simply replacing the `base_url` and `api_key` with AReaL's RL
 service - no complicated dependencies, no code changes, works with any agentic runtime!
@@ -52,14 +60,14 @@ the [paper](https://arxiv.org/pdf/2601.22607),
 [data](https://huggingface.co/datasets/inclusionAI/AReaL-tau2-data), and
 [code](https://github.com/inclusionAI/AReaL/tree/main/examples/tau2).
 
+<details>
+<summary><b>📋 Previous Releases</b></summary>
+
 **\[2026/01/15\]** Congrats to our friends at [CAMEL-AI](https://www.camel-ai.org/) for
 open-sourcing [SETA](https://github.com/camel-ai/seta), their terminal agent RL project
 trained with AReaL! Check out
 [their training workflow](https://github.com/camel-ai/seta/tree/main/training/tbench_areal_workflow)
 and the [announcement on X](https://x.com/guohao_li/status/2009678513574408636).
-
-<details>
-<summary><b>📋 Previous Releases</b></summary>
 
 **\[2026/01/01\]** Happy New Year! Thanks to the outstanding contribution from
 @HwVanICI, we are excited to officially announce stable support for AReaL training on

--- a/assets/community/README.md
+++ b/assets/community/README.md
@@ -12,15 +12,15 @@ For background on how the project is governed and how to participate, please see
 
 ## Upcoming Meetings
 
-| Date | Agenda | Slides | Recording |
-| ---- | ------ | ------ | --------- |
-| TBD  | TBD    | TBD    | TBD       |
+| Date       | Agenda | Slides | Recording |
+| ---------- | ------ | ------ | --------- |
+| 2026/05/01 | TBD    | TBD    | TBD       |
 
 ## Past Meetings
 
-| Date | Agenda | Slides | Recording |
-| ---- | ------ | ------ | --------- |
-| TBD  | TBD    | TBD    | TBD       |
+| Date       | Agenda                                                                                                         | Slides                                                                                                                                                   | Recording                                                               |
+| ---------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| 2026/04/18 | [Google Doc](https://docs.google.com/document/d/1t4JSoXuPgtMsjAHio4keh3PM1elDeQAXC_BZGnv9kco/edit?usp=sharing) | [Google Slides](https://docs.google.com/presentation/d/1MaZL2Tq39YPYQYIIWNiKaBo2MonLLbW-/edit?usp=sharing&ouid=102752648406195568586&rtpof=true&sd=true) | [Tencent Meeting (Chinese)](https://meeting.tencent.com/crm/2MW8w0q6b7) |
 
 ## How to Add Materials
 


### PR DESCRIPTION
## Description

Record the first AReaL community biweekly meeting (2026/04/18) with agenda, slides, and recording links in the community README. Add a news entry to the main README announcing the meeting and the next scheduled session (2026/05/01). Meetings are currently conducted in Chinese; English-language meetings will be scheduled in the future.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Files changed:
- `README.md`: Add news entry for first community biweekly meeting
- `assets/community/README.md`: Update meeting tables with first meeting record and next scheduled meeting