### PR TITLE
refactor(experimental): reuse HTTP clients, add response models, and parallelize ops

### DIFF
--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import TYPE_CHECKING, Any, cast
 
+import httpx
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
 if TYPE_CHECKING:
@@ -168,6 +169,11 @@ class GatewayInferenceController:
         # Each entry: (guard_addr, role, worker_index) for /kill_forked_worker.
         self._forked_services: list[tuple[str, str, int]] = []
 
+        # Shared HTTP clients
+        self._sync_client = httpx.Client(timeout=30.0)
+        self._async_client = httpx.AsyncClient(timeout=config.request_timeout)
+        self._destroyed = False
+
         # Proxy compatibility (no-ops — gateway IS the proxy)
         self._proxy_started = False
         self.proxy_workers: list = []
@@ -258,8 +264,6 @@ class GatewayInferenceController:
           start with an empty ``--backend-addr``.
         """
         from dataclasses import asdict
-
-        import requests
 
         from areal.api.cli_args import SchedulingSpec, SchedulingStrategy
         from areal.api.scheduler_api import Job
@@ -431,10 +435,9 @@ class GatewayInferenceController:
                 # Allocate rendezvous port on head node for distributed init
                 dist_init_addr = None
                 if nnodes_per_instance > 1:
-                    resp = requests.post(
+                    resp = self._sync_client.post(
                         f"{head_guard_addr}/alloc_ports",
                         json={"count": 1},
-                        timeout=30,
                     )
                     resp.raise_for_status()
                     rendezvous_data = resp.json()
@@ -449,10 +452,9 @@ class GatewayInferenceController:
                     guard_addr = f"http://{format_hostport(worker.ip, int(worker.worker_ports[0]))}"
 
                     # Allocate port for inference server on this node
-                    resp = requests.post(
+                    resp = self._sync_client.post(
                         f"{guard_addr}/alloc_ports",
                         json={"count": 1},
-                        timeout=30,
                     )
                     resp.raise_for_status()
                     port_data = resp.json()
@@ -494,10 +496,9 @@ class GatewayInferenceController:
                             "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True",
                         }
 
-                    resp = requests.post(
+                    resp = self._sync_client.post(
                         f"{guard_addr}/fork",
                         json=fork_payload,
-                        timeout=30,
                     )
                     resp.raise_for_status()
                     self._forked_services.append(
@@ -659,41 +660,54 @@ class GatewayInferenceController:
         self, url: str, name: str, timeout: float | None = None
     ) -> None:
         """Wait for a service to become healthy."""
-        import requests
-
         timeout = timeout or self.config.setup_timeout
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
-                resp = requests.get(url, timeout=2)
+                resp = self._sync_client.get(url, timeout=2)
                 if resp.status_code == 200:
                     logger.info("%s is ready at %s", name, url)
                     return
-            except requests.RequestException:
+            except httpx.HTTPError:
                 pass
             time.sleep(0.1)
         raise TimeoutError(f"{name} did not become healthy at {url} within {timeout}s")
 
     def _register_data_proxies_in_router(self) -> None:
         """Register all data proxy workers in the router and store their worker IDs."""
-        import requests
+        if not self._data_proxy_addrs:
+            return
 
-        for data_proxy_addr in self._data_proxy_addrs:
-            resp = requests.post(
-                f"{self._router_addr}/register",
-                json={"worker_addr": data_proxy_addr},
-                headers={"Authorization": f"Bearer {self.config.admin_api_key}"},
-                timeout=5,
-            )
+        from concurrent.futures import ThreadPoolExecutor
+
+        admin_key = self.config.admin_api_key
+        router_addr = self._router_addr
+
+        def _register_one(data_proxy_addr: str) -> tuple[str, str | None]:
+            # Each thread gets its own httpx.Client because httpx.Client
+            # is not thread-safe and must not be shared across threads.
+            with httpx.Client() as client:
+                resp = client.post(
+                    f"{router_addr}/register",
+                    json={"worker_addr": data_proxy_addr},
+                    headers={"Authorization": f"Bearer {admin_key}"},
+                    timeout=5,
+                )
             resp.raise_for_status()
             worker_id = resp.json().get("worker_id")
-            if worker_id:
-                self._worker_ids[data_proxy_addr] = worker_id
             logger.info(
                 "Registered data proxy %s in router (worker_id=%s)",
                 data_proxy_addr,
                 worker_id,
             )
+            return data_proxy_addr, worker_id
+
+        with ThreadPoolExecutor(max_workers=len(self._data_proxy_addrs)) as pool:
+            results = list(pool.map(_register_one, self._data_proxy_addrs))
+
+        for data_proxy_addr, worker_id in results:
+            if worker_id:
+                self._worker_ids[data_proxy_addr] = worker_id
 
     def register_model(
         self,
@@ -702,11 +716,9 @@ class GatewayInferenceController:
         api_key: str | None = None,
         data_proxy_addrs: list[str] | None = None,
     ) -> None:
-        import requests
-
         if data_proxy_addrs is None:
             data_proxy_addrs = self._data_proxy_addrs
-        resp = requests.post(
+        resp = self._sync_client.post(
             f"{self._gateway_addr}/register_model",
             json={
                 "model": model,
@@ -872,6 +884,9 @@ class GatewayInferenceController:
 
     def destroy(self) -> None:
         """Tear down all services and release resources."""
+        if self._destroyed:
+            return
+        self._destroyed = True
         self._stop_online_callback_server()
 
         # Destroy workflow executor
@@ -892,6 +907,16 @@ class GatewayInferenceController:
                     traceback.format_exc(),
                 )
         self._forked_services.clear()
+
+        # Close shared HTTP clients after all kill requests have been sent
+        self._sync_client.close()
+        try:
+            from areal.infra.utils.concurrent import run_async_task
+
+            run_async_task(self._async_client.aclose)
+        except Exception:
+            # Best-effort cleanup on the destroy path.
+            pass
 
         # RPCGuard's shutdown `finally` block automatically kills all
         # forked children, so explicit teardown above is best-effort.
@@ -939,8 +964,20 @@ class GatewayInferenceController:
 
     async def _async_set_version(self, version: int) -> None:
         payload = {"version": version}
-        for wid in self._worker_ids.values():
-            await self._async_gateway_http_post(f"/set_version/{wid}", payload)
+        results = await asyncio.gather(
+            *[
+                self._async_gateway_http_post(f"/set_version/{wid}", payload)
+                for wid in self._worker_ids.values()
+            ],
+            return_exceptions=True,
+        )
+        failed = [r for r in results if isinstance(r, Exception)]
+        for r in failed:
+            logger.error("Failed to set version on a worker: %s", r)
+        if failed and len(failed) == len(results):
+            raise RuntimeError(
+                f"set_version({version}) failed on ALL {len(failed)} workers"
+            )
 
     def get_version(self) -> int:
         """Return the local version (compatible with VersionProvider protocol)."""
@@ -1196,8 +1233,9 @@ class GatewayInferenceController:
             return self._stream_chat_completion(url, body, headers)
 
         # Non-streaming path
-        timeout = aiohttp.ClientTimeout(total=self.config.request_timeout)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=self.config.request_timeout)
+        ) as session:
             async with session.post(url, json=body, headers=headers) as resp:
                 if resp.status != 200:
                     text = await resp.text()
@@ -1217,8 +1255,9 @@ class GatewayInferenceController:
         """Parse SSE stream from the gateway into ChatCompletionChunk objects."""
         import aiohttp
 
-        timeout = aiohttp.ClientTimeout(total=self.config.request_timeout)
-        session = aiohttp.ClientSession(timeout=timeout)
+        session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=self.config.request_timeout)
+        )
         try:
             resp = await session.post(url, json=body, headers=headers)
             if resp.status != 200:
@@ -1270,8 +1309,20 @@ class GatewayInferenceController:
         if worker_id is not None:
             await self._async_gateway_http_post(f"/pause_generation/{worker_id}", {})
         else:
-            for wid in self._worker_ids.values():
-                await self._async_gateway_http_post(f"/pause_generation/{wid}", {})
+            results = await asyncio.gather(
+                *[
+                    self._async_gateway_http_post(f"/pause_generation/{wid}", {})
+                    for wid in self._worker_ids.values()
+                ],
+                return_exceptions=True,
+            )
+            failed = [r for r in results if isinstance(r, Exception)]
+            for r in failed:
+                logger.error("Failed to pause generation on a worker: %s", r)
+            if failed and len(failed) == len(results):
+                raise RuntimeError(
+                    f"pause_generation failed on ALL {len(failed)} workers"
+                )
 
     async def continue_generation(self, worker_id: str | None = None) -> None:
         """Continue generation on a specific worker, or all workers if worker_id is None."""
@@ -1280,8 +1331,20 @@ class GatewayInferenceController:
         if worker_id is not None:
             await self._async_gateway_http_post(f"/continue_generation/{worker_id}", {})
         else:
-            for wid in self._worker_ids.values():
-                await self._async_gateway_http_post(f"/continue_generation/{wid}", {})
+            results = await asyncio.gather(
+                *[
+                    self._async_gateway_http_post(f"/continue_generation/{wid}", {})
+                    for wid in self._worker_ids.values()
+                ],
+                return_exceptions=True,
+            )
+            failed = [r for r in results if isinstance(r, Exception)]
+            for r in failed:
+                logger.error("Failed to continue generation on a worker: %s", r)
+            if failed and len(failed) == len(results):
+                raise RuntimeError(
+                    f"continue_generation failed on ALL {len(failed)} workers"
+                )
 
     # -- Stats -------------------------------------------------------------
 
@@ -1505,12 +1568,9 @@ class GatewayInferenceController:
         Returns ``(host, port)`` of the forked service and records the entry
         in ``_forked_services`` for cleanup.
         """
