### PR TITLE
feat: Implement Megatron PP and CP with Awex for Weight Update

### DIFF
--- a/areal/experimental/weight_update/awex/megatron_adapter.py
+++ b/areal/experimental/weight_update/awex/megatron_adapter.py
@@ -57,13 +57,16 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
         from megatron.core import parallel_state as mpu
 
         tp_size = mpu.get_tensor_model_parallel_world_size()
+        cp_size = mpu.get_context_parallel_world_size()
         return {
             "world_size": self._engine.world_size,
             "tp_size": tp_size,
             "pp_size": mpu.get_pipeline_model_parallel_world_size(),
             "dp_size": self._engine.data_parallel_world_size,
-            "ep_size": mpu.get_expert_model_parallel_world_size(),
-            "dp_replicated": tp_size > 1,
+            # TP and CP ranks within a DP group hold identical full parameters
+            # (TP via all_gather_param, CP because it only splits the sequence).
+            # Mark as replicated so awex picks one sender per group.
+            "dp_replicated": tp_size > 1 or cp_size > 1,
         }
 
     def get_weight_metadata(self) -> list[ParameterMeta]:
@@ -201,8 +204,8 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
         tp_rank = mpu.get_tensor_model_parallel_rank()
         pp_size = mpu.get_pipeline_model_parallel_world_size()
         pp_rank = mpu.get_pipeline_model_parallel_rank()
-        ep_size = mpu.get_expert_model_parallel_world_size()
-        ep_rank = mpu.get_expert_model_parallel_rank()
+        cp_size = mpu.get_context_parallel_world_size()
+        cp_rank = mpu.get_context_parallel_rank()
         local_rank = int(os.environ.get("LOCAL_RANK", self._engine.rank))
 
         return RankInfo(
@@ -212,8 +215,8 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
             pp_size=pp_size,
             dp_size=self._engine.data_parallel_world_size,
             dp_rank=self._engine.data_parallel_rank,
-            ep_rank=ep_rank,
-            ep_size=ep_size,
+            ep_rank=0,
+            ep_size=1,
             ep_tp_rank=0,
             ep_tp_size=1,
             attn_tp_rank=tp_rank,
@@ -224,9 +227,9 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
             local_rank=local_rank,
             engine_rank=0,
             is_infer=False,
-            cp_rank=0,
-            cp_size=1,
-            cp_mode="none",
+            cp_rank=cp_rank,
+            cp_size=cp_size,
+            cp_mode="ulysses" if cp_size > 1 else "none",
         )
 
     def _iter_hf_params(self):
@@ -245,14 +248,13 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
             get_named_parameters,
         )
 
