### PR TITLE
test(infra): regression for single-controller SFT batch partitioning

### DIFF
--- a/tests/test_train_controller.py
+++ b/tests/test_train_controller.py
@@ -675,6 +675,33 @@ class TestTrainControllerDispatchInputs:
         assert len(split_args) == 1
         assert len(split_args[0]) == train_controller.parallel_strategy.dp_size
 
+    def test_prepare_dispatch_partitions_without_duplication(
+        self, train_controller, ft_spec
+    ):
+        """Regression for #1202: trajectories are partitioned across DP ranks,
+        never replicated. Each DP rank must see a disjoint slice so that total
+        tokens processed equal the original batch, not batch * dp_size."""
+        train_controller.initialize(
+            role="train_worker",
+            ft_spec=ft_spec,
+        )
+
+        dp_size = train_controller.parallel_strategy.dp_size
+        batch_size = 4 * dp_size
+        batch = create_mock_distributed_batch(size=batch_size)
+
+        split_args, _, group_indices = train_controller._prepare_dispatch(batch)
+
+        # Sanity: tensor-like list triggers the partition path, not replication.
+        assert group_indices is not None
+        assert len(group_indices) == dp_size
+
+        shards = split_args[0]
+        assert sum(len(shard) for shard in shards) == batch_size
+
+        flat_indices = [idx for group in group_indices for idx in group]
+        assert sorted(flat_indices) == list(range(batch_size))
+
     def test_prepare_dispatch_replicates_non_batch_args(
         self, train_controller, ft_spec
     ):


### PR DESCRIPTION
## Summary

Issue #1202 reported that single-controller SFT replicated every batch to every DP rank, producing `dp_size × tokens` per step instead of a partition. The fix landed with the per-trajectory list pipeline in commit `e97f2a0c`, and the collaborator [already verified](https://github.com/inclusionAI/AReaL/issues/1202#issuecomment-4295031768) on main that `n_seqs` matches the batch size and DP ranks receive distinct `input_ids`.

However, the existing dispatch test (`test_prepare_dispatch_splits_distributed_batch`) only asserts that `_prepare_dispatch` returns a list of length `dp_size` — a regression that *replicated* the full batch into each of those shards would still pass. This PR adds a test that catches that specific failure mode.

- Asserts `group_indices is not None` (tensor-partition path, not replicate path).
- Asserts `sum(len(shard) for shard in shards) == batch_size` (no duplication / loss).
- Asserts flattened `group_indices == range(batch_size)` (every trajectory in exactly one shard).

No production code changes.

## Test plan

- [ ] `uv run pytest tests/test_train_controller.py::TestTrainControllerDispatchInputs -v`
- [ ] `pre-commit run --files tests/test_train_controller.py` (ruff lint + format pass locally)