### PR TITLE
fix: correct community meeting date from 2026/05/01 to 2026/05/02

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ innovative modules.
 Meeting** was successfully held! Thank you to everyone who joined us. Meeting materials
 are now available
 [here](https://github.com/inclusionAI/AReaL/tree/main/assets/community). Our next
-meeting is scheduled for **2026/05/01** and will also be conducted in Chinese;
+meeting is scheduled for **2026/05/02** and will also be conducted in Chinese;
 English-language meetings will be scheduled in the future. We warmly welcome everyone to
 participate! See [Community](./assets/community/README.md) for more details.
 

--- a/assets/community/README.md
+++ b/assets/community/README.md
@@ -14,7 +14,7 @@ For background on how the project is governed and how to participate, please see
 
 | Date       | Agenda | Slides | Recording |
 | ---------- | ------ | ------ | --------- |
-| 2026/05/01 | TBD    | TBD    | TBD       |
+| 2026/05/02 | TBD    | TBD    | TBD       |
 
 ## Past Meetings
 


### PR DESCRIPTION
## Description

Fix the community meeting date from 2026/05/01 to 2026/05/02.

Based on the Tencent Meeting schedule and the convention of holding meetings every two weeks on Saturday, the correct date for the upcoming community meeting should be 2026/05/02 (Saturday), not 2026/05/01 (Friday).

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
