### PR TITLE
feat(evaluation): functionality to specify evaluation starting epoch

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1955,6 +1955,19 @@ class _Timer:
 class EvaluatorConfig(_Timer):
     """Configuration for model evaluation scheduling and timing."""
 
+    start_epoch: int = field(
+        default=1,
+        metadata={
+            "help": "First epoch index to allow eval. 0 enables a pre-train eval on fresh runs. 1 keeps current behavior (first eval after epoch 1)."
+        },
+    )
+
+    def __post_init__(self):
+        if self.start_epoch < 0:
+            raise ValueError(
+                f"evaluator.start_epoch must be >= 0, got {self.start_epoch}"
+            )
+
 
 @dataclass
 class SaverConfig(_Timer):

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -534,6 +534,29 @@ class PPOTrainer:
         elif self._requires_proxy_workflow(workflow):
             self._ensure_proxy_started()
 
+        if config.evaluator.start_epoch == 0 and start_step == 0:
+            with (
+                stats_tracker.record_timing("eval_at_start"),
+                perf_tracer.trace_scope(
+                    "train.eval_at_start",
+                    category=Category.COMPUTE,
+                    args={"global_step": -1},
+                ),
+            ):
+                self._evaluate(
+                    eval_workflow=eval_workflow,
+                    eval_workflow_kwargs=eval_workflow_kwargs,
+                    epoch=0,
+                    epoch_step=-1,
+                    global_step=-1,
+                )
+            with perf_tracer.trace_scope(
+                "train.log_stats_before_train",
+                category=Category.INSTR,
+                args={"global_step": -1},
+            ):
+                self._export_and_commit_stats(epoch=0, epoch_step=-1, global_step=-1)
+
         for global_step in range(start_step, max_steps):
             if (
                 config.total_train_steps is not None

--- a/areal/trainer/rw_trainer.py
+++ b/areal/trainer/rw_trainer.py
@@ -190,6 +190,23 @@ class RWTrainer:
         steps_per_epoch = len(self.train_dataloader)
         max_steps = total_epochs * steps_per_epoch
 
+        if config.evaluator.start_epoch == 0 and start_step == 0:
+            with (
+                stats_tracker.record_timing("eval_at_start"),
+                perf_tracer.trace_scope(
+                    "train.eval_at_start",
+                    category=Category.COMPUTE,
+                    args={"global_step": -1},
+                ),
+            ):
+                self._evaluate(epoch=0, epoch_step=-1, global_step=-1)
+            with perf_tracer.trace_scope(
+                "train.log_stats_before_train",
+                category=Category.INSTR,
+                args={"global_step": -1},
+            ):
+                self._export_and_commit_stats(epoch=0, epoch_step=-1, global_step=-1)
+
         global_step = 0
         data_generator = cycle_dataloader(self.train_dataloader)
         for global_step in range(start_step, max_steps):

--- a/areal/trainer/sft_trainer.py
+++ b/areal/trainer/sft_trainer.py
@@ -157,6 +157,23 @@ class SFTTrainer:
         steps_per_epoch = len(self.train_dataloader)
         max_steps = total_epochs * steps_per_epoch
 
+        if config.evaluator.start_epoch == 0 and start_step == 0:
+            with (
+                stats_tracker.record_timing("eval_at_start"),
+                perf_tracer.trace_scope(
+                    "train.eval_at_start",
+                    category=Category.COMPUTE,
+                    args={"global_step": -1},
+                ),
+            ):
+                self._evaluate(epoch=0, epoch_step=-1, global_step=-1)
+            with perf_tracer.trace_scope(
+                "train.log_stats_before_train",
+                category=Category.INSTR,
+                args={"global_step": -1},
+            ):
+                self._export_and_commit_stats(epoch=0, epoch_step=-1, global_step=-1)
+
         global_step = 0
         data_generator = cycle_dataloader(self.train_dataloader)
         for global_step in range(start_step, max_steps):

--- a/areal/utils/evaluator.py
+++ b/areal/utils/evaluator.py
@@ -15,6 +15,7 @@ class Evaluator:
             freq_epoch=config.freq_epochs,
             freq_step=config.freq_steps,
             freq_sec=config.freq_secs,
+            start_epoch=config.start_epoch,
         )
 
     def state_dict(self):

