### PR TITLE
feat: add disk-mode weight update flow to gateway

### DIFF
--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -165,7 +165,7 @@ def get_versioned_lora_name(lora_name: str, version: int) -> str:
 
 @dataclass
 class WeightUpdateMeta:
-    type: Literal["disk", "xccl"]
+    type: Literal["disk", "xccl", "awex"]
     path: str | None = None
     gen_allocation: ModelAllocation | None = None
 
@@ -261,6 +261,22 @@ class WeightUpdateMeta:
             type="xccl",
             gen_allocation=gen_allocation,
             weight_chunked_mem_mb=weight_chunked_mem_mb,
+            use_lora=use_lora,
+            lora_name=lora_name,
+            lora_int_id=lora_int_id,
+            base_model_name=base_model_name,
+        )
+
+    @classmethod
+    def from_awex(
+        cls,
+        use_lora: bool = False,
+        lora_name: str = "",
+        lora_int_id: int = 1,
+        base_model_name: str = "",
+    ):
+        return cls(
+            type="awex",
             use_lora=use_lora,
             lora_name=lora_name,
             lora_int_id=lora_int_id,

--- a/areal/experimental/weight_update/controller/controller.py
+++ b/areal/experimental/weight_update/controller/controller.py
@@ -108,6 +108,10 @@ class WeightUpdateController:
         pair_name: str,
         train_worker_urls: list[str],
         inference_worker_urls: list[str],
+        mode: str = "awex",
+        save_path: str = "",
+        use_lora: bool = False,
+        lora_name: str = "",
     ) -> None:
         self._pair_name = pair_name
         resp = self._http.post(
@@ -116,11 +120,15 @@ class WeightUpdateController:
                 "pair_name": pair_name,
                 "train_worker_urls": train_worker_urls,
                 "inference_worker_urls": inference_worker_urls,
+                "mode": mode,
+                "save_path": save_path,
+                "use_lora": use_lora,
+                "lora_name": lora_name,
             },
             timeout=self.config.request_timeout,
         )
         resp.raise_for_status()
-        logger.info("Connected pair '%s'", pair_name)
+        logger.info("Connected pair '%s' (mode=%s)", pair_name, mode)
 
     def update_weights(self, version: int) -> WeightUpdateResult:
         if self._pair_name is None:

--- a/areal/experimental/weight_update/gateway/app.py
+++ b/areal/experimental/weight_update/gateway/app.py
@@ -197,6 +197,23 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         inference_urls = body.inference_worker_urls
 
         if body.mode == "disk":