-        import requests
-
-        resp = requests.post(
+        resp = self._sync_client.post(
             f"{guard_addr}/alloc_ports",
             json={"count": 1},
-            timeout=30,
         )
         resp.raise_for_status()
         port_data = resp.json()
@@ -1519,14 +1579,13 @@ class GatewayInferenceController:
 
         cmd = list(raw_cmd) + ["--host", host, "--port", str(port)]
 
-        resp = requests.post(
+        resp = self._sync_client.post(
             f"{guard_addr}/fork",
             json={
                 "role": role,
                 "worker_index": worker_index,
                 "raw_cmd": cmd,
             },
-            timeout=30,
         )
         resp.raise_for_status()
 
@@ -1540,10 +1599,8 @@ class GatewayInferenceController:
     def _kill_forked_service(
         self, guard_addr: str, role: str, worker_index: int
     ) -> None:
-        import requests
-
         try:
-            resp = requests.post(
+            resp = self._sync_client.post(
                 f"{guard_addr}/kill_forked_worker",
                 json={"role": role, "worker_index": worker_index},
                 timeout=10,
@@ -1557,7 +1614,7 @@ class GatewayInferenceController:
                     worker_index,
                     resp.text,
                 )
-        except requests.RequestException as exc:
+        except httpx.HTTPError as exc:
             logger.error(
                 "Error killing forked service %s/%d: %s", role, worker_index, exc
             )
@@ -1571,11 +1628,9 @@ class GatewayInferenceController:
         Raises ``RuntimeError`` on HTTP errors or connection failures so that
         callers (e.g. ``pause()`` / ``resume()``) can detect and handle them.
         """
-        import requests
-
         url = f"{self._gateway_addr}{endpoint}"
         try:
-            resp = requests.post(
+            resp = self._sync_client.post(
                 url,
                 json=payload,
                 headers={"Authorization": f"Bearer {self.config.admin_api_key}"},
@@ -1585,7 +1640,7 @@ class GatewayInferenceController:
                 raise RuntimeError(
                     f"Gateway {endpoint} returned {resp.status_code}: {resp.text}"
                 )
-        except requests.RequestException as exc:
+        except httpx.HTTPError as exc:
             raise RuntimeError(f"Failed to POST {endpoint}: {exc}") from exc
 
     async def _async_gateway_http_post(
@@ -1597,19 +1652,16 @@ class GatewayInferenceController:
         callers (e.g. ``pause_generation()`` / ``continue_generation()``) can
         detect and handle them.
         """
-        import httpx
-
         url = f"{self._gateway_addr}{endpoint}"
         try:
-            async with httpx.AsyncClient(timeout=self.config.request_timeout) as client:
-                resp = await client.post(
-                    url,
-                    json=payload,
-                    headers={"Authorization": f"Bearer {self.config.admin_api_key}"},
+            resp = await self._async_client.post(
+                url,
+                json=payload,
+                headers={"Authorization": f"Bearer {self.config.admin_api_key}"},
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"Gateway {endpoint} returned {resp.status_code}: {resp.text}"
                 )
-                if resp.status_code >= 400:
-                    raise RuntimeError(
-                        f"Gateway {endpoint} returned {resp.status_code}: {resp.text}"
-                    )
         except httpx.HTTPError as exc:
             raise RuntimeError(f"Failed to POST {endpoint}: {exc}") from exc

--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -14,6 +14,7 @@ from fastapi.middleware.wsgi import WSGIMiddleware
 from fastapi.responses import Response as RawResponse
 from fastapi.responses import StreamingResponse
 from flask import Flask
+from pydantic import BaseModel
 
 from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
 from areal.experimental.inference_service.data_proxy.pause import PauseState
@@ -41,6 +42,56 @@ from areal.infra.rpc.guard.data_blueprint import (
 from areal.utils import logging
 
 logger = logging.getLogger("InferenceDataProxy")
+
+
+# =============================================================================
+# Response models
+# =============================================================================
+
+
+class DataProxyHealthResponse(BaseModel):
+    status: str
+    backend: str | None
+    sessions: int
+    paused: bool
+    version: int
+
+
+class DataProxyStatusResponse(BaseModel):
+    status: str
+
+
+class PauseGenerationResponse(BaseModel):
+    status: str
+    paused: bool
+
+
+class SetVersionResponse(BaseModel):
+    status: str
+    version: int
+
+
+class GetVersionResponse(BaseModel):
+    version: int
+
+
+class SetRewardResponse(BaseModel):
+    message: str
+    interaction_count: int
+    session_id: str
+    trajectory_id: int | None
+    trajectory_ready: bool
+    ready_transition: bool
+
+
+class RegisterModelResponse(BaseModel):
+    status: str
+    name: str
+
+
+class ConfigureBackendResponse(BaseModel):
+    status: str
+    backend_addr: str
 
 
 # =============================================================================
@@ -156,21 +207,32 @@ async def _post_online_ready_callback(
     admin_api_key: str,
     notification: ReadyNotification,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> bool:
     if not callback_server_addr:
         return False
 
     callback_base = callback_server_addr.rstrip("/")
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+
+        async def _do(c: httpx.AsyncClient) -> httpx.Response:
+            return await c.post(
                 f"{callback_base}/callback/online_ready",
                 json={
                     "session_id": notification.session_id,
                     "trajectory_id": notification.trajectory_id,
                 },
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
+
+        if client is not None:
+            resp = await _do(client)
+        else:
+            async with httpx.AsyncClient(timeout=timeout) as c:
+                resp = await _do(c)
+
         if resp.status_code >= 400:
             logger.warning(
                 "Online ready callback failed for %s/%s with %d: %s",
@@ -194,6 +256,7 @@ async def _post_online_ready_callback(
 async def _flush_ready_trajectories(app: FastAPI) -> None:
     store: SessionStore = app.state.session_store
     config: DataProxyConfig = app.state.config
+    http_client: httpx.AsyncClient | None = getattr(app.state, "http_client", None)
 
     for ready_result in store.finalize_rewarded_trajectories():
         logger.info(
@@ -204,13 +267,30 @@ async def _flush_ready_trajectories(app: FastAPI) -> None:
         )
 
     pending_notifications = store.pending_online_callbacks()
-    for notification in pending_notifications:
-        delivered = await _post_online_ready_callback(
-            config.callback_server_addr,
-            config.admin_api_key,
-            notification,
-            config.request_timeout,
-        )
+
+    async def _deliver(
+        notification: ReadyNotification,
+    ) -> tuple[ReadyNotification, bool]:
+        try:
+            delivered = await _post_online_ready_callback(
+                config.callback_server_addr,
+                config.admin_api_key,
+                notification,
+                config.request_timeout,
+                client=http_client,
+            )
+        except BaseException as exc:
+            logger.warning(
+                "Callback delivery failed for %s/%s: %s",
+                notification.session_id,
+                notification.trajectory_id,
+                exc,
+            )
+            delivered = False
+        return notification, delivered
+
+    results = await asyncio.gather(*[_deliver(n) for n in pending_notifications])
+    for notification, delivered in results:
         if delivered:
             store.mark_online_callback_delivered(
                 notification.session_id,
@@ -243,6 +323,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         )
         app.state.session_store.set_admin_key(config.admin_api_key)
         app.state.version = 0
+        app.state.http_client = httpx.AsyncClient(timeout=config.request_timeout)
 
         if not config.backend_addr:
             app.state.tokenizer = None
@@ -265,6 +346,9 @@ def create_app(config: DataProxyConfig) -> FastAPI:
                 await ready_task
             except asyncio.CancelledError:
                 pass
+            if app.state.inf_bridge is not None:
+                await app.state.inf_bridge.aclose()
+            await app.state.http_client.aclose()
         logger.info("Data proxy shutting down")
 
     app = FastAPI(title="AReaL Data Proxy", lifespan=lifespan)
@@ -274,27 +358,27 @@ def create_app(config: DataProxyConfig) -> FastAPI:
     # Health
     # =========================================================================
 
-    @app.get("/health")
+    @app.get("/health", response_model=DataProxyHealthResponse)
     async def health():
         store: SessionStore = app.state.session_store
         pause_state: PauseState = app.state.pause_state
-        return {
-            "status": "ok",
-            "backend": config.backend_addr,
-            "sessions": store.session_count,
-            "paused": await pause_state.is_paused(),
-            "version": app.state.version,
-        }
+        return DataProxyHealthResponse(
+            status="ok",
+            backend=config.backend_addr,
+            sessions=store.session_count,
+            paused=await pause_state.is_paused(),
+            version=app.state.version,
+        )
 
-    @app.post("/configure")
+    @app.post("/configure", response_model=DataProxyStatusResponse)
     async def configure():
-        return {"status": "ok"}
+        return DataProxyStatusResponse(status="ok")
 
     # =========================================================================
     # Pause/Resume — internal control plane (no auth at data proxy level)
     # =========================================================================
 
-    @app.post("/pause_generation")
+    @app.post("/pause_generation", response_model=PauseGenerationResponse)
     async def pause_generation():
         inf_bridge: InfBridge | None = app.state.inf_bridge
         if inf_bridge is None:
@@ -303,9 +387,9 @@ def create_app(config: DataProxyConfig) -> FastAPI:
                 detail="No inference backend configured (external model mode).",
             )
         await inf_bridge.pause()
-        return {"status": "ok", "paused": True}
+        return PauseGenerationResponse(status="ok", paused=True)
 
-    @app.post("/continue_generation")
+    @app.post("/continue_generation", response_model=PauseGenerationResponse)
     async def continue_generation():
         inf_bridge: InfBridge | None = app.state.inf_bridge
         if inf_bridge is None:
@@ -314,24 +398,24 @@ def create_app(config: DataProxyConfig) -> FastAPI:
                 detail="No inference backend configured (external model mode).",
             )
         await inf_bridge.resume()
-        return {"status": "ok", "paused": False}
+        return PauseGenerationResponse(status="ok", paused=False)
 
     # =========================================================================
     # Version management — internal control plane (no auth at data proxy level)
     # =========================================================================
 
-    @app.post("/set_version")
+    @app.post("/set_version", response_model=SetVersionResponse)
     async def set_version(request: Request):
         body = await request.json()
         version = body.get("version")
         if version is None or not isinstance(version, int):
             raise HTTPException(status_code=400, detail="'version' (int) is required")
         app.state.version = version
-        return {"status": "ok", "version": version}
+        return SetVersionResponse(status="ok", version=version)
 
-    @app.get("/get_version")
+    @app.get("/get_version", response_model=GetVersionResponse)
     async def get_version():
-        return {"version": app.state.version}
+        return GetVersionResponse(version=app.state.version)
 
     # =========================================================================
     # Session management (admin key / session key required)
@@ -351,7 +435,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
             raise HTTPException(status_code=409, detail=str(e))
         return StartSessionResponse(session_id=session_id, api_key=session_api_key)
 
-    @app.post("/rl/set_reward")
+    @app.post("/rl/set_reward", response_model=SetRewardResponse)
     async def set_reward(body: SetRewardRequest, request: Request):
         store: SessionStore = app.state.session_store
         token = _extract_bearer_token(request)
@@ -369,14 +453,14 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-        return {
-            "message": "success",
-            "interaction_count": reward_result.interaction_count,
-            "session_id": reward_result.session_id,
-            "trajectory_id": reward_result.trajectory_id,
-            "trajectory_ready": reward_result.trajectory_id is not None,
-            "ready_transition": reward_result.ready_transition,
-        }
+        return SetRewardResponse(
+            message="success",
+            interaction_count=reward_result.interaction_count,
+            session_id=reward_result.session_id,
+            trajectory_id=reward_result.trajectory_id,
+            trajectory_ready=reward_result.trajectory_id is not None,
+            ready_transition=reward_result.ready_transition,
+        )
 
     # =========================================================================
     # Chat completions — OpenAI-compatible
@@ -435,8 +519,8 @@ def create_app(config: DataProxyConfig) -> FastAPI:
                     try:
                         async with httpx.AsyncClient(
                             timeout=httpx.Timeout(config.request_timeout)
-                        ) as client:
-                            async with client.stream(
+                        ) as stream_client:
+                            async with stream_client.stream(
                                 "POST",
                                 f"{ext_url}/chat/completions",
                                 json=forward_body,
@@ -476,12 +560,11 @@ def create_app(config: DataProxyConfig) -> FastAPI:
 
             full_url = f"{ext_url}/chat/completions"
             try:
-                async with httpx.AsyncClient(timeout=config.request_timeout) as client:
-                    resp = await client.post(
-                        full_url,
-                        json=forward_body,
-                        headers=forward_headers,
-                    )
+                resp = await app.state.http_client.post(
+                    full_url,
+                    json=forward_body,
+                    headers=forward_headers,
+                )
             except Exception as exc:
                 raise HTTPException(
                     status_code=502, detail=f"External API error: {exc}"
@@ -562,7 +645,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
 
         return result
 
-    @app.post("/register_model")
+    @app.post("/register_model", response_model=RegisterModelResponse)
     async def register_model(request: Request):
         body = await request.json()
         name = body.get("name") or body.get("model")
@@ -573,7 +656,7 @@ def create_app(config: DataProxyConfig) -> FastAPI:
             raise HTTPException(status_code=400, detail="model name is required")
         _registered_models[name] = {"url": url, "model": model, "api_key": api_key}
         logger.info("Model registered: name=%s url=%s", name, url or "(internal)")
-        return {"status": "ok", "name": name}
+        return RegisterModelResponse(status="ok", name=name)
 
     # =========================================================================
     # Trajectory export (admin key required)
@@ -631,13 +714,9 @@ def create_app(config: DataProxyConfig) -> FastAPI:
     # Runtime backend reconfiguration (for fork-based deployment)
     # =========================================================================
 
-    @app.post("/configure_backend")
+    @app.post("/configure_backend", response_model=ConfigureBackendResponse)
     async def configure_backend(request: Request):
-        """Reconfigure the inference backend address after process start.
-
-        Administrative endpoint to dynamically change which SGLang server
-        this data proxy connects to.
-        """
+        """Reconfigure the inference backend address after process start."""
         store: SessionStore = app.state.session_store
         _require_admin_key(request, store)
         body = await request.json()
@@ -647,13 +726,20 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         pause_state: PauseState = app.state.pause_state
         tok: TokenizerProxy = app.state.tokenizer
 
+        old_inf_bridge: InfBridge | None = app.state.inf_bridge
+
         # Recreate InfBridge + ArealOpenAI with new backend address
         new_inf_bridge = _create_inf_bridge(new_addr, pause_state, app.state.config)
-        new_areal_client = _create_areal_client(new_inf_bridge, tok, app.state.config)
+        try:
+            new_areal_client = _create_areal_client(
+                new_inf_bridge, tok, app.state.config
+            )
+        except Exception:
+            await new_inf_bridge.aclose()
+            raise
 
         # Build updated config copy, then swap all three state fields.
-        # Concurrent requests already hold their own references so they
-        # finish with the old backend; new requests see the new one.
+        # Swap references first so new requests immediately use the new bridge.
         from dataclasses import replace as _dc_replace
 
         new_config = _dc_replace(app.state.config, backend_addr=new_addr)
@@ -661,8 +747,13 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         app.state.inf_bridge = new_inf_bridge
         app.state.areal_client = new_areal_client
 
+        # Close old InfBridge after the swap so in-flight requests that already
+        # hold a reference to the old bridge can still finish their HTTP calls.
+        if old_inf_bridge is not None:
+            await old_inf_bridge.aclose()
+
         logger.info("Backend reconfigured to %s", new_addr)
-        return {"status": "ok", "backend_addr": new_addr}
+        return ConfigureBackendResponse(status="ok", backend_addr=new_addr)
 
     # =========================================================================
     # RTensor data storage endpoints

--- a/areal/experimental/inference_service/data_proxy/pause.py
+++ b/areal/experimental/inference_service/data_proxy/pause.py
@@ -41,17 +41,33 @@ class PauseState:
         return self._paused
 
 
-async def pause_backend(backend_addr: str) -> None:
+async def pause_backend(
+    backend_addr: str, *, client: httpx.AsyncClient | None = None
+) -> None:
     """Call SGLang POST /pause_generation to abort in-flight requests."""
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.post(f"{backend_addr}/pause_generation", json={})
+    if client is not None:
+        resp = await client.post(
+            f"{backend_addr}/pause_generation", json={}, timeout=10.0
+        )
         resp.raise_for_status()
+    else:
+        async with httpx.AsyncClient(timeout=10.0) as c:
+            resp = await c.post(f"{backend_addr}/pause_generation", json={})
+            resp.raise_for_status()
     logger.info("SGLang pause_generation called on %s", backend_addr)
 
 
-async def resume_backend(backend_addr: str) -> None:
+async def resume_backend(
+    backend_addr: str, *, client: httpx.AsyncClient | None = None
+) -> None:
     """Call SGLang POST /continue_generation to resume inference."""
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.post(f"{backend_addr}/continue_generation", json={})
+    if client is not None:
+        resp = await client.post(
+            f"{backend_addr}/continue_generation", json={}, timeout=10.0
+        )
         resp.raise_for_status()
+    else:
+        async with httpx.AsyncClient(timeout=10.0) as c:
+            resp = await c.post(f"{backend_addr}/continue_generation", json={})
+            resp.raise_for_status()
     logger.info("SGLang continue_generation called on %s", backend_addr)

--- a/areal/experimental/inference_service/gateway/app.py
+++ b/areal/experimental/inference_service/gateway/app.py
@@ -8,11 +8,14 @@ session pinning, and routing strategies live in the Router service.
 
 from __future__ import annotations
 
+import asyncio
 import json
+from contextlib import asynccontextmanager
 
 import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from pydantic import BaseModel
 
 from areal.experimental.inference_service.gateway.auth import (
     extract_bearer_token,
@@ -40,6 +43,31 @@ from areal.utils import logging
 logger = logging.getLogger("InferenceGateway")
 
 
+# =============================================================================
+# Response models
+# =============================================================================
+
+
+class GatewayHealthResponse(BaseModel):
+    status: str
+    router_addr: str
+
+
+class GatewayModelsResponse(BaseModel):
+    models: list[str]
+
+
+class BroadcastResultItem(BaseModel):
+    worker_addr: str
+    status: int
+    ok: bool
+    error: str | None = None
+
+
+class BroadcastResponse(BaseModel):
+    results: list[BroadcastResultItem]
+
+
 def _router_error_response(exc: Exception) -> JSONResponse:
     """Convert router exceptions to HTTP responses."""
     if isinstance(exc, RouterUnreachableError):
@@ -53,15 +81,41 @@ def _router_error_response(exc: Exception) -> JSONResponse:
 def create_app(config: GatewayConfig) -> FastAPI:
     """Factory that creates the inference gateway FastAPI app."""
 
-    app = FastAPI(title="AReaL Inference Gateway")
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.http_client = httpx.AsyncClient(timeout=config.router_timeout)
+        try:
+            yield
+        finally:
+            await app.state.http_client.aclose()
+            if _fallback_client is not None:
+                await _fallback_client.aclose()
+
+    app = FastAPI(title="AReaL Inference Gateway", lifespan=lifespan)
+
+    # Fallback client for tests that bypass the lifespan.
+    # NOTE: When testing without ASGI transport (which runs the lifespan),
+    # this client will NOT be cleaned up automatically. Tests should prefer
+    # using httpx.AsyncClient(transport=ASGITransport(app=app)) to ensure
+    # proper lifespan management and client cleanup.
+    _fallback_client: httpx.AsyncClient | None = None
+
+    def _client() -> httpx.AsyncClient:
+        nonlocal _fallback_client
+        try:
+            return app.state.http_client
+        except AttributeError:
+            if _fallback_client is None:
+                _fallback_client = httpx.AsyncClient(timeout=config.router_timeout)
+            return _fallback_client
 
     # =========================================================================
     # Health
     # =========================================================================
 
-    @app.get("/health")
+    @app.get("/health", response_model=GatewayHealthResponse)
     async def health():
-        return {"status": "ok", "router_addr": config.router_addr}
+        return GatewayHealthResponse(status="ok", router_addr=config.router_addr)
 
     # =========================================================================
     # POST /chat/completions — admin OR session key, streaming or non-streaming
@@ -90,6 +144,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.router_timeout,
                 admin_api_key=config.admin_api_key,
                 model=model_name,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -107,7 +162,11 @@ def create_app(config: GatewayConfig) -> FastAPI:
             )
 
         resp = await forward_request(
-            f"{worker_addr}/chat/completions", body, headers, config.forward_timeout
+            f"{worker_addr}/chat/completions",
+            body,
+            headers,
+            config.forward_timeout,
+            client=_client(),
         )
         return Response(
             content=resp.content,
@@ -134,6 +193,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 data_proxy_addrs,
                 config.admin_api_key,
                 config.router_timeout,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -141,8 +201,9 @@ def create_app(config: GatewayConfig) -> FastAPI:
         resolved_addrs = result.get("data_proxy_addrs", data_proxy_addrs)
         headers = _forwarding_headers(dict(request.headers))
 
-        for addr in resolved_addrs:
-            resp = await forward_request(
+        # Phase 3: parallelize data proxy registration
+        async def _register_one(addr: str) -> httpx.Response:
+            return await forward_request(
                 f"{addr}/register_model",
                 json.dumps(
                     {
@@ -154,18 +215,41 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 ).encode(),
                 headers,
                 config.forward_timeout,
+                client=_client(),
             )
-            if resp.status_code != 200:
-                await remove_model_from_router(
-                    config.router_addr,
-                    model,
-                    config.admin_api_key,
-                    config.router_timeout,
+
+        responses = await asyncio.gather(
+            *[_register_one(addr) for addr in resolved_addrs],
+            return_exceptions=True,
+        )
+        # Check for failures after all tasks have completed
+        failed = False
+        errors = []
+        for resp in responses:
+            if isinstance(resp, Exception):
+                logger.error("Data proxy registration raised: %s", resp)
+                errors.append(str(resp))
+                failed = True
+            elif resp.status_code != 200:
+                logger.error(
+                    "Data proxy registration failed with status %d: %s",
+                    resp.status_code,
+                    resp.text,
                 )
-                return JSONResponse(
-                    {"error": f"Data proxy registration failed: {resp.text}"},
-                    status_code=502,
-                )
+                errors.append(f"status {resp.status_code}: {resp.text}")
+                failed = True
+        if failed:
+            await remove_model_from_router(
+                config.router_addr,
+                model,
+                config.admin_api_key,
+                config.router_timeout,
+                client=_client(),
+            )
+            return JSONResponse(
+                {"error": "Data proxy registration failed", "details": errors},
+                status_code=502,
+            )
         return result
 
     @app.get("/models")
@@ -176,10 +260,11 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.router_addr,
                 config.admin_api_key,
                 config.router_timeout,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
-        return {"models": names}
+        return GatewayModelsResponse(models=names)
 
     # =========================================================================
     # POST /rl/start_session — admin key ONLY, intercept response
@@ -196,6 +281,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 "/rl/start_session",
                 config.router_timeout,
                 admin_api_key=config.admin_api_key,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -208,6 +294,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
             body,
             headers,
             config.forward_timeout,
+            client=_client(),
         )
 
         # Intercept: if data proxy returned 201, extract session info and register
@@ -224,6 +311,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                         worker_addr,
                         config.router_timeout,
                         admin_api_key=config.admin_api_key,
+                        client=_client(),
                     )
             except Exception as exc:
                 logger.error("Failed to register session in router: %s", exc)
@@ -265,12 +353,17 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.router_timeout,
                 admin_api_key=config.admin_api_key,
                 model=model,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
 
         resp = await forward_request(
-            f"{worker_addr}/rl/set_reward", body, headers, config.forward_timeout
+            f"{worker_addr}/rl/set_reward",
+            body,
+            headers,
+            config.forward_timeout,
+            client=_client(),
         )
         return Response(
             content=resp.content,
@@ -282,7 +375,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
     # POST /pause_generation/{worker_id} — admin key ONLY, target single worker
     # =========================================================================
 
-    @app.post("/pause_generation/{worker_id}")
+    @app.post("/pause_generation/{worker_id}", response_model=BroadcastResponse)
     async def pause_generation(worker_id: str, request: Request):
         require_admin_key(request, config.admin_api_key)
         try:
@@ -291,6 +384,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -298,15 +392,15 @@ def create_app(config: GatewayConfig) -> FastAPI:
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
         results = await broadcast_to_workers(
-            [worker_addr], "/pause_generation", body, headers
+            [worker_addr], "/pause_generation", body, headers, client=_client()
         )
-        return {"results": results}
+        return BroadcastResponse(results=[BroadcastResultItem(**r) for r in results])
 
     # =========================================================================
     # POST /continue_generation/{worker_id} — admin key ONLY, target single worker
     # =========================================================================
 
-    @app.post("/continue_generation/{worker_id}")
+    @app.post("/continue_generation/{worker_id}", response_model=BroadcastResponse)
     async def continue_generation(worker_id: str, request: Request):
         require_admin_key(request, config.admin_api_key)
         try:
@@ -315,6 +409,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -322,9 +417,9 @@ def create_app(config: GatewayConfig) -> FastAPI:
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
         results = await broadcast_to_workers(
-            [worker_addr], "/continue_generation", body, headers
+            [worker_addr], "/continue_generation", body, headers, client=_client()
         )
-        return {"results": results}
+        return BroadcastResponse(results=[BroadcastResultItem(**r) for r in results])
 
     # =========================================================================
     # POST /export_trajectories — admin key ONLY, route by session_id or model field
@@ -358,6 +453,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 session_id=session_id,
                 admin_api_key=config.admin_api_key,
                 model=model,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -368,6 +464,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
             body,
             headers,
             config.forward_timeout,
+            client=_client(),
         )
 
         if resp.status_code == 200:
@@ -376,6 +473,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 session_id,
                 config.router_timeout,
+                client=_client(),
             )
 
         return Response(
@@ -397,6 +495,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -404,7 +503,11 @@ def create_app(config: GatewayConfig) -> FastAPI:
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
         resp = await forward_request(
-            f"{worker_addr}/set_version", body, headers, config.forward_timeout
+            f"{worker_addr}/set_version",
+            body,
+            headers,
+            config.forward_timeout,
+            client=_client(),
         )
         return Response(
             content=resp.content,
@@ -425,16 +528,17 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
 
         try:
-            async with httpx.AsyncClient(timeout=config.forward_timeout) as client:
-                resp = await client.get(
-                    f"{worker_addr}/get_version",
-                    headers=_forwarding_headers(dict(request.headers)),
-                )
+            resp = await _client().get(
+                f"{worker_addr}/get_version",
+                headers=_forwarding_headers(dict(request.headers)),
+                timeout=config.forward_timeout,
+            )
             return Response(
                 content=resp.content,
                 status_code=resp.status_code,
@@ -453,7 +557,10 @@ def create_app(config: GatewayConfig) -> FastAPI:
         require_admin_key(request, config.admin_api_key)
         try:
             result = await grant_capacity_in_router(
-                config.router_addr, config.admin_api_key, config.router_timeout
+                config.router_addr,
+                config.admin_api_key,
+                config.router_timeout,
+                client=_client(),
             )
         except RouterUnreachableError as exc:
             return _router_error_response(exc)

--- a/areal/experimental/inference_service/gateway/streaming.py
+++ b/areal/experimental/inference_service/gateway/streaming.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
@@ -30,6 +31,18 @@ class RouterKeyRejectedError(Exception):
         self.status_code = status_code
 
 
+@asynccontextmanager
+async def _use_client(
+    client: httpx.AsyncClient | None, timeout: float
+) -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Yield the shared *client* if provided, otherwise create a temporary one."""
+    if client is not None:
+        yield client
+    else:
+        async with httpx.AsyncClient(timeout=timeout) as c:
+            yield c
+
+
 async def query_router(
     router_addr: str,
     api_key: str | None = None,
@@ -39,6 +52,7 @@ async def query_router(
     session_id: str | None = None,
     admin_api_key: str | None = None,
     model: str | None = None,
+    client: httpx.AsyncClient | None = None,
 ) -> str:
     """Ask the Router for a worker address.
 
@@ -49,13 +63,20 @@ async def query_router(
     Parameters
     ----------
     admin_api_key : str | None
-        Admin API key for authenticating with the router.  Required since
-        the ``/route`` endpoint requires admin auth.
+        When set, sent as ``Authorization: Bearer <key>`` so the Router
+        can authenticate the request.
+    session_id : str | None
+        Pin routing to the session's worker.
+    model : str | None
+        Route to a specific model's data proxies.
+    client : httpx.AsyncClient | None
+        Shared HTTP client.  When ``None``, a per-request client is created
+        (backwards-compatible, but less efficient).
 
     Raises
     ------
     RouterUnreachableError
-        Router connection failed.
+        Router is unreachable or returned an unexpected HTTP error.
     RouterKeyRejectedError
         Router returned 404 (unknown key / session) or 503 (no healthy workers).
     """
@@ -73,12 +94,12 @@ async def query_router(
         headers = {}
         if admin_api_key is not None:
             headers["Authorization"] = f"Bearer {admin_api_key}"
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
-                f"{router_addr}/route",
-                json=payload,
-                headers=headers,
+
+        async with _use_client(client, timeout) as c:
+            resp = await c.post(
+                f"{router_addr}/route", json=payload, headers=headers, timeout=timeout
             )
+
         if resp.status_code == 404:
             data = resp.json()
             raise RouterKeyRejectedError(
@@ -108,6 +129,8 @@ async def register_session_in_router(
     worker_addr: str,
     timeout: float,
     admin_api_key: str | None = None,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> None:
     """Register a session→worker mapping in the Router.
 
@@ -118,8 +141,9 @@ async def register_session_in_router(
         headers = {}
         if admin_api_key is not None:
             headers["Authorization"] = f"Bearer {admin_api_key}"
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+
+        async with _use_client(client, timeout) as c:
+            resp = await c.post(
                 f"{router_addr}/register_session",
                 json={
                     "session_api_key": session_api_key,
@@ -127,7 +151,9 @@ async def register_session_in_router(
                     "worker_addr": worker_addr,
                 },
                 headers=headers,
+                timeout=timeout,
             )
+
         resp.raise_for_status()
     except Exception as exc:
         logger.error("Failed to register session in router: %s", exc)
@@ -139,6 +165,8 @@ async def revoke_session_in_router(
     admin_api_key: str,
     session_id: str,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> None:
     """Remove a session from the Router's session registry.
 
@@ -148,11 +176,12 @@ async def revoke_session_in_router(
     Best-effort: logs errors but never raises.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _use_client(client, timeout) as c:
+            resp = await c.post(
                 f"{router_addr}/remove_session",
                 json={"session_id": session_id},
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         if resp.status_code != 200:
             logger.warning(
@@ -166,6 +195,8 @@ async def grant_capacity_in_router(
     router_addr: str,
     admin_api_key: str,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> dict:
     """Forward a grant_capacity request to the Router.
 
@@ -173,10 +204,11 @@ async def grant_capacity_in_router(
     Returns the JSON response body from the router.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _use_client(client, timeout) as c:
+            resp = await c.post(
                 f"{router_addr}/grant_capacity",
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         resp.raise_for_status()
         return resp.json()
@@ -194,6 +226,8 @@ async def release_capacity_in_router(
     router_addr: str,
     admin_api_key: str,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> None:
     """Return one capacity permit to the Router.
 
@@ -202,10 +236,11 @@ async def release_capacity_in_router(
     already handling a failure path.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _use_client(client, timeout) as c:
+            resp = await c.post(
                 f"{router_addr}/release_capacity",
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         if resp.status_code != 200:
             logger.warning(
@@ -219,16 +254,19 @@ async def get_all_worker_addrs(
     router_addr: str,
     admin_api_key: str,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> list[str]:
     """Fetch all worker addresses from the Router (for broadcast).
 
     GET ``{router_addr}/workers`` with admin key auth.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.get(
+        async with _use_client(client, timeout) as c:
+            resp = await c.get(
                 f"{router_addr}/workers",
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         resp.raise_for_status()
         data = resp.json()
@@ -245,10 +283,12 @@ async def register_model_in_router(
     data_proxy_addrs: list[str],
     admin_api_key: str,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> dict:
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _use_client(client, timeout) as c:
+            resp = await c.post(
                 f"{router_addr}/register_model",
                 json={
                     "model": model,
@@ -257,6 +297,7 @@ async def register_model_in_router(
                     "data_proxy_addrs": data_proxy_addrs,
                 },
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         if resp.status_code == 503:
             raise RouterKeyRejectedError("No healthy workers", 503)
@@ -271,13 +312,16 @@ async def route_external_model(
     name: str,
     admin_api_key: str,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> dict:
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _use_client(client, timeout) as c:
+            resp = await c.post(
                 f"{router_addr}/route",
                 json={"model": name},
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         if resp.status_code == 404:
             raise RouterKeyRejectedError(f"Model '{name}' not found", 404)
@@ -295,12 +339,15 @@ async def list_models_from_router(
     router_addr: str,
     admin_api_key: str,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> list[str]:
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.get(
+        async with _use_client(client, timeout) as c:
+            resp = await c.get(
                 f"{router_addr}/models",
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         resp.raise_for_status()
         return resp.json().get("models", [])
@@ -313,14 +360,17 @@ async def remove_model_from_router(
     name: str,
     admin_api_key: str,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> None:
     """Remove an external model from the router registry (best-effort rollback)."""
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
+        async with _use_client(client, timeout) as c:
+            resp = await c.post(
                 f"{router_addr}/remove_model",
                 json={"name": name},
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         resp.raise_for_status()
     except Exception:
@@ -332,6 +382,8 @@ async def resolve_worker_addr(
     admin_api_key: str,
     worker_id: str,
     timeout: float,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> str:
     """Resolve a worker_id to its address via the Router.
 
@@ -345,10 +397,11 @@ async def resolve_worker_addr(
         Router connection failed.
     """
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.get(
+        async with _use_client(client, timeout) as c:
+            resp = await c.get(
                 f"{router_addr}/resolve_worker/{worker_id}",
                 headers={"Authorization": f"Bearer {admin_api_key}"},
+                timeout=timeout,
             )
         if resp.status_code == 404:
             data = resp.json()
@@ -384,6 +437,8 @@ async def forward_sse_stream(
     body: bytes,
     headers: dict[str, str],
     timeout: float | None = None,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> AsyncGenerator[bytes, None]:
     """True SSE streaming proxy — yields bytes as they arrive from upstream.
 
@@ -393,18 +448,20 @@ async def forward_sse_stream(
     On upstream HTTP errors or mid-stream failures, an SSE error event
     (``data: {"error": ...}``) is emitted so clients can distinguish a
     clean end-of-stream from a backend failure.
+
+    Note: streaming requires owning the client context for the duration
+    of the stream, so a per-request client is always created here.
+    The ``client`` parameter is accepted for API consistency but not used.
     """
     import json as _json
 
     fwd_headers = _forwarding_headers(headers)
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout)) as client:
-            async with client.stream(
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout)) as c:
+            async with c.stream(
                 "POST", upstream_url, content=body, headers=fwd_headers
             ) as resp:
                 if resp.status_code != 200:
-                    # Upstream returned a non-200 status — read body and emit
-                    # an SSE error event so the client sees the failure.
                     error_body = await resp.aread()
                     try:
                         detail = _json.loads(error_body)
@@ -428,12 +485,15 @@ async def forward_request(
     body: bytes,
     headers: dict[str, str],
     timeout: float = 120.0,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> httpx.Response:
     """Forward a non-streaming request to upstream, return full response."""
     fwd_headers = _forwarding_headers(headers)
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        resp = await client.post(upstream_url, content=body, headers=fwd_headers)
-    return resp
+    async with _use_client(client, timeout) as c:
+        return await c.post(
+            upstream_url, content=body, headers=fwd_headers, timeout=timeout
+        )
 
 
 async def broadcast_to_workers(
@@ -442,6 +502,8 @@ async def broadcast_to_workers(
     body: bytes,
     headers: dict[str, str],
     timeout: float = 10.0,
+    *,
+    client: httpx.AsyncClient | None = None,
 ) -> list[dict[str, Any]]:
     """Broadcast a request to all workers (best-effort).
 
@@ -454,11 +516,12 @@ async def broadcast_to_workers(
 
     async def _call(addr: str) -> dict[str, Any]:
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                resp = await client.post(
+            async with _use_client(client, timeout) as c:
+                resp = await c.post(
                     f"{addr}{path}",
                     content=body,
                     headers=_forwarding_headers(headers),
+                    timeout=timeout,
                 )
             return {
                 "worker_addr": addr,

--- a/areal/experimental/inference_service/inf_bridge.py
+++ b/areal/experimental/inference_service/inf_bridge.py
@@ -75,6 +75,11 @@ class InfBridge:
         self.max_resubmit_retries = max_resubmit_retries
         self.resubmit_wait = resubmit_wait
         self._version = version
+        self._client = httpx.AsyncClient(timeout=request_timeout)
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
 
     # -- version tracking ---------------------------------------------------
 
@@ -130,13 +135,12 @@ class InfBridge:
         """
         _timeout = timeout if timeout is not None else self.request_timeout
         url = f"{self.backend_addr}{http_req.endpoint}"
-        async with httpx.AsyncClient(timeout=_timeout) as client:
-            if http_req.method == "GET":
-                resp = await client.get(url)
-            else:
-                resp = await client.post(url, json=http_req.payload)
-            resp.raise_for_status()
-            return resp.json()
+        if http_req.method == "GET":
+            resp = await self._client.get(url, timeout=_timeout)
+        else:
+            resp = await self._client.post(url, json=http_req.payload, timeout=_timeout)
+        resp.raise_for_status()
+        return resp.json()
 
     # -- main generation with pause/abort/resubmit --------------------------
 

--- a/areal/experimental/inference_service/router/app.py
+++ b/areal/experimental/inference_service/router/app.py
@@ -101,6 +101,81 @@ class RemoveModelRequest(BaseModel):
 
 
 # =============================================================================
+# Response models
+# =============================================================================
+
+
+class StatusResponse(BaseModel):
+    status: str
+
+
+class HealthResponse(BaseModel):
+    status: str
+    workers: int
+    sessions: int
+    capacity: int
+    strategy: str
+
+
+class RegisterWorkerResponse(BaseModel):
+    status: str
+    worker_id: str
+
+
+class UnregisterWorkerResponse(BaseModel):
+    status: str
+    sessions_revoked: int
+
+
+class RouteResponse(BaseModel):
+    worker_addr: str
+    url: str | None = None
+    api_key: str | None = None
+
+
+class RemoveSessionResponse(BaseModel):
+    status: str
+    removed: bool
+    persistent: bool
+
+
+class WorkerInfo(BaseModel):
+    worker_id: str
+    addr: str
+    healthy: bool
+    active_requests: int
+
+
+class WorkersResponse(BaseModel):
+    workers: list[WorkerInfo]
+
+
+class RegisterModelResponse(BaseModel):
+    status: str
+    model: str
+    data_proxy_addrs: list[str]
+
+
+class ModelsResponse(BaseModel):
+    models: list[str]
+
+
+class RemoveModelResponse(BaseModel):
+    status: str
+    name: str
+
+
+class ResolveWorkerResponse(BaseModel):
+    worker_id: str
+    worker_addr: str
+
+
+class CapacityResponse(BaseModel):
+    status: str
+    capacity: int
+
+
+# =============================================================================
 # App factory
 # =============================================================================
 
@@ -118,17 +193,17 @@ def create_app(config: RouterConfig) -> FastAPI:
         """Background task: periodically poll worker /health endpoints."""
         while True:
             workers = await worker_registry.get_all_workers()
-            for w in workers:
+
+            async def _check(w):
                 try:
-                    async with httpx.AsyncClient(
-                        timeout=config.worker_health_timeout
-                    ) as client:
-                        resp = await client.get(f"{w.worker_addr}/health")
-                        await worker_registry.update_health(
-                            w.worker_addr, resp.status_code == 200
-                        )
+                    resp = await app.state.http_client.get(f"{w.worker_addr}/health")
+                    await worker_registry.update_health(
+                        w.worker_addr, resp.status_code == 200
+                    )
                 except Exception:
                     await worker_registry.update_health(w.worker_addr, False)
+
+            await asyncio.gather(*[_check(w) for w in workers])
             await asyncio.sleep(config.poll_interval)
 
     @asynccontextmanager
@@ -138,19 +213,23 @@ def create_app(config: RouterConfig) -> FastAPI:
             config.routing_strategy,
             config.poll_interval,
         )
+        app.state.http_client = httpx.AsyncClient(timeout=config.worker_health_timeout)
         poll_task = asyncio.create_task(_poll_workers())
         app.state.worker_registry = worker_registry
         app.state.session_registry = session_registry
         app.state.model_registry = model_registry
         app.state.capacity_manager = capacity_manager
         app.state.strategy = strategy
-        yield
-        poll_task.cancel()
         try:
-            await poll_task
-        except asyncio.CancelledError:
-            pass
-        logger.info("Router shutting down")
+            yield
+        finally:
+            poll_task.cancel()
+            try:
+                await poll_task
+            except asyncio.CancelledError:
+                pass
+            await app.state.http_client.aclose()
+            logger.info("Router shutting down")
 
     app = FastAPI(title="AReaL Router", lifespan=lifespan)
 
@@ -165,31 +244,31 @@ def create_app(config: RouterConfig) -> FastAPI:
     # Health
     # =========================================================================
 
-    @app.get("/health")
+    @app.get("/health", response_model=HealthResponse)
     async def health():
         all_workers = await worker_registry.get_all_workers()
         session_count = await session_registry.count()
         capacity = await capacity_manager.get_capacity()
-        return {
-            "status": "ok",
-            "workers": len(all_workers),
-            "sessions": session_count,
-            "capacity": capacity,
-            "strategy": config.routing_strategy,
-        }
+        return HealthResponse(
+            status="ok",
+            workers=len(all_workers),
+            sessions=session_count,
+            capacity=capacity,
+            strategy=config.routing_strategy,
+        )
 
     # =========================================================================
     # Worker management (admin key required)
     # =========================================================================
 
-    @app.post("/register")
+    @app.post("/register", response_model=RegisterWorkerResponse)
     async def register(body: RegisterWorkerRequest, request: Request):
         _require_admin_key(request, config.admin_api_key)
         worker_id = await worker_registry.register(body.worker_addr)
         logger.info("Worker registered: %s (id=%s)", body.worker_addr, worker_id)
-        return {"status": "ok", "worker_id": worker_id}
+        return RegisterWorkerResponse(status="ok", worker_id=worker_id)
 
-    @app.post("/unregister")
+    @app.post("/unregister", response_model=UnregisterWorkerResponse)
     async def unregister(body: UnregisterWorkerRequest, request: Request):
         _require_admin_key(request, config.admin_api_key)
         if body.worker_id is not None:
@@ -205,10 +284,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                 worker_addr,
                 revoked,
             )
-            return {
-                "status": "ok",
-                "sessions_revoked": revoked,
-            }
+            return UnregisterWorkerResponse(status="ok", sessions_revoked=revoked)
         elif body.worker_addr is not None:
             await worker_registry.deregister(body.worker_addr)
             revoked = await session_registry.revoke_by_worker(body.worker_addr)
@@ -217,10 +293,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                 body.worker_addr,
                 revoked,
             )
-            return {
-                "status": "ok",
-                "sessions_revoked": revoked,
-            }
+            return UnregisterWorkerResponse(status="ok", sessions_revoked=revoked)
         else:
             raise HTTPException(
                 status_code=422,
@@ -231,7 +304,7 @@ def create_app(config: RouterConfig) -> FastAPI:
     # Routing (admin key required)
     # =========================================================================
 
-    @app.post("/route")
+    @app.post("/route", response_model=RouteResponse)
     async def route(body: RouteRequest, request: Request):
         _require_admin_key(request, config.admin_api_key)
 
@@ -256,7 +329,7 @@ def create_app(config: RouterConfig) -> FastAPI:
         if body.session_id is not None:
             worker = await session_registry.lookup_by_id(body.session_id)
             if worker is not None:
-                return {"worker_addr": worker}
+                return RouteResponse(worker_addr=worker)
             if model_addrs is None:
                 raise HTTPException(status_code=404, detail="Session not found")
 
@@ -275,11 +348,11 @@ def create_app(config: RouterConfig) -> FastAPI:
                 if body.model
                 else await model_registry.first()
             )
-            return {
-                "worker_addr": worker.worker_addr,
-                "url": info.url if info else "",
-                "api_key": info.api_key if info else None,
-            }
+            return RouteResponse(
+                worker_addr=worker.worker_addr,
+                url=info.url if info else None,
+                api_key=info.api_key if info else None,
+            )
 
         if body.api_key is None and body.model is not None and model_addrs is None:
             raise HTTPException(
@@ -300,7 +373,7 @@ def create_app(config: RouterConfig) -> FastAPI:
             w = worker_map.get(pinned)
             if w is None or not w.is_healthy:
                 raise HTTPException(status_code=503, detail="Pinned worker unhealthy")
-            return {"worker_addr": pinned}
+            return RouteResponse(worker_addr=pinned)
 
         # Step D: Admin key → pick from model addrs
         if hmac.compare_digest(body.api_key, config.admin_api_key):
@@ -316,7 +389,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                 "__hitl__",
                 worker.worker_addr,
             )
-            return {"worker_addr": worker.worker_addr}
+            return RouteResponse(worker_addr=worker.worker_addr)
 
         # Step E: Unknown key
         raise HTTPException(status_code=404, detail="Unknown API key")
@@ -328,7 +401,7 @@ def create_app(config: RouterConfig) -> FastAPI:
     # no permits remain.
     # =========================================================================
 
-    @app.post("/register_session")
+    @app.post("/register_session", response_model=StatusResponse)
     async def register_session(body: RegisterSessionRequest, request: Request):
         _require_admin_key(request, config.admin_api_key)
 
@@ -343,13 +416,13 @@ def create_app(config: RouterConfig) -> FastAPI:
         await session_registry.register_session(
             body.session_api_key, body.session_id, body.worker_addr
         )
-        return {"status": "ok"}
+        return StatusResponse(status="ok")
 
     # =========================================================================
     # Session cleanup (admin key required)
     # =========================================================================
 
-    @app.post("/remove_session")
+    @app.post("/remove_session", response_model=RemoveSessionResponse)
     async def remove_session(body: RemoveSessionRequest, request: Request):
         """Remove a session from the registry after export.
 
@@ -366,33 +439,33 @@ def create_app(config: RouterConfig) -> FastAPI:
             if is_hitl_persistent
             else await session_registry.revoke_session(body.session_id)
         )
-        return {
-            "status": "ok",
-            "removed": removed,
-            "persistent": is_hitl_persistent,
-        }
+        return RemoveSessionResponse(
+            status="ok",
+            removed=removed,
+            persistent=is_hitl_persistent,
+        )
 
     # =========================================================================
     # Worker listing (admin key required)
     # =========================================================================
 
-    @app.get("/workers")
+    @app.get("/workers", response_model=WorkersResponse)
     async def list_workers(request: Request):
         _require_admin_key(request, config.admin_api_key)
         all_workers = await worker_registry.get_all_workers()
-        return {
-            "workers": [
-                {
-                    "worker_id": w.worker_id,
-                    "addr": w.worker_addr,
-                    "healthy": w.is_healthy,
-                    "active_requests": w.active_requests,
-                }
+        return WorkersResponse(
+            workers=[
+                WorkerInfo(
+                    worker_id=w.worker_id,
+                    addr=w.worker_addr,
+                    healthy=w.is_healthy,
+                    active_requests=w.active_requests,
+                )
                 for w in all_workers
             ]
-        }
+        )
 
-    @app.post("/register_model")
+    @app.post("/register_model", response_model=RegisterModelResponse)
     async def register_model(body: RegisterModelRequest, request: Request):
         _require_admin_key(request, config.admin_api_key)
         addrs = body.data_proxy_addrs
@@ -413,19 +486,19 @@ def create_app(config: RouterConfig) -> FastAPI:
             body.url or "(internal)",
             addrs,
         )
-        return {
-            "status": "ok",
-            "model": body.model,
-            "data_proxy_addrs": addrs,
-        }
+        return RegisterModelResponse(
+            status="ok",
+            model=body.model,
+            data_proxy_addrs=addrs,
+        )
 
-    @app.get("/models")
+    @app.get("/models", response_model=ModelsResponse)
     async def list_models(request: Request):
         _require_admin_key(request, config.admin_api_key)
         names = await model_registry.list_names()
-        return {"models": names}
+        return ModelsResponse(models=names)
 
-    @app.post("/remove_model")
+    @app.post("/remove_model", response_model=RemoveModelResponse)
     async def remove_model(body: RemoveModelRequest, request: Request):
         _require_admin_key(request, config.admin_api_key)
         removed = await model_registry.remove(body.name)
@@ -435,56 +508,43 @@ def create_app(config: RouterConfig) -> FastAPI:
                 detail=f"External model '{body.name}' not found",
             )
         logger.info("External model removed: name=%s", body.name)
-        return {"status": "ok", "name": body.name}
+        return RemoveModelResponse(status="ok", name=body.name)
 
     # =========================================================================
     # Worker resolution by ID (admin key required)
     # =========================================================================
 
-    @app.get("/resolve_worker/{worker_id}")
+    @app.get("/resolve_worker/{worker_id}", response_model=ResolveWorkerResponse)
     async def resolve_worker(worker_id: str, request: Request):
-        """Resolve a worker_id to its address.
-
-        Returns the worker address for a given worker ID.
-        Used by the gateway to target specific workers for
-        pause/continue generation.
-        """
+        """Resolve a worker_id to its address."""
         _require_admin_key(request, config.admin_api_key)
         worker = await worker_registry.get_by_id(worker_id)
         if worker is None:
             raise HTTPException(
                 status_code=404, detail=f"Worker ID {worker_id} not found"
             )
-        return {"worker_id": worker.worker_id, "worker_addr": worker.worker_addr}
+        return ResolveWorkerResponse(
+            worker_id=worker.worker_id, worker_addr=worker.worker_addr
+        )
 
     # =========================================================================
     # Capacity management (admin key required)
     # =========================================================================
 
-    @app.post("/grant_capacity")
+    @app.post("/grant_capacity", response_model=CapacityResponse)
     async def grant_capacity(request: Request):
-        """Increment session capacity by 1.
-
-        Called by the rollout controller (via the gateway) when the current
-        weight version is within the allowed staleness window.  Each call
-        issues one permit for a future ``/register_session`` request.
-        """
+        """Increment session capacity by 1."""
         _require_admin_key(request, config.admin_api_key)
         new_capacity = await capacity_manager.grant()
         logger.info("Capacity granted — now %d", new_capacity)
-        return {"status": "ok", "capacity": new_capacity}
+        return CapacityResponse(status="ok", capacity=new_capacity)
 
-    @app.post("/release_capacity")
+    @app.post("/release_capacity", response_model=CapacityResponse)
     async def release_capacity(request: Request):
-        """Return one previously acquired capacity permit.
-
-        Called by the gateway when ``/rl/start_session`` fails after
-        capacity was acquired via ``/register_session``, to avoid
-        leaking permits.
-        """
+        """Return one previously acquired capacity permit."""
         _require_admin_key(request, config.admin_api_key)
         new_capacity = await capacity_manager.release()
         logger.info("Capacity released — now %d", new_capacity)
-        return {"status": "ok", "capacity": new_capacity}
+        return CapacityResponse(status="ok", capacity=new_capacity)
 
     return app

--- a/tests/experimental/inference_service/test_data_proxy_chat.py
+++ b/tests/experimental/inference_service/test_data_proxy_chat.py
@@ -593,7 +593,7 @@ async def test_set_reward_timeout_delays_readiness_and_direct_callback(
     callback_calls = []
 
     async def _mock_post_callback(
-        callback_server_addr, admin_api_key, notification, timeout
+        callback_server_addr, admin_api_key, notification, timeout, **kwargs
     ):
         callback_calls.append(
             (


### PR DESCRIPTION
## Description

Refactor the inference service HTTP layer to reuse long-lived httpx clients instead of creating per-request clients. Adds Pydantic response models across all services for type safety, and parallelizes sequential operations (health checks, proxy registrations, broadcasts) for better throughput.

## Related Issue

Fixes #1217

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Key changes:
- **Controller**: shared `httpx.Client`/`AsyncClient`, idempotent `destroy()`, parallel proxy registration via `ThreadPoolExecutor`, parallel `set_version`/`pause`/`continue` via `asyncio.gather`
- **Gateway**: shared `AsyncClient` via lifespan, `_use_client()` context manager in streaming module, parallel data proxy registration
- **Router**: shared `AsyncClient`, parallel health checks via `asyncio.gather`, proper lifespan cleanup with `try/finally`
- **Data proxy**: Pydantic response models, shared client for non-streaming requests, parallel callback delivery, proper `InfBridge` cleanup on shutdown and backend reconfiguration
- **InfBridge**: shared `AsyncClient` with `aclose()` lifecycle method

Files changed:
- `areal/experimental/inference_service/controller/controller.py`
- `areal/experimental/inference_service/data_proxy/app.py`
- `areal/experimental/inference_service/data_proxy/pause.py`
- `areal/experimental/inference_service/gateway/app.py`
- `areal/experimental/inference_service/gateway/streaming.py`
- `areal/experimental/inference_service/inf_bridge.py`
- `areal/experimental/inference_service/router/app.py`
- `tests/experimental/inference_service/test_data_proxy_chat.py`