### PR TITLE
fix(engine): eagerly init HCCL subgroups to fix ref compute_logp on NPU

### DIFF
--- a/areal/engine/core/distributed.py
+++ b/areal/engine/core/distributed.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from datetime import timedelta
 
-import torch  # noqa: F401 (used by callers)
+import torch
+import torch.distributed as dist
 
 
 def patch_dist_group_timeout(timeout: timedelta):
@@ -19,6 +21,51 @@ def patch_dist_group_timeout(timeout: timedelta):
 
     if hasattr(distributed_c10d, "default_pg_nccl_timeout"):
         distributed_c10d.default_pg_nccl_timeout = timeout
+
+
+def warmup_process_groups(*groups: dist.ProcessGroup | None) -> None:
+    """Force eager initialization of the collective communicator for each group.
+
+    NCCL/HCCL communicators are created lazily on the first collective call.
+    On Ascend NPU (HCCL), deferring init until a collective runs during
+    training is prone to fail with HCCP process initialization errors
+    (e.g. ``hcclCommInitRootInfoConfig`` error code 7) when multiple
+    colocated engines (for example actor + reference) independently mint
+    overlapping subgroups and trigger their first collective in the middle
+    of training work. Running a small dummy all-reduce at setup time forces
+    the communicator to be initialized while all ranks are aligned and the
+    device is idle, which avoids the race.
+
+    ``None`` groups and duplicates are skipped. No-op on CPU-only platforms
+    or before ``dist.init_process_group``. Safe to call repeatedly;
+    subsequent calls on already-initialized groups are cheap.
+    """
+    # Deferred import to keep this module importable without a platform
+    # (e.g. during lightweight tooling or unit tests).
+    from areal.infra.platforms import current_platform
+
+    if not dist.is_initialized() or current_platform.device_type == "cpu":
+        return
+
+    seen: set[int] = set()
+    unique_groups: list[dist.ProcessGroup] = []
+    for group in groups:
+        if group is None:
+            continue
+        key = id(group)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_groups.append(group)
+    if not unique_groups:
+        return
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    current_platform.set_device(local_rank)
+    device = torch.device(current_platform.device_type, local_rank)
+    tensor = torch.zeros(1, device=device)
+    for group in unique_groups:
+        dist.all_reduce(tensor, group=group)
 
 
 # Copy from pytorch and OpenRLHF to allow creating multiple main groups.

--- a/areal/engine/core/distributed.py
+++ b/areal/engine/core/distributed.py
@@ -47,21 +47,21 @@ def warmup_process_groups(*groups: dist.ProcessGroup | None) -> None:
     if not dist.is_initialized() or current_platform.device_type == "cpu":
         return
 
-    seen: set[int] = set()
-    unique_groups: list[dist.ProcessGroup] = []
-    for group in groups:
-        if group is None:
-            continue
-        key = id(group)
-        if key in seen:
-            continue
-        seen.add(key)
-        unique_groups.append(group)
+    # Preserve argument order while dropping None and duplicates.
+    unique_groups = list(dict.fromkeys(g for g in groups if g is not None))
     if not unique_groups:
         return
 
-    local_rank = int(os.environ["LOCAL_RANK"])
-    current_platform.set_device(local_rank)
+    # Prefer LOCAL_RANK (set by torchrun/most launchers); fall back to the
+    # device the caller has already configured via ``set_device``. This keeps
+    # the helper usable under custom launchers that don't export LOCAL_RANK.
+    local_rank_env = os.environ.get("LOCAL_RANK")
+    if local_rank_env is not None:
+        local_rank = int(local_rank_env)
+        current_platform.set_device(local_rank)
+    else:
+        local_rank = current_platform.current_device()
+
     device = torch.device(current_platform.device_type, local_rank)
     tensor = torch.zeros(1, device=device)
     for group in unique_groups:

--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -64,6 +64,7 @@ from areal.engine.core import (
 from areal.engine.core.distributed import (
     init_custom_process_group,
     patch_dist_group_timeout,
+    warmup_process_groups,
 )
 from areal.engine.core.model import (
     disable_dropout_in_model,
@@ -266,6 +267,10 @@ class FSDPEngine(TrainEngine):
         self.dp_rank = dist.get_rank(self.dp_group)
 
         self.logger.info(f"Data parallel head {self.dp_head} and rank {self.dp_rank}")
+
+        # Eagerly initialize HCCL/NCCL communicators for the subgroups so
+        # that lazy init doesn't race with colocated engines (issue #1099).
+        warmup_process_groups(self.dp_group, self.sp_group, self.mp_group)
 
     def initialize(self, addr: str | None, ft_spec: FinetuneSpec, *args, **kwargs):
         # Initialize distributed enviroments and load model.

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -51,7 +51,10 @@ from areal.engine.core import (
     compute_total_loss_weight,
     reorder_and_pad_outputs,
 )
-from areal.engine.core.distributed import init_custom_process_group
+from areal.engine.core.distributed import (
+    init_custom_process_group,
+    warmup_process_groups,
+)
 from areal.engine.core.model import disable_dropout_in_model
 from areal.engine.megatron_utils.checkpointer import MegatronCheckpointManager
 from areal.engine.megatron_utils.deterministic import set_deterministic_algorithms
@@ -218,6 +221,13 @@ class MegatronEngine(TrainEngine):
             timeout=DIST_GROUP_DEFAULT_TIMEOUT, backend="gloo"
         )
         self.process_group_initialized = True
+
+        # Eagerly initialize HCCL/NCCL communicators for the subgroups so
+        # that lazy init doesn't race with colocated engines (issue #1099).
+        warmup_process_groups(
+            self._context_and_model_parallel_group,
+            mpu.get_data_parallel_group(),
+        )
 
     def _apply_megatron_bridge_lora(self) -> None:
         assert self.model is not None, "Model must be initialized before applying LoRA."

--- a/areal/experimental/engine/archon_engine.py
+++ b/areal/experimental/engine/archon_engine.py
@@ -35,7 +35,10 @@ from areal.api import (
 )
 from areal.api.cli_args import MicroBatchSpec
 from areal.api.io_struct import DeviceRuntimeInfo
-from areal.engine.core.distributed import patch_dist_group_timeout
+from areal.engine.core.distributed import (
+    patch_dist_group_timeout,
+    warmup_process_groups,
+)
 from areal.engine.core.train_engine import (
     aggregate_eval_losses,
     compute_total_loss_weight,
@@ -282,6 +285,15 @@ class ArchonEngine(TrainEngine):
             f"pp={self.parallel_dims.pp}, dp_shard={self.parallel_dims.dp_shard}, "
             f"tp={self.parallel_dims.tp}, cp={self.parallel_dims.cp} (Ulysses SP), "
             f"ep={self.parallel_dims.ep}, etp={self.parallel_dims.etp}"
+        )
+
+        # Eagerly initialize HCCL/NCCL communicators for the subgroups so
+        # that lazy init doesn't race with colocated engines (issue #1099).
+        warmup_process_groups(
+            self.parallel_dims.world_mesh["dp"].get_group(),
+            self._pp_cp_tp_group,
+            self._tp_group,
+            self._cp_group,
         )
 
     def initialize(self, addr: str | None, ft_spec: FinetuneSpec, *args, **kwargs):

--- a/tests/test_warmup_process_groups.py
+++ b/tests/test_warmup_process_groups.py
@@ -61,10 +61,29 @@ def test_dedupes_repeated_groups(mock_all_reduce, monkeypatch):
         patch("torch.zeros") as zeros,
     ):
         platform.device_type = "cuda"
-        platform.set_device = lambda _: None
         zeros.return_value = object()
         warmup_process_groups(group, group, None, group)
 
     assert mock_all_reduce.call_count == 1
+    platform.set_device.assert_called_once_with(0)
     kwargs = mock_all_reduce.call_args.kwargs
     assert kwargs["group"] is group
+
+
+def test_falls_back_to_current_device_without_local_rank(mock_all_reduce, monkeypatch):
+    """When LOCAL_RANK is unset, the caller's current device is used."""
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+    group = object()
+    with (
+        patch.object(dist, "is_initialized", return_value=True),
+        patch("areal.infra.platforms.current_platform") as platform,
+        patch("torch.zeros") as zeros,
+    ):
+        platform.device_type = "cuda"
+        platform.current_device.return_value = 3
+        zeros.return_value = object()
+        warmup_process_groups(group)
+
+    platform.current_device.assert_called_once_with()
+    platform.set_device.assert_not_called()
+    assert mock_all_reduce.call_count == 1

