### PR TITLE
feat(experimental): add MegatronEngine awex weight update adapter with EP

### DIFF
--- a/areal/experimental/weight_update/awex/megatron_adapter.py
+++ b/areal/experimental/weight_update/awex/megatron_adapter.py
@@ -63,9 +63,7 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
             "tp_size": tp_size,
             "pp_size": mpu.get_pipeline_model_parallel_world_size(),
             "dp_size": self._engine.data_parallel_world_size,
-            # TP and CP ranks within a DP group hold identical full parameters
-            # (TP via all_gather_param, CP because it only splits the sequence).
-            # Mark as replicated so awex picks one sender per group.
+            "ep_size": mpu.get_expert_model_parallel_world_size(),
             "dp_replicated": tp_size > 1 or cp_size > 1,
         }
 
@@ -204,6 +202,10 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
         tp_rank = mpu.get_tensor_model_parallel_rank()
         pp_size = mpu.get_pipeline_model_parallel_world_size()
         pp_rank = mpu.get_pipeline_model_parallel_rank()
+        ep_size = mpu.get_expert_model_parallel_world_size()
+        ep_rank = mpu.get_expert_model_parallel_rank()
+        etp_size = mpu.get_expert_tensor_parallel_world_size()
+        etp_rank = mpu.get_expert_tensor_parallel_rank()
         cp_size = mpu.get_context_parallel_world_size()
         cp_rank = mpu.get_context_parallel_rank()
         local_rank = int(os.environ.get("LOCAL_RANK", self._engine.rank))
@@ -215,10 +217,10 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
             pp_size=pp_size,
             dp_size=self._engine.data_parallel_world_size,
             dp_rank=self._engine.data_parallel_rank,
-            ep_rank=0,
-            ep_size=1,
-            ep_tp_rank=0,
-            ep_tp_size=1,
+            ep_rank=ep_rank,
+            ep_size=ep_size,
+            ep_tp_rank=etp_rank,
+            ep_tp_size=etp_size,
             attn_tp_rank=tp_rank,
             attn_tp_size=tp_size,
             attn_dp_rank=self._engine.data_parallel_rank,
@@ -235,12 +237,10 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
     def _iter_hf_params(self):
         """Yield (hf_name, tensor) for every parameter on this rank.
 
-        Uses the same get_named_parameters + all_gather_param + convert_to_hf
-        pipeline that MegatronEngine._collect_param uses for weight broadcast,
-        so the names and shapes are guaranteed to match what SGLang expects.
-
-        For DP-only (tp=1, pp=1): all_gather_param is a no-op (returns
-        param.data directly) and convert_to_hf remaps mcore names to HF names.
+        Uses get_named_parameters + all_gather_param + convert_to_hf to produce
+        HF-style per-expert names (e.g. experts.0.gate_proj.weight). The SGLang
+        adapter's _unfuse_params converts SGLang's fused w13/w2 format to the
+        same per-expert names, so both sides match for the transfer plan.
         """
         from areal.engine.megatron_utils.megatron import (
             all_gather_param,
@@ -248,13 +248,14 @@ class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
             get_named_parameters,
         )
 
