### PR TITLE
feat(experimental): add offload/onload endpoints for inference service

### DIFF
--- a/areal/experimental/inference_service/backend.py
+++ b/areal/experimental/inference_service/backend.py
@@ -71,6 +71,14 @@ class InfBridgeBackend(Protocol):
         """Return the HTTP request that resumes generation on the backend."""
         ...
 
+    def get_offload_request(self) -> HttpRequest:
+        """Return the HTTP request that offloads model memory on the backend."""
+        ...
+
+    def get_onload_request(self, tags: list[str] | None = None) -> HttpRequest:
+        """Return the HTTP request that reloads model memory on the backend."""
+        ...
+
     def get_generation_max_new_tokens(self, http_req: HttpRequest) -> int:
         """Return the current generation budget encoded in ``http_req``."""
         ...

--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -1284,7 +1284,7 @@ class GatewayInferenceController:
         finally:
             await session.close()
 
-    # -- Pause / Resume ----------------------------------------------------
+    # -- Pause / Resume / Offload -------------------------------------------
 
     def pause(self) -> None:
         """Pause dispatcher + pause all workers."""
@@ -1301,6 +1301,41 @@ class GatewayInferenceController:
         run_async_task(self.continue_generation)
         if self._workflow_executor is not None:
             self._workflow_executor.resume()
+
+    def offload(self) -> None:
+        """Offload model memory on all inference workers."""
+        from areal.infra.utils.concurrent import run_async_task
+
+        run_async_task(self._async_offload)
+
+    async def _async_offload(self) -> None:
+        if not self._gateway_addr:
+            return
+        await asyncio.gather(
+            *(
+                self._async_gateway_http_post(f"/release_memory_occupation/{wid}", {})
+                for wid in self._worker_ids.values()
+            )
+        )
+
+    def onload(self, tags: list[str] | None = None) -> None:
+        """Reload model memory on all inference workers."""
+        from areal.infra.utils.concurrent import run_async_task
+
+        run_async_task(self._async_onload, tags)
+
+    async def _async_onload(self, tags: list[str] | None = None) -> None:
+        if not self._gateway_addr:
+            return
+        payload: dict = {"tags": tags} if tags is not None else {}
+        await asyncio.gather(
+            *(
+                self._async_gateway_http_post(
+                    f"/resume_memory_occupation/{wid}", payload
+                )
+                for wid in self._worker_ids.values()
+            )
+        )
 
     async def pause_generation(self, worker_id: str | None = None) -> None:
         """Pause generation on a specific worker, or all workers if worker_id is None."""

--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -1311,12 +1311,18 @@ class GatewayInferenceController:
     async def _async_offload(self) -> None:
         if not self._gateway_addr:
             return
-        await asyncio.gather(
+        results = await asyncio.gather(
             *(
                 self._async_gateway_http_post(f"/release_memory_occupation/{wid}", {})
                 for wid in self._worker_ids.values()
-            )
+            ),
+            return_exceptions=True,
         )
+        failed = [r for r in results if isinstance(r, Exception)]
+        for r in failed:
+            logger.error("Failed to offload a worker: %s", r)
+        if failed and len(failed) == len(results):
+            raise RuntimeError(f"offload failed on ALL {len(failed)} workers")
 
     def onload(self, tags: list[str] | None = None) -> None:
         """Reload model memory on all inference workers."""
@@ -1328,14 +1334,20 @@ class GatewayInferenceController:
         if not self._gateway_addr:
             return
         payload: dict = {"tags": tags} if tags is not None else {}
-        await asyncio.gather(
+        results = await asyncio.gather(
             *(
                 self._async_gateway_http_post(
                     f"/resume_memory_occupation/{wid}", payload
                 )
                 for wid in self._worker_ids.values()
-            )
+            ),
+            return_exceptions=True,
         )
+        failed = [r for r in results if isinstance(r, Exception)]
+        for r in failed:
+            logger.error("Failed to onload a worker: %s", r)
+        if failed and len(failed) == len(results):
+            raise RuntimeError(f"onload failed on ALL {len(failed)} workers")
 
     async def pause_generation(self, worker_id: str | None = None) -> None:
         """Pause generation on a specific worker, or all workers if worker_id is None."""

--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -400,6 +400,30 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         await inf_bridge.resume()
         return PauseGenerationResponse(status="ok", paused=False)
 
