### PR TITLE
fix: stabilize versioned vllm lora routing

### DIFF
--- a/areal/engine/vllm_ext/areal_vllm_server.py
+++ b/areal/engine/vllm_ext/areal_vllm_server.py
@@ -2,6 +2,9 @@
 
 import asyncio
 import logging
+import re
+import time
+from collections import OrderedDict
 from http import HTTPStatus
 
 import uvloop
@@ -31,6 +34,10 @@ logger.setLevel(logging.INFO)
 # Global event to control generation resume/pause
 _generation_run_event = asyncio.Event()
 _generation_run_event.set()  # Initially not paused
+_LORA_VERSION_PATTERN = re.compile(r"^(?P<base>.+)-v(?P<version>\d+)$")
+_RUNTIME_LORA_PREPARED_TTL_S = 300.0
+_RUNTIME_LORA_PENDING_PHASE_PREPARED = "prepared"
+_RUNTIME_LORA_PENDING_PHASE_UPDATING = "updating"
 
 
 class UpdateWeightsRequest(OpenAIBaseModel):
@@ -48,7 +55,7 @@ class UpdateWeightsRequestLora(OpenAIBaseModel):
     # The name of lora adaptor
     lora_name: str
     # The id of the lora adaptor in vllm
-    lora_int_id: int
+    lora_int_id: int | None = None
     # The name of the base model for lora adaptors
     base_model_name: str
     # The format to load the weights
@@ -78,7 +85,7 @@ class UpdateWeightsFromXcclRequestLora(OpenAIBaseModel):
     dtypes: list[str]
     shapes: list[list[int]]
     lora_name: str
-    lora_int_id: int
+    lora_int_id: int | None = None
     lora_target_modules: list[str] | str
     lora_rank: int
     lora_alpha: int
@@ -122,12 +129,179 @@ def _infer_runtime_lora_path(serving_models, lora_name: str, lora_int_id: int) -
     return f"xccl://{lora_name}"
 
 