+        num_moe_experts = getattr(self._engine.tf_config, "num_moe_experts", None)
         model_name = self._engine.hf_config.model_type
         tie_word_embeddings = getattr(
             self._engine.hf_config, "tie_word_embeddings", False
         )
 
         for mcore_name, param in get_named_parameters(
-            self._engine.model, num_experts=None
+            self._engine.model, num_moe_experts
         ):
             gathered = all_gather_param(
                 mcore_name,

--- a/areal/experimental/weight_update/awex/sglang_adapter.py
+++ b/areal/experimental/weight_update/awex/sglang_adapter.py
@@ -115,9 +115,9 @@ class AwexSGLangAdapter(WeightUpdateInferenceAdapter):
         """Split SGLang fused parameters into HuggingFace-style unfused pairs.
 
         SGLang fuses Q/K/V into ``qkv_proj`` and gate/up into ``gate_up_proj``
-        for efficiency.  The training side (FSDP) keeps the original HF names,
-        so we need to report the same unfused names for the transfer plan
-        builder to match them.
+        for efficiency.  For MoE models, SGLang also fuses all routed experts
+        into ``experts.w13_weight`` (gate+up) and ``experts.w2_weight`` (down).
+        The training side keeps per-expert HF names, so we unfuse here to match.
         """
         if "qkv_proj" in name:
             cfg = self._get_model().config
@@ -144,6 +144,69 @@ class AwexSGLangAdapter(WeightUpdateInferenceAdapter):
                 (name.replace("gate_up_proj", "gate_proj"), tensor.narrow(0, 0, half)),
                 (name.replace("gate_up_proj", "up_proj"), tensor.narrow(0, half, half)),
             ]
+        if "shared_experts" in name and "gate_up_weight" in name:
+            half = tensor.shape[0] // 2
+            return [
+                (
+                    name.replace("gate_up_weight", "gate_proj.weight"),
+                    tensor.narrow(0, 0, half),
+                ),
+                (
+                    name.replace("gate_up_weight", "up_proj.weight"),
+                    tensor.narrow(0, half, half),
+                ),
+            ]
+        if "shared_experts" in name and name.endswith("down_weight"):
+            return [(name.replace("down_weight", "down_proj.weight"), tensor)]
+        if ".experts.w13_weight" in name:
+            # w13_weight shape: [num_total_experts, 2*ffn_hidden, hidden]
+            # num_total_experts may include shared experts appended after
+            # routed experts (e.g. 128 routed + 1 shared = 129 total).
+            cfg = self._get_model().config
+            num_routed = getattr(cfg, "num_experts", None) or cfg.n_routed_experts
+            prefix = name.replace(".w13_weight", "")
+            result = []
+            ffn_hidden = tensor.shape[1] // 2
+            for i in range(tensor.shape[0]):
+                expert_tensor = tensor[i]
+                if i < num_routed:
+                    expert_prefix = f"{prefix}.{i}"
+                else:
+                    shared_idx = i - num_routed
+                    num_shared = tensor.shape[0] - num_routed
+                    if num_shared > 1:
+                        expert_prefix = prefix.replace(
+                            "experts", f"shared_experts.{shared_idx}"
+                        )
+                    else:
+                        expert_prefix = prefix.replace("experts", "shared_experts")
+                result.append(
+                    (f"{expert_prefix}.gate_proj.weight", expert_tensor[:ffn_hidden])
+                )
+                result.append(
+                    (f"{expert_prefix}.up_proj.weight", expert_tensor[ffn_hidden:])
+                )
+            return result
+        if ".experts.w2_weight" in name:
+            # w2_weight shape: [num_total_experts, hidden, ffn_hidden]
+            cfg = self._get_model().config
+            num_routed = getattr(cfg, "num_experts", None) or cfg.n_routed_experts
+            prefix = name.replace(".w2_weight", "")
+            result = []
+            for i in range(tensor.shape[0]):
+                if i < num_routed:
+                    expert_prefix = f"{prefix}.{i}"
+                else:
+                    shared_idx = i - num_routed
+                    num_shared = tensor.shape[0] - num_routed
+                    if num_shared > 1:
+                        expert_prefix = prefix.replace(
+                            "experts", f"shared_experts.{shared_idx}"
+                        )
+                    else:
+                        expert_prefix = prefix.replace("experts", "shared_experts")
+                result.append((f"{expert_prefix}.down_proj.weight", tensor[i]))
+            return result
         return [(name, tensor)]
 
     def _build_rank_info(self) -> RankInfo:

--- a/tests/experimental/weight_update/test_nccl_integration.py
+++ b/tests/experimental/weight_update/test_nccl_integration.py
@@ -95,6 +95,53 @@ def _get_test_model_path() -> str:
     return "Qwen/Qwen3-0.6B"
 
 