--- a/tests/test_warmup_process_groups.py
+++ b/tests/test_warmup_process_groups.py
@@ -1,0 +1,70 @@
+"""Unit tests for ``warmup_process_groups``.
+
+The collective warmup itself needs a distributed environment, but the
+no-op short-circuits can be exercised with plain unit tests so we catch
+regressions in the guard logic without requiring a GPU.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import torch.distributed as dist
+
+from areal.engine.core.distributed import warmup_process_groups
+
+
+@pytest.fixture
+def mock_all_reduce():
+    with patch.object(dist, "all_reduce") as m:
+        yield m
+
+
+def test_noop_when_dist_uninitialized(mock_all_reduce):
+    with patch.object(dist, "is_initialized", return_value=False):
+        warmup_process_groups(object(), object())
+    mock_all_reduce.assert_not_called()
+
+
+def test_noop_on_cpu_platform(mock_all_reduce):
+    with (
+        patch.object(dist, "is_initialized", return_value=True),
+        patch("areal.infra.platforms.current_platform") as platform,
+    ):
+        platform.device_type = "cpu"
+        warmup_process_groups(object(), object())
+    mock_all_reduce.assert_not_called()
+
+
+def test_noop_when_all_groups_are_none(mock_all_reduce):
+    with (
+        patch.object(dist, "is_initialized", return_value=True),
+        patch("areal.infra.platforms.current_platform") as platform,
+    ):
+        platform.device_type = "cuda"
+        warmup_process_groups(None, None)
+    mock_all_reduce.assert_not_called()
+
+
+def test_noop_with_no_arguments(mock_all_reduce):
+    warmup_process_groups()
+    mock_all_reduce.assert_not_called()
+
+
+def test_dedupes_repeated_groups(mock_all_reduce, monkeypatch):
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    group = object()
+    with (
+        patch.object(dist, "is_initialized", return_value=True),
+        patch("areal.infra.platforms.current_platform") as platform,
+        patch("torch.zeros") as zeros,
+    ):
+        platform.device_type = "cuda"
+        platform.set_device = lambda _: None
+        zeros.return_value = object()
+        warmup_process_groups(group, group, None, group)
+
+    assert mock_all_reduce.call_count == 1
+    kwargs = mock_all_reduce.call_args.kwargs
+    assert kwargs["group"] is group


### PR DESCRIPTION
## Summary

Fixes #1099. On Ascend NPU with `kl_ctl > 0`, training crashed inside
`ref.compute_logp()` with:

```
HCCL function error: hcclCommInitRootInfoConfig ... error code is 7
HCCP_Process_Initialization_Failure(EJ0001)
```

### Root cause

NCCL/HCCL communicators are created lazily on the first collective call.
When actor and ref engines are colocated, each mints its own
data-parallel (and other) subgroups over the same ranks. The actor's
HCCL comm is initialized during FSDP setup, but the ref's DP subgroup
stays uninitialized until its first collective — which is the
`dist.all_gather` inside `allocate_balanced_mbs_synced` during
`ref.compute_logp`. That late HCCL init contends with the already-live
actor communicator and intermittently fails on Ascend with the HCCP
process-initialization error. With `kl_ctl=0` the ref engine is never
built, so the race doesn't trigger.

### Fix

Add `warmup_process_groups(*groups)` in `areal/engine/core/distributed.py`
and call it at the end of `create_process_group` in FSDP, Megatron, and
Archon engines. The helper runs a 1-element dummy `all_reduce` on each
non-None, non-duplicate group to synchronously construct the comm while
all ranks are aligned and the device is idle. No-op on CPU platforms or
before `dist.init_process_group`.

### Commits

- `feat(engine): add warmup_process_groups helper`
- `fix(engine): eagerly init FSDPEngine HCCL subgroups`
- `fix(engine): eagerly init MegatronEngine HCCL subgroups`
- `fix(archon): eagerly init ArchonEngine HCCL subgroups`

## Test plan

- [x] Added `tests/test_warmup_process_groups.py` — 5 unit tests covering
  no-op paths (uninitialized dist, CPU platform, all-None, no args) and
  dedup behavior. All pass.
- [x] `pre-commit run --all-files` clean on all edited files.
- [ ] NPU validation: cannot reproduce locally (no Ascend hardware).
  Requesting validation by the issue reporter / maintainers on the
  4-NPU gsm8k-grpo-mt config with `kl_ctl: 0.1`.

Refs: #1099