+def _split_versioned_lora_name(lora_name: str) -> tuple[str, int | None]:
+    match = _LORA_VERSION_PATTERN.fullmatch(lora_name)
+    if match is None:
+        return lora_name, None
+    return match.group("base"), int(match.group("version"))
+
+
+def _get_runtime_lora_capacity(app) -> int:
+    """Return the maximum number of runtime LoRA slots vLLM can hold."""
+    max_loras = getattr(getattr(app.state, "args", None), "max_loras", 1)
+    return max(1, int(max_loras))
+
+
+def _get_runtime_lora_state(
+    app,
+) -> tuple[OrderedDict[str, int], dict[str, tuple[int, str | None, str, float]]]:
+    """Get mutable runtime LoRA slot state kept on the API server.
+
+    `_areal_runtime_lora_slots` only tracks runtime-managed versioned LoRA routes
+    that may be replaced by newer versions. Static non-versioned adapters still
+    count toward the vLLM LoRA capacity limit, but they are not eviction targets.
+    `_areal_runtime_lora_pending_slots` keeps temporary reservations while a new
+    adapter version is being loaded so concurrent requests cannot race and allocate
+    the same slot inconsistently.
+    """
+    if not hasattr(app.state, "_areal_runtime_lora_slots"):
+        serving_models = getattr(app.state, "openai_serving_models", None)
+        loaded = OrderedDict()
+        if serving_models is not None:
+            for name, request in serving_models.lora_requests.items():
+                _, version = _split_versioned_lora_name(name)
+                if version is not None:
+                    loaded[name] = request.lora_int_id
+        app.state._areal_runtime_lora_slots = loaded
+        app.state._areal_runtime_lora_pending_slots = {}
+    return (
+        app.state._areal_runtime_lora_slots,
+        app.state._areal_runtime_lora_pending_slots,
+    )
+
+
+def _prune_runtime_lora_pending(app) -> None:
+    """Drop stale reservations that never progressed beyond metadata setup."""
+    _, pending = _get_runtime_lora_state(app)
+    now = time.monotonic()
+    stale_names = [
+        name
+        for name, (_, _, phase, reserved_at) in pending.items()
+        if phase == _RUNTIME_LORA_PENDING_PHASE_PREPARED
+        and now - reserved_at > _RUNTIME_LORA_PREPARED_TTL_S
+    ]
+    for name in stale_names:
+        pending.pop(name, None)
+
+
+def _get_occupied_lora_slots(app) -> set[int]:
+    """Return all currently occupied LoRA adapter ids.
+
+    This includes static adapters already registered in vLLM plus pending runtime
+    reservations that have not been finalized yet.
+    """
+    occupied = set()
+    serving_models = getattr(app.state, "openai_serving_models", None)
+    if serving_models is not None:
+        for request in serving_models.lora_requests.values():
+            lora_int_id = getattr(request, "lora_int_id", None)
+            if lora_int_id is not None:
+                occupied.add(int(lora_int_id))
+    _prune_runtime_lora_pending(app)
+    _, pending = _get_runtime_lora_state(app)
+    for lora_int_id, _, _, _ in pending.values():
+        occupied.add(int(lora_int_id))
+    return occupied
+
+
+def _choose_eviction_candidate(
+    slots: OrderedDict[str, int], incoming_lora_name: str
+) -> tuple[str, int]:
+    """Pick a slot to recycle when all runtime LoRA slots are occupied.
+
+    Prefer evicting an older version from the same LoRA family so unrelated LoRAs
+    do not interfere with one another. If no same-base version exists, fall back to
+    the oldest resident adapter.
+    """
+    incoming_base, _ = _split_versioned_lora_name(incoming_lora_name)
+    for name, slot in slots.items():
+        base, _ = _split_versioned_lora_name(name)
+        if base == incoming_base:
+            return name, slot
+    return next(iter(slots.items()))
+
+
+def _reserve_runtime_lora_slot(
+    app,
+    lora_name: str,
+    *,
+    phase: str = _RUNTIME_LORA_PENDING_PHASE_UPDATING,
+) -> tuple[int, str | None]:
+    """Reserve a bounded runtime LoRA slot for a versioned adapter name.
+
+    This keeps adapter ids unique within the current vLLM server, respects the
+    configured `max_loras` capacity, and avoids the unbounded `version + 1` growth
+    pattern that caused the previous reviewer concerns.
+    """
+    slots, pending = _get_runtime_lora_state(app)
+    _prune_runtime_lora_pending(app)
+    if lora_name in pending:
+        lora_int_id, replaced_lora_name, current_phase, reserved_at = pending[lora_name]
+        if (
+            current_phase != phase
+            and current_phase == _RUNTIME_LORA_PENDING_PHASE_PREPARED
+            and phase == _RUNTIME_LORA_PENDING_PHASE_UPDATING
+        ):
+            pending[lora_name] = (
+                lora_int_id,
+                replaced_lora_name,
+                phase,
+                reserved_at,
+            )
+        return lora_int_id, replaced_lora_name
+    if lora_name in slots:
+        slots.move_to_end(lora_name)
+        reservation = (slots[lora_name], None, phase, time.monotonic())
+        pending[lora_name] = reservation
+        return reservation[:2]
+
+    capacity = _get_runtime_lora_capacity(app)
+    used_slots = _get_occupied_lora_slots(app)
+    free_slots = [slot for slot in range(1, capacity + 1) if slot not in used_slots]
+    if free_slots:
+        reservation = (free_slots[0], None, phase, time.monotonic())
+    else:
+        if not slots:
+            raise RuntimeError(
+                "All LoRA slots are occupied by non-runtime adapters; cannot reserve "
+                f"a runtime slot for {lora_name!r}."
+            )
+        evicted_name, evicted_slot = _choose_eviction_candidate(slots, lora_name)
+        reservation = (evicted_slot, evicted_name, phase, time.monotonic())
+    pending[lora_name] = reservation
+    return reservation[:2]
+
+
+def _finalize_runtime_lora_slot(
+    app,
+    *,
+    lora_name: str,
+    lora_int_id: int,
+    replaced_lora_name: str | None,
+) -> None:
+    """Commit a pending reservation after the adapter has been loaded successfully."""
+    slots, pending = _get_runtime_lora_state(app)
+    pending.pop(lora_name, None)
+    if replaced_lora_name is not None and replaced_lora_name != lora_name:
+        slots.pop(replaced_lora_name, None)
+    slots[lora_name] = lora_int_id
+    slots.move_to_end(lora_name)
+
+
+def _clear_runtime_lora_reservation(app, lora_name: str) -> None:
+    """Drop a failed reservation so later retries can allocate a fresh slot."""
+    _, pending = _get_runtime_lora_state(app)
+    pending.pop(lora_name, None)
+
+
 def _register_runtime_lora_name(
     app,
     *,
     lora_name: str,
     lora_int_id: int,
+    lora_path: str | None = None,
     base_model_name: str | None,
+    replaced_lora_name: str | None = None,
 ) -> None:
     serving_models = getattr(app.state, "openai_serving_models", None)
     if serving_models is None:
@@ -138,10 +312,13 @@ def _register_runtime_lora_name(
         return
 
     requests = serving_models.lora_requests
-    runtime_lora_path = _infer_runtime_lora_path(serving_models, lora_name, lora_int_id)
+    runtime_lora_path = lora_path or _infer_runtime_lora_path(
+        serving_models, lora_name, lora_int_id
+    )
 
-    # Keep at most one public name per adapter id so /v1/models and request
-    # routing reflect the current versioned adapter name.
+    if replaced_lora_name is not None and replaced_lora_name != lora_name:
+        requests.pop(replaced_lora_name, None)
+
     for name, request in list(requests.items()):
         if getattr(request, "lora_int_id", None) == lora_int_id and name != lora_name:
             del requests[name]
@@ -154,6 +331,12 @@ def _register_runtime_lora_name(
     if base_model_name is not None:
         lora_request.base_model_name = base_model_name
     requests[lora_name] = lora_request
+    _finalize_runtime_lora_slot(
+        app,
+        lora_name=lora_name,
+        lora_int_id=lora_int_id,
+        replaced_lora_name=replaced_lora_name,
+    )
     logger.info(
         "Registered runtime LoRA adapter name '%s' for adapter id %s",
         lora_name,
@@ -181,8 +364,13 @@ async def areal_update_weight(request: UpdateWeightsRequest, raw_request: Reques
 async def areal_update_weight_lora(
     request: UpdateWeightsRequestLora, raw_request: Request
 ):
+    lora_int_id, replaced_lora_name = _reserve_runtime_lora_slot(
+        raw_request.app,
+        request.lora_name,
+        phase=_RUNTIME_LORA_PENDING_PHASE_UPDATING,
+    )
     logger.info(
-        f"API server starts areal_update_weight_lora, lora_model_path-{request.lora_model_path}, lora_name-{request.lora_name}, lora_int_id-{request.lora_int_id}, base_model_name-{request.base_model_name}"
+        f"API server starts areal_update_weight_lora, lora_model_path-{request.lora_model_path}, lora_name-{request.lora_name}, lora_int_id-{lora_int_id}, base_model_name-{request.base_model_name}"
     )
     llm = raw_request.app.state.engine_client
     await llm.pause_generation(wait_for_inflight_requests=False, clear_cache=True)
@@ -194,10 +382,24 @@ async def areal_update_weight_lora(
             args=(
                 request.lora_model_path,
                 request.lora_name,
-                request.lora_int_id,
+                lora_int_id,
                 request.base_model_name,
             ),
         )
+        if all(success for success, _ in ret_list):
+            _register_runtime_lora_name(
+                raw_request.app,
+                lora_name=request.lora_name,
+                lora_int_id=lora_int_id,
+                lora_path=request.lora_model_path,
+                base_model_name=request.base_model_name,
+                replaced_lora_name=replaced_lora_name,
+            )
+        else:
+            _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+    except Exception:
+        _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+        raise
     finally:
         await llm.resume_generation()
 
@@ -221,6 +423,11 @@ async def areal_update_weight_xccl(raw_request: Request):
 async def areal_update_weight_lora_xccl(
     request: UpdateWeightsFromXcclRequestLora, raw_request: Request
 ):
+    lora_int_id, replaced_lora_name = _reserve_runtime_lora_slot(
+        raw_request.app,
+        request.lora_name,
+        phase=_RUNTIME_LORA_PENDING_PHASE_UPDATING,
+    )
     logger.info("API server starts areal_update_weight_lora_xccl")
     llm = raw_request.app.state.engine_client
     await llm.pause_generation(wait_for_inflight_requests=False, clear_cache=True)
@@ -232,9 +439,15 @@ async def areal_update_weight_lora_xccl(
             _register_runtime_lora_name(
                 raw_request.app,
                 lora_name=request.lora_name,
-                lora_int_id=request.lora_int_id,
+                lora_int_id=lora_int_id,
                 base_model_name=request.base_model_name,
+                replaced_lora_name=replaced_lora_name,
             )
+        else:
+            _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+    except Exception:
+        _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+        raise
     finally:
         await llm.resume_generation()
 
@@ -283,26 +496,37 @@ async def areal_set_weight_meta_xccl(
 async def areal_set_weight_meta_xccl_lora(
     request: UpdateWeightsFromXcclRequestLora, raw_request: Request
 ):
+    lora_int_id, _ = _reserve_runtime_lora_slot(
+        raw_request.app,
+        request.lora_name,
+        phase=_RUNTIME_LORA_PENDING_PHASE_PREPARED,
+    )
     logger.info(
-        f"API server starts areal_set_update_weight_meta_lora for {request.lora_name} with id {request.lora_int_id}"
+        f"API server starts areal_set_update_weight_meta_lora for {request.lora_name} with id {lora_int_id}"
     )
     llm = raw_request.app.state.engine_client
-    ret_list = await llm.collective_rpc(
-        "areal_set_weight_meta_lora",
-        args=(
-            request.names,
-            request.dtypes,
-            request.shapes,
-            request.group_name,
-            request.lora_name,
-            request.lora_int_id,
-            request.lora_target_modules,
-            request.lora_rank,
-            request.lora_alpha,
-            request.lora_bias,
-            request.base_model_name,
-        ),
-    )
+    try:
+        ret_list = await llm.collective_rpc(
+            "areal_set_weight_meta_lora",
+            args=(
+                request.names,
+                request.dtypes,
+                request.shapes,
+                request.group_name,
+                request.lora_name,
+                lora_int_id,
+                request.lora_target_modules,
+                request.lora_rank,
+                request.lora_alpha,
+                request.lora_bias,
+                request.base_model_name,
+            ),
+        )
+        if not all(success for success, _ in ret_list):
+            _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+    except Exception:
+        _clear_runtime_lora_reservation(raw_request.app, request.lora_name)
+        raise
     return build_response(ret_list)
 
 

--- a/areal/engine/vllm_ext/vllm_worker_extension.py
+++ b/areal/engine/vllm_ext/vllm_worker_extension.py
@@ -57,12 +57,13 @@ class VLLMWorkerExtension:
         )
         try:
             # load lora weight
-            self.model_runner.lora_manager.remove_adapter(lora_int_id)
+            adapter_ids = self.model_runner.lora_manager.list_adapters()
             lora_request = LoRARequest(
                 lora_name=lora_name,
                 lora_int_id=lora_int_id,
                 lora_path=lora_model_path,
                 base_model_name=base_model_name,
+                load_inplace=lora_int_id in adapter_ids,
             )
             logger.info(f"Reloading lora weights with request {lora_request}")
             self.model_runner.add_lora(lora_request)
@@ -171,24 +172,17 @@ class VLLMWorkerExtension:
         lora_int_id = self.areal_lora_int_id
 
         try:
-            # Check if LoRA manager and adapter exist
+            # Check if LoRA manager is initialized.
             if self.model_runner.lora_manager is None:
                 raise RuntimeError("LoRA manager is not initialized")
 
-            # Check if the LoRA adapter exists
             adapter_ids = self.model_runner.lora_manager.list_adapters()
             if lora_int_id not in adapter_ids:
-                raise RuntimeError(
-                    f"LoRA adapter {lora_int_id} not found. Available: {adapter_ids}"
+                logger.info(
+                    "LoRA adapter %s not found. Available: %s. Creating a new adapter slot.",
+                    lora_int_id,
+                    adapter_ids,
                 )
-
-            # Get the currently registered LoRA model (used for diagnostics).
-            lora_model = (
-                self.model_runner.lora_manager._adapter_manager._registered_adapters[
-                    lora_int_id
-                ]
-            )
-            logger.info(f"Found LoRA model with {len(lora_model.loras)} LoRA modules")
 
             # Receive all weights via XCCL broadcast
             logger.info(f"Receiving {len(names)} LoRA parameters via XCCL")
@@ -209,7 +203,7 @@ class VLLMWorkerExtension:
                     async_op=False,
                 )
 
-                received_weights[name] = tensor.cpu()
+                received_weights[name] = tensor
 
             logger.info(f"Received {len(received_weights)} LoRA parameters via XCCL")
 
@@ -259,7 +253,7 @@ class VLLMWorkerExtension:
                 lora_model_id=self.areal_lora_int_id,
                 tensors=merged_weights,
                 peft_helper=peft_helper,
-                device="cpu",
+                device=self.model_runner.device,
                 dtype=self.model_runner.lora_manager.lora_config.lora_dtype,
                 model_vocab_size=model_vocab_size,
                 weights_mapper=getattr(
@@ -267,7 +261,8 @@ class VLLMWorkerExtension:
                 ),
             )
 
-            self.model_runner.lora_manager.remove_adapter(lora_int_id)
+            if lora_int_id in adapter_ids:
+                self.model_runner.lora_manager.remove_adapter(lora_int_id)
 
             self.model_runner.lora_manager._adapter_manager._add_adapter(new_lora_model)
             self.model_runner.lora_manager._adapter_manager.activate_adapter(
@@ -277,11 +272,6 @@ class VLLMWorkerExtension:
                 f"Updated New LoRA model with {len(new_lora_model.loras)} LoRA modules "
                 f"from {len(merged_weights)} tensors across {len(self.weight_update_groups)} groups"
             )
-            if len(new_lora_model.loras) != len(lora_model.loras):
-                logger.warning(
-                    f"Number of modules in the new LoRA model ({len(new_lora_model.loras)}) "
-                    f"does not match the old LoRA model ({len(lora_model.loras)})."
-                )
 
             self.sync()
             return True, "Success"

--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -131,10 +131,11 @@ class VLLMBackend:
             if meta.version is None:
                 raise ValueError("Version is required for LoRA update.")
             lora_name = get_versioned_lora_name(meta.lora_name, meta.version)
-            endpoint = "/v1/load_lora_adapter"
+            endpoint = "/areal_update_weights_lora"
             payload = {
-                "lora_path": str(meta.path),
+                "lora_model_path": str(meta.path),
                 "lora_name": lora_name,
+                "base_model_name": meta.base_model_name,
             }
         else:
             endpoint = "/areal_update_weights"
@@ -165,7 +166,6 @@ class VLLMBackend:
             lora_name = get_versioned_lora_name(meta.lora_name, meta.version)
             lora_payload = {
                 "lora_name": lora_name,
-                "lora_int_id": meta.lora_int_id,
                 "lora_target_modules": meta.peft_config["target_modules"],
                 "lora_rank": meta.peft_config["r"],
                 "lora_alpha": meta.peft_config["lora_alpha"],

--- a/tests/test_vllm_remote.py
+++ b/tests/test_vllm_remote.py
@@ -1,0 +1,315 @@
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from areal.api import WeightUpdateMeta
+from areal.api.io_struct import ParamSpec
+from areal.engine.vllm_ext.areal_vllm_server import (
+    _RUNTIME_LORA_PENDING_PHASE_PREPARED,
+    _RUNTIME_LORA_PENDING_PHASE_UPDATING,
+    _choose_eviction_candidate,
+    _get_runtime_lora_state,
+    _register_runtime_lora_name,
+    _reserve_runtime_lora_slot,
+)
+from areal.engine.vllm_remote import VLLMBackend
+
+
+def _make_fake_app(*, max_loras=4, requests=None):
+    if requests is None:
+        requests = OrderedDict()
+    serving_models = SimpleNamespace(lora_requests=requests)
+    state = SimpleNamespace(
+        args=SimpleNamespace(max_loras=max_loras),
+        openai_serving_models=serving_models,
+    )
+    return SimpleNamespace(state=state)
+
+
+def _make_lora_request(name: str, adapter_id: int, path: str | None = None):
+    req = SimpleNamespace(
+        lora_name=name,
+        lora_int_id=adapter_id,
+        lora_path=path or f"/tmp/{name}",
+        base_model_name="base-model",
+    )
+    return req
+
+
+def test_build_distributed_lora_weight_update_requests_uses_versioned_name_only():
+    backend = VLLMBackend()
+    meta = WeightUpdateMeta(
+        type="xccl",
+        use_lora=True,
+        lora_name="demo-lora",
+        lora_int_id=1,
+        base_model_name="base-model",
+        peft_config={
+            "target_modules": ["q_proj", "v_proj"],
+            "r": 64,
+            "lora_alpha": 16,
+            "bias": "none",
+        },
+        version=3,
+        nccl_group_name="weight-update",
+    )
+    param_specs = [ParamSpec(name="a", shape=(1,), dtype="float16")]
+
+    requests = backend.build_distributed_weight_update_requests(meta, param_specs)
+
+    meta_req, update_req = requests.requests
+    assert meta_req.payload["lora_name"] == "demo-lora-v3"
+    assert "lora_int_id" not in meta_req.payload
+    assert update_req.payload["lora_name"] == "demo-lora-v3"
+    assert "lora_int_id" not in update_req.payload
+    assert update_req.endpoint == "/areal_update_weights_lora_xccl"
+
+
+def test_build_disk_lora_weight_update_requests_uses_areal_endpoint():
+    backend = VLLMBackend()
+    meta = WeightUpdateMeta(
+        type="disk",
+        path="/tmp/adapter",
+        use_lora=True,
+        lora_name="demo-lora",
+        base_model_name="base-model",
+        version=7,
+    )
+
+    requests = backend.build_disk_weight_update_requests(meta)
+
+    (req,) = requests.requests
+    assert req.endpoint == "/areal_update_weights_lora"
+    assert req.payload == {
+        "lora_model_path": "/tmp/adapter",
+        "lora_name": "demo-lora-v7",
+        "base_model_name": "base-model",
+    }
+
+
+def test_reserve_runtime_lora_slot_reuses_existing_version_slot():
+    app = _make_fake_app(
+        requests=OrderedDict(
+            {
+                "demo-lora-v1": _make_lora_request("demo-lora-v1", 2),
+            }
+        )
+    )
+
+    slot, replaced = _reserve_runtime_lora_slot(app, "demo-lora-v1")
+
+    assert slot == 2
+    assert replaced is None
+
+
+def test_reserve_runtime_lora_slot_prefers_same_base_eviction():
+    app = _make_fake_app(
+        max_loras=2,
+        requests=OrderedDict(
+            {
+                "demo-lora-v1": _make_lora_request("demo-lora-v1", 1),
+                "other-lora-v4": _make_lora_request("other-lora-v4", 2),
+            }
+        ),
+    )
+
+    slot, replaced = _reserve_runtime_lora_slot(app, "demo-lora-v2")
+
+    assert slot == 1
+    assert replaced == "demo-lora-v1"
+
+
+def test_reserve_runtime_lora_slot_counts_pending_reservations_as_occupied():
+    app = _make_fake_app(
+        max_loras=3,
+        requests=OrderedDict(
+            {
+                "demo-lora-v1": _make_lora_request("demo-lora-v1", 1),
+            }
+        ),
+    )
+
+    first_slot, first_replaced = _reserve_runtime_lora_slot(app, "demo-lora-v2")
+    second_slot, second_replaced = _reserve_runtime_lora_slot(app, "other-lora-v1")
+
+    assert first_slot == 2
+    assert first_replaced is None
+    assert second_slot == 3
+    assert second_replaced is None
+
+
+def test_choose_eviction_candidate_falls_back_to_oldest_other_base():
+    slots = OrderedDict(
+        {
+            "first-lora-v1": 3,
+            "second-lora-v1": 4,
+        }
+    )
+
+    name, slot = _choose_eviction_candidate(slots, "third-lora-v9")
+
+    assert name == "first-lora-v1"
+    assert slot == 3
+
+
+def test_register_runtime_lora_name_replaces_public_route_and_updates_slots():
+    requests = OrderedDict(
+        {
+            "demo-lora-v1": _make_lora_request(
+                "demo-lora-v1", 1, "xccl://demo-lora-v1"
+            ),
+            "other-lora-v3": _make_lora_request(
+                "other-lora-v3", 2, "xccl://other-lora-v3"
+            ),
+        }
+    )
+    app = _make_fake_app(max_loras=2, requests=requests)
+
+    # Simulate a reserved replacement of the old version.
+    slots, pending = _get_runtime_lora_state(app)
+    slots["demo-lora-v1"] = 1
+    slots["other-lora-v3"] = 2
+    pending["demo-lora-v2"] = (
+        1,
+        "demo-lora-v1",
+        _RUNTIME_LORA_PENDING_PHASE_UPDATING,
+        1.0,
+    )
+
+    _register_runtime_lora_name(
+        app,
+        lora_name="demo-lora-v2",
+        lora_int_id=1,
+        base_model_name="base-model",
+        replaced_lora_name="demo-lora-v1",
+    )
+
+    assert "demo-lora-v1" not in requests
+    assert "demo-lora-v2" in requests
+    assert requests["demo-lora-v2"].lora_int_id == 1
+    assert requests["demo-lora-v2"].base_model_name == "base-model"
+    assert list(slots.items()) == [("other-lora-v3", 2), ("demo-lora-v2", 1)]
+    assert "demo-lora-v2" not in pending
+
+
+def test_register_runtime_lora_name_uses_explicit_disk_lora_path():
+    requests = OrderedDict()
+    app = _make_fake_app(max_loras=1, requests=requests)
+
+    _, pending = _get_runtime_lora_state(app)
+    pending["demo-lora-v2"] = (
+        1,
+        None,
+        _RUNTIME_LORA_PENDING_PHASE_UPDATING,
+        1.0,
+    )
+
+    _register_runtime_lora_name(
+        app,
+        lora_name="demo-lora-v2",
+        lora_int_id=1,
+        lora_path="/tmp/weight_update_v2",
+        base_model_name="base-model",
+    )
+
+    assert requests["demo-lora-v2"].lora_path == "/tmp/weight_update_v2"
+
+
+def test_reserve_runtime_lora_slot_prunes_stale_pending_reservations():
+    app = _make_fake_app(max_loras=1)
+    _, pending = _get_runtime_lora_state(app)
+    pending["demo-lora-v1"] = (
+        1,
+        None,
+        _RUNTIME_LORA_PENDING_PHASE_PREPARED,
+        0.0,
+    )
+
+    with patch(
+        "areal.engine.vllm_ext.areal_vllm_server.time.monotonic",
+        return_value=301.0,
+    ):
+        slot, replaced = _reserve_runtime_lora_slot(app, "demo-lora-v2")
+
+    assert slot == 1
+    assert replaced is None
+    assert "demo-lora-v1" not in pending
+
+
+def test_reserve_runtime_lora_slot_keeps_inflight_updates_reserved():
+    app = _make_fake_app(max_loras=1)
+    _, pending = _get_runtime_lora_state(app)
+    pending["demo-lora-v1"] = (
+        1,
+        None,
+        _RUNTIME_LORA_PENDING_PHASE_UPDATING,
+        0.0,
+    )
+
+    with patch(
+        "areal.engine.vllm_ext.areal_vllm_server.time.monotonic",
+        return_value=301.0,
+    ):
+        slot, replaced = _reserve_runtime_lora_slot(app, "demo-lora-v1")
+
+    assert slot == 1
+    assert replaced is None
+    assert pending["demo-lora-v1"][2] == _RUNTIME_LORA_PENDING_PHASE_UPDATING
+
+
+def test_set_update_weight_meta_lora_clears_reservation_on_collective_failure():
+    import asyncio
+
+    from areal.engine.vllm_ext.areal_vllm_server import (
+        UpdateWeightsFromXcclRequestLora,
+        areal_set_weight_meta_xccl_lora,
+    )
+
+    async def _failing_collective_rpc(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    app = _make_fake_app(max_loras=1)
+    app.state.engine_client = SimpleNamespace(collective_rpc=_failing_collective_rpc)
+    raw_request = SimpleNamespace(app=app)
+    request = UpdateWeightsFromXcclRequestLora(
+        names=["x"],
+        dtypes=["float16"],
+        shapes=[[1]],
+        lora_name="demo-lora-v1",
+        lora_target_modules=["q_proj"],
+        lora_rank=8,
+        lora_alpha=16,
+        lora_bias="none",
+        base_model_name="base-model",
+        group_name="group",
+    )
+
+    async def _run():
+        try:
+            await areal_set_weight_meta_xccl_lora(request, raw_request)
+        except RuntimeError:
+            pass
+
+    asyncio.run(_run())
+
+    _, pending = _get_runtime_lora_state(app)
+    assert pending == {}
+
+
+def test_static_non_versioned_lora_is_not_an_eviction_candidate():
+    app = _make_fake_app(
+        max_loras=2,
+        requests=OrderedDict(
+            {
+                "static-ocr": _make_lora_request("static-ocr", 1, "/models/static-ocr"),
+                "demo-lora-v1": _make_lora_request(
+                    "demo-lora-v1", 2, "xccl://demo-lora-v1"
+                ),
+            }
+        ),
+    )
+
+    slot, replaced = _reserve_runtime_lora_slot(app, "demo-lora-v2")
+
+    assert slot == 2
+    assert replaced == "demo-lora-v1"


### PR DESCRIPTION
## Description

  This PR fixes a vLLM LoRA routing issue where versioned LoRA model names can become unavailable during runtime updates.

  In the previous behavior, a runtime LoRA update could invalidate an older versioned route while requests targeting that version were still in flight. This led to failures such as 404 responses for versioned model names.

  This PR keeps versioned LoRA routing stable during runtime updates by introducing bounded runtime slot reservation and consistent route registration for versioned LoRA adapters.

  The main changes are:
  - reserve runtime LoRA slots before update application
  - distinguish prepared reservations from active update reservations
  - clear failed reservations immediately instead of leaving stale slot state behind
  - keep versioned route registration consistent with the runtime slot that actually serves the adapter

  ## Related Issue

  Fixes #1193

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [ ] ⚡ Performance improvement
  - [x] ✅ Test coverage improvement

  ## Checklist

  - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
  - [x] Relevant tests pass; new tests added for new functionality
  - [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
  - [x] Branch is up to date with `main`
  - [x] Self-reviewed via `/review-pr` command
  - [ ] This PR was created by a coding agent via `/create-pr`
  - [ ] This PR is a breaking change

  **Breaking Change Details (if applicable):**

  N/A

  ## Additional Context

  This fixes failures where versioned LoRA model names could return 404 during runtime updates because the route state and runtime adapter slot state became inconsistent.