+def _get_test_moe_model_path() -> str:
+    local = "/storage/openpsi/models/Qwen__Qwen3-30B-A3B/"
+    if os.path.isdir(local):
+        return local
+    return "Qwen/Qwen3-30B-A3B"
+
+
+def _make_truncated_moe_model(tmp_path, num_layers: int = 4) -> str:
+    import glob
+    import json
+    import shutil
+
+    src = _get_test_moe_model_path()
+    dst = str(tmp_path / "truncated_moe")
+    os.makedirs(dst, exist_ok=True)
+
+    with open(os.path.join(src, "config.json")) as f:
+        config = json.load(f)
+    config["num_hidden_layers"] = num_layers
+    with open(os.path.join(dst, "config.json"), "w") as f:
+        json.dump(config, f)
+
+    for fname in (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "vocab.json",
+        "merges.txt",
+        "generation_config.json",
+    ):
+        src_file = os.path.join(src, fname)
+        if os.path.isfile(src_file):
+            shutil.copy2(src_file, dst)
+
+    for weight_file in glob.glob(os.path.join(src, "*.safetensors")) + glob.glob(
+        os.path.join(src, "*.bin")
+    ):
+        os.symlink(weight_file, os.path.join(dst, os.path.basename(weight_file)))
+
+    for index_file in glob.glob(
+        os.path.join(src, "*.safetensors.index.json")
+    ) + glob.glob(os.path.join(src, "*.bin.index.json")):
+        shutil.copy2(index_file, dst)
+
+    return dst
+
+
 def _make_local_scheduler(tmp_path, name: str, gpu_devices: list[int]):
     from areal.infra.scheduler.local import LocalScheduler
 
@@ -123,6 +170,19 @@ _VALIDATE_PARAM_NAMES = [
     "model.layers.0.mlp.gate_proj.weight",
     "model.layers.0.mlp.up_proj.weight",
     "model.layers.27.self_attn.q_proj.weight",
+    "model.norm.weight",
+]
+
+# Qwen3-30B-A3B (truncated to 4 layers) MoE validation params.
+# This model has no shared experts — pure MoE with 128 routed experts.
+_VALIDATE_PARAM_NAMES_MOE = [
+    "model.layers.0.self_attn.q_proj.weight",
+    "model.layers.0.self_attn.k_proj.weight",
+    "model.layers.0.self_attn.v_proj.weight",
+    "model.layers.1.mlp.experts.0.gate_proj.weight",
+    "model.layers.1.mlp.experts.0.up_proj.weight",
+    "model.layers.1.mlp.experts.0.down_proj.weight",
+    "model.layers.3.self_attn.q_proj.weight",
     "model.norm.weight",
 ]
 
@@ -207,10 +267,11 @@ def _validate_weight_update_correctness_megatron(
     inf_worker_url: str,
     param_dir,
     tag: str = "megatron",
+    param_names: list[str] | None = None,
 ) -> None:
     import concurrent.futures
 
