### PR TITLE
feat: bootstrap fsdp lora training from adapter checkpoints

### DIFF
--- a/areal/api/engine_api.py
+++ b/areal/api/engine_api.py
@@ -309,6 +309,12 @@ class TrainEngine(abc.ABC):
         """
         raise NotImplementedError()
 
+    def load_lora_adapter(self, path: str):
+        """Load LoRA adapter weights from an adapter-only HF checkpoint."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support adapter-only LoRA loading."
+        )
+
     @abc.abstractmethod
     def optimizer_zero_grad(self):
         """Zero out all gradients in the optimizer."""

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -22,6 +22,8 @@ from peft import (
     TaskType,
     get_peft_model,
 )
+from peft.mapping import PEFT_TYPE_TO_PREFIX_MAPPING
+from safetensors.torch import load_file as load_safetensors_file
 from torch import nn
 from torch.distributed.checkpoint.state_dict import (
     StateDictOptions,
@@ -132,6 +134,40 @@ from areal.utils.save_load import get_state_dict_from_repo_id_or_path
 if TYPE_CHECKING:
     from areal.api import Scheduler
     from areal.api.cli_args import PPOActorConfig, PPOCriticConfig
+
+
+def _get_active_peft_adapter_name(model: nn.Module) -> str:
+    active_adapter = getattr(model, "active_adapter", None)
+    if isinstance(active_adapter, str):
+        return active_adapter
+    if isinstance(active_adapter, (list, tuple)) and active_adapter:
+        return str(active_adapter[0])
+
+    peft_config = getattr(model, "peft_config", None)
+    if isinstance(peft_config, dict):
+        if "default" in peft_config:
+            return "default"
+        if len(peft_config) == 1:
+            return next(iter(peft_config))
+    return "default"
+
+
+def _insert_adapter_name_into_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    adapter_name: str,
+    parameter_prefix: str,
+) -> dict[str, torch.Tensor]:
+    remapped_state = {}
+    for key, value in state_dict.items():
+        if parameter_prefix in key:
+            _, _, suffix = key.rpartition(parameter_prefix)
+            if "." in suffix:
+                parts = suffix.split(".", 1)
+                key = f"{key[: -len(suffix)]}{parts[0]}.{adapter_name}.{parts[1]}"
+            else:
+                key = f"{key}.{adapter_name}"
+        remapped_state[key] = value
+    return remapped_state
 
 
 @dataclasses.dataclass
@@ -532,6 +568,10 @@ class FSDPEngine(TrainEngine):
             # pinning and normalization established by PerLayerOptimWrapper.__init__.
             if meta.with_optim and self._per_layer_optim_wrapper is not None:
                 self._per_layer_optim_wrapper.refresh_states()
+
+    def load_lora_adapter(self, path: str):
+        with self._offload_aware_context():
+            self._load_lora_adapter_from_hf(path)
 
     @contextmanager
     def _offload_aware_context(self):
@@ -1396,6 +1436,47 @@ class FSDPEngine(TrainEngine):
             full_state,
             self.cpu_offload,
             tie_word_embeddings=self.model_config.tie_word_embeddings,