+    @app.post("/release_memory_occupation")
+    async def release_memory_occupation():
+        inf_bridge: InfBridge | None = app.state.inf_bridge
+        if inf_bridge is None:
+            raise HTTPException(
+                status_code=503,
+                detail="No inference backend configured (external model mode).",
+            )
+        await inf_bridge.offload()
+        return {"status": "ok"}
+
+    @app.post("/resume_memory_occupation")
+    async def resume_memory_occupation(request: Request):
+        inf_bridge: InfBridge | None = app.state.inf_bridge
+        if inf_bridge is None:
+            raise HTTPException(
+                status_code=503,
+                detail="No inference backend configured (external model mode).",
+            )
+        body = await request.json() if await request.body() else {}
+        tags = body.get("tags")
+        await inf_bridge.onload(tags=tags)
+        return {"status": "ok"}
+
     # =========================================================================
     # Version management — internal control plane (no auth at data proxy level)
     # =========================================================================

--- a/areal/experimental/inference_service/gateway/app.py
+++ b/areal/experimental/inference_service/gateway/app.py
@@ -422,6 +422,54 @@ def create_app(config: GatewayConfig) -> FastAPI:
         return BroadcastResponse(results=[BroadcastResultItem(**r) for r in results])
 
     # =========================================================================
+    # POST /release_memory_occupation/{worker_id} — admin key ONLY
+    # =========================================================================
+
+    @app.post("/release_memory_occupation/{worker_id}")
+    async def release_memory_occupation(worker_id: str, request: Request):
+        require_admin_key(request, config.admin_api_key)
+        try:
+            worker_addr = await resolve_worker_addr(
+                config.router_addr,
+                config.admin_api_key,
+                worker_id,
+                config.router_timeout,
+            )
+        except (RouterUnreachableError, RouterKeyRejectedError) as exc:
+            return _router_error_response(exc)
+
+        body = await request.body()
+        headers = _forwarding_headers(dict(request.headers))
+        results = await broadcast_to_workers(
+            [worker_addr], "/release_memory_occupation", body, headers
+        )
+        return {"results": results}
+
+    # =========================================================================
+    # POST /resume_memory_occupation/{worker_id} — admin key ONLY
+    # =========================================================================
+
+    @app.post("/resume_memory_occupation/{worker_id}")
+    async def resume_memory_occupation(worker_id: str, request: Request):
+        require_admin_key(request, config.admin_api_key)
+        try:
+            worker_addr = await resolve_worker_addr(
+                config.router_addr,
+                config.admin_api_key,
+                worker_id,
+                config.router_timeout,
+            )
+        except (RouterUnreachableError, RouterKeyRejectedError) as exc:
+            return _router_error_response(exc)
+
+        body = await request.body()
+        headers = _forwarding_headers(dict(request.headers))
+        results = await broadcast_to_workers(
+            [worker_addr], "/resume_memory_occupation", body, headers
+        )
+        return {"results": results}
+
+    # =========================================================================
     # POST /export_trajectories — admin key ONLY, route by session_id or model field
     # =========================================================================
 

--- a/areal/experimental/inference_service/gateway/app.py
+++ b/areal/experimental/inference_service/gateway/app.py
@@ -425,7 +425,9 @@ def create_app(config: GatewayConfig) -> FastAPI:
     # POST /release_memory_occupation/{worker_id} — admin key ONLY
     # =========================================================================
 
-    @app.post("/release_memory_occupation/{worker_id}")
+    @app.post(
+        "/release_memory_occupation/{worker_id}", response_model=BroadcastResponse
+    )
     async def release_memory_occupation(worker_id: str, request: Request):
         require_admin_key(request, config.admin_api_key)
         try:
@@ -434,6 +436,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -441,15 +444,15 @@ def create_app(config: GatewayConfig) -> FastAPI:
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
         results = await broadcast_to_workers(
-            [worker_addr], "/release_memory_occupation", body, headers
+            [worker_addr], "/release_memory_occupation", body, headers, client=_client()
         )
-        return {"results": results}
+        return BroadcastResponse(results=[BroadcastResultItem(**r) for r in results])
 
     # =========================================================================
     # POST /resume_memory_occupation/{worker_id} — admin key ONLY
     # =========================================================================
 
-    @app.post("/resume_memory_occupation/{worker_id}")
+    @app.post("/resume_memory_occupation/{worker_id}", response_model=BroadcastResponse)
     async def resume_memory_occupation(worker_id: str, request: Request):
         require_admin_key(request, config.admin_api_key)
         try:
@@ -458,6 +461,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 config.admin_api_key,
                 worker_id,
                 config.router_timeout,
+                client=_client(),
             )
         except (RouterUnreachableError, RouterKeyRejectedError) as exc:
             return _router_error_response(exc)
@@ -465,9 +469,9 @@ def create_app(config: GatewayConfig) -> FastAPI:
         body = await request.body()
         headers = _forwarding_headers(dict(request.headers))
         results = await broadcast_to_workers(
-            [worker_addr], "/resume_memory_occupation", body, headers
+            [worker_addr], "/resume_memory_occupation", body, headers, client=_client()
         )
