### PR TITLE
fix(engine): avoid duplicating multimodal tensors

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -117,6 +117,7 @@ from areal.utils.data import (
     MicroBatchList,
     amend_position_ids,
     concat_batch,
+    is_multi_modal_key,
     pack_tensor_dict,
     pad_mb_list,
     split_batch,
@@ -172,6 +173,45 @@ class _PendingWeightUpdateBucket:
     fut: Future[None]
     named_tensors: list[tuple[str, torch.Tensor]]
     stream: torch.cuda.Stream | None = None
+
+
+_MULTIMODAL_FORWARD_KEYS = ("image_grid_thw", "pixel_values", "video_grid_thw")
+
+
+def _is_multimodal_payload_key(key: str) -> bool:
+    return is_multi_modal_key(key) or key in _MULTIMODAL_FORWARD_KEYS
+
+
+def _drop_multimodal_payloads(data: dict[str, Any]) -> None:
+    for key in list(data.keys()):
+        if _is_multimodal_payload_key(key):
+            data.pop(key, None)
+
+
+def _prepare_multimodal_forward_inputs(
+    mb: dict[str, Any],
+    padded_mb: dict[str, Any],
+) -> None:
+    """Keep multimodal tensors only in the forward micro-batch.
+
+    ``mb`` is used by loss and bookkeeping callbacks, while ``padded_mb`` is
+    passed to the model forward. Large multimodal tensors such as
+    ``pixel_values`` should not be duplicated on both sides.
+    """
+
+    multi_modal_input = mb.pop("multi_modal_input", None)
+    if multi_modal_input is None:
+        multi_modal_input = padded_mb.pop("multi_modal_input", None)
+    else:
+        padded_mb.pop("multi_modal_input", None)
+
+    if multi_modal_input is not None:
+        for key in _MULTIMODAL_FORWARD_KEYS:
+            values = [item[key] for item in multi_modal_input if key in item]
+            if values:
+                padded_mb[key] = torch.cat(values, dim=0)
+
+    _drop_multimodal_payloads(mb)
 
 
 class FSDPEngine(TrainEngine):
@@ -1577,31 +1617,8 @@ class FSDPEngine(TrainEngine):
                 padded_mb["attention_mask"] = dict(
                     full_attention=None, sliding_attention=None
                 )
-            if "multi_modal_input" in mb:
-                image_grid_thw_list = [
-                    item["image_grid_thw"]
-                    for item in mb["multi_modal_input"]
-                    if "image_grid_thw" in item
-                ]
-                if image_grid_thw_list:
-                    mb["image_grid_thw"] = torch.cat(image_grid_thw_list, dim=0)
-                    padded_mb["image_grid_thw"] = torch.cat(image_grid_thw_list, dim=0)
-                pixel_values_list = [
-                    item["pixel_values"]
-                    for item in mb["multi_modal_input"]
-                    if "pixel_values" in item
-                ]
-                if pixel_values_list:
-                    mb["pixel_values"] = torch.cat(pixel_values_list, dim=0)
-                    padded_mb["pixel_values"] = torch.cat(pixel_values_list, dim=0)
-                video_grid_thw_list = [
-                    item["video_grid_thw"]
-                    for item in mb["multi_modal_input"]
-                    if "video_grid_thw" in item
-                ]
-                if video_grid_thw_list:
-                    mb["video_grid_thw"] = torch.cat(video_grid_thw_list, dim=0)
-                    padded_mb["video_grid_thw"] = torch.cat(video_grid_thw_list, dim=0)
+            _prepare_multimodal_forward_inputs(mb, padded_mb)
+        _drop_multimodal_payloads(mb_list.data)
         return mb_list
 
     def _prepare_mb_inputs(

--- a/tests/test_fsdp_multimodal_batch.py
+++ b/tests/test_fsdp_multimodal_batch.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from areal.engine.fsdp_engine import _prepare_multimodal_forward_inputs
+
+
+def test_multimodal_forward_inputs_are_not_kept_in_loss_mb():
+    pixel_values = [torch.randn(2, 4), torch.randn(3, 4)]
+    image_grid_thw = [torch.tensor([[1, 1, 2]]), torch.tensor([[1, 1, 3]])]
+    mb = {
+        "input_ids": torch.ones(5, dtype=torch.long),
+        "multi_modal_input": [
+            {
+                "pixel_values": pixel_values[0],
+                "image_grid_thw": image_grid_thw[0],
+            },
+            {
+                "pixel_values": pixel_values[1],
+                "image_grid_thw": image_grid_thw[1],
+            },
+        ],
+    }
+    padded_mb = dict(mb)
+
+    _prepare_multimodal_forward_inputs(mb, padded_mb)
+
+    assert "multi_modal_input" not in mb
+    assert "multi_modal_input" not in padded_mb
+    assert "pixel_values" not in mb
+    assert "image_grid_thw" not in mb
+    assert torch.equal(padded_mb["pixel_values"], torch.cat(pixel_values, dim=0))
+    assert torch.equal(padded_mb["image_grid_thw"], torch.cat(image_grid_thw, dim=0))
+
+
+def test_multimodal_forward_inputs_fall_back_to_padded_mb():
+    pixel_values = [torch.randn(2, 4)]
+    mb = {"input_ids": torch.ones(2, dtype=torch.long)}
+    padded_mb = {
+        "input_ids": torch.ones(2, dtype=torch.long),
+        "multi_modal_input": [{"pixel_values": pixel_values[0]}],
+    }
+
+    _prepare_multimodal_forward_inputs(mb, padded_mb)
+
+    assert "multi_modal_input" not in mb
+    assert "multi_modal_input" not in padded_mb
+    assert "pixel_values" not in mb
+    assert torch.equal(padded_mb["pixel_values"], torch.cat(pixel_values, dim=0))


### PR DESCRIPTION
  ## Description

  This PR reduces CPU memory usage during FSDP multimodal training.

  Currently, multimodal tensors from `multi_modal_input` are materialized into both the loss/bookkeeping microbatch (`mb`)
  and the forward microbatch (`padded_mb`). Large tensors such as `pixel_values` are only needed for model forward, so
  keeping them in the loss-side microbatch unnecessarily duplicates CPU tensor storage.

  This PR keeps multimodal forward tensors only in `padded_mb` and removes them from the loss-side microbatch. It also adds
  a unit test to verify that `pixel_values` and related multimodal fields are not retained in the loss-side batch.

  ## Related Issue

  Fixes #1271

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [ ] ⚡ Performance improvement
  - [ ] ✅ Test coverage improvement

  ## Checklist

  - [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
  - [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
  - [x] Relevant tests pass; new tests added for new functionality
  - [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
  - [x] Branch is up to date with `main`
  - [ ] Self-reviewed via `/review-pr` command
  - [ ] This PR was created by a coding agent via `/create-pr`
  - [ ] This PR is a breaking change

  **Breaking Change Details (if applicable):**

  N/A

  ## Additional Context

  Validation performed:

  ```text
  python -m py_compile areal/engine/fsdp_engine.py tests/test_fsdp_multimodal_batch.py
  pytest -q tests/test_fsdp_multimodal_batch.py
  pre-commit run --files areal/engine/fsdp_engine.py tests/test_fsdp_multimodal_batch.py

  pre-commit run --all-files was attempted, but local environment dependencies for two repository-wide hooks were missing.