### PR TITLE
refactor(inference_service): reuse shared httpx clients in gateway/router/data_proxy

### DIFF
--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -118,6 +118,7 @@ def _create_inf_bridge(
     backend_addr: str,
     pause_state: PauseState,
     config: DataProxyConfig,
+    http_client: httpx.AsyncClient | None = None,
 ) -> InfBridge:
     """Create an InfBridge instance from proxy config."""
     if config.backend_type == "sglang":
@@ -134,6 +135,7 @@ def _create_inf_bridge(
         request_timeout=config.request_timeout,
         max_resubmit_retries=config.max_resubmit_retries,
         resubmit_wait=config.resubmit_wait,
+        http_client=http_client,
     )
 
 
@@ -153,21 +155,22 @@ async def _post_online_ready_callback(
     admin_api_key: str,
     notification: ReadyNotification,
     timeout: float,
+    client: httpx.AsyncClient,
 ) -> bool:
     if not callback_server_addr:
         return False
 
     callback_base = callback_server_addr.rstrip("/")
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
-                f"{callback_base}/callback/online_ready",
-                json={
-                    "session_id": notification.session_id,
-                    "trajectory_id": notification.trajectory_id,
-                },
-                headers={"Authorization": f"Bearer {admin_api_key}"},
-            )
+        resp = await client.post(
+            f"{callback_base}/callback/online_ready",
+            json={
+                "session_id": notification.session_id,
+                "trajectory_id": notification.trajectory_id,
+            },
+            headers={"Authorization": f"Bearer {admin_api_key}"},
+            timeout=timeout,
+        )
         if resp.status_code >= 400:
             logger.warning(
                 "Online ready callback failed for %s/%s with %d: %s",
@@ -191,6 +194,7 @@ async def _post_online_ready_callback(
 async def _flush_ready_trajectories(app: FastAPI) -> None:
     store: SessionStore = app.state.session_store
     config: DataProxyConfig = app.state.config
+    http_client: httpx.AsyncClient = app.state.http_client
 
     for ready_result in store.finalize_rewarded_trajectories():
         logger.info(
@@ -207,6 +211,7 @@ async def _flush_ready_trajectories(app: FastAPI) -> None:
             config.admin_api_key,
             notification,
             config.request_timeout,
+            http_client,
         )
         if delivered:
             store.mark_online_callback_delivered(
@@ -224,6 +229,8 @@ async def _ready_trajectory_loop(app: FastAPI) -> None:
 def create_app(config: DataProxyConfig) -> FastAPI:
     """Factory that creates the FastAPI app with lifespan-managed resources."""
 
+    shared_http_client = httpx.AsyncClient()
+
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         logger.info(
@@ -234,8 +241,13 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         tok = TokenizerProxy(config.tokenizer_path)
         pause_state = PauseState()
 
-        # InfBridge + ArealOpenAI for /chat/completions
-        inf_bridge = _create_inf_bridge(config.backend_addr, pause_state, config)
+        # Share one client across backend calls and control-plane callbacks.
+        inf_bridge = _create_inf_bridge(
+            config.backend_addr,
+            pause_state,
+            config,
+            http_client=shared_http_client,
+        )
         areal_client = _create_areal_client(inf_bridge, tok)
 
         app.state.tokenizer = tok
@@ -243,6 +255,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         app.state.areal_client = areal_client
         app.state.pause_state = pause_state
         app.state.config = config
+        app.state.http_client = shared_http_client
         app.state.session_store = SessionStore(
             set_reward_finish_timeout=config.set_reward_finish_timeout,
         )
@@ -257,9 +270,11 @@ def create_app(config: DataProxyConfig) -> FastAPI:
                 await ready_task
             except asyncio.CancelledError:
                 pass
+            await shared_http_client.aclose()
         logger.info("Data proxy shutting down")
 
     app = FastAPI(title="AReaL Data Proxy", lifespan=lifespan)
+    app.state.http_client = shared_http_client
 
     # =========================================================================
     # Health
@@ -500,7 +515,12 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         tok: TokenizerProxy = app.state.tokenizer
 
         # Recreate InfBridge + ArealOpenAI with new backend address
-        new_inf_bridge = _create_inf_bridge(new_addr, pause_state, app.state.config)
+        new_inf_bridge = _create_inf_bridge(
+            new_addr,
+            pause_state,
+            app.state.config,
+            http_client=app.state.http_client,
+        )
         new_areal_client = _create_areal_client(new_inf_bridge, tok)
 
         # Build updated config copy, then swap all three state fields.

--- a/areal/experimental/inference_service/data_proxy/inf_bridge.py
+++ b/areal/experimental/inference_service/data_proxy/inf_bridge.py
@@ -67,6 +67,7 @@ class InfBridge:
         max_resubmit_retries: int = 20,
         resubmit_wait: float = 0.5,
         version: int = 0,
+        http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self.backend = backend
         self.backend_addr = backend_addr.rstrip("/")
@@ -75,6 +76,7 @@ class InfBridge:
         self.max_resubmit_retries = max_resubmit_retries
         self.resubmit_wait = resubmit_wait
         self._version = version
+        self.http_client = http_client
 
     # -- version tracking ---------------------------------------------------
 
@@ -130,6 +132,16 @@ class InfBridge:
         """
         _timeout = timeout if timeout is not None else self.request_timeout
         url = f"{self.backend_addr}{http_req.endpoint}"
+        if self.http_client is not None:
+            if http_req.method == "GET":
+                resp = await self.http_client.get(url, timeout=_timeout)
+            else:
+                resp = await self.http_client.post(
+                    url, json=http_req.payload, timeout=_timeout
+                )
+            resp.raise_for_status()
+            return resp.json()
+
         async with httpx.AsyncClient(timeout=_timeout) as client:
             if http_req.method == "GET":
                 resp = await client.get(url)

--- a/areal/experimental/inference_service/data_proxy/pause.py
+++ b/areal/experimental/inference_service/data_proxy/pause.py
@@ -41,17 +41,41 @@ class PauseState:
         return self._paused
 
 
-async def pause_backend(backend_addr: str) -> None:
+async def pause_backend(
+    backend_addr: str,
+    client: httpx.AsyncClient | None = None,
+) -> None:
     """Call SGLang POST /pause_generation to abort in-flight requests."""
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.post(f"{backend_addr}/pause_generation", json={})
+    if client is not None:
+        resp = await client.post(
+            f"{backend_addr}/pause_generation", json={}, timeout=10.0
+        )
+        resp.raise_for_status()
+        logger.info("SGLang pause_generation called on %s", backend_addr)
+        return
+
+    async with httpx.AsyncClient(timeout=10.0) as transient_client:
+        resp = await transient_client.post(f"{backend_addr}/pause_generation", json={})
         resp.raise_for_status()
     logger.info("SGLang pause_generation called on %s", backend_addr)
 
 
-async def resume_backend(backend_addr: str) -> None:
+async def resume_backend(
+    backend_addr: str,
+    client: httpx.AsyncClient | None = None,
+) -> None:
     """Call SGLang POST /continue_generation to resume inference."""
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.post(f"{backend_addr}/continue_generation", json={})
+    if client is not None:
+        resp = await client.post(
+            f"{backend_addr}/continue_generation", json={}, timeout=10.0
+        )
+        resp.raise_for_status()
+        logger.info("SGLang continue_generation called on %s", backend_addr)
+        return
+
+    async with httpx.AsyncClient(timeout=10.0) as transient_client:
+        resp = await transient_client.post(
+            f"{backend_addr}/continue_generation", json={}
+        )
         resp.raise_for_status()
     logger.info("SGLang continue_generation called on %s", backend_addr)

--- a/areal/experimental/inference_service/gateway/app.py
+++ b/areal/experimental/inference_service/gateway/app.py
@@ -50,7 +50,9 @@ def _router_error_response(exc: Exception) -> JSONResponse:
 def create_app(config: GatewayConfig) -> FastAPI:
     """Factory that creates the inference gateway FastAPI app."""
 
+    shared_http_client = httpx.AsyncClient()
     app = FastAPI(title="AReaL Inference Gateway")
+    app.state.http_client = shared_http_client
 
     # =========================================================================
     # Health
@@ -74,6 +76,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 "/chat/completions",
                 config.router_timeout,
                 admin_api_key=config.admin_api_key,
+                client=shared_http_client,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -96,13 +99,18 @@ def create_app(config: GatewayConfig) -> FastAPI:
                     body,
                     headers,
                     config.forward_timeout,
+                    client=shared_http_client,
                 ),
                 media_type="text/event-stream",
                 headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
             )
 
         resp = await forward_request(
-            f"{worker_addr}/chat/completions", body, headers, config.forward_timeout
+            f"{worker_addr}/chat/completions",
+            body,
+            headers,
+            config.forward_timeout,
+            client=shared_http_client,
         )
         return Response(
             content=resp.content,
@@ -125,6 +133,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 "/rl/start_session",
                 config.router_timeout,
                 admin_api_key=config.admin_api_key,
+                client=shared_http_client,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -137,6 +146,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
             body,
             headers,
             config.forward_timeout,
+            client=shared_http_client,
         )
 
         # Intercept: if data proxy returned 201, extract session info and register
@@ -153,6 +163,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                         worker_addr,
                         config.router_timeout,
                         admin_api_key=config.admin_api_key,
+                        client=shared_http_client,
                     )
             except Exception as exc:
                 logger.error("Failed to register session in router: %s", exc)
@@ -183,6 +194,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 "/rl/set_reward",
                 config.router_timeout,
                 admin_api_key=config.admin_api_key,
+                client=shared_http_client,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -190,7 +202,11 @@ def create_app(config: GatewayConfig) -> FastAPI:
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
         resp = await forward_request(
-            f"{worker_addr}/rl/set_reward", body, headers, config.forward_timeout
+            f"{worker_addr}/rl/set_reward",
+            body,
+            headers,
+            config.forward_timeout,
+            client=shared_http_client,
         )
 
         return Response(
@@ -212,6 +228,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=shared_http_client,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -219,7 +236,11 @@ def create_app(config: GatewayConfig) -> FastAPI:
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
         results = await broadcast_to_workers(
-            [worker_addr], "/pause_generation", body, headers
+            [worker_addr],
+            "/pause_generation",
+            body,
+            headers,
+            client=shared_http_client,
         )
         return {"results": results}
 
@@ -236,6 +257,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=shared_http_client,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -243,7 +265,11 @@ def create_app(config: GatewayConfig) -> FastAPI:
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
         results = await broadcast_to_workers(
-            [worker_addr], "/continue_generation", body, headers
+            [worker_addr],
+            "/continue_generation",
+            body,
+            headers,
+            client=shared_http_client,
         )
         return {"results": results}
 
@@ -276,6 +302,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 timeout=config.router_timeout,
                 session_id=session_id,
                 admin_api_key=config.admin_api_key,
+                client=shared_http_client,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -286,6 +313,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
             body,
             headers,
             config.forward_timeout,
+            client=shared_http_client,
         )
 
         # Always ask the router to clean up after successful export.
@@ -297,6 +325,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 session_id,
                 config.router_timeout,
+                client=shared_http_client,
             )
 
         return Response(
@@ -318,6 +347,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=shared_http_client,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -325,7 +355,11 @@ def create_app(config: GatewayConfig) -> FastAPI:
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
         resp = await forward_request(
-            f"{worker_addr}/set_version", body, headers, config.forward_timeout
+            f"{worker_addr}/set_version",
+            body,
+            headers,
+            config.forward_timeout,
+            client=shared_http_client,
         )
         return Response(
             content=resp.content,
@@ -346,16 +380,17 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=shared_http_client,
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
 
         try:
-            async with httpx.AsyncClient(timeout=config.forward_timeout) as client:
-                resp = await client.get(
-                    f"{worker_addr}/get_version",
-                    headers=_forwarding_headers(dict(request.headers)),
-                )
+            resp = await shared_http_client.get(
+                f"{worker_addr}/get_version",
+                headers=_forwarding_headers(dict(request.headers)),
+                timeout=config.forward_timeout,
+            )
             return Response(
                 content=resp.content,
                 status_code=resp.status_code,
@@ -374,7 +409,10 @@ def create_app(config: GatewayConfig) -> FastAPI:
         require_admin_key(request, config.admin_api_key)
         try:
             result = await grant_capacity_in_router(
-                config.router_addr, config.admin_api_key, config.router_timeout
+                config.router_addr,
+                config.admin_api_key,
+                config.router_timeout,
+                client=shared_http_client,
             )
         except RouterUnreachableError as exc:
             return _router_error_response(exc)
@@ -399,4 +437,9 @@ def create_app(config: GatewayConfig) -> FastAPI:
         continue_generation,
         methods=["POST"],
     )
+
+    @app.on_event("shutdown")
+    async def _close_http_client() -> None:
+        await shared_http_client.aclose()
+
     return app

--- a/areal/experimental/inference_service/gateway/streaming.py
+++ b/areal/experimental/inference_service/gateway/streaming.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
@@ -30,6 +31,17 @@ class RouterKeyRejectedError(Exception):
         self.status_code = status_code
 
 
+@asynccontextmanager
+async def _client_scope(
+    client: httpx.AsyncClient | None,
+) -> AsyncGenerator[httpx.AsyncClient, None]:
+    if client is not None:
+        yield client
+        return
+    async with httpx.AsyncClient() as transient_client:
+        yield transient_client
+
+
 async def query_router(
     router_addr: str,
     api_key: str | None = None,
@@ -38,6 +50,7 @@ async def query_router(
     *,
     session_id: str | None = None,
     admin_api_key: str | None = None,
+    client: httpx.AsyncClient | None = None,
 ) -> str:
     """Ask the Router for a worker address.
 
@@ -70,11 +83,12 @@ async def query_router(
         headers = {}
         if admin_api_key is not None:
             headers["Authorization"] = f"Bearer {admin_api_key}"
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _client_scope(client) as http_client:
+            resp = await http_client.post(
                 f"{router_addr}/route",
                 json=payload,
                 headers=headers,
+                timeout=timeout,
             )
         if resp.status_code == 404:
             data = resp.json()
@@ -105,6 +119,7 @@ async def register_session_in_router(
     worker_addr: str,
     timeout: float,
     admin_api_key: str | None = None,
+    client: httpx.AsyncClient | None = None,
 ) -> None:
     """Register a session→worker mapping in the Router.
 
@@ -115,8 +130,8 @@ async def register_session_in_router(
         headers = {}
         if admin_api_key is not None:
             headers["Authorization"] = f"Bearer {admin_api_key}"
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _client_scope(client) as http_client:
+            resp = await http_client.post(
                 f"{router_addr}/register_session",
                 json={
                     "session_api_key": session_api_key,
@@ -124,6 +139,7 @@ async def register_session_in_router(
                     "worker_addr": worker_addr,
                 },
                 headers=headers,
+                timeout=timeout,
             )
         resp.raise_for_status()
     except Exception as exc:
@@ -136,6 +152,7 @@ async def revoke_session_in_router(
     admin_api_key: str,
     session_id: str,
     timeout: float,
+    client: httpx.AsyncClient | None = None,
 ) -> None:
     """Remove a session from the Router's session registry.
 
@@ -145,11 +162,12 @@ async def revoke_session_in_router(
     Best-effort: logs errors but never raises.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _client_scope(client) as http_client:
+            resp = await http_client.post(
                 f"{router_addr}/remove_session",
                 json={"session_id": session_id},
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         if resp.status_code != 200:
             logger.warning(
@@ -163,6 +181,7 @@ async def grant_capacity_in_router(
     router_addr: str,
     admin_api_key: str,
     timeout: float,
+    client: httpx.AsyncClient | None = None,
 ) -> dict:
     """Forward a grant_capacity request to the Router.
 
@@ -170,10 +189,11 @@ async def grant_capacity_in_router(
     Returns the JSON response body from the router.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _client_scope(client) as http_client:
+            resp = await http_client.post(
                 f"{router_addr}/grant_capacity",
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         resp.raise_for_status()
         return resp.json()
@@ -191,6 +211,7 @@ async def release_capacity_in_router(
     router_addr: str,
     admin_api_key: str,
     timeout: float,
+    client: httpx.AsyncClient | None = None,
 ) -> None:
     """Return one capacity permit to the Router.
 
@@ -199,10 +220,11 @@ async def release_capacity_in_router(
     already handling a failure path.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _client_scope(client) as http_client:
+            resp = await http_client.post(
                 f"{router_addr}/release_capacity",
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         if resp.status_code != 200:
             logger.warning(
@@ -216,16 +238,18 @@ async def get_all_worker_addrs(
     router_addr: str,
     admin_api_key: str,
     timeout: float,
+    client: httpx.AsyncClient | None = None,
 ) -> list[str]:
     """Fetch all worker addresses from the Router (for broadcast).
 
     GET ``{router_addr}/workers`` with admin key auth.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.get(
+        async with _client_scope(client) as http_client:
+            resp = await http_client.get(
                 f"{router_addr}/workers",
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         resp.raise_for_status()
         data = resp.json()
@@ -239,6 +263,7 @@ async def resolve_worker_addr(
     admin_api_key: str,
     worker_id: str,
     timeout: float,
+    client: httpx.AsyncClient | None = None,
 ) -> str:
     """Resolve a worker_id to its address via the Router.
 
@@ -252,10 +277,11 @@ async def resolve_worker_addr(
         Router connection failed.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.get(
+        async with _client_scope(client) as http_client:
+            resp = await http_client.get(
                 f"{router_addr}/resolve_worker/{worker_id}",
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         if resp.status_code == 404:
             data = resp.json()
@@ -291,6 +317,7 @@ async def forward_sse_stream(
     body: bytes,
     headers: dict[str, str],
     timeout: float | None = None,
+    client: httpx.AsyncClient | None = None,
 ) -> AsyncGenerator[bytes, None]:
     """True SSE streaming proxy — yields bytes as they arrive from upstream.
 
@@ -305,9 +332,13 @@ async def forward_sse_stream(
 
     fwd_headers = _forwarding_headers(headers)
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout)) as client:
-            async with client.stream(
-                "POST", upstream_url, content=body, headers=fwd_headers
+        async with _client_scope(client) as http_client:
+            async with http_client.stream(
+                "POST",
+                upstream_url,
+                content=body,
+                headers=fwd_headers,
+                timeout=httpx.Timeout(timeout),
             ) as resp:
                 if resp.status_code != 200:
                     # Upstream returned a non-200 status — read body and emit
@@ -335,11 +366,17 @@ async def forward_request(
     body: bytes,
     headers: dict[str, str],
     timeout: float = 120.0,
+    client: httpx.AsyncClient | None = None,
 ) -> httpx.Response:
     """Forward a non-streaming request to upstream, return full response."""
     fwd_headers = _forwarding_headers(headers)
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        resp = await client.post(upstream_url, content=body, headers=fwd_headers)
+    async with _client_scope(client) as http_client:
+        resp = await http_client.post(
+            upstream_url,
+            content=body,
+            headers=fwd_headers,
+            timeout=timeout,
+        )
     return resp
 
 
@@ -349,6 +386,7 @@ async def broadcast_to_workers(
     body: bytes,
     headers: dict[str, str],
     timeout: float = 10.0,
+    client: httpx.AsyncClient | None = None,
 ) -> list[dict[str, Any]]:
     """Broadcast a request to all workers (best-effort).
 
@@ -358,28 +396,29 @@ async def broadcast_to_workers(
 
     Failed workers get ``ok=False`` with an ``error`` field.
     """
+    async with _client_scope(client) as http_client:
 
-    async def _call(addr: str) -> dict[str, Any]:
-        try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                resp = await client.post(
+        async def _call(addr: str) -> dict[str, Any]:
+            try:
+                resp = await http_client.post(
                     f"{addr}{path}",
                     content=body,
                     headers=_forwarding_headers(headers),
+                    timeout=timeout,
                 )
-            return {
-                "worker_addr": addr,
-                "status": resp.status_code,
-                "ok": resp.status_code < 400,
-            }
-        except Exception as exc:
-            return {
-                "worker_addr": addr,
-                "status": 502,
-                "ok": False,
-                "error": str(exc),
-            }
+                return {
+                    "worker_addr": addr,
+                    "status": resp.status_code,
+                    "ok": resp.status_code < 400,
+                }
+            except Exception as exc:
+                return {
+                    "worker_addr": addr,
+                    "status": 502,
+                    "ok": False,
+                    "error": str(exc),
+                }
 
-    tasks = [_call(addr) for addr in worker_addrs]
-    results = await asyncio.gather(*tasks)
+        tasks = [_call(addr) for addr in worker_addrs]
+        results = await asyncio.gather(*tasks)
     return list(results)

--- a/areal/experimental/inference_service/router/app.py
+++ b/areal/experimental/inference_service/router/app.py
@@ -99,6 +99,7 @@ def create_app(config: RouterConfig) -> FastAPI:
     session_registry = SessionRegistry()
     capacity_manager = CapacityManager()
     strategy = get_strategy(config.routing_strategy)
+    shared_http_client = httpx.AsyncClient()
 
     async def _poll_workers() -> None:
         """Background task: periodically poll worker /health endpoints."""
@@ -106,13 +107,13 @@ def create_app(config: RouterConfig) -> FastAPI:
             workers = await worker_registry.get_all_workers()
             for w in workers:
                 try:
-                    async with httpx.AsyncClient(
-                        timeout=config.worker_health_timeout
-                    ) as client:
-                        resp = await client.get(f"{w.worker_addr}/health")
-                        await worker_registry.update_health(
-                            w.worker_addr, resp.status_code == 200
-                        )
+                    resp = await shared_http_client.get(
+                        f"{w.worker_addr}/health",
+                        timeout=config.worker_health_timeout,
+                    )
+                    await worker_registry.update_health(
+                        w.worker_addr, resp.status_code == 200
+                    )
                 except Exception:
                     await worker_registry.update_health(w.worker_addr, False)
             await asyncio.sleep(config.poll_interval)
@@ -129,12 +130,14 @@ def create_app(config: RouterConfig) -> FastAPI:
         app.state.session_registry = session_registry
         app.state.capacity_manager = capacity_manager
         app.state.strategy = strategy
+        app.state.http_client = shared_http_client
         yield
         poll_task.cancel()
         try:
             await poll_task
         except asyncio.CancelledError:
             pass
+        await shared_http_client.aclose()
         logger.info("Router shutting down")
 
     app = FastAPI(title="AReaL Router", lifespan=lifespan)
@@ -144,6 +147,7 @@ def create_app(config: RouterConfig) -> FastAPI:
     app.state.session_registry = session_registry
     app.state.capacity_manager = capacity_manager
     app.state.strategy = strategy
+    app.state.http_client = shared_http_client
 
     # =========================================================================
     # Health

--- a/tests/experimental/inference_service/test_http_client_reuse.py
+++ b/tests/experimental/inference_service/test_http_client_reuse.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from areal.api.io_struct import HttpRequest
+from areal.experimental.inference_service.data_proxy.app import (
+    _post_online_ready_callback,
+)
+from areal.experimental.inference_service.data_proxy.app import (
+    create_app as create_data_proxy_app,
+)
+from areal.experimental.inference_service.data_proxy.backend import SGLangBridgeBackend
+from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
+from areal.experimental.inference_service.data_proxy.inf_bridge import InfBridge
+from areal.experimental.inference_service.data_proxy.pause import PauseState
+from areal.experimental.inference_service.data_proxy.session import ReadyNotification
+from areal.experimental.inference_service.gateway.app import (
+    create_app as create_gateway_app,
+)
+from areal.experimental.inference_service.gateway.config import GatewayConfig
+from areal.experimental.inference_service.gateway.streaming import (
+    grant_capacity_in_router,
+    query_router,
+)
+from areal.experimental.inference_service.router.app import (
+    create_app as create_router_app,
+)
+from areal.experimental.inference_service.router.config import RouterConfig
+
+
+@pytest.mark.asyncio
+async def test_gateway_streaming_helpers_accept_shared_client() -> None:
+    calls: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append((request.method, request.url.path))
+        if request.url.path == "/route":
+            return httpx.Response(200, json={"worker_addr": "http://worker-1"})
+        if request.url.path == "/grant_capacity":
+            return httpx.Response(200, json={"capacity": 1})
+        raise AssertionError(f"unexpected path: {request.url.path}")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        worker_addr = await query_router(
+            "http://router",
+            api_key="session-key",
+            path="/chat/completions",
+            client=client,
+        )
+        capacity = await grant_capacity_in_router(
+            "http://router",
+            "admin-key",
+            2.0,
+            client=client,
+        )
+
+    assert worker_addr == "http://worker-1"
+    assert capacity == {"capacity": 1}
+    assert calls == [
+        ("POST", "/route"),
+        ("POST", "/grant_capacity"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_inf_bridge_uses_injected_http_client() -> None:
+    calls: list[tuple[str, str, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = None
+        if request.content:
+            payload = request.content.decode("utf-8")
+        calls.append((request.method, request.url.path, payload))
+        return httpx.Response(200, json={"status": "ok"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        bridge = InfBridge(
+            backend=SGLangBridgeBackend(),
+            backend_addr="http://backend",
+            pause_state=PauseState(),
+            http_client=client,
+        )
+        data = await bridge._send_request(
+            HttpRequest(endpoint="/pause_generation", payload={})
+        )
+
+    assert data == {"status": "ok"}
+    assert calls == [("POST", "/pause_generation", "{}")]
+
+
+@pytest.mark.asyncio
+async def test_online_ready_callback_uses_injected_http_client() -> None:
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        return httpx.Response(200, json={"status": "ok"})
+
+    transport = httpx.MockTransport(handler)
+    notification = ReadyNotification(session_id="s1", trajectory_id=3)
+    async with httpx.AsyncClient(transport=transport) as client:
+        delivered = await _post_online_ready_callback(
+            "http://callback",
+            "admin-key",
+            notification,
+            5.0,
+            client,
+        )
+
+    assert delivered is True
+    assert calls == ["/callback/online_ready"]
+
+
+@pytest.mark.asyncio
+async def test_service_apps_expose_shared_http_client_state() -> None:
+    gateway_app = create_gateway_app(
+        GatewayConfig(
+            host="127.0.0.1",
+            port=18080,
+            admin_api_key="admin-key",
+            router_addr="http://router:18081",
+        )
+    )
+    router_app = create_router_app(
+        RouterConfig(
+            host="127.0.0.1",
+            port=18081,
+            admin_api_key="admin-key",
+        )
+    )
+    data_proxy_app = create_data_proxy_app(
+        DataProxyConfig(
+            host="127.0.0.1",
+            port=18082,
+            backend_addr="http://backend:30000",
+            tokenizer_path="mock-tokenizer",
+        )
+    )
+
+    assert isinstance(gateway_app.state.http_client, httpx.AsyncClient)
+    assert isinstance(router_app.state.http_client, httpx.AsyncClient)
+    assert isinstance(data_proxy_app.state.http_client, httpx.AsyncClient)
+
+    await gateway_app.state.http_client.aclose()
+    await router_app.state.http_client.aclose()
+    await data_proxy_app.state.http_client.aclose()


### PR DESCRIPTION
## Description

Phase 1 slice for #1213.

This PR keeps the scope limited to shared `httpx.AsyncClient` reuse in the FastAPI inference services:
- add one shared client per service in `gateway`, `router`, and `data_proxy`
- thread injected clients through `gateway/streaming.py` helpers instead of creating a new client per request
- reuse the shared client for router health polling, data-proxy online-ready callbacks, and `InfBridge` backend calls
- add focused tests for helper-level injected client usage and app state wiring

Out of scope:
- `controller/controller.py` migration from `aiohttp` / `requests`
- sequential-to-parallel changes with `asyncio.gather`
- Pydantic model migration / response model cleanup

## Related Issue

Fixes #1213

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

Validation run locally:
- `ruff check` on changed files: pass
- `python3 -m py_compile` on changed files: pass

Validation blocked locally:
- `uv run` could not finish environment bootstrap because fetching `torchvision==0.24.1+cu129` from `download-r2.pytorch.org` failed with DNS resolution errors
- host-Python `pytest` collection fails before tests run because the host `torch` package lacks `torch.distributed.checkpoint.staging.DefaultStager`