-        return {"results": results}
+        return BroadcastResponse(results=[BroadcastResultItem(**r) for r in results])
 
     # =========================================================================
     # POST /export_trajectories — admin key ONLY, route by session_id or model field

--- a/areal/experimental/inference_service/inf_bridge.py
+++ b/areal/experimental/inference_service/inf_bridge.py
@@ -105,6 +105,18 @@ class InfBridge:
         await self.pause_state.set_paused(False)
         logger.info("Resume request sent to %s", self.backend_addr)
 
+    async def offload(self) -> None:
+        """Offload model memory on the backend inference server."""
+        http_req = self.backend.get_offload_request()
+        await self._send_request(http_req, timeout=30.0)
+        logger.info("Offload request sent to %s", self.backend_addr)
+
+    async def onload(self, tags: list[str] | None = None) -> None:
+        """Reload model memory on the backend inference server."""
+        http_req = self.backend.get_onload_request(tags=tags)
+        await self._send_request(http_req, timeout=30.0)
+        logger.info("Onload request sent to %s", self.backend_addr)
+
     # -- HTTP transport (shared across all backends) -------------------------
 
     async def _send_request(

--- a/areal/experimental/inference_service/sglang/bridge.py
+++ b/areal/experimental/inference_service/sglang/bridge.py
@@ -127,6 +127,13 @@ class SGLangBridgeBackend:
     def get_resume_request(self) -> HttpRequest:
         return HttpRequest(endpoint="/continue_generation", payload={})
 
+    def get_offload_request(self) -> HttpRequest:
+        return HttpRequest(endpoint="/release_memory_occupation", payload={})
+
+    def get_onload_request(self, tags: list[str] | None = None) -> HttpRequest:
+        payload = {"tags": tags} if tags is not None else {}
+        return HttpRequest(endpoint="/resume_memory_occupation", payload=payload)
+
     def get_generation_max_new_tokens(self, http_req: HttpRequest) -> int:
         return int(http_req.payload["sampling_params"]["max_new_tokens"])
 

--- a/areal/experimental/inference_service/vllm/bridge.py
+++ b/areal/experimental/inference_service/vllm/bridge.py
@@ -122,6 +122,17 @@ class VLLMBridgeBackend:
     def get_resume_request(self) -> HttpRequest:
         return HttpRequest(endpoint="/areal_continue_generation", payload={})
 
+    def get_offload_request(self) -> HttpRequest:
+        return HttpRequest(endpoint="/sleep", payload={}, method="POST")
+
+    def get_onload_request(self, tags: list[str] | None = None) -> HttpRequest:
+        if tags is not None:
+            tags_query = "&".join([f"tags={tag}" for tag in tags])
+            endpoint = f"/wake_up?{tags_query}"
+        else:
+            endpoint = "/wake_up"
+        return HttpRequest(endpoint=endpoint, payload={}, method="POST")
+
     def get_generation_max_new_tokens(self, http_req: HttpRequest) -> int:
         return int(http_req.payload["max_tokens"])
 

--- a/areal/experimental/inference_service/vllm/bridge.py
+++ b/areal/experimental/inference_service/vllm/bridge.py
@@ -127,7 +127,9 @@ class VLLMBridgeBackend:
 
     def get_onload_request(self, tags: list[str] | None = None) -> HttpRequest:
         if tags is not None:
-            tags_query = "&".join([f"tags={tag}" for tag in tags])
+            from urllib.parse import urlencode
+
+            tags_query = urlencode({"tags": tags}, doseq=True)
             endpoint = f"/wake_up?{tags_query}"
         else:
             endpoint = "/wake_up"


### PR DESCRIPTION
## Summary

Add offload/onload endpoints to the inference service HTTP stack, enabling backends to release and reload GPU memory on demand. This is useful for memory-constrained deployments where training and inference share GPUs.

## Key Changes

**Protocol layer:**
- Add `get_offload_request()` and `get_onload_request()` to `InfBridgeBackend` protocol

**Backend implementations:**
- SGLang: maps to `/release_memory_occupation` and `/resume_memory_occupation`
- vLLM: maps to `/sleep` and `/wake_up`

**HTTP layer:**
- `InfBridge`: new `offload()` and `onload()` methods
- Data proxy: new `/release_memory_occupation` and `/resume_memory_occupation` endpoints
- Gateway: new per-worker proxy endpoints `/release_memory_occupation/{worker_id}` and `/resume_memory_occupation/{worker_id}`

**Controller:**
- `GatewayInferenceController`: new `offload()` and `onload()` methods that fan out to all workers via gateway

## Design

Follows the same pattern as the existing `pause()`/`resume()` flow:
- Protocol → Bridge backend → InfBridge → Data proxy endpoint → Gateway proxy → Controller orchestration
- All operations are async and fan out to all workers concurrently

## Testing

- Pure additive change — no existing behavior is modified
- Existing tests continue to pass