+            if not body.save_path:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "save_path is required when mode='disk'"},
+                )
+            if not os.path.isabs(body.save_path):
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": "save_path must be an absolute path when mode='disk'"
+                    },
+                )
+            if body.use_lora and not body.lora_name:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "lora_name is required when use_lora=True"},
+                )
             pair_info = PairInfo(
                 pair_name=pair_name,
                 train_worker_urls=train_urls,

--- a/areal/experimental/weight_update/gateway/app.py
+++ b/areal/experimental/weight_update/gateway/app.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import socket
 import time
 from contextlib import asynccontextmanager
@@ -29,6 +30,10 @@ class ConnectRequest(BaseModel):
     pair_name: str
     train_worker_urls: list[str]
     inference_worker_urls: list[str]
+    mode: str = "awex"  # "awex" or "disk"
+    save_path: str = ""
+    use_lora: bool = False
+    lora_name: str = ""
 
 
 class UpdateWeightsRequest(BaseModel):
@@ -191,6 +196,22 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         train_urls = body.train_worker_urls
         inference_urls = body.inference_worker_urls
 
+        if body.mode == "disk":
+            pair_info = PairInfo(
+                pair_name=pair_name,
+                train_worker_urls=train_urls,
+                inference_worker_urls=inference_urls,
+                mode="disk",
+                save_path=body.save_path,
+                use_lora=body.use_lora,
+                lora_name=body.lora_name,
+            )
+            registry.register(pair_info)
+            logger.info(
+                "Connected disk pair '%s' (save_path=%s)", pair_name, body.save_path
+            )
+            return ConnectResponse(pair_name=pair_name)
+
         session = request.app.state.http_session
         init_timeout_s = config.init_timeout_s
 
@@ -325,6 +346,114 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         logger.info("Connected pair '%s'", pair_name)
         return ConnectResponse(pair_name=pair_name)
 
+    @asynccontextmanager
+    async def _inference_paused(
+        session: aiohttp.ClientSession,
+        inference_urls: list[str],
+        timeout_s: float,
+        pair_name: str,
+    ):
+        await asyncio.gather(
+            *[
+                _post(session, f"{url}/pause_generation", timeout_s, json_data={})
+                for url in inference_urls
+            ]
+        )
+        try:
+            yield
+        finally:
+            try:
+                await asyncio.gather(
+                    *[
+                        _post(
+                            session,
+                            f"{url}/continue_generation",
+                            timeout_s,
+                            json_data={},
+                        )
+                        for url in inference_urls
+                    ]
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to resume inference for pair '%s'",
+                    pair_name,
+                    exc_info=True,
+                )
+
+    async def _awex_transfer_weights(
+        pair_info: PairInfo,
+        version: int,
+        session: aiohttp.ClientSession,
+        timeout_s: float,
+    ) -> None:
+        await asyncio.gather(
+            *[
+                _post(
+                    session,
+                    f"{url}/awex/update_weights",
+                    timeout_s,
+                    json_data={"version": version},
+                )
+                for url in pair_info.train_worker_urls + pair_info.inference_worker_urls
+            ]
+        )
+
+    async def _disk_transfer_weights(
+        pair_info: PairInfo,
+        version: int,
+        session: aiohttp.ClientSession,
+        timeout_s: float,
+    ) -> None:
+        from areal.api.io_struct import SaveLoadMeta, get_versioned_lora_name
+        from areal.infra.rpc.serialization import serialize_value
+
+        save_path = os.path.join(pair_info.save_path, f"weight_update_v{version}")
+
+        save_meta = SaveLoadMeta(path=save_path, weight_format="hf", with_optim=False)
+        save_payload = {
+            "args": serialize_value([save_meta]),
+            "kwargs": serialize_value({}),
+        }
+        await asyncio.gather(
+            *[
+                _post_json(session, f"{url}/save", timeout_s, json_data=save_payload)
+                for url in pair_info.train_worker_urls
+            ]
+        )
+
+        if pair_info.use_lora:
+            lora_name = get_versioned_lora_name(pair_info.lora_name, version)
+            await asyncio.gather(
+                *[
+                    _post_json(
+                        session,
+                        f"{url}/load_lora_adapter",
+                        timeout_s,
+                        json_data={
+                            "lora_name": lora_name,
+                            "lora_path": save_path,
+                        },
+                    )
+                    for url in pair_info.inference_worker_urls
+                ]
+            )
+        else:
+            await asyncio.gather(
+                *[
+                    _post_json(
+                        session,
+                        f"{url}/update_weights_from_disk",
+                        timeout_s,
+                        json_data={
+                            "model_path": save_path,
+                            "abort_all_requests": True,
+                        },
+                    )
+                    for url in pair_info.inference_worker_urls
+                ]
+            )
+
     @app.post("/update_weights")
     async def update_weights(
         request: Request, body: UpdateWeightsRequest
@@ -334,27 +463,51 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
         pair_info = registry.get_by_name(body.pair_name)
         if pair_info is None:
             return JSONResponse(
-                status_code=404, content={"error": f"Pair '{body.pair_name}' not found"}
+                status_code=404,
+                content={"error": f"Pair '{body.pair_name}' not found"},
             )
 
         session = request.app.state.http_session
-        update_timeout_s = config.update_timeout_s
-
+        timeout_s = config.update_timeout_s
         start = time.monotonic()
-        tasks = [
-            _post(
+
+        try:
+            async with _inference_paused(
                 session,
-                f"{url}/awex/update_weights",
-                update_timeout_s,
-                json_data={"version": body.version},
+                pair_info.inference_worker_urls,
+                timeout_s,
+                pair_info.pair_name,
+            ):
+                if pair_info.mode == "disk":
+                    await _disk_transfer_weights(
+                        pair_info, body.version, session, timeout_s
+                    )
+                else:
+                    await _awex_transfer_weights(
+                        pair_info, body.version, session, timeout_s
+                    )
+        except Exception as e:
+            duration_ms = (time.monotonic() - start) * 1000
+            logger.error(
+                "Weight update failed for pair '%s': %s",
+                pair_info.pair_name,
+                e,
             )
-            for url in pair_info.train_worker_urls + pair_info.inference_worker_urls
-        ]
-        await asyncio.gather(*tasks)
+            return WeightUpdateResult(
+                status="error",
+                version=body.version,
+                duration_ms=duration_ms,
+                error=str(e),
+            )
 
         duration_ms = (time.monotonic() - start) * 1000
         pair_info.last_version = body.version
-
+        logger.info(
+            "Weight update completed for pair '%s' v%d (%.1fms)",
+            pair_info.pair_name,
+            body.version,
+            duration_ms,
+        )
         return WeightUpdateResult(
             status="ok", version=body.version, duration_ms=duration_ms
         )

--- a/areal/experimental/weight_update/gateway/config.py
+++ b/areal/experimental/weight_update/gateway/config.py
@@ -54,6 +54,14 @@ class PairInfo:
     master_port: int = 0
     last_version: int = 0
 
+    # Disk-mode fields (used when mode="disk")
+    mode: str = "awex"  # "awex" or "disk"
+    save_path: str = ""
+    use_lora: bool = False
+    lora_name: str = ""
+
     def __post_init__(self):
         if not self.pair_name:
             raise ValueError("pair_name must not be empty")
+        if self.mode not in ("awex", "disk"):
+            raise ValueError(f"mode must be 'awex' or 'disk', got '{self.mode}'")

--- a/tests/experimental/weight_update/test_disk_integration.py
+++ b/tests/experimental/weight_update/test_disk_integration.py
@@ -1,0 +1,453 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import torch
+
+from tests.experimental.weight_update.test_nccl_integration import (
+    _get_test_model_path,
+    _make_local_scheduler,
+    _validate_weight_update_correctness,
+)
+
+from areal.experimental.weight_update.gateway.app import create_app
+from areal.experimental.weight_update.gateway.config import (
+    PairInfo,
+    WeightUpdateConfig,
+)
+from areal.infra.platforms import current_platform
+
+
+@pytest.fixture()
+def config() -> WeightUpdateConfig:
+    return WeightUpdateConfig(
+        admin_api_key="test-key",
+        init_timeout_s=5,
+        update_timeout_s=5,
+    )
+
+
+@pytest.fixture()
+def app(config):
+    return create_app(config)
+
+
+@pytest.fixture()
+def client(app):
+    from starlette.testclient import TestClient
+
+    return TestClient(app)
+
+
+ADMIN_HEADERS = {"Authorization": "Bearer test-key"}
+
+
+def _make_mock_aiohttp_session(called_urls: list[tuple[str, str]]):
+    mock_session = MagicMock()
+
+    @asynccontextmanager
+    async def _fake_post(url, **kwargs):
+        called_urls.append(("POST", url))
+        resp = MagicMock()
+        resp.status = 200
+        resp.raise_for_status = MagicMock()
+        resp.json = AsyncMock(return_value={"status": "success", "result": None})
+        yield resp
+
+    @asynccontextmanager
+    async def _fake_get(url, **kwargs):
+        called_urls.append(("GET", url))
+        resp = MagicMock()
+        resp.status = 200
+        resp.raise_for_status = MagicMock()
+        resp.json = AsyncMock(return_value={})
+        yield resp
+
+    mock_session.post = _fake_post
+    mock_session.get = _fake_get
+    return mock_session
+
+
+class TestDiskConnect:
+    def test_disk_connect_registers_pair(self, client, app):
+        resp = client.post(
+            "/connect",
+            json={
+                "pair_name": "disk_pair",
+                "train_worker_urls": ["http://train:8000"],
+                "inference_worker_urls": ["http://infer:9000"],
+                "mode": "disk",
+                "save_path": "/shared/weights",
+            },
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["pair_name"] == "disk_pair"
+
+        registry = app.state.registry
+        pair = registry.get_by_name("disk_pair")
+        assert pair is not None
+        assert pair.mode == "disk"
+        assert pair.save_path == "/shared/weights"
+        assert pair.train_worker_urls == ["http://train:8000"]
+        assert pair.inference_worker_urls == ["http://infer:9000"]
+
+    def test_disk_connect_with_lora(self, client, app):
+        resp = client.post(
+            "/connect",
+            json={
+                "pair_name": "lora_pair",
+                "train_worker_urls": ["http://train:8000"],
+                "inference_worker_urls": ["http://infer:9000"],
+                "mode": "disk",
+                "save_path": "/shared/lora",
+                "use_lora": True,
+                "lora_name": "my-adapter",
+            },
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 200
+
+        pair = app.state.registry.get_by_name("lora_pair")
+        assert pair.use_lora is True
+        assert pair.lora_name == "my-adapter"
+
+    def test_disk_connect_does_not_call_awex_endpoints(self, client, app):
+        called_urls: list[tuple[str, str]] = []
+        app.state.http_session = _make_mock_aiohttp_session(called_urls)
+
+        resp = client.post(
+            "/connect",
+            json={
+                "pair_name": "disk_only",
+                "train_worker_urls": ["http://train:8000"],
+                "inference_worker_urls": ["http://infer:9000"],
+                "mode": "disk",
+                "save_path": "/tmp/w",
+            },
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert len(called_urls) == 0
+
+
+class TestDiskUpdateWeights:
+    @pytest.fixture(autouse=True)
+    def _register_disk_pair(self, app):
+        pair_info = PairInfo(
+            pair_name="test_disk",
+            train_worker_urls=["http://train:8000"],
+            inference_worker_urls=["http://infer:9000"],
+            mode="disk",
+            save_path="/shared/weights",
+        )
+        app.state.registry.register(pair_info)
+
+    def test_disk_update_calls_pause_save_load_resume(self, client, app):
+        called_urls: list[tuple[str, str]] = []
+        app.state.http_session = _make_mock_aiohttp_session(called_urls)
+
+        resp = client.post(
+            "/update_weights",
+            json={"pair_name": "test_disk", "version": 1},
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["version"] == 1
+
+        urls = [url for _, url in called_urls]
+        assert "http://infer:9000/pause_generation" in urls
+        assert any("/save" in u for u in urls)
+        assert "http://infer:9000/update_weights_from_disk" in urls
+        assert "http://infer:9000/continue_generation" in urls
+
+        pause_idx = urls.index("http://infer:9000/pause_generation")
+        save_idx = next(i for i, u in enumerate(urls) if "/save" in u)
+        load_idx = urls.index("http://infer:9000/update_weights_from_disk")
+        resume_idx = urls.index("http://infer:9000/continue_generation")
+        assert pause_idx < save_idx < load_idx < resume_idx
+
+    def test_disk_update_versioned_save_path(self, client, app):
+        called_urls: list[tuple[str, str]] = []
+        app.state.http_session = _make_mock_aiohttp_session(called_urls)
+
+        client.post(
+            "/update_weights",
+            json={"pair_name": "test_disk", "version": 42},
+            headers=ADMIN_HEADERS,
+        )
+
+        save_url = next(url for _, url in called_urls if "/save" in url)
+        assert save_url == "http://train:8000/save"
+
+    def test_disk_update_not_found_pair(self, client, app):
+        resp = client.post(
+            "/update_weights",
+            json={"pair_name": "nonexistent", "version": 1},
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 404
+
+    def test_disk_update_error_still_resumes_inference(self, client, app):
+        called_urls: list[tuple[str, str]] = []
+
+        @asynccontextmanager
+        async def _failing_post(url, **kwargs):
+            called_urls.append(("POST", url))
+            if "/save" in url:
+                raise RuntimeError("save failed")
+            resp = MagicMock()
+            resp.status = 200
+            resp.raise_for_status = MagicMock()
+            resp.json = AsyncMock(return_value={"status": "success", "result": None})
+            yield resp
+
+        mock_session = MagicMock()
+        mock_session.post = _failing_post
+        app.state.http_session = mock_session
+
+        resp = client.post(
+            "/update_weights",
+            json={"pair_name": "test_disk", "version": 1},
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "error"
+        assert "save failed" in data["error"]
+
+        urls = [url for _, url in called_urls]
+        assert "http://infer:9000/continue_generation" in urls
+
+
+class TestDiskUpdateWeightsLora:
+    @pytest.fixture(autouse=True)
+    def _register_lora_pair(self, app):
+        pair_info = PairInfo(
+            pair_name="lora_disk",
+            train_worker_urls=["http://train:8000"],
+            inference_worker_urls=["http://infer:9000"],
+            mode="disk",
+            save_path="/shared/lora_weights",
+            use_lora=True,
+            lora_name="my-adapter",
+        )
+        app.state.registry.register(pair_info)
+
+    def test_lora_update_uses_load_lora_adapter(self, client, app):
+        called_urls: list[tuple[str, str]] = []
+        app.state.http_session = _make_mock_aiohttp_session(called_urls)
+
+        resp = client.post(
+            "/update_weights",
+            json={"pair_name": "lora_disk", "version": 3},
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+        urls = [url for _, url in called_urls]
+        assert "http://infer:9000/load_lora_adapter" in urls
+        assert "http://infer:9000/update_weights_from_disk" not in urls
+
+
+class TestDiskDisconnect:
+    def test_disconnect_removes_disk_pair(self, client, app):
+        client.post(
+            "/connect",
+            json={
+                "pair_name": "to_remove",
+                "train_worker_urls": ["http://train:8000"],
+                "inference_worker_urls": ["http://infer:9000"],
+                "mode": "disk",
+                "save_path": "/tmp/w",
+            },
+            headers=ADMIN_HEADERS,
+        )
+        assert app.state.registry.get_by_name("to_remove") is not None
+
+        resp = client.post(
+            "/disconnect",
+            json={"pair_name": "to_remove"},
+            headers=ADMIN_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert app.state.registry.get_by_name("to_remove") is None
+
+
+# ---------------------------------------------------------------------------
+# E2E disk weight update: real FSDPEngine + SGLang server + gateway
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("n_gpus", [2, 4, 8], ids=["2gpu", "4gpu", "8gpu"])
+def test_disk_e2e_weight_update(n_gpus, tmp_path_factory):
+    """Full round trip: FSDPEngine save → shared disk → SGLang load.
+
+    Same infrastructure as :func:`test_awex_e2e_weight_update` but uses
+    the disk-based weight update path (``mode="disk"``).  The gateway
+    orchestrates pause → FSDP save to HF → SGLang
+    ``/update_weights_from_disk`` → resume.
+    """
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+
+    from areal.api import FinetuneSpec
+    from areal.api.cli_args import (
+        OptimizerConfig,
+        SchedulingSpec,
+        TrainEngineConfig,
+    )
+    from areal.experimental.inference_service.controller.config import (
+        GatewayControllerConfig,
+    )
+    from areal.experimental.inference_service.controller.controller import (
+        GatewayInferenceController,
+    )
+    from areal.experimental.training_service.controller.controller import (
+        GatewayTrainController,
+    )
+    from areal.experimental.weight_update.controller import (
+        WeightUpdateController,
+        WeightUpdateControllerConfig,
+    )
+
+    n_half = n_gpus // 2
+    tmp = tmp_path_factory.mktemp("disk_e2e")
+    model_path = _get_test_model_path()
+    shared_weight_dir = str(tmp / "shared_weights")
+
+    scheduler = _make_local_scheduler(tmp, "disk_e2e", gpu_devices=list(range(n_gpus)))
+
+    inf_config = GatewayControllerConfig(
+        tokenizer_path=model_path,
+        model_path=model_path,
+        backend=f"sglang:d{n_half}",
+        scheduling_spec=(
+            SchedulingSpec(
+                gpu=1,
+                cmd="python -m areal.experimental.inference_service.guard",
+            ),
+        ),
+        consumer_batch_size=8,
+        max_head_offpolicyness=1024,
+        setup_timeout=300.0,
+        admin_api_key="test-admin",
+    )
+    inf_ctrl = GatewayInferenceController(config=inf_config, scheduler=scheduler)
+
+    train_config = TrainEngineConfig(
+        backend=f"fsdp:d{n_half}",
+        experiment_name="test-disk-e2e",
+        trial_name="t0",
+        path=model_path,
+        optimizer=OptimizerConfig(),
+        _version="v2",
+        setup_timeout=300.0,
+        scheduling_spec=(
+            SchedulingSpec(
+                gpu=1,
+                cmd="python -m areal.experimental.training_service.guard",
+                env_vars=dict(NCCL_CUMEM_ENABLE="0", NCCL_NVLS_ENABLE="0"),
+            ),
+        ),
+    )
+    train_ctrl = GatewayTrainController(
+        train_engine="areal.engine.fsdp_engine.FSDPEngine",
+        config=train_config,
+        scheduler=scheduler,
+    )
+
+    wu_ctrl: WeightUpdateController | None = None
+
+    try:
+        # -- 1. SGLang via inference controller ----------------------------
+        inf_ctrl.initialize(
+            role="rollout",
+            server_args={"mem_fraction_static": 0.7},
+        )
+        inf_worker_urls = list(inf_ctrl._inf_addrs)
+
+        for url in inf_worker_urls:
+            resp = httpx.post(f"{url}/awex/debug/randomize_parameters", timeout=120.0)
+            assert resp.status_code == 200, f"randomize_parameters failed: {resp.text}"
+
+        # -- 2. FSDP engine via training controller -------------------------
+        ft_spec = FinetuneSpec(
+            total_train_epochs=1, dataset_size=100, train_batch_size=2
+        )
+        train_ctrl.initialize(role="actor", ft_spec=ft_spec)
+        train_worker_urls = list(train_ctrl._worker_addrs)
+
+        # -- 3. Weight update gateway -------------------------------------
+        wu_ctrl = WeightUpdateController(
+            config=WeightUpdateControllerConfig(
+                host="127.0.0.1",
+                request_timeout=300.0,
+            )
+        )
+        wu_ctrl.initialize()
+
+        # -- 4. Disk weight update lifecycle -------------------------------
+        assert wu_ctrl.health_check(), "Weight update gateway health check failed"
+
+        wu_ctrl.connect(
+            pair_name="test_disk_e2e",
+            train_worker_urls=train_worker_urls,
+            inference_worker_urls=inf_worker_urls,
+            mode="disk",
+            save_path=shared_weight_dir,
+        )
+
+        result = wu_ctrl.update_weights(version=1)
+        assert result.status == "ok", f"Disk weight update failed: {result.error}"
+        assert result.version == 1
+
+        wu_ctrl.disconnect()
+
+        # -- 5. Verify the HF checkpoint exists on disk --------------------
+        versioned_path = os.path.join(shared_weight_dir, "weight_update_v1")
+        assert os.path.isdir(versioned_path), (
+            f"Expected HF checkpoint at {versioned_path}"
+        )
+        assert os.path.isfile(os.path.join(versioned_path, "config.json")), (
+            "Missing config.json in saved checkpoint"
+        )
+
+        # -- 6. Verify inference server still works post-update -----------
+        gen_resp = httpx.post(
+            f"{inf_worker_urls[0]}/generate",
+            json={
+                "text": "Hello",
+                "sampling_params": {"max_new_tokens": 5, "temperature": 0},
+            },
+            timeout=30.0,
+        )
+        assert gen_resp.status_code == 200, (
+            f"Generation failed after weight update: {gen_resp.text}"
+        )
+
+        # -- 7. Validate training ↔ inference parameter equality ----------
+        _validate_weight_update_correctness(
+            train_worker_urls=train_worker_urls,
+            inf_worker_url=inf_worker_urls[0],
+            param_dir=tmp,
+        )
+
+    finally:
+        if wu_ctrl is not None:
+            wu_ctrl.destroy()
+        train_ctrl.destroy()
+        inf_ctrl.destroy()
+        scheduler.delete_workers(None)

--- a/tests/experimental/weight_update/test_disk_integration.py
+++ b/tests/experimental/weight_update/test_disk_integration.py
@@ -74,6 +74,61 @@ def _make_mock_aiohttp_session(called_urls: list[tuple[str, str]]):
 
 
 class TestDiskConnect:
+    def test_disk_connect_requires_non_empty_save_path(self, client, app):
+        resp = client.post(
+            "/connect",
+            json={
+                "pair_name": "missing_path",
+                "train_worker_urls": ["http://train:8000"],
+                "inference_worker_urls": ["http://infer:9000"],
+                "mode": "disk",
+                "save_path": "",
+            },
+            headers=ADMIN_HEADERS,
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "save_path is required when mode='disk'"
+        assert app.state.registry.get_by_name("missing_path") is None
+
+    def test_disk_connect_requires_absolute_save_path(self, client, app):
+        resp = client.post(
+            "/connect",
+            json={
+                "pair_name": "relative_path",
+                "train_worker_urls": ["http://train:8000"],
+                "inference_worker_urls": ["http://infer:9000"],
+                "mode": "disk",
+                "save_path": "shared/weights",
+            },
+            headers=ADMIN_HEADERS,
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"] == (
+            "save_path must be an absolute path when mode='disk'"
+        )
+        assert app.state.registry.get_by_name("relative_path") is None
+
+    def test_disk_connect_requires_lora_name_when_lora_enabled(self, client, app):
+        resp = client.post(
+            "/connect",
+            json={
+                "pair_name": "missing_lora_name",
+                "train_worker_urls": ["http://train:8000"],
+                "inference_worker_urls": ["http://infer:9000"],
+                "mode": "disk",
+                "save_path": "/shared/lora",
+                "use_lora": True,
+                "lora_name": "",
+            },
+            headers=ADMIN_HEADERS,
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "lora_name is required when use_lora=True"
+        assert app.state.registry.get_by_name("missing_lora_name") is None
+
     def test_disk_connect_registers_pair(self, client, app):
         resp = client.post(
             "/connect",

--- a/tests/experimental/weight_update/test_wu_controller.py
+++ b/tests/experimental/weight_update/test_wu_controller.py
@@ -77,6 +77,39 @@ class TestConnect:
                 "pair_name": "pair0",
                 "train_worker_urls": train_urls,
                 "inference_worker_urls": infer_urls,
+                "mode": "awex",
+                "save_path": "",
+                "use_lora": False,
+                "lora_name": "",
+            },
+            timeout=10.0,
+        )
+
+    def test_connect_disk_mode_sends_disk_fields(self, ctrl):
+        ctrl._session.post.return_value = _mock_response(200, {"pair_name": "pair0"})
+        train_urls = ["http://train1:8000"]
+        infer_urls = ["http://infer1:8000"]
+
+        ctrl.connect(
+            "pair0",
+            train_urls,
+            infer_urls,
+            mode="disk",
+            save_path="/shared/weights",
+            use_lora=True,
+            lora_name="my-lora",
+        )
+
+        ctrl._session.post.assert_called_once_with(
+            f"{GATEWAY_URL}/connect",
+            json={
+                "pair_name": "pair0",
+                "train_worker_urls": train_urls,
+                "inference_worker_urls": infer_urls,
+                "mode": "disk",
+                "save_path": "/shared/weights",
+                "use_lora": True,
+                "lora_name": "my-lora",
             },
             timeout=10.0,
         )


### PR DESCRIPTION
## Description

Add disk-mode weight updates to the experimental weight-update gateway so training workers can save checkpoints to shared storage and inference workers can load from disk. The update flow now consistently pauses and resumes inference around transfer operations, including error paths, and extends controller/gateway contracts for mode-specific fields.

## Related Issue

Fixes #(issue)

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Risk areas:
- Disk path correctness and shared storage permissions in deployment.
- Inference pause/continue endpoint behavior under transient failures.

Test commands run:
- `uv run pytest tests/experimental/weight_update/test_wu_controller.py`
- `uv run pytest tests/experimental/weight_update/test_disk_integration.py -k "not multi_gpu and not slow and not sglang"`

Skipped suites:
- 3 multi-GPU/slow/sglang-marked cases in `test_disk_integration.py` (environment-dependent E2E coverage).