-    names = _VALIDATE_PARAM_NAMES
+    names = param_names or _VALIDATE_PARAM_NAMES
     n_train = len(train_worker_urls)
     print(
         f"\n[weight-validation] Fetching parameters from {n_train} Megatron "
@@ -508,6 +569,8 @@ def _run_megatron_awex_e2e(
     tag: str,
     tmp_path_factory,
     model_path: str | None = None,
+    validate_param_names: list[str] | None = None,
+    init_from_scratch: bool = False,
 ):
     from areal.api import FinetuneSpec
     from areal.api.cli_args import OptimizerConfig, SchedulingSpec, TrainEngineConfig
@@ -552,6 +615,7 @@ def _run_megatron_awex_e2e(
         experiment_name=f"test-awex-{tag}",
         trial_name="t0",
         path=model_path,
+        init_from_scratch=init_from_scratch,
         optimizer=OptimizerConfig(),
         _version="v2",
         setup_timeout=300.0,
@@ -619,6 +683,7 @@ def _run_megatron_awex_e2e(
             inf_worker_url=inf_worker_urls[0],
             param_dir=tmp,
             tag=tag,
+            param_names=validate_param_names,
         )
     finally:
         if wu_ctrl is not None:
@@ -759,4 +824,67 @@ def test_awex_megatron_dp_cp_e2e_weight_update(
         pair_name=f"test_megatron_dp{dp_size}cp{cp_size}",
         tag=f"megatron_dp{dp_size}cp{cp_size}",
         tmp_path_factory=tmp_path_factory,
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.parametrize(
+    "n_gpus,ep_size",
+    [(4, 2), (8, 4)],
+    ids=["4gpu-dp2ep2", "8gpu-dp4ep4"],
+)
+def test_awex_megatron_ep_e2e_weight_update(n_gpus, ep_size, tmp_path_factory):
+    """Full round trip: MegatronEngine (EP) → weight-update gateway → SGLang.
+
+    Each EP rank owns a different subset of expert parameters while attention
+    and norm weights are replicated. Uses a truncated Qwen3-30B-A3B MoE model
+    (4 layers) with init_from_scratch=True to avoid loading full weights.
+    """
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+    n_train = n_gpus - n_gpus // 2
+    tmp = tmp_path_factory.mktemp(f"megatron_ep{ep_size}_model")
+    _run_megatron_awex_e2e(
+        n_gpus=n_gpus,
+        backend=f"megatron:d{n_train}e{ep_size}",
+        pair_name=f"test_megatron_ep{ep_size}",
+        tag=f"megatron_ep{ep_size}",
+        tmp_path_factory=tmp_path_factory,
+        model_path=_make_truncated_moe_model(tmp, num_layers=4),
+        validate_param_names=_VALIDATE_PARAM_NAMES_MOE,
+        init_from_scratch=True,
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.parametrize(
+    "n_gpus,dp_size,ep_size",
+    [(8, 4, 2)],
+    ids=["8gpu-dp4ep2"],
+)
+def test_awex_megatron_dp_ep_e2e_weight_update(
+    n_gpus, dp_size, ep_size, tmp_path_factory
+):
+    """Full round trip: MegatronEngine (DP+EP hybrid) → weight-update gateway → SGLang.
+
+    Combines data parallelism with expert parallelism. Each DP replica has
+    ep_size EP ranks owning different expert subsets. Non-expert params
+    (attention, norms) are replicated across all ranks.
+    """
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+    tmp = tmp_path_factory.mktemp(f"megatron_dp{dp_size}ep{ep_size}_model")
+    _run_megatron_awex_e2e(
+        n_gpus=n_gpus,
+        backend=f"megatron:d{dp_size}e{ep_size}",
+        pair_name=f"test_megatron_dp{dp_size}ep{ep_size}",
+        tag=f"megatron_dp{dp_size}ep{ep_size}",
+        tmp_path_factory=tmp_path_factory,
+        model_path=_make_truncated_moe_model(tmp, num_layers=4),
+        validate_param_names=_VALIDATE_PARAM_NAMES_MOE,
+        init_from_scratch=True,
     )


### PR DESCRIPTION
## Description

Following PR#1246, add support EP for Megatron engine for weight update with awex.

This implements a full connect → update_weights → disconnect lifecycle orchestrated
by an HTTP gateway. Megatron and SGLang adapters handle parameter shard mapping.

Current scope: Megatron engine (hybrid DP + PP + TP + CP + EP) + SGLang (pure DP) only. 

## Related Issue

NA

## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

NA

## Additional Context

tests/experimental/weight_update/test_nccl_integration.py: Integrate Megatron engine test for hybrid DP + TP + PP + CP + EP. The pytest function names are clearly annotated and easy to differentiate.