-        num_moe_experts = getattr(self._engine.tf_config, "num_moe_experts", None)
         model_name = self._engine.hf_config.model_type
         tie_word_embeddings = getattr(
             self._engine.hf_config, "tie_word_embeddings", False
         )
 
         for mcore_name, param in get_named_parameters(
-            self._engine.model, num_moe_experts
+            self._engine.model, num_experts=None
         ):
             gathered = all_gather_param(
                 mcore_name,

--- a/areal/experimental/weight_update/awex/megatron_adapter.py
+++ b/areal/experimental/weight_update/awex/megatron_adapter.py
@@ -33,12 +33,17 @@ logger = logging.getLogger("AwexMegatronAdapter")
 
 
 class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
-    """Awex training adapter wrapping MegatronEngine for DP-only NCCL P2P weight updates.
+    """Awex training adapter for MegatronEngine supporting DP, TP, and PP.
 
-    Scope: DP-only (tp=1, pp=1). Each rank holds a full replica of every
-    parameter. Parameters are converted to HF naming via convert_to_hf before
-    being handed to the awex transfer planner, matching what the inference
-    engine (SGLang) expects.
+    PP: get_named_parameters already yields only the current stage's layers
+    (with globally-correct HF layer indices via get_transformer_layer_offset),
+    so each rank naturally reports and sends only its own subset of parameters.
+    The gateway's _merge_training_meta_by_name unions disjoint PP stage params
+    by name, so the full model is covered across all PP ranks.
+
+    TP: all_gather_param gathers the full tensor on every TP rank before
+    convert_to_hf. dp_replicated=True tells awex that TP ranks within a DP
+    group hold identical full tensors and only one needs to send.
     """
 
     def __init__(self, engine: MegatronEngine):
@@ -242,6 +247,9 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
 
         num_moe_experts = getattr(self._engine.tf_config, "num_moe_experts", None)
         model_name = self._engine.hf_config.model_type
+        tie_word_embeddings = getattr(
+            self._engine.hf_config, "tie_word_embeddings", False
+        )
 
         for mcore_name, param in get_named_parameters(
             self._engine.model, num_moe_experts
@@ -262,4 +270,6 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
                 mcore_name,
                 gathered,
             ):
+                if tie_word_embeddings and hf_name == "lm_head.weight":
+                    continue
                 yield hf_name, tensor.detach()

--- a/areal/experimental/weight_update/awex/megatron_adapter.py
+++ b/areal/experimental/weight_update/awex/megatron_adapter.py
@@ -229,7 +229,7 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
             is_infer=False,
             cp_rank=cp_rank,
             cp_size=cp_size,
-            cp_mode="ulysses" if cp_size > 1 else "none",
+            cp_mode="ring" if cp_size > 1 else "none",
         )
 
     def _iter_hf_params(self):

--- a/tests/experimental/weight_update/test_nccl_integration.py
+++ b/tests/experimental/weight_update/test_nccl_integration.py
@@ -206,6 +206,7 @@ def _validate_weight_update_correctness_megatron(
     train_worker_urls: list[str],
     inf_worker_url: str,
     param_dir,
+    tag: str = "megatron",
 ) -> None:
     import concurrent.futures
 
@@ -216,7 +217,7 @@ def _validate_weight_update_correctness_megatron(
     )
 
     train_paths = [
-        str(param_dir / f"megatron_train_params_rank{i}.pt") for i in range(n_train)
+        str(param_dir / f"{tag}_train_params_rank{i}.pt") for i in range(n_train)
     ]
 
     def _fetch_train(args):
@@ -241,7 +242,7 @@ def _validate_weight_update_correctness_megatron(
             )
         )
 
-    inf_path = str(param_dir / "megatron_infer_params.pt")
+    inf_path = str(param_dir / f"{tag}_infer_params.pt")
     resp = httpx.post(
         f"{inf_worker_url}/awex/debug/get_parameters",
         json={"save_path": inf_path, "names": _VALIDATE_PARAM_NAMES},
@@ -252,12 +253,20 @@ def _validate_weight_update_correctness_megatron(
     )
 
     infer_params = torch.load(inf_path, map_location="cpu", weights_only=True)
-    train_params = torch.load(train_paths[0], map_location="cpu", weights_only=True)
+
+    # Union params across all training ranks: with PP each rank owns a disjoint
+    # subset of layers, so we need all ranks to cover _VALIDATE_PARAM_NAMES.
+    train_params: dict[str, torch.Tensor] = {}
+    for p in train_paths:
+        train_params.update(torch.load(p, map_location="cpu", weights_only=True))
 
     print(f"[weight-validation] Comparing {len(_VALIDATE_PARAM_NAMES)} parameters …")
     for name in _VALIDATE_PARAM_NAMES:
         assert name in infer_params, f"Inference missing param: {name}"
-        assert name in train_params, f"Training rank 0 missing param: {name}"
+        assert name in train_params, (
+            f"No training rank owns param: {name}. "
+            f"Available: {sorted(train_params.keys())[:5]}…"
+        )
 
         torch.testing.assert_close(
             train_params[name],
@@ -441,7 +450,7 @@ def test_awex_fsdp_e2e_weight_update(n_gpus, tmp_path_factory):
 @pytest.mark.slow
 @pytest.mark.sglang
 @pytest.mark.parametrize("n_gpus", [2, 4, 8], ids=["2gpu", "4gpu", "8gpu"])
-def test_awex_megatron_e2e_weight_update(n_gpus, tmp_path_factory):
+def test_awex_megatron_dp_e2e_weight_update(n_gpus, tmp_path_factory):
     """Full round trip: MegatronEngine (pure DP) → weight-update gateway → SGLang.
 
     Mirrors test_awex_e2e_weight_update but uses MegatronLMEngine as the
@@ -592,9 +601,9 @@ def test_awex_megatron_e2e_weight_update(n_gpus, tmp_path_factory):
 @pytest.mark.parametrize(
     "n_gpus,tp_size",
     [(4, 2), (8, 2), (8, 4)],
-    ids=["4gpu-tp2", "8gpu-tp2", "8gpu-tp4"],
+    ids=["4gpu-dp1tp2", "8gpu-dp2tp2", "8gpu-dp1tp4"],
 )
-def test_awex_megatron_tp_e2e_weight_update(n_gpus, tp_size, tmp_path_factory):
+def test_awex_megatron_dp_tp_e2e_weight_update(n_gpus, tp_size, tmp_path_factory):
     """Full round trip: MegatronEngine (DP+TP) → weight-update gateway → SGLang.
 
     Uses dp_replicated=True in parallelism_strategy so awex knows TP ranks
@@ -743,3 +752,194 @@ def test_awex_megatron_tp_e2e_weight_update(n_gpus, tp_size, tmp_path_factory):
         train_ctrl.destroy()
         inf_ctrl.destroy()
         scheduler.delete_workers(None)
+
+
+def _run_megatron_awex_e2e(
+    *,
+    n_gpus: int,
+    backend: str,
+    pair_name: str,
+    tag: str,
+    tmp_path_factory,
+):
+    from areal.api import FinetuneSpec
+    from areal.api.cli_args import OptimizerConfig, SchedulingSpec, TrainEngineConfig
+    from areal.experimental.inference_service.controller.config import (
+        GatewayControllerConfig,
+    )
+    from areal.experimental.inference_service.controller.controller import (
+        GatewayInferenceController,
+    )
+    from areal.experimental.training_service.controller.controller import (
+        GatewayTrainController,
+    )
+    from areal.experimental.weight_update.controller import (
+        WeightUpdateController,
+        WeightUpdateControllerConfig,
+    )
+
+    n_infer = n_gpus // 2
+    tmp = tmp_path_factory.mktemp(tag)
+    model_path = _get_test_model_path()
+    scheduler = _make_local_scheduler(tmp, tag, gpu_devices=list(range(n_gpus)))
+
+    inf_config = GatewayControllerConfig(
+        tokenizer_path=model_path,
+        model_path=model_path,
+        backend=f"sglang:d{n_infer}",
+        scheduling_spec=(
+            SchedulingSpec(
+                gpu=1,
+                cmd="python -m areal.experimental.inference_service.guard",
+            ),
+        ),
+        consumer_batch_size=8,
+        max_head_offpolicyness=1024,
+        setup_timeout=300.0,
+        admin_api_key="test-admin",
+    )
+    inf_ctrl = GatewayInferenceController(config=inf_config, scheduler=scheduler)
+
+    train_config = TrainEngineConfig(
+        backend=backend,
+        experiment_name=f"test-awex-{tag}",
+        trial_name="t0",
+        path=model_path,
+        optimizer=OptimizerConfig(),
+        _version="v2",
+        setup_timeout=300.0,
+        scheduling_spec=(
+            SchedulingSpec(
+                gpu=1,
+                cmd="python -m areal.experimental.training_service.guard",
+                env_vars=dict(NCCL_CUMEM_ENABLE="0", NCCL_NVLS_ENABLE="0"),
+            ),
+        ),
+    )
+    train_ctrl = GatewayTrainController(
+        train_engine="areal.engine.megatron_engine.MegatronLMEngine",
+        config=train_config,
+        scheduler=scheduler,
+    )
+
+    wu_ctrl: WeightUpdateController | None = None
+    try:
+        inf_ctrl.initialize(role="rollout", server_args={"mem_fraction_static": 0.7})
+        inf_worker_urls = list(inf_ctrl._inf_addrs)
+
+        for url in inf_worker_urls:
+            resp = httpx.post(f"{url}/awex/debug/randomize_parameters", timeout=120.0)
+            assert resp.status_code == 200, f"randomize_parameters failed: {resp.text}"
+
+        train_ctrl.initialize(
+            role="actor",
+            ft_spec=FinetuneSpec(
+                total_train_epochs=1, dataset_size=100, train_batch_size=2
+            ),
+        )
+        train_worker_urls = list(train_ctrl._worker_addrs)
+
+        wu_ctrl = WeightUpdateController(
+            config=WeightUpdateControllerConfig(host="127.0.0.1", request_timeout=300.0)
+        )
+        wu_ctrl.initialize()
+        assert wu_ctrl.health_check(), "Weight update gateway health check failed"
+
+        wu_ctrl.connect(
+            pair_name=pair_name,
+            train_worker_urls=train_worker_urls,
+            inference_worker_urls=inf_worker_urls,
+        )
+        result = wu_ctrl.update_weights(version=1)
+        assert result.status == "ok"
+        assert result.version == 1
+        wu_ctrl.disconnect()
+
+        gen_resp = httpx.post(
+            f"{inf_worker_urls[0]}/generate",
+            json={
+                "text": "Hello",
+                "sampling_params": {"max_new_tokens": 5, "temperature": 0},
+            },
+            timeout=30.0,
+        )
+        assert gen_resp.status_code == 200, (
+            f"Generation failed after weight update: {gen_resp.text}"
+        )
+
+        _validate_weight_update_correctness_megatron(
+            train_worker_urls=train_worker_urls,
+            inf_worker_url=inf_worker_urls[0],
+            param_dir=tmp,
+            tag=tag,
+        )
+    finally:
+        if wu_ctrl is not None:
+            wu_ctrl.destroy()
+        train_ctrl.destroy()
+        inf_ctrl.destroy()
+        scheduler.delete_workers(None)
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.parametrize(
+    "n_gpus,pp_size",
+    [(4, 2), (8, 4)],
+    ids=["4gpu-dp1pp2", "8gpu-dp1pp4"],
+)
+def test_awex_megatron_pp_e2e_weight_update(n_gpus, pp_size, tmp_path_factory):
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+    _run_megatron_awex_e2e(
+        n_gpus=n_gpus,
+        backend=f"megatron:d1p{pp_size}",
+        pair_name=f"test_megatron_pp{pp_size}",
+        tag=f"megatron_pp{pp_size}",
+        tmp_path_factory=tmp_path_factory,
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.parametrize(
+    "n_gpus,dp_size,pp_size",
+    [(8, 2, 2)],
+    ids=["8gpu-dp2pp2"],
+)
+def test_awex_megatron_dp_pp_e2e_weight_update(
+    n_gpus, dp_size, pp_size, tmp_path_factory
+):
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+    _run_megatron_awex_e2e(
+        n_gpus=n_gpus,
+        backend=f"megatron:d{dp_size}p{pp_size}",
+        pair_name=f"test_megatron_dp{dp_size}pp{pp_size}",
+        tag=f"megatron_dp{dp_size}pp{pp_size}",
+        tmp_path_factory=tmp_path_factory,
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.parametrize(
+    "n_gpus,pp_size,tp_size",
+    [(8, 2, 2)],
+    ids=["8gpu-dp1pp2tp2"],
+)
+def test_awex_megatron_pp_tp_e2e_weight_update(
+    n_gpus, pp_size, tp_size, tmp_path_factory
+):
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+    _run_megatron_awex_e2e(
+        n_gpus=n_gpus,
+        backend=f"megatron:d1p{pp_size}t{tp_size}",
+        pair_name=f"test_megatron_pp{pp_size}tp{tp_size}",
+        tag=f"megatron_pp{pp_size}tp{tp_size}",
+        tmp_path_factory=tmp_path_factory,
+    )

--- a/tests/experimental/weight_update/test_nccl_integration.py
+++ b/tests/experimental/weight_update/test_nccl_integration.py
@@ -210,6 +210,7 @@ def _validate_weight_update_correctness_megatron(
 ) -> None:
     import concurrent.futures
 
+    names = _VALIDATE_PARAM_NAMES
     n_train = len(train_worker_urls)
     print(
         f"\n[weight-validation] Fetching parameters from {n_train} Megatron "
@@ -224,7 +225,7 @@ def _validate_weight_update_correctness_megatron(
         i, url, p = args
         resp = httpx.post(
             f"{url}/awex/debug/get_parameters",
-            json={"save_path": p, "names": _VALIDATE_PARAM_NAMES},
+            json={"save_path": p, "names": names},
             timeout=120.0,
         )
         assert resp.status_code == 200, (
@@ -245,7 +246,7 @@ def _validate_weight_update_correctness_megatron(
     inf_path = str(param_dir / f"{tag}_infer_params.pt")
     resp = httpx.post(
         f"{inf_worker_url}/awex/debug/get_parameters",
-        json={"save_path": inf_path, "names": _VALIDATE_PARAM_NAMES},
+        json={"save_path": inf_path, "names": names},
         timeout=120.0,
     )
     assert resp.status_code == 200, (
@@ -255,13 +256,13 @@ def _validate_weight_update_correctness_megatron(
     infer_params = torch.load(inf_path, map_location="cpu", weights_only=True)
 
     # Union params across all training ranks: with PP each rank owns a disjoint
-    # subset of layers, so we need all ranks to cover _VALIDATE_PARAM_NAMES.
+    # subset of layers, so we need all ranks to cover the validate param names.
     train_params: dict[str, torch.Tensor] = {}
     for p in train_paths:
         train_params.update(torch.load(p, map_location="cpu", weights_only=True))
 
-    print(f"[weight-validation] Comparing {len(_VALIDATE_PARAM_NAMES)} parameters …")
-    for name in _VALIDATE_PARAM_NAMES:
+    print(f"[weight-validation] Comparing {len(names)} parameters …")
+    for name in names:
         assert name in infer_params, f"Inference missing param: {name}"
         assert name in train_params, (
             f"No training rank owns param: {name}. "
@@ -281,7 +282,7 @@ def _validate_weight_update_correctness_megatron(
         )
 
     print(
-        f"[weight-validation] All {len(_VALIDATE_PARAM_NAMES)} parameters "
+        f"[weight-validation] All {len(names)} parameters "
         f"match between Megatron training and inference ✓"
     )
 
@@ -453,146 +454,19 @@ def test_awex_fsdp_e2e_weight_update(n_gpus, tmp_path_factory):
 def test_awex_megatron_dp_e2e_weight_update(n_gpus, tmp_path_factory):
     """Full round trip: MegatronEngine (pure DP) → weight-update gateway → SGLang.
 
-    Mirrors test_awex_e2e_weight_update but uses MegatronLMEngine as the
-    training backend.  DP-only (tp=1, pp=1): every training rank holds a full
-    copy of every parameter, so validation compares rank-0's params directly
-    against the inference server without any concatenation.
+    Each training rank holds a full copy of every parameter. Validation unions
+    params across all training ranks and compares bitwise against SGLang.
     """
     if current_platform.device_count() < n_gpus:
         pytest.skip(f"This test requires {n_gpus} GPUs")
-
-    from areal.api import FinetuneSpec
-    from areal.api.cli_args import (
-        OptimizerConfig,
-        SchedulingSpec,
-        TrainEngineConfig,
-    )
-    from areal.experimental.inference_service.controller.config import (
-        GatewayControllerConfig,
-    )
-    from areal.experimental.inference_service.controller.controller import (
-        GatewayInferenceController,
-    )
-    from areal.experimental.training_service.controller.controller import (
-        GatewayTrainController,
-    )
-    from areal.experimental.weight_update.controller import (
-        WeightUpdateController,
-        WeightUpdateControllerConfig,
-    )
-
     n_half = n_gpus // 2
-    tmp = tmp_path_factory.mktemp("awex_megatron_e2e")
-    model_path = _get_test_model_path()
-
-    scheduler = _make_local_scheduler(
-        tmp, "megatron-e2e", gpu_devices=list(range(n_gpus))
-    )
-
-    inf_config = GatewayControllerConfig(
-        tokenizer_path=model_path,
-        model_path=model_path,
-        backend=f"sglang:d{n_half}",
-        scheduling_spec=(
-            SchedulingSpec(
-                gpu=1,
-                cmd="python -m areal.experimental.inference_service.guard",
-            ),
-        ),
-        consumer_batch_size=8,
-        max_head_offpolicyness=1024,
-        setup_timeout=300.0,
-        admin_api_key="test-admin",
-    )
-    inf_ctrl = GatewayInferenceController(config=inf_config, scheduler=scheduler)
-
-    train_config = TrainEngineConfig(
+    _run_megatron_awex_e2e(
+        n_gpus=n_gpus,
         backend=f"megatron:d{n_half}",
-        experiment_name="test-awex-megatron-e2e",
-        trial_name="t0",
-        path=model_path,
-        optimizer=OptimizerConfig(),
-        _version="v2",
-        setup_timeout=300.0,
-        scheduling_spec=(
-            SchedulingSpec(
-                gpu=1,
-                cmd="python -m areal.experimental.training_service.guard",
-                env_vars=dict(NCCL_CUMEM_ENABLE="0", NCCL_NVLS_ENABLE="0"),
-            ),
-        ),
+        pair_name="test_megatron_dp_e2e",
+        tag="megatron_dp_e2e",
+        tmp_path_factory=tmp_path_factory,
     )
-    train_ctrl = GatewayTrainController(
-        train_engine="areal.engine.megatron_engine.MegatronLMEngine",
-        config=train_config,
-        scheduler=scheduler,
-    )
-
-    wu_ctrl: WeightUpdateController | None = None
-
-    try:
-        inf_ctrl.initialize(
-            role="rollout",
-            server_args={"mem_fraction_static": 0.7},
-        )
-        inf_worker_urls = list(inf_ctrl._inf_addrs)
-
-        for url in inf_worker_urls:
-            resp = httpx.post(f"{url}/awex/debug/randomize_parameters", timeout=120.0)
-            assert resp.status_code == 200, f"randomize_parameters failed: {resp.text}"
-
-        ft_spec = FinetuneSpec(
-            total_train_epochs=1, dataset_size=100, train_batch_size=2
-        )
-        train_ctrl.initialize(role="actor", ft_spec=ft_spec)
-        train_worker_urls = list(train_ctrl._worker_addrs)
-
-        wu_ctrl = WeightUpdateController(
-            config=WeightUpdateControllerConfig(
-                host="127.0.0.1",
-                request_timeout=300.0,
-            )
-        )
-        wu_ctrl.initialize()
-
-        assert wu_ctrl.health_check(), "Weight update gateway health check failed"
-
-        wu_ctrl.connect(
-            pair_name="test_megatron_e2e",
-            train_worker_urls=train_worker_urls,
-            inference_worker_urls=inf_worker_urls,
-        )
-
-        result = wu_ctrl.update_weights(version=1)
-        assert result.status == "ok"
-        assert result.version == 1
-
-        wu_ctrl.disconnect()
-
-        gen_resp = httpx.post(
-            f"{inf_worker_urls[0]}/generate",
-            json={
-                "text": "Hello",
-                "sampling_params": {"max_new_tokens": 5, "temperature": 0},
-            },
-            timeout=30.0,
-        )
-        assert gen_resp.status_code == 200, (
-            f"Generation failed after weight update: {gen_resp.text}"
-        )
-
-        _validate_weight_update_correctness_megatron(
-            train_worker_urls=train_worker_urls,
-            inf_worker_url=inf_worker_urls[0],
-            param_dir=tmp,
-        )
-
-    finally:
-        if wu_ctrl is not None:
-            wu_ctrl.destroy()
-        train_ctrl.destroy()
-        inf_ctrl.destroy()
-        scheduler.delete_workers(None)
 
 
 @pytest.mark.multi_gpu
@@ -606,152 +480,24 @@ def test_awex_megatron_dp_e2e_weight_update(n_gpus, tmp_path_factory):
 def test_awex_megatron_dp_tp_e2e_weight_update(n_gpus, tp_size, tmp_path_factory):
     """Full round trip: MegatronEngine (DP+TP) → weight-update gateway → SGLang.
 
-    Uses dp_replicated=True in parallelism_strategy so awex knows TP ranks
-    within a DP group all hold the same full parameter (gathered via
-    all_gather_param) and only one rank per group needs to send.
-
-    Minimum 4 GPUs: 2 for SGLang inference, 2 for Megatron (dp=1, tp=2).
+    TP ranks within a DP group each hold the same full parameter after
+    all_gather_param. dp_replicated=True tells awex only one rank per group
+    needs to send, avoiding redundant transfers.
     """
     if current_platform.device_count() < n_gpus:
         pytest.skip(f"This test requires {n_gpus} GPUs")
-
-    from areal.api import FinetuneSpec
-    from areal.api.cli_args import (
-        OptimizerConfig,
-        SchedulingSpec,
-        TrainEngineConfig,
-    )
-    from areal.experimental.inference_service.controller.config import (
-        GatewayControllerConfig,
-    )
-    from areal.experimental.inference_service.controller.controller import (
-        GatewayInferenceController,
-    )
-    from areal.experimental.training_service.controller.controller import (
-        GatewayTrainController,
-    )
-    from areal.experimental.weight_update.controller import (
-        WeightUpdateController,
-        WeightUpdateControllerConfig,
-    )
-
     n_infer = n_gpus // 2
     n_train = n_gpus - n_infer
     dp_size = n_train // tp_size
     if dp_size < 1:
         pytest.skip(f"Not enough GPUs for dp={dp_size} tp={tp_size}")
-
-    tmp = tmp_path_factory.mktemp("awex_megatron_tp_e2e")
-    model_path = _get_test_model_path()
-
-    scheduler = _make_local_scheduler(
-        tmp, "megatron-tp-e2e", gpu_devices=list(range(n_gpus))
-    )
-
-    inf_config = GatewayControllerConfig(
-        tokenizer_path=model_path,
-        model_path=model_path,
-        backend=f"sglang:d{n_infer}",
-        scheduling_spec=(
-            SchedulingSpec(
-                gpu=1,
-                cmd="python -m areal.experimental.inference_service.guard",
-            ),
-        ),
-        consumer_batch_size=8,
-        max_head_offpolicyness=1024,
-        setup_timeout=300.0,
-        admin_api_key="test-admin",
-    )
-    inf_ctrl = GatewayInferenceController(config=inf_config, scheduler=scheduler)
-
-    train_config = TrainEngineConfig(
+    _run_megatron_awex_e2e(
+        n_gpus=n_gpus,
         backend=f"megatron:d{dp_size}t{tp_size}",
-        experiment_name="test-awex-megatron-tp-e2e",
-        trial_name="t0",
-        path=model_path,
-        optimizer=OptimizerConfig(),
-        _version="v2",
-        setup_timeout=300.0,
-        scheduling_spec=(
-            SchedulingSpec(
-                gpu=1,
-                cmd="python -m areal.experimental.training_service.guard",
-                env_vars=dict(NCCL_CUMEM_ENABLE="0", NCCL_NVLS_ENABLE="0"),
-            ),
-        ),
+        pair_name=f"test_megatron_dp{dp_size}tp{tp_size}",
+        tag=f"megatron_dp{dp_size}tp{tp_size}",
+        tmp_path_factory=tmp_path_factory,
     )
-    train_ctrl = GatewayTrainController(
-        train_engine="areal.engine.megatron_engine.MegatronLMEngine",
-        config=train_config,
-        scheduler=scheduler,
-    )
-
-    wu_ctrl: WeightUpdateController | None = None
-
-    try:
-        inf_ctrl.initialize(
-            role="rollout",
-            server_args={"mem_fraction_static": 0.7},
-        )
-        inf_worker_urls = list(inf_ctrl._inf_addrs)
-
-        for url in inf_worker_urls:
-            resp = httpx.post(f"{url}/awex/debug/randomize_parameters", timeout=120.0)
-            assert resp.status_code == 200, f"randomize_parameters failed: {resp.text}"
-
-        ft_spec = FinetuneSpec(
-            total_train_epochs=1, dataset_size=100, train_batch_size=2
-        )
-        train_ctrl.initialize(role="actor", ft_spec=ft_spec)
-        train_worker_urls = list(train_ctrl._worker_addrs)
-
-        wu_ctrl = WeightUpdateController(
-            config=WeightUpdateControllerConfig(
-                host="127.0.0.1",
-                request_timeout=300.0,
-            )
-        )
-        wu_ctrl.initialize()
-
-        assert wu_ctrl.health_check(), "Weight update gateway health check failed"
-
-        wu_ctrl.connect(
-            pair_name="test_megatron_tp_e2e",
-            train_worker_urls=train_worker_urls,
-            inference_worker_urls=inf_worker_urls,
-        )
-
-        result = wu_ctrl.update_weights(version=1)
-        assert result.status == "ok"
-        assert result.version == 1
-
-        wu_ctrl.disconnect()
-
-        gen_resp = httpx.post(
-            f"{inf_worker_urls[0]}/generate",
-            json={
-                "text": "Hello",
-                "sampling_params": {"max_new_tokens": 5, "temperature": 0},
-            },
-            timeout=30.0,
-        )
-        assert gen_resp.status_code == 200, (
-            f"Generation failed after weight update: {gen_resp.text}"
-        )
-
-        _validate_weight_update_correctness_megatron(
-            train_worker_urls=train_worker_urls,
-            inf_worker_url=inf_worker_urls[0],
-            param_dir=tmp,
-        )
-
-    finally:
-        if wu_ctrl is not None:
-            wu_ctrl.destroy()
-        train_ctrl.destroy()
-        inf_ctrl.destroy()
-        scheduler.delete_workers(None)
 
 
 def _run_megatron_awex_e2e(
@@ -761,6 +507,7 @@ def _run_megatron_awex_e2e(
     pair_name: str,
     tag: str,
     tmp_path_factory,
+    model_path: str | None = None,
 ):
     from areal.api import FinetuneSpec
     from areal.api.cli_args import OptimizerConfig, SchedulingSpec, TrainEngineConfig
@@ -780,7 +527,7 @@ def _run_megatron_awex_e2e(
 
     n_infer = n_gpus // 2
     tmp = tmp_path_factory.mktemp(tag)
-    model_path = _get_test_model_path()
+    model_path = model_path or _get_test_model_path()
     scheduler = _make_local_scheduler(tmp, tag, gpu_devices=list(range(n_gpus)))
 
     inf_config = GatewayControllerConfig(
@@ -890,6 +637,11 @@ def _run_megatron_awex_e2e(
     ids=["4gpu-dp1pp2", "8gpu-dp1pp4"],
 )
 def test_awex_megatron_pp_e2e_weight_update(n_gpus, pp_size, tmp_path_factory):
+    """Full round trip: MegatronEngine (pure PP) → weight-update gateway → SGLang.
+
+    Each PP stage owns a disjoint subset of layers. Validation unions params
+    across all PP ranks to reconstruct the full parameter set for comparison.
+    """
     if current_platform.device_count() < n_gpus:
         pytest.skip(f"This test requires {n_gpus} GPUs")
     _run_megatron_awex_e2e(
@@ -912,6 +664,12 @@ def test_awex_megatron_pp_e2e_weight_update(n_gpus, pp_size, tmp_path_factory):
 def test_awex_megatron_dp_pp_e2e_weight_update(
     n_gpus, dp_size, pp_size, tmp_path_factory
 ):
+    """Full round trip: MegatronEngine (DP+PP) → weight-update gateway → SGLang.
+
+    Combines data parallelism (multiple replicas) with pipeline parallelism
+    (each replica split across PP stages). Each PP stage of each DP replica
+    sends its own layer subset independently.
+    """
     if current_platform.device_count() < n_gpus:
         pytest.skip(f"This test requires {n_gpus} GPUs")
     _run_megatron_awex_e2e(
@@ -934,6 +692,11 @@ def test_awex_megatron_dp_pp_e2e_weight_update(
 def test_awex_megatron_pp_tp_e2e_weight_update(
     n_gpus, pp_size, tp_size, tmp_path_factory
 ):
+    """Full round trip: MegatronEngine (PP+TP) → weight-update gateway → SGLang.
+
+    PP splits layers across stages; TP shards each stage's weights across ranks.
+    Both dp_replicated=True (TP) and disjoint layer ownership (PP) apply.
+    """
     if current_platform.device_count() < n_gpus:
         pytest.skip(f"This test requires {n_gpus} GPUs")
     _run_megatron_awex_e2e(
@@ -941,5 +704,59 @@ def test_awex_megatron_pp_tp_e2e_weight_update(
         backend=f"megatron:d1p{pp_size}t{tp_size}",
         pair_name=f"test_megatron_pp{pp_size}tp{tp_size}",
         tag=f"megatron_pp{pp_size}tp{tp_size}",
+        tmp_path_factory=tmp_path_factory,
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.parametrize(
+    "n_gpus,cp_size",
+    [(4, 2), (8, 4)],
+    ids=["4gpu-dp1cp2", "8gpu-dp1cp4"],
+)
+def test_awex_megatron_cp_e2e_weight_update(n_gpus, cp_size, tmp_path_factory):
+    """Full round trip: MegatronEngine (pure CP) → weight-update gateway → SGLang.
+
+    CP splits the sequence across ranks for attention but all CP ranks hold
+    identical parameters. dp_replicated=True tells awex only one CP rank per
+    group needs to send.
+    """
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+    _run_megatron_awex_e2e(
+        n_gpus=n_gpus,
+        backend=f"megatron:d1c{cp_size}",
+        pair_name=f"test_megatron_cp{cp_size}",
+        tag=f"megatron_cp{cp_size}",
+        tmp_path_factory=tmp_path_factory,
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.parametrize(
+    "n_gpus,dp_size,cp_size",
+    [(8, 2, 2)],
+    ids=["8gpu-dp2cp2"],
+)
+def test_awex_megatron_dp_cp_e2e_weight_update(
+    n_gpus, dp_size, cp_size, tmp_path_factory
+):
+    """Full round trip: MegatronEngine (DP+CP hybrid) → weight-update gateway → SGLang.
+
+    Combines data parallelism with context parallelism. Each DP replica has
+    cp_size CP ranks all holding identical parameters. dp_replicated=True
+    ensures only one CP rank per DP group sends, avoiding redundant transfers.
+    """
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+    _run_megatron_awex_e2e(
+        n_gpus=n_gpus,
+        backend=f"megatron:d{dp_size}c{cp_size}",
+        pair_name=f"test_megatron_dp{dp_size}cp{cp_size}",
+        tag=f"megatron_dp{dp_size}cp{cp_size}",
         tmp_path_factory=tmp_path_factory,
     )


### PR DESCRIPTION
## Description

Following PR#1239, add support PP and CP for Megatron engine for weight update with awex.

This implements a full connect → update_weights → disconnect lifecycle orchestrated
by an HTTP gateway. Megatron and SGLang adapters handle parameter shard mapping. 

Current scope: Megatron engine (hybrid DP + PP + TP + CP) + SGLang (pure DP) only. EP sharding
is not yet supported.

## Related Issue

PP is not supported in PR#1239. Fixed in this PR

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

NA

## Additional Context

`tests/experimental/weight_update/test_nccl_integration.py`: Integrate Megatron engine test for hybrid DP + TP + PP + CP. The pytest function names are clearly annotated and easy to differentiate.