--- a/areal/utils/timeutil.py
+++ b/areal/utils/timeutil.py
@@ -146,32 +146,51 @@ class EpochStepTimeFreqCtl:
     freq_epoch: int | None
     freq_step: int | None
     freq_sec: int | None
+    start_epoch: int = 1
     group: dist.ProcessGroup | None = None
 
     def __post_init__(self):
-        self.epoch_ctl = FrequencyControl(frequency_steps=self.freq_epoch)
+        if self.start_epoch < 0:
+            raise ValueError(f"start_epoch must be >= 0, got {self.start_epoch}")
+        self.epoch_ctl = FrequencyControl(
+            frequency_steps=self.freq_epoch,
+            initial_value=(self.start_epoch == 0),
+        )
+        self._epoch_count = 0
         self.step_ctl = FrequencyControl(frequency_steps=self.freq_step)
         self.time_ctl = FrequencyControl(
             frequency_seconds=self.freq_sec, group=self.group
         )
 
     def check(self, epochs: int, steps: int):
-        x, y, z = (
-            self.epoch_ctl.check(epochs),
-            self.step_ctl.check(steps),
-            self.time_ctl.check(),
-        )
-        return x or y or z
+        if self.start_epoch <= 1:
+            epoch_trigger = self.epoch_ctl.check(epochs)
+        else:
+            self._epoch_count += epochs
+            epoch_trigger = False
+            if self.freq_epoch is not None and epochs > 0:
+                if self._epoch_count >= self.start_epoch:
+                    epoch_trigger = (
+                        self._epoch_count - self.start_epoch
+                    ) % self.freq_epoch == 0
+
+        step_trigger = self.step_ctl.check(steps)
+        time_trigger = self.time_ctl.check()
+        return epoch_trigger or step_trigger or time_trigger
 
     def state_dict(self):
         return dict(
             epoch=self.epoch_ctl.state_dict(),
             step=self.step_ctl.state_dict(),
             time=self.time_ctl.state_dict(),
+            start_epoch=self.start_epoch,
+            epoch_count=self._epoch_count,
         )
 
     def load_state_dict(self, state_dict):
-        self.epoch_ctl.load_state_dict(state_dict["epoch"])
+        self.start_epoch = int(state_dict.get("start_epoch", self.start_epoch))
+        self._epoch_count = int(state_dict.get("epoch_count", 0))
+        self.epoch_ctl.load_state_dict(state_dict.get("epoch"))
         self.step_ctl.load_state_dict(state_dict["step"])
         self.time_ctl.load_state_dict(state_dict["time"])
 

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -719,14 +719,15 @@ Configuration for distributed name resolution and service discovery.
 
 Configuration for model evaluation scheduling and timing.
 
-| Parameter         | Type            | Default      | Description                                                    |
-| ----------------- | --------------- | ------------ | -------------------------------------------------------------- |
-| `experiment_name` | string          | **Required** | -                                                              |
-| `trial_name`      | string          | **Required** | -                                                              |
-| `fileroot`        | string          | **Required** | -                                                              |
-| `freq_epochs`     | integer \| None | `None`       | Trigger frequency in epochs. None disables epoch-based saving. |
-| `freq_steps`      | integer \| None | `None`       | Trigger frequency in steps. None disables step-based saving.   |
-| `freq_secs`       | integer \| None | `None`       | Trigger frequency in seconds. None disables time-based saving. |
+| Parameter         | Type            | Default      | Description                                                                                                                     |
+| ----------------- | --------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `experiment_name` | string          | **Required** | -                                                                                                                               |
+| `trial_name`      | string          | **Required** | -                                                                                                                               |
+| `fileroot`        | string          | **Required** | -                                                                                                                               |
+| `freq_epochs`     | integer \| None | `None`       | Trigger frequency in epochs. None disables epoch-based saving.                                                                  |
+| `freq_steps`      | integer \| None | `None`       | Trigger frequency in steps. None disables step-based saving.                                                                    |
+| `freq_secs`       | integer \| None | `None`       | Trigger frequency in seconds. None disables time-based saving.                                                                  |
+| `start_epoch`     | integer         | `1`          | First epoch index to allow eval. 0 enables a pre-train eval on fresh runs. 1 keeps current behavior (first eval after epoch 1). |
 
 (section-recover)=
 