+        )
+
+    def _load_lora_adapter_from_hf(self, path: str):
+        """Load adapter-only HF checkpoint into the current PEFT model."""
+        if self.model is None:
+            raise RuntimeError("Model not initialized")
+        if not self.config.use_lora:
+            raise RuntimeError("LoRA adapter load requires config.use_lora=True")
+
+        adapter_path = os.path.join(path, "adapter_model.safetensors")
+        if dist.get_rank() == 0:
+            if not os.path.isfile(adapter_path):
+                raise FileNotFoundError(
+                    f"LoRA adapter checkpoint not found: {adapter_path}"
+                )
+            adapter_name = _get_active_peft_adapter_name(self.model)
+            peft_config = getattr(self.model, "peft_config", {})
+            if adapter_name not in peft_config:
+                raise RuntimeError(
+                    f"Active LoRA adapter '{adapter_name}' not found in model.peft_config"
+                )
+            peft_type = peft_config[adapter_name].peft_type
+            parameter_prefix = PEFT_TYPE_TO_PREFIX_MAPPING.get(peft_type)
+            if parameter_prefix is None:
+                raise RuntimeError(
+                    f"Unsupported PEFT type '{peft_type}' for adapter '{adapter_name}'"
+                )
+            adapter_state = load_safetensors_file(adapter_path, device="cpu")
+            partial_state = _insert_adapter_name_into_state_dict(
+                adapter_state,
+                adapter_name=adapter_name,
+                parameter_prefix=parameter_prefix,
+            )
+        else:
+            partial_state = {}
+
+        fsdp2_load_full_state_dict(
+            self.model,
+            partial_state,
+            self.cpu_offload,
+            strict=False,
         )
 
     def _save_to_dcp(

--- a/areal/engine/fsdp_utils/__init__.py
+++ b/areal/engine/fsdp_utils/__init__.py
@@ -112,6 +112,7 @@ def fsdp2_load_full_state_dict(
     full_state: dict,
     cpu_offload=None,
     tie_word_embeddings=False,
+    strict: bool | None = None,
 ):
     """
     Loads the full state dict (could be only on rank 0) into the sharded model. This is done by broadcasting the
@@ -138,11 +139,14 @@ def fsdp2_load_full_state_dict(
     else:
         model = model.to(device=device, non_blocking=True)
     cpu_offload = cpu_offload is not None
+    if strict is None:
+        strict = not tie_word_embeddings
+
     options = StateDictOptions(
         full_state_dict=True,
         cpu_offload=cpu_offload,
         broadcast_from_rank0=True,
-        strict=not tie_word_embeddings,
+        strict=strict,
     )
     set_model_state_dict(model, full_state, options=options)
 

--- a/areal/infra/controller/train_controller.py
+++ b/areal/infra/controller/train_controller.py
@@ -676,6 +676,10 @@ class TrainController:
         """
         self._custom_function_call("load", meta)
 
+    def load_lora_adapter(self, path: str):
+        """Load LoRA adapter weights from a HF adapter directory."""
+        self._custom_function_call("load_lora_adapter", path)
+
     def step_lr_scheduler(self):
         """Step the learning rate scheduler.
 

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import functools
 import os
+import shlex
+import subprocess
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
@@ -51,6 +54,7 @@ from areal.utils.dataloader import create_dataloader
 from areal.utils.environ import is_single_controller
 from areal.utils.evaluator import Evaluator
 from areal.utils.hf_utils import load_hf_processor_and_tokenizer
+from areal.utils.network import gethostip
 from areal.utils.perf_tracer import Category
 from areal.utils.recover import RecoverHandler
 from areal.utils.saver import Saver
@@ -70,6 +74,13 @@ if TYPE_CHECKING:
     from areal.trainer.ppo.critic import PPOCriticController
 
 logger = logging.getLogger("RLTrainer")
+
+_LORA_ADAPTER_REQUIRED_FILES = (
+    "adapter_config.json",
+    "adapter_model.safetensors",
+    "config.json",
+)
+_LORA_ADAPTER_SYNC_TIMEOUT_S = 300
 
 
 class _EmptyDataLoader:
@@ -281,8 +292,8 @@ class PPOTrainer:
         if self.teacher is not None:
             self.teacher.initialize(**engine_init_kwargs, role="teacher")
 
-        # Save initial LoRA weights if enabled (for inference server pre-loading)
-        initial_lora_path = self._save_initial_lora_weights()
+        # Prepare actor LoRA state before rollout initialization.
+        initial_lora_path = self._prepare_initial_actor_lora()
 
         # Initialize inference with LoRA path
         self.rollout = self._init_rollout(
@@ -1003,13 +1014,34 @@ class PPOTrainer:
         controller.initialize(**init_kwargs)
         return controller
 
-    def _save_initial_lora_weights(self) -> str | None:
-        """Save initial LoRA weights for inference server pre-loading.
+    def _get_actor_lora_bootstrap_hf_path(self) -> str | None:
+        path = os.getenv("GUI_LORA_BOOTSTRAP_HF_PATH", "").strip()
+        if not path:
+            return None
+        if not self.config.actor.use_lora:
+            raise RuntimeError(
+                "GUI_LORA_BOOTSTRAP_HF_PATH is set, but actor.use_lora is false."
+            )
+        actor_backend = str(getattr(self.config.actor, "backend", ""))
+        if not actor_backend.startswith("fsdp"):
+            raise RuntimeError(
+                "GUI_LORA_BOOTSTRAP_HF_PATH is currently only supported for FSDP actors."
+            )
+        return path
 
-        Returns path to saved LoRA weights, or None if LoRA is disabled.
-        """
+    def _prepare_initial_actor_lora(self) -> str | None:
+        """Load optional bootstrap LoRA weights and persist initial adapter weights."""
+        bootstrap_path = self._get_actor_lora_bootstrap_hf_path()
         if not self.config.actor.use_lora:
             return None
+
+        if bootstrap_path:
+            logger.info(
+                "Bootstrapping actor LoRA weights from HF path: %s", bootstrap_path
+            )
+            self._sync_lora_adapter_dir_to_cluster_nodes(bootstrap_path)
+            self.actor.load_lora_adapter(bootstrap_path)
+            logger.info("Loaded bootstrap actor LoRA weights from %s", bootstrap_path)
 
         path = os.path.join(
             Saver.get_model_save_root(
@@ -1033,6 +1065,151 @@ class PPOTrainer:
         self.actor.save(meta=meta)
 
         return path
+
+    def _local_lora_adapter_ready(self, path: str) -> bool:
+        return all(
+            os.path.isfile(os.path.join(path, name))
+            for name in _LORA_ADAPTER_REQUIRED_FILES
+        )
+
+    def _remote_lora_adapter_ready(self, host: str, path: str) -> bool:
+        checks = " && ".join(
+            f"test -f {shlex.quote(os.path.join(path, name))}"
+            for name in _LORA_ADAPTER_REQUIRED_FILES
+        )
+        result = subprocess.run(
+            ["ssh", host, f"bash -lc {shlex.quote(checks)}"],
+            capture_output=True,
+            text=True,
+            timeout=_LORA_ADAPTER_SYNC_TIMEOUT_S,
+        )
+        return result.returncode == 0
+
+    def _get_actor_worker_ips(self) -> list[str]:
+        return sorted({worker.ip for worker in self.actor.workers if worker.ip})
+
+    def _copy_dir_between_hosts(
+        self,
+        src_host: str | None,
+        src_path: str,
+        dst_host: str | None,
+        dst_path: str,
+    ) -> None:
+        src_parent, src_name = os.path.dirname(src_path), os.path.basename(src_path)
+        dst_parent = os.path.dirname(dst_path)
+
+        if dst_host is None:
+            os.makedirs(dst_parent, exist_ok=True)
+        else:
+            subprocess.run(
+                ["ssh", dst_host, f"mkdir -p {shlex.quote(dst_parent)}"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=_LORA_ADAPTER_SYNC_TIMEOUT_S,
+            )
+
+        if src_host is None:
+            src_proc = subprocess.Popen(
+                ["tar", "-cf", "-", "-C", src_parent, src_name],
+                stdout=subprocess.PIPE,
+            )
+        else:
+            src_proc = subprocess.Popen(
+                [
+                    "ssh",
+                    src_host,
+                    f"tar -cf - -C {shlex.quote(src_parent)} {shlex.quote(src_name)}",
+                ],
+                stdout=subprocess.PIPE,
+            )
+
+        if dst_host is None:
+            dst_proc = subprocess.Popen(
+                ["tar", "-xf", "-", "-C", dst_parent],
+                stdin=src_proc.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=False,
+            )
+        else:
+            dst_proc = subprocess.Popen(
+                ["ssh", dst_host, f"tar -xf - -C {shlex.quote(dst_parent)}"],
+                stdin=src_proc.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=False,
+            )
+
+        assert src_proc.stdout is not None
+        src_proc.stdout.close()
+        try:
+            _, dst_err = dst_proc.communicate(timeout=_LORA_ADAPTER_SYNC_TIMEOUT_S)
+            src_return = src_proc.wait(timeout=_LORA_ADAPTER_SYNC_TIMEOUT_S)
+        except subprocess.TimeoutExpired as exc:
+            src_proc.kill()
+            dst_proc.kill()
+            raise RuntimeError(
+                f"LoRA adapter sync timed out after {_LORA_ADAPTER_SYNC_TIMEOUT_S}s "
+                f"from {src_host or 'local'}:{src_path} to {dst_host or 'local'}:{dst_path}"
+            ) from exc
+        if src_return != 0:
+            raise RuntimeError(
+                f"LoRA adapter sync source copy failed from {src_host or 'local'}:{src_path}"
+            )
+        if dst_proc.returncode != 0:
+            stderr = dst_err.decode("utf-8", errors="replace") if dst_err else ""
+            raise RuntimeError(
+                f"LoRA adapter sync destination copy failed to {dst_host or 'local'}:{dst_path}: {stderr}"
+            )
+
+    def _sync_lora_adapter_dir_to_cluster_nodes(self, path: str) -> None:
+        if not is_single_controller():
+            return
+        if self.config.cluster.n_nodes <= 1:
+            return
+        if not isinstance(self.scheduler, RayScheduler):
+            logger.warning(
+                "Skipping LoRA adapter multi-node sync because scheduler is not RayScheduler."
+            )
+            return
+
+        node_ips = self._get_actor_worker_ips()
+        if not node_ips:
+            raise RuntimeError(
+                "Could not determine actor worker nodes for LoRA adapter sync."
+            )
+
+        local_ip = gethostip()
+        if not self._local_lora_adapter_ready(path):
+            raise RuntimeError(
+                f"LoRA adapter checkpoint was not found on the controller node at {path}."
+            )
+
+        copy_targets = [
+            node_ip
+            for node_ip in node_ips
+            if node_ip != local_ip
+            and not self._remote_lora_adapter_ready(node_ip, path)
+        ]
+        if not copy_targets:
+            return
+
+        with ThreadPoolExecutor(max_workers=min(len(copy_targets), 8)) as executor:
+            futures = {
+                executor.submit(
+                    self._copy_dir_between_hosts, None, path, node_ip, path
+                ): node_ip
+                for node_ip in copy_targets
+            }
+            for future in as_completed(futures):
+                node_ip = futures[future]
+                try:
+                    future.result()
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Failed to sync LoRA adapter checkpoint to actor node {node_ip}."
+                    ) from exc
 
     def _save_hf(self, epoch: int, epoch_step: int, global_step: int):
         # Save as HF models for evaluation

--- a/tests/test_fsdp_lora_adapter_load.py
+++ b/tests/test_fsdp_lora_adapter_load.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import areal.engine.fsdp_engine as fsdp_engine_mod
+
+
+def _make_engine():
+    engine = object.__new__(fsdp_engine_mod.FSDPEngine)
+    engine.model = SimpleNamespace(
+        active_adapter="default",
+        peft_config={"default": SimpleNamespace(peft_type="mock_lora")},
+    )
+    engine.config = SimpleNamespace(use_lora=True)
+    engine.cpu_offload = None
+    engine.model_config = SimpleNamespace(tie_word_embeddings=False)
+    engine.logger = Mock()
+    return engine
+
+
+def test_load_lora_adapter_collects_empty_partial_state_on_nonzero_rank(monkeypatch):
+    engine = _make_engine()
+    events = []
+
+    monkeypatch.setattr(fsdp_engine_mod.dist, "get_rank", lambda: 1)
+    monkeypatch.setattr(
+        fsdp_engine_mod,
+        "load_safetensors_file",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("nonzero ranks must not read adapter safetensors")
+        ),
+    )
+    monkeypatch.setattr(
+        fsdp_engine_mod,
+        "fsdp2_load_full_state_dict",
+        lambda model, partial_state, cpu_offload, strict=None: events.append(
+            ("fsdp2_load_full_state_dict", dict(partial_state), strict)
+        ),
+    )
+
+    engine._load_lora_adapter_from_hf("/tmp/adapter")
+
+    assert events == [
+        ("fsdp2_load_full_state_dict", {}, False),
+    ]
+
+
+def test_load_lora_adapter_rank0_remaps_adapter_keys(monkeypatch, tmp_path):
+    engine = _make_engine()
+    events = []
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir()
+    adapter_path = adapter_dir / "adapter_model.safetensors"
+    adapter_path.write_bytes(b"stub")
+
+    monkeypatch.setattr(fsdp_engine_mod.dist, "get_rank", lambda: 0)
+    monkeypatch.setitem(
+        fsdp_engine_mod.PEFT_TYPE_TO_PREFIX_MAPPING,
+        "mock_lora",
+        "lora_",
+    )
+    monkeypatch.setattr(
+        fsdp_engine_mod,
+        "load_safetensors_file",
+        lambda path, device="cpu": events.append(
+            ("load_safetensors_file", path, device)
+        )
+        or {
+            "base_model.model.layers.0.self_attn.q_proj.lora_A.weight": 2,
+            "base_model.model.layers.0.self_attn.q_proj.lora_B.weight": 3,
+        },
+    )
+    monkeypatch.setattr(
+        fsdp_engine_mod,
+        "fsdp2_load_full_state_dict",
+        lambda model, partial_state, cpu_offload, strict=None: events.append(
+            ("fsdp2_load_full_state_dict", dict(partial_state), strict)
+        ),
+    )
+
+    engine._load_lora_adapter_from_hf(str(adapter_dir))
+
+    assert events == [
+        ("load_safetensors_file", str(adapter_path), "cpu"),
+        (
+            "fsdp2_load_full_state_dict",
+            {
+                "base_model.model.layers.0.self_attn.q_proj.lora_A.default.weight": 2,
+                "base_model.model.layers.0.self_attn.q_proj.lora_B.default.weight": 3,
+            },
+            False,
+        ),
+    ]

--- a/tests/test_rl_trainer_lora_bootstrap.py
+++ b/tests/test_rl_trainer_lora_bootstrap.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import areal.trainer.rl_trainer as rl_trainer_mod
+from areal.trainer.rl_trainer import PPOTrainer
+
+
+def test_prepare_initial_actor_lora_loads_bootstrap_before_save(monkeypatch):
+    trainer = object.__new__(PPOTrainer)
+    trainer.config = SimpleNamespace(
+        actor=SimpleNamespace(
+            use_lora=True,
+            backend="fsdp:d2p1t1",
+            path="/tmp/base-model",
+        ),
+        cluster=SimpleNamespace(fileroot="/tmp/fileroot"),
+        experiment_name="exp",
+        trial_name="trial",
+    )
+    trainer.actor = Mock()
+    trainer.actor.load = Mock(
+        side_effect=AssertionError("full-model load should not be used")
+    )
+    trainer.actor.load_lora_adapter = Mock()
+    trainer.actor.save = Mock()
+    trainer.tokenizer = Mock()
+    trainer.processor = Mock()
+    trainer._sync_lora_adapter_dir_to_cluster_nodes = Mock()
+
+    path = "/tmp/test-lora-checkpoint"
+    monkeypatch.setenv("GUI_LORA_BOOTSTRAP_HF_PATH", path)
+    monkeypatch.setattr(
+        rl_trainer_mod.Saver,
+        "get_model_save_root",
+        lambda *args, **kwargs: "/tmp/actor-root",
+    )
+
+    initial_lora_path = trainer._prepare_initial_actor_lora()
+
+    assert initial_lora_path == "/tmp/actor-root/initial_lora"
+    trainer._sync_lora_adapter_dir_to_cluster_nodes.assert_called_once_with(path)
+    trainer.actor.load_lora_adapter.assert_called_once_with(path)
+    trainer.actor.load.assert_not_called()
+    trainer.actor.save.assert_called_once()
+    assert trainer.actor.save.call_args.kwargs["meta"].path == initial_lora_path
+
+
+def test_lora_bootstrap_hf_path_requires_lora(monkeypatch):
+    trainer = object.__new__(PPOTrainer)
+    trainer.config = SimpleNamespace(
+        actor=SimpleNamespace(use_lora=False, backend="fsdp:d2p1t1")
+    )
+    trainer.actor = Mock()
+    trainer._sync_lora_adapter_dir_to_cluster_nodes = Mock()
+
+    monkeypatch.setenv("GUI_LORA_BOOTSTRAP_HF_PATH", "/tmp/test-lora-checkpoint")
+
+    with pytest.raises(RuntimeError, match="actor.use_lora is false"):
+        trainer._get_actor_lora_bootstrap_hf_path()
+
+
+def test_lora_bootstrap_hf_path_rejects_non_fsdp_backends(monkeypatch):
+    trainer = object.__new__(PPOTrainer)
+    trainer.config = SimpleNamespace(
+        actor=SimpleNamespace(use_lora=True, backend="megatron:d2p1t1")
+    )
+    trainer.actor = Mock()
+    trainer._sync_lora_adapter_dir_to_cluster_nodes = Mock()
+
+    monkeypatch.setenv("GUI_LORA_BOOTSTRAP_HF_PATH", "/tmp/test-lora-checkpoint")
+
+    with pytest.raises(RuntimeError, match="only supported for FSDP actors"):
+        trainer._get_actor_lora_bootstrap_hf_path()
+
+
+def test_get_actor_worker_ips_uses_current_actor_workers_only():
+    trainer = object.__new__(PPOTrainer)
+    trainer.actor = SimpleNamespace(
+        workers=[
+            SimpleNamespace(ip="10.0.0.2"),
+            SimpleNamespace(ip="10.0.0.1"),
+            SimpleNamespace(ip="10.0.0.2"),
+        ]
+    )
+
+    assert trainer._get_actor_worker_ips() == ["10.0.0.1", "10.0.0.2"]


### PR DESCRIPTION
## Description

  This PR adds support for bootstrapping LoRA-enabled FSDP training from adapter-only HF checkpoints.

  AReaL already supports saving LoRA checkpoints in adapter-only format, but previously did
  not provide a matching training-side path for loading those checkpoints back into an FSDP
  LoRA actor to initialize a new training run.

  This PR adds an explicit adapter-only bootstrap path that:
  - synchronizes the adapter checkpoint to the active actor worker nodes
  - loads adapter-only LoRA weights into the current FSDP PEFT model
  - keeps this flow separate from full checkpoint loading and full training-state recovery

  This enables warm-starting a new LoRA training run from a previously saved adapter
  checkpoint without requiring optimizer or scheduler state restoration.

  ## Related Issue

  Fixes #1240

  ## Type of Change

  - [ ] 🐛 Bug fix
  - [x] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [ ] ⚡ Performance improvement
  - [x] ✅ Test coverage improvement

  ## Checklist

  - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
  - [x] Relevant tests pass; new tests added for new functionality
  - [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
  - [x] Branch is up to date with `main`
  - [x] Self-reviewed via `/review-pr` command
  - [ ] This PR was created by a coding agent via `/create-pr`
  - [ ] This PR is a breaking change

  **Breaking Change Details (if applicable):**

  N/A

  ## Additional Context

  This feature is intentionally scoped to adapter-only LoRA bootstrap for FSDP actors.

  It is not a full training-state recovery path and does not restore optimizer state, LR
  scheduler state, or exact global-step continuation.