### PR TITLE
feat(eval): support for running eval before training

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -2119,6 +2119,13 @@ class _Timer:
 class EvaluatorConfig(_Timer):
     """Configuration for model evaluation scheduling and timing."""
 
+    eval_before_train: bool = field(
+        default=False,
+        metadata={
+            "help": "Run one evaluation before training begins, then continue with the configured evaluation frequency.",
+        },
+    )
+
 
 @dataclass
 class SaverConfig(_Timer):

--- a/areal/utils/evaluator.py
+++ b/areal/utils/evaluator.py
@@ -15,6 +15,7 @@ class Evaluator:
             freq_epoch=config.freq_epochs,
             freq_step=config.freq_steps,
             freq_sec=config.freq_secs,
+            initial_epoch_value=config.eval_before_train,
         )
 
     def state_dict(self):

--- a/areal/utils/timeutil.py
+++ b/areal/utils/timeutil.py
@@ -146,10 +146,14 @@ class EpochStepTimeFreqCtl:
     freq_epoch: int | None
     freq_step: int | None
     freq_sec: int | None
+    initial_epoch_value: bool = False
     group: dist.ProcessGroup | None = None
 
     def __post_init__(self):
-        self.epoch_ctl = FrequencyControl(frequency_steps=self.freq_epoch)
+        self.epoch_ctl = FrequencyControl(
+            frequency_steps=self.freq_epoch,
+            initial_value=self.initial_epoch_value,
+        )
         self.step_ctl = FrequencyControl(frequency_steps=self.freq_step)
         self.time_ctl = FrequencyControl(
             frequency_seconds=self.freq_sec, group=self.group

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -720,14 +720,15 @@ Configuration for distributed name resolution and service discovery.
 
 Configuration for model evaluation scheduling and timing.
 
-| Parameter         | Type            | Default      | Description                                                    |
-| ----------------- | --------------- | ------------ | -------------------------------------------------------------- |
-| `experiment_name` | string          | **Required** | -                                                              |
-| `trial_name`      | string          | **Required** | -                                                              |
-| `fileroot`        | string          | **Required** | -                                                              |
-| `freq_epochs`     | integer \| None | `None`       | Trigger frequency in epochs. None disables epoch-based saving. |
-| `freq_steps`      | integer \| None | `None`       | Trigger frequency in steps. None disables step-based saving.   |
-| `freq_secs`       | integer \| None | `None`       | Trigger frequency in seconds. None disables time-based saving. |
+| Parameter           | Type            | Default      | Description                                                                                        |
+| ------------------- | --------------- | ------------ | -------------------------------------------------------------------------------------------------- |
+| `experiment_name`   | string          | **Required** | -                                                                                                  |
+| `trial_name`        | string          | **Required** | -                                                                                                  |
+| `fileroot`          | string          | **Required** | -                                                                                                  |
+| `freq_epochs`       | integer \| None | `None`       | Trigger frequency in epochs. None disables epoch-based saving.                                     |
+| `freq_steps`        | integer \| None | `None`       | Trigger frequency in steps. None disables step-based saving.                                       |
+| `freq_secs`         | integer \| None | `None`       | Trigger frequency in seconds. None disables time-based saving.                                     |
+| `eval_before_train` | boolean         | `False`      | Run one evaluation before training begins, then continue with the configured evaluation frequency. |
 
 (section-recover)=
 

--- a/docs/en/reference/metrics_tracking.md
+++ b/docs/en/reference/metrics_tracking.md
@@ -205,6 +205,9 @@ stats_tracker.get("eval-rollout").scalar(reward=0.9)
 all_stats = stats_tracker.export_all(reduce_group=group)
 ```
 
+If `evaluator.eval_before_train: true`, evaluation runs once before the first training
+step to get an estimate of the initial model's performance before finetuning.
+
 ## Data Flow
 
 The complete metrics flow from collection to logging:

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -718,14 +718,15 @@ Configuration for distributed name resolution and service discovery.
 
 Configuration for model evaluation scheduling and timing.
 
-| Parameter         | Type            | Default      | Description                                                    |
-| ----------------- | --------------- | ------------ | -------------------------------------------------------------- |
-| `experiment_name` | string          | **Required** | -                                                              |
-| `trial_name`      | string          | **Required** | -                                                              |
-| `fileroot`        | string          | **Required** | -                                                              |
-| `freq_epochs`     | integer \| None | `None`       | Trigger frequency in epochs. None disables epoch-based saving. |
-| `freq_steps`      | integer \| None | `None`       | Trigger frequency in steps. None disables step-based saving.   |
-| `freq_secs`       | integer \| None | `None`       | Trigger frequency in seconds. None disables time-based saving. |
+| Parameter           | Type            | Default      | Description                                                                                        |
+| ------------------- | --------------- | ------------ | -------------------------------------------------------------------------------------------------- |
+| `experiment_name`   | string          | **Required** | -                                                                                                  |
+| `trial_name`        | string          | **Required** | -                                                                                                  |
+| `fileroot`          | string          | **Required** | -                                                                                                  |
+| `freq_epochs`       | integer \| None | `None`       | Trigger frequency in epochs. None disables epoch-based saving.                                     |
+| `freq_steps`        | integer \| None | `None`       | Trigger frequency in steps. None disables step-based saving.                                       |
+| `freq_secs`         | integer \| None | `None`       | Trigger frequency in seconds. None disables time-based saving.                                     |
+| `eval_before_train` | boolean         | `False`      | Run one evaluation before training begins, then continue with the configured evaluation frequency. |
 
 (section-recover)=
 

--- a/docs/zh/reference/metrics_tracking.md
+++ b/docs/zh/reference/metrics_tracking.md
@@ -200,6 +200,8 @@ stats_tracker.get("eval-rollout").scalar(reward=0.9)
 all_stats = stats_tracker.export_all(reduce_group=group)
 ```
 
+如果设置 `evaluator.eval_before_train: true`，系统会在第一个训练 step 开始前执行一次评估，以便在微调开始前估计初始模型的性能。
+
 ## 数据流
 
 从收集到记录的完整指标流程：


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does -->
This PR adds support for `evaluator.eval_before_train` so users can trigger one evaluation at the beginning of training to estimate initial model quality before finetuning, while keeping existing eval frequency logic unchanged.

- When true, evaluation is configured to trigger once at startup through the scheduler’s initial epoch trigger.
- Existing freq_epochs / freq_steps / freq_secs behavior is preserved for subsequent evaluation scheduling.

## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