--- a/docs/en/reference/metrics_tracking.md
+++ b/docs/en/reference/metrics_tracking.md
@@ -205,6 +205,15 @@ stats_tracker.get("eval-rollout").scalar(reward=0.9)
 all_stats = stats_tracker.export_all(reduce_group=group)
 ```
 
+During training, validation metrics usually appear under the `eval-rollout/*` namespace.
+The first time these metrics appear depends on the evaluator schedule:
+
+- `evaluator.start_epoch=0` logs validation metrics before training starts
+- `evaluator.start_epoch=1` logs them after the first epoch
+- later `start_epoch` values delay when `eval-rollout/*` first appears in dashboards
+
+After that, epoch-based validation follows `evaluator.freq_epochs`.
+
 ## Data Flow
 
 The complete metrics flow from collection to logging:

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -717,14 +717,15 @@ Configuration for distributed name resolution and service discovery.
 
 Configuration for model evaluation scheduling and timing.
 
-| Parameter         | Type            | Default      | Description                                                    |
-| ----------------- | --------------- | ------------ | -------------------------------------------------------------- |
-| `experiment_name` | string          | **Required** | -                                                              |
-| `trial_name`      | string          | **Required** | -                                                              |
-| `fileroot`        | string          | **Required** | -                                                              |
-| `freq_epochs`     | integer \| None | `None`       | Trigger frequency in epochs. None disables epoch-based saving. |
-| `freq_steps`      | integer \| None | `None`       | Trigger frequency in steps. None disables step-based saving.   |
-| `freq_secs`       | integer \| None | `None`       | Trigger frequency in seconds. None disables time-based saving. |
+| Parameter         | Type            | Default      | Description                                                                                                                     |
+| ----------------- | --------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `experiment_name` | string          | **Required** | -                                                                                                                               |
+| `trial_name`      | string          | **Required** | -                                                                                                                               |
+| `fileroot`        | string          | **Required** | -                                                                                                                               |
+| `freq_epochs`     | integer \| None | `None`       | Trigger frequency in epochs. None disables epoch-based saving.                                                                  |
+| `freq_steps`      | integer \| None | `None`       | Trigger frequency in steps. None disables step-based saving.                                                                    |
+| `freq_secs`       | integer \| None | `None`       | Trigger frequency in seconds. None disables time-based saving.                                                                  |
+| `start_epoch`     | integer         | `1`          | First epoch index to allow eval. 0 enables a pre-train eval on fresh runs. 1 keeps current behavior (first eval after epoch 1). |
 
 (section-recover)=
 

--- a/docs/zh/reference/metrics_tracking.md
+++ b/docs/zh/reference/metrics_tracking.md
@@ -200,6 +200,14 @@ stats_tracker.get("eval-rollout").scalar(reward=0.9)
 all_stats = stats_tracker.export_all(reduce_group=group)
 ```
 
+在训练过程中，验证指标通常出现在 `eval-rollout/*` 命名空间下。这些指标首次出现的时间取决于评估调度配置：
+
+- `evaluator.start_epoch=0`：在训练开始前记录一次验证指标
+- `evaluator.start_epoch=1`：在第一个 epoch 结束后记录验证指标
+- 更大的 `start_epoch` 值会推迟 `eval-rollout/*` 在面板或仪表盘中的首次出现时间
+
+之后，基于 epoch 的验证会按照 `evaluator.freq_epochs` 的频率继续执行。
+
 ## 数据流
 
 从收集到记录的完整指标流程：

--- a/tests/test_timeutil.py
+++ b/tests/test_timeutil.py
@@ -1,0 +1,138 @@
+import pytest
+
+from areal.utils.timeutil import EpochStepTimeFreqCtl
+
+
+def test_start_epoch_zero_triggers_initial_check_once():
+    ctl = EpochStepTimeFreqCtl(
+        freq_epoch=1,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=0,
+    )
+
+    assert ctl.check(epochs=0, steps=0) is True
+    assert ctl.check(epochs=0, steps=0) is False
+
+
+def test_start_epoch_one_matches_legacy_epoch_end_trigger():
+    ctl = EpochStepTimeFreqCtl(
+        freq_epoch=1,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=1,
+    )
+
+    # No epoch boundary yet.
+    assert ctl.check(epochs=0, steps=0) is False
+    # First epoch end triggers.
+    assert ctl.check(epochs=1, steps=0) is True
+
+
+def test_start_epoch_three_freq_one():
+    ctl = EpochStepTimeFreqCtl(
+        freq_epoch=1,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=3,
+    )
+
+    assert ctl.check(epochs=1, steps=0) is False
+    assert ctl.check(epochs=1, steps=0) is False
+    assert ctl.check(epochs=1, steps=0) is True
+    assert ctl.check(epochs=1, steps=0) is True
+
+
+def test_start_epoch_two_freq_two():
+    ctl = EpochStepTimeFreqCtl(
+        freq_epoch=2,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=2,
+    )
+
+    # Epoch 1: before start.
+    assert ctl.check(epochs=1, steps=0) is False
+    # Epoch 2: first trigger.
+    assert ctl.check(epochs=1, steps=0) is True
+    # Epoch 3: not on interval.
+    assert ctl.check(epochs=1, steps=0) is False
+    # Epoch 4: second trigger.
+    assert ctl.check(epochs=1, steps=0) is True
+
+
+def test_state_dict_roundtrip_keeps_schedule_progress():
+    ctl = EpochStepTimeFreqCtl(
+        freq_epoch=2,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=2,
+    )
+    assert ctl.check(epochs=1, steps=0) is False  # epoch_count=1
+
+    state = ctl.state_dict()
+    recovered = EpochStepTimeFreqCtl(
+        freq_epoch=2,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=2,
+    )
+    recovered.load_state_dict(state)
+
+    # epoch_count goes 1->2 and should trigger.
+    assert recovered.check(epochs=1, steps=0) is True
+
+
+def test_load_state_dict_restores_start_epoch():
+    source = EpochStepTimeFreqCtl(
+        freq_epoch=1,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=3,
+    )
+    state = source.state_dict()
+
+    target = EpochStepTimeFreqCtl(
+        freq_epoch=1,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=1,
+    )
+    target.load_state_dict(state)
+
+    assert target.start_epoch == 3
+
+
+def test_load_state_dict_supports_missing_new_fields():
+    ctl = EpochStepTimeFreqCtl(
+        freq_epoch=1,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=0,
+    )
+
+    state = ctl.state_dict()
+    # Simulate older checkpoint payload without newly added fields.
+    state.pop("start_epoch")
+    state.pop("epoch_count")
+
+    recovered = EpochStepTimeFreqCtl(
+        freq_epoch=1,
+        freq_step=None,
+        freq_sec=None,
+        start_epoch=1,
+    )
+    recovered.load_state_dict(state)
+
+    # Missing fields should fall back to runtime defaults.
+    assert recovered.start_epoch == 1
+
+
+def test_start_epoch_negative_raises():
+    with pytest.raises(ValueError):
+        EpochStepTimeFreqCtl(
+            freq_epoch=1,
+            freq_step=None,
+            freq_sec=None,
+            start_epoch=-1,
+        )


### PR DESCRIPTION

## Description

- Adds support for evaluation at epoch 0.
- Adds start_epoch control so users can delay the first evaluation until a chosen epoch.
- Keeps periodic evaluation behavior with freq_epochs after the start point.
- Refactors evaluation scheduling to be handled cleanly in the frequency controller.
- Adds unit tests to validate scheduling behavior and checkpoint save/load behavior.

** Usage**
```yaml
evaluator:
  start_epoch: 0 # default 1 if skipped keeps usual behavior
```


**Behavior summary**
- start_epoch=0, freq_epochs=1: evaluate at 0,1,2,3,...
- start_epoch=0, freq_epochs=2: evaluate at 0,2,4,6,...
- start_epoch=3, freq_epochs=1: first evaluation at epoch 3, then every epoch
- start_epoch=2, freq_epochs=2: evaluate at 2,4,6,8,...


## Type of Change


- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change



______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
