### PR TITLE
feat: add configurable setup_timeout for data service gateway

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -2532,6 +2532,14 @@ class _DatasetConfig:
             "If set, dataset loading will be offloaded to a data service with remote workers."
         },
     )
+    setup_timeout: float = field(
+        default=120.0,
+        metadata={
+            "help": "Timeout in seconds for the data service to load and register a dataset. "
+            "Increase this value when loading large datasets for the first time "
+            "(e.g. HuggingFace datasets that require downloading and preprocessing)."
+        },
+    )
 
 
 @dataclass

--- a/areal/infra/data_service/controller/config.py
+++ b/areal/infra/data_service/controller/config.py
@@ -36,6 +36,7 @@ class DataServiceConfig:
             num_workers=max(dataset_config.num_dataset_workers, 1),
             scheduling_spec=dataset_config.scheduling_spec,
             dataloader_num_workers=max(dataset_config.num_workers, 0),
+            setup_timeout=dataset_config.setup_timeout,
             seed=seed,
         )
 

--- a/areal/infra/data_service/controller/controller.py
+++ b/areal/infra/data_service/controller/controller.py
@@ -199,7 +199,7 @@ class DataController:
                             "--router-addr",
                             self._router_addr,
                             "--forward-timeout",
-                            str(60.0),
+                            str(cfg.setup_timeout),
                         ],
                     ),
                     _register_workers(),


### PR DESCRIPTION
Previously the gateway's --forward-timeout was hardcoded to 60s, which caused timeouts when loading large datasets (e.g. HuggingFace datasets requiring download and preprocessing on first use).

Changes:
- Add setup_timeout field to _DatasetConfig (default 120s) with help text
- Wire setup_timeout through DataServiceConfig.from_dataset_config()
- Replace hardcoded 60.0 with cfg.setup_timeout in gateway launch args

Users can now set setup_timeout in their YAML config to control how long the data service waits for dataset loading to complete.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #1264 

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
