### PR TITLE
refactor(experimental): rename WeightUpdate*Adapter to Awex*Adapter

### DIFF
--- a/areal/experimental/weight_update/awex/fsdp_adapter.py
+++ b/areal/experimental/weight_update/awex/fsdp_adapter.py
@@ -25,7 +25,7 @@ from areal.experimental.weight_update.nccl_group import (
     setup_batch_isend_irecv,
 )
 from areal.experimental.weight_update.training_adapter import (
-    WeightUpdateTrainingAdapter,
+    AwexTrainingAdapter,
 )
 from areal.utils import logging
 
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("AwexFSDPAdapter")
 
 
-class AwexFSDPAdapter(WeightUpdateTrainingAdapter):
+class AwexFSDPAdapter(AwexTrainingAdapter):
     """Awex training adapter wrapping FSDPEngine for shard-direct NCCL P2P updates."""
 
     def __init__(self, engine: FSDPEngine):

--- a/areal/experimental/weight_update/awex/megatron_adapter.py
+++ b/areal/experimental/weight_update/awex/megatron_adapter.py
@@ -22,7 +22,7 @@ from areal.experimental.weight_update.nccl_group import (
     setup_batch_isend_irecv,
 )
 from areal.experimental.weight_update.training_adapter import (
-    WeightUpdateTrainingAdapter,
+    AwexTrainingAdapter,
 )
 from areal.utils import logging
 
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("AwexMegatronAdapter")
 
 
-class AwexMegatronAdapter(WeightUpdateTrainingAdapter):
+class AwexMegatronAdapter(AwexTrainingAdapter):
     """Awex training adapter for MegatronEngine supporting DP, TP, and PP.
 
     PP: get_named_parameters already yields only the current stage's layers

--- a/areal/experimental/weight_update/awex/sglang_adapter.py
+++ b/areal/experimental/weight_update/awex/sglang_adapter.py
@@ -24,7 +24,7 @@ from awex.transfer.transfer_plan import TransferPlan, TransferPlanBuilder
 
 from areal.experimental.weight_update.awex import fetch_kv_metadata
 from areal.experimental.weight_update.inference_adapter import (
-    WeightUpdateInferenceAdapter,
+    AwexInferenceAdapter,
 )
 from areal.experimental.weight_update.nccl_group import (
     init_weights_update_group,
@@ -35,7 +35,7 @@ from areal.utils import logging
 logger = logging.getLogger("AwexSGLangAdapter")
 
 
-class AwexSGLangAdapter(WeightUpdateInferenceAdapter):
+class AwexSGLangAdapter(AwexInferenceAdapter):
     """Awex inference adapter for in-process SGLang schedulers."""
 
     def __init__(self, scheduler: Any):

--- a/areal/experimental/weight_update/inference_adapter.py
+++ b/areal/experimental/weight_update/inference_adapter.py
@@ -7,7 +7,7 @@ import torch
 
 
 @runtime_checkable
-class WeightUpdateInferenceAdapter(Protocol):
+class AwexInferenceAdapter(Protocol):
     """Protocol for inference-side weight update adapters."""
 
     @property

--- a/areal/experimental/weight_update/training_adapter.py
+++ b/areal/experimental/weight_update/training_adapter.py
@@ -7,7 +7,7 @@ import torch
 
 
 @runtime_checkable
-class WeightUpdateTrainingAdapter(Protocol):
+class AwexTrainingAdapter(Protocol):
     """Protocol for training-side weight update adapters."""
 
     @property


### PR DESCRIPTION
## Description

Rename the generic `WeightUpdateInferenceAdapter` and `WeightUpdateTrainingAdapter`
Protocol classes to `AwexInferenceAdapter` and `AwexTrainingAdapter`, along with
all import sites and subclass declarations. The old names were overly generic and
collided semantically with the higher-level `WeightUpdateController`/`WeightUpdateConfig`
concepts. The new names clarify that these protocols are awex-specific.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Pure mechanical rename — no functional or behavioral changes.

Files changed:
- `areal/experimental/weight_update/inference_adapter.py` — Protocol class renamed
- `areal/experimental/weight_update/training_adapter.py` — Protocol class renamed
- `areal/experimental/weight_update/awex/fsdp_adapter.py` — import + subclass updated
- `areal/experimental/weight_update/awex/megatron_adapter.py` — import + subclass updated
- `areal/experimental/weight_update/awex/sglang_adapter.py` — import + subclass updated