### PR TITLE
feat(engine): add Megatron support for Qwen2.5-VL

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -7,6 +7,7 @@ import functools
 import gc
 import math
 import os
+import re
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from contextlib import contextmanager
@@ -118,6 +119,22 @@ from areal.utils.seeding import get_seed
 if TYPE_CHECKING:
     from areal.api import Scheduler
     from areal.api.cli_args import DPOEngineConfig, PPOActorConfig, PPOCriticConfig
+
+
+# `model.named_modules()` yields LOCAL layer indices on each PP rank, while
+# `get_named_parameters` rewrites them to GLOBAL indices via layer_offset. Strip
+# the index so the GLU detection set matches across PP ranks. Also strip trailing
+# numeric suffixes on `weight`/`bias` so TEGroupedLinear MoE expert weights
+# (`weight0`, `weight1`, …, `weight{global_expert_idx}` after expert_offset
+# rewriting) collapse to the same canonical form.
+_LAYER_IDX_RE = re.compile(r"\.layers\.\d+\.")
+_EXPERT_NUM_RE = re.compile(r"\.(weight|bias)\d+$")
+
+
+def _normalize_glu_param_name(name: str) -> str:
+    name = _LAYER_IDX_RE.sub(".layers.", name)
+    name = _EXPERT_NUM_RE.sub(r".\1", name)
+    return name
 
 
 class _MegatronModelList(list):
@@ -386,6 +403,51 @@ class MegatronEngine(TrainEngine):
                     delattr(param, "clear_high_precision_init_val")
 
         assert self.model, "Megatron models failed to initialize."
+
+        # Detect which linear_fc1 params belong to GLU MLPs by comparing weight
+        # shapes: if fc1.weight.shape[0] == 2 * fc2.weight.shape[1] at the TP-local
+        # level, the MLP is gated and fc1 needs stride-2 de-interleave at TP>1.
+        # Shape-based detection is model-agnostic and doesn't rely on config flags.
+        # Names are stored with layer indices stripped so they match across PP
+        # ranks: `model.named_modules()` yields LOCAL indices (0..N_local-1) while
+        # `get_named_parameters` rewrites them to GLOBAL indices via layer_offset.
+        # Also handles TEGroupedLinear (MoE grouped experts), which exposes per-
+        # expert `weight0`/`weight1`/... in place of a single `.weight`.
+        self._glu_fc1_names: set[str] = set()
+        for model in self.model:
+            for mod_name, module in model.named_modules():
+                fc1 = getattr(module, "linear_fc1", None)
+                fc2 = getattr(module, "linear_fc2", None)
+                if fc1 is None or fc2 is None:
+                    continue
+                # Pick a representative weight: standard linear has `.weight`;
+                # TEGroupedLinear has `weight0` per local expert (all experts
+                # share the same shape).
+                fc1_w = getattr(fc1, "weight", None)
+                if fc1_w is None:
+                    fc1_w = getattr(fc1, "weight0", None)
+                fc2_w = getattr(fc2, "weight", None)
+                if fc2_w is None:
+                    fc2_w = getattr(fc2, "weight0", None)
+                if fc1_w is None or fc2_w is None:
+                    continue
+                fc1_out = fc1_w.shape[0]
+                fc2_in = fc2_w.shape[1] if fc2_w.dim() >= 2 else fc2_w.shape[0]
+                if fc1_out != 2 * fc2_in:
+                    continue
+                # Iterate fc1's direct parameters (recurse=False) and pick
+                # `weight`/`bias` plus their grouped-MoE numbered variants.
+                for p_name, _ in fc1.named_parameters(recurse=False):
+                    base = p_name.rstrip("0123456789")
+                    if base not in ("weight", "bias"):
+                        continue
+                    full_name = (
+                        f"{mod_name}.linear_fc1.{p_name}"
+                        if mod_name
+                        else f"linear_fc1.{p_name}"
+                    )
+                    self._glu_fc1_names.add(_normalize_glu_param_name(full_name))
+
         modules = [m.module if isinstance(m, DDP) else m for m in self.model]
         total_params = sum(
             param.numel() for module in modules for param in module.parameters()
@@ -1351,12 +1413,15 @@ class MegatronEngine(TrainEngine):
         Returns:
             Tuple of (prepared_param, param_size_in_bytes)
         """
+        normalized = _normalize_glu_param_name(name)
+        is_glu = any(normalized.endswith(glu_name) for glu_name in self._glu_fc1_names)
         param = all_gather_param(
             name,
             param,
             self.fp8_direct_convert,
             quantization_config=self.quantization_config,
             duplicated_param_names=self._duplicated_param_names,
+            gated_linear_unit=is_glu,
         )
         param = remove_padding(name, param, self.hf_config.vocab_size)
 

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -55,7 +55,7 @@ from areal.engine.core.distributed import (
     init_custom_process_group,
     warmup_process_groups,
 )
-from areal.engine.core.model import disable_dropout_in_model
+from areal.engine.core.model import disable_dropout_in_model, is_valid_vision_model
 from areal.engine.megatron_utils.checkpointer import MegatronCheckpointManager
 from areal.engine.megatron_utils.deterministic import set_deterministic_algorithms
 from areal.engine.megatron_utils.fp8 import FP8BlockwiseTensorHelper
@@ -67,6 +67,7 @@ from areal.engine.megatron_utils.megatron import (
 )
 from areal.engine.megatron_utils.megatron_lora import get_vllm_lora_target_modules
 from areal.engine.megatron_utils.packed_context_parallel import (
+    extract_vision_from_multi_modal,
     packed_context_parallel_forward,
     split_packed_seqs_for_context_parallel,
 )
@@ -107,7 +108,7 @@ from areal.utils.data import (
     unpad_logits,
 )
 from areal.utils.functional import gather_logprobs, gather_logprobs_entropy
-from areal.utils.hf_utils import load_hf_tokenizer
+from areal.utils.hf_utils import load_hf_processor_and_tokenizer, load_hf_tokenizer
 from areal.utils.lock import DistributedLock
 from areal.utils.network import find_free_ports, format_host_for_url, gethostip
 from areal.utils.offload import is_tms_enabled, torch_memory_saver
@@ -181,6 +182,8 @@ class MegatronEngine(TrainEngine):
         self.quantization_config: dict[str, int | str | list[str]] | None = None
         self.bridge_cls: str = getattr(self.mcore_config, "bridge_type", "mbridge")
         self.bridge_lora: MegatronBridgeLoRA | None = None
+        self.is_vision_model: bool = False
+        self.processor = None
 
     def create_process_group(self, parallel_strategy: ParallelStrategy | None = None):
         if parallel_strategy is None:
@@ -315,6 +318,22 @@ class MegatronEngine(TrainEngine):
             self.tf_config = configure_pipeline_layer_splits(
                 self.parallel_strategy, self.hf_config, self.tf_config
             )
+
+            self.is_vision_model = is_valid_vision_model(self.hf_config.model_type)
+            if self.is_vision_model:
+                if self.parallel_strategy.context_parallel_size > 1:
+                    raise NotImplementedError(
+                        "Context parallel (CP > 1) is not supported with VLM models. "
+                        f"Got context_parallel_size={self.parallel_strategy.context_parallel_size} "
+                        f"for model_type={self.hf_config.model_type}."
+                    )
+                self.processor, self.tokenizer = load_hf_processor_and_tokenizer(
+                    self.config.path
+                )
+                self.logger.info(
+                    f"VLM model detected (type={self.hf_config.model_type}). "
+                    f"Loaded processor and tokenizer."
+                )
 
             self.quantization_config = getattr(
                 self.hf_config, "quantization_config", None
@@ -744,6 +763,7 @@ class MegatronEngine(TrainEngine):
                 model,
                 mb_input.padded_mb,
                 gather_cp_output=not cp_local,
+                is_vision_model=self.is_vision_model,
             )
 
             # Release tree attention metadata after forward pass
@@ -1378,6 +1398,7 @@ class MegatronEngine(TrainEngine):
                 param,
                 quantization_config=self.quantization_config,
                 fp8_direct_convert=self.fp8_direct_convert,
+                hf_config=self.hf_config,
             )
         )
         buffer_size += param_size
@@ -1450,6 +1471,7 @@ class MegatronEngine(TrainEngine):
                     param,
                     quantization_config=self.quantization_config,
                     fp8_direct_convert=self.fp8_direct_convert,
+                    hf_config=self.hf_config,
                 )
             )
 
@@ -1593,7 +1615,7 @@ class MegatronEngine(TrainEngine):
             self.rollout_engine.pause_generation()
             fut = self.rollout_engine.update_weights_from_disk(meta)
 
-        self._save_model_to_hf(meta.path, self.tokenizer, None)
+        self._save_model_to_hf(meta.path, self.tokenizer, self.processor)
         # dist.barrier() are called when _save_model_to_hf finished
 
         if dist.get_rank() == 0:
@@ -1707,8 +1729,9 @@ class MegatronEngine(TrainEngine):
                     f" minimum ({recommended_min_n_mbs}) to avoid pipeline bubbles."
                 )
             return mb_list
-        # Amend position ids
-        input_ = amend_position_ids(input_)
+        # Amend position ids (skip for VLM — model computes mRoPE internally)
+        if not self.is_vision_model:
+            input_ = amend_position_ids(input_)
         # Split the input into micro-batches
         # NOTE: Here we use 2*pp_size in forward to align logprob precision
         # TODO: Performance check
@@ -1763,6 +1786,12 @@ class MegatronEngine(TrainEngine):
             mb["max_seqlen"] = int(mb["max_seqlen"])
         for mb in mb_list.padded_mbs:
             mb["max_seqlen"] = int(mb["max_seqlen"])
+
+        # Extract vision data from multi_modal_input into top-level keys
+        if self.is_vision_model:
+            for mb, padded_mb in zip(mb_list.mbs, mb_list.padded_mbs):
+                extract_vision_from_multi_modal(mb, padded_mb)
+
         return mb_list
 
     def _compute_logprobs_and_loss(

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -404,49 +404,7 @@ class MegatronEngine(TrainEngine):
 
         assert self.model, "Megatron models failed to initialize."
 
-        # Detect which linear_fc1 params belong to GLU MLPs by comparing weight
-        # shapes: if fc1.weight.shape[0] == 2 * fc2.weight.shape[1] at the TP-local
-        # level, the MLP is gated and fc1 needs stride-2 de-interleave at TP>1.
-        # Shape-based detection is model-agnostic and doesn't rely on config flags.
-        # Names are stored with layer indices stripped so they match across PP
-        # ranks: `model.named_modules()` yields LOCAL indices (0..N_local-1) while
-        # `get_named_parameters` rewrites them to GLOBAL indices via layer_offset.
-        # Also handles TEGroupedLinear (MoE grouped experts), which exposes per-
-        # expert `weight0`/`weight1`/... in place of a single `.weight`.
-        self._glu_fc1_names: set[str] = set()
-        for model in self.model:
-            for mod_name, module in model.named_modules():
-                fc1 = getattr(module, "linear_fc1", None)
-                fc2 = getattr(module, "linear_fc2", None)
-                if fc1 is None or fc2 is None:
-                    continue
-                # Pick a representative weight: standard linear has `.weight`;
-                # TEGroupedLinear has `weight0` per local expert (all experts
-                # share the same shape).
-                fc1_w = getattr(fc1, "weight", None)
-                if fc1_w is None:
-                    fc1_w = getattr(fc1, "weight0", None)
-                fc2_w = getattr(fc2, "weight", None)
-                if fc2_w is None:
-                    fc2_w = getattr(fc2, "weight0", None)
-                if fc1_w is None or fc2_w is None:
-                    continue
-                fc1_out = fc1_w.shape[0]
-                fc2_in = fc2_w.shape[1] if fc2_w.dim() >= 2 else fc2_w.shape[0]
-                if fc1_out != 2 * fc2_in:
-                    continue
-                # Iterate fc1's direct parameters (recurse=False) and pick
-                # `weight`/`bias` plus their grouped-MoE numbered variants.
-                for p_name, _ in fc1.named_parameters(recurse=False):
-                    base = p_name.rstrip("0123456789")
-                    if base not in ("weight", "bias"):
-                        continue
-                    full_name = (
-                        f"{mod_name}.linear_fc1.{p_name}"
-                        if mod_name
-                        else f"linear_fc1.{p_name}"
-                    )
-                    self._glu_fc1_names.add(_normalize_glu_param_name(full_name))
+        self._glu_fc1_names: set[str] = self._build_glu_fc1_names()
 
         modules = [m.module if isinstance(m, DDP) else m for m in self.model]
         total_params = sum(
@@ -496,6 +454,53 @@ class MegatronEngine(TrainEngine):
         model_config.finalize_model_grads_func = finalize_model_grads
         self._create_optimizer(ft_spec)
         self._initialized = True
+
+    def _build_glu_fc1_names(self) -> set[str]:
+        """Detect which `linear_fc1` parameters belong to GLU MLPs.
+
+        Compares weight shapes: if ``fc1.weight.shape[0] == 2 * fc2.weight.shape[1]``
+        at the TP-local level, the MLP is gated and fc1 needs stride-2 de-interleave
+        at TP>1. Shape-based detection is model-agnostic and doesn't rely on config
+        flags. Names are stored with layer indices and per-expert numeric suffixes
+        stripped so they match across PP ranks (`model.named_modules()` yields LOCAL
+        indices while `get_named_parameters` rewrites to GLOBAL via `layer_offset`)
+        and across TEGroupedLinear MoE expert weights (`weight0`, `weight1`, ...).
+        """
+        glu_fc1_names: set[str] = set()
+        for model in self.model:
+            for mod_name, module in model.named_modules():
+                fc1 = getattr(module, "linear_fc1", None)
+                fc2 = getattr(module, "linear_fc2", None)
+                if fc1 is None or fc2 is None:
+                    continue
+                # Pick a representative weight: standard linear has `.weight`;
+                # TEGroupedLinear has `weight0` per local expert (all experts
+                # share the same shape).
+                fc1_w = getattr(fc1, "weight", None)
+                if fc1_w is None:
+                    fc1_w = getattr(fc1, "weight0", None)
+                fc2_w = getattr(fc2, "weight", None)
+                if fc2_w is None:
+                    fc2_w = getattr(fc2, "weight0", None)
+                if fc1_w is None or fc2_w is None:
+                    continue
+                fc1_out = fc1_w.shape[0]
+                fc2_in = fc2_w.shape[1] if fc2_w.dim() >= 2 else fc2_w.shape[0]
+                if fc1_out != 2 * fc2_in:
+                    continue
+                # Iterate fc1's direct parameters (recurse=False) and pick
+                # `weight`/`bias` plus their grouped-MoE numbered variants.
+                for p_name, _ in fc1.named_parameters(recurse=False):
+                    base = p_name.rstrip("0123456789")
+                    if base not in ("weight", "bias"):
+                        continue
+                    full_name = (
+                        f"{mod_name}.linear_fc1.{p_name}"
+                        if mod_name
+                        else f"linear_fc1.{p_name}"
+                    )
+                    glu_fc1_names.add(_normalize_glu_param_name(full_name))
+        return glu_fc1_names
 
     def _build_hf_mcore_bridge(self):
         if self.bridge_cls == "mbridge":

--- a/areal/engine/megatron_utils/megatron.py
+++ b/areal/engine/megatron_utils/megatron.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
+import inspect
 import re
 
 import torch
@@ -23,6 +25,11 @@ from areal.engine.megatron_utils.megatron_lora import (
 )
 
 
+@functools.cache
+def _accepts_hf_config(fn) -> bool:
+    return "hf_config" in inspect.signature(fn).parameters
+
+
 def _all_gather_and_concat(
     tensor: torch.Tensor,
     tp_size: int,
@@ -30,6 +37,7 @@ def _all_gather_and_concat(
     partition_dim: int,
     partition_stride: int,
     name: str,
+    gated_linear_unit: bool = False,
 ) -> torch.Tensor:
     """All-gather tensor partitions and concatenate along partition dimension.
 
@@ -38,6 +46,21 @@ def _all_gather_and_concat(
     these must be de-interleaved before concatenation to reconstruct the correct
     full tensor.
     """
+    # mcore sets partition_stride=1 for ``linear_fc1.weight|bias`` even when
+    # gated_linear_unit=True, but the per-rank storage is ``[gate_local | up_local]``
+    # (what makes the in-place ``chunk(2, dim=-1)`` in MLP.forward valid). Without
+    # de-interleaving here, plain cat yields ``[gate_r0 | up_r0 | gate_r1 | up_r1]``
+    # and downstream ``chunk(2)`` mislabels mixed halves as gate_proj/up_proj.
+    # Override to stride=2 to trigger the de-interleave below.
+    # Covers both ``mlp.linear_fc1`` (language/vision) and
+    # ``projection.encoder.linear_fc1`` (vision→language merger).
+    if (
+        gated_linear_unit
+        and partition_stride == 1
+        and ("linear_fc1.weight" in name or "linear_fc1.bias" in name)
+    ):
+        partition_stride = 2
+
     partitions = [torch.empty_like(tensor) for _ in range(tp_size)]
     dist.all_gather(partitions, tensor, group=tp_group)
 
@@ -68,6 +91,7 @@ def _all_gather_fp8_tensor_and_concat(
     partition_stride: int,
     name: str,
     block_size: int = 128,
+    gated_linear_unit: bool = False,
 ) -> FP8BlockwiseTensorHelper:
     """All-gather a Float8BlockwiseQTensor along the partition dimension.
 
@@ -75,7 +99,13 @@ def _all_gather_fp8_tensor_and_concat(
     This allows conversion functions to work with FP8 tensors as regular tensors.
     """
     gathered_rowwise_data = _all_gather_and_concat(
-        tensor._rowwise_data, tp_size, tp_group, partition_dim, partition_stride, name
+        tensor._rowwise_data,
+        tp_size,
+        tp_group,
+        partition_dim,
+        partition_stride,
+        name,
+        gated_linear_unit=gated_linear_unit,
     )
     gathered_rowwise_scale_inv = _all_gather_and_concat(
         tensor._rowwise_scale_inv,
@@ -84,6 +114,7 @@ def _all_gather_fp8_tensor_and_concat(
         partition_dim,
         partition_stride,
         name,
+        gated_linear_unit=gated_linear_unit,
     )
 
     return FP8BlockwiseTensorHelper(
@@ -98,6 +129,7 @@ def all_gather_param(
     fp8_direct_convert: bool = False,
     quantization_config: dict[str, int | str | list[str]] | None = None,
     duplicated_param_names: set[str] | None = None,
+    gated_linear_unit: bool = False,
 ) -> torch.Tensor | FP8BlockwiseTensorHelper:
     if "expert_bias" in name:
         return param
@@ -142,12 +174,25 @@ def all_gather_param(
     if param_is_fp8 and fp8_direct_convert:
         block_size = get_block_size_from_config(quantization_config)
         return _all_gather_fp8_tensor_and_concat(
-            param, tp_size, tp_group, partition_dim, partition_stride, name, block_size
+            param,
+            tp_size,
+            tp_group,
+            partition_dim,
+            partition_stride,
+            name,
+            block_size,
+            gated_linear_unit=gated_linear_unit,
         )
 
     # bf16/fp32
     param = _all_gather_and_concat(
-        param.data, tp_size, tp_group, partition_dim, partition_stride, name
+        param.data,
+        tp_size,
+        tp_group,
+        partition_dim,
+        partition_stride,
+        name,
+        gated_linear_unit=gated_linear_unit,
     )
     return param
 
@@ -156,9 +201,11 @@ def all_gather_param(
 def remove_padding(
     name: str, param: Parameter | Tensor | FP8BlockwiseTensorHelper, vocab_size: int
 ):
-    if (
-        name == "module.module.embedding.word_embeddings.weight"
-        or name == "module.module.output_layer.weight"
+    if name in (
+        "module.module.embedding.word_embeddings.weight",
+        "module.module.output_layer.weight",
+        "module.module.language_model.embedding.word_embeddings.weight",
+        "module.module.language_model.output_layer.weight",
     ):
         return param[:vocab_size]
     return param
@@ -317,6 +364,116 @@ def convert_qwen3moe_to_hf(
             return [(f"model.layers.{layer_idx}.self_attn.q_norm.weight", param)]
         elif rest == "self_attention.k_layernorm.weight":
             return [(f"model.layers.{layer_idx}.self_attn.k_norm.weight", param)]
+
+    raise ValueError(f"Unknown parameter name: {name}")
+
+
+def _vision_qkv_mcore_to_hf(param: Tensor, vision_num_heads: int) -> Tensor:
+    """Convert vision encoder QKV from mcore interleaved to HF grouped format.
+
+    mcore: per-head interleaved [num_heads, 3, head_dim, H] flattened to [3*H_v, H_v]
+    HF:    grouped [3, num_heads, head_dim, H] flattened to [3*H_v, H_v]
+
+    Reverse of mbridge Qwen2_5VLBridge._weight_to_mcore_format for vision QKV.
+
+    Args:
+        param: Vision QKV weight [3*hidden_vision, hidden_vision] or bias [3*hidden_vision]
+        vision_num_heads: Number of attention heads in the vision encoder
+    """
+    hidden_vision = param.shape[0] // 3
+    head_dim = hidden_vision // vision_num_heads
+    is_bias = param.ndim == 1
+
+    if is_bias:
+        x = param.view(vision_num_heads, 3, head_dim)
+        return x.permute(1, 0, 2).contiguous().view(-1)
+    else:
+        in_features = param.shape[-1]
+        x = param.view(vision_num_heads, 3, head_dim, in_features)
+        return x.permute(1, 0, 2, 3).contiguous().view(-1, in_features)
+
+
+def convert_qwen2_5_vl_to_hf(
+    tf_config: TransformerConfig,
+    name: str,
+    param: Parameter | Tensor | FP8BlockwiseTensorHelper,
+    hf_config=None,
+):
+    """Convert Qwen2.5-VL Megatron parameters to HuggingFace format.
+
+    Handles both vision_model and language_model parameters.
+    Language model params are delegated to convert_qwen2_to_hf after
+    stripping the 'language_model.' prefix.
+    """
+    # --- Language model: strip prefix and delegate ---
+    _LM_PREFIX = "module.module.language_model."
+    if name.startswith(_LM_PREFIX):
+        lm_name = "module.module." + name[len(_LM_PREFIX) :]
+        return convert_qwen2_to_hf(tf_config, lm_name, param)
+
+    # --- Vision model direct mappings ---
+    _VISION_DIRECT = {
+        "module.module.vision_model.patch_embed.proj.weight": "visual.patch_embed.proj.weight",
+        "module.module.vision_model.decoder.final_layernorm.weight": "visual.merger.ln_q.weight",
+        "module.module.vision_model.projection.encoder.linear_fc1.weight": "visual.merger.mlp.0.weight",
+        "module.module.vision_model.projection.encoder.linear_fc1.bias": "visual.merger.mlp.0.bias",
+        "module.module.vision_model.projection.encoder.linear_fc2.weight": "visual.merger.mlp.2.weight",
+        "module.module.vision_model.projection.encoder.linear_fc2.bias": "visual.merger.mlp.2.bias",
+    }
+    if name in _VISION_DIRECT:
+        return [(_VISION_DIRECT[name], param)]
+
+    # --- Vision model per-layer params ---
+    vision_layers_pattern = (
+        r"module\.module\.vision_model\.decoder\.layers\.(\d+)\.(.+)"
+    )
+    match = re.match(vision_layers_pattern, name)
+    if match:
+        layer_idx, rest = match.groups()
+
+        # Attention — vision QKV needs reordering from mcore interleaved
+        # [num_heads, 3*head_dim, ...] to HF grouped [3*num_heads*head_dim, ...]
+        if rest in (
+            "self_attention.linear_qkv.weight",
+            "self_attention.linear_qkv.bias",
+        ):
+            vision_num_heads = getattr(
+                getattr(hf_config, "vision_config", None), "num_heads", None
+            )
+            if vision_num_heads is None:
+                raise ValueError(
+                    "hf_config.vision_config.num_heads is required for vision QKV "
+                    "conversion. Pass hf_config to convert_to_hf()."
+                )
+            param = _vision_qkv_mcore_to_hf(param, vision_num_heads)
+            hf_key = "weight" if "weight" in rest else "bias"
+            return [(f"visual.blocks.{layer_idx}.attn.qkv.{hf_key}", param)]
+        elif rest == "self_attention.linear_proj.weight":
+            return [(f"visual.blocks.{layer_idx}.attn.proj.weight", param)]
+        elif rest == "self_attention.linear_proj.bias":
+            return [(f"visual.blocks.{layer_idx}.attn.proj.bias", param)]
+        elif rest == "self_attention.linear_qkv.layer_norm_weight":
+            return [(f"visual.blocks.{layer_idx}.norm1.weight", param)]
+
+        # MLP
+        elif rest == "mlp.linear_fc1.weight":
+            gate_weight, up_weight = param.chunk(2, dim=0)
+            return [
+                (f"visual.blocks.{layer_idx}.mlp.gate_proj.weight", gate_weight),
+                (f"visual.blocks.{layer_idx}.mlp.up_proj.weight", up_weight),
+            ]
+        elif rest == "mlp.linear_fc1.bias":
+            gate_bias, up_bias = param.chunk(2, dim=0)
+            return [
+                (f"visual.blocks.{layer_idx}.mlp.gate_proj.bias", gate_bias),
+                (f"visual.blocks.{layer_idx}.mlp.up_proj.bias", up_bias),
+            ]
+        elif rest == "mlp.linear_fc2.weight":
+            return [(f"visual.blocks.{layer_idx}.mlp.down_proj.weight", param)]
+        elif rest == "mlp.linear_fc2.bias":
+            return [(f"visual.blocks.{layer_idx}.mlp.down_proj.bias", param)]
+        elif rest == "mlp.linear_fc1.layer_norm_weight":
+            return [(f"visual.blocks.{layer_idx}.norm2.weight", param)]
 
     raise ValueError(f"Unknown parameter name: {name}")
 
@@ -767,6 +924,7 @@ _CONVERSION_FN_REGISTRY = {
     "qwen3_lora": convert_qwen3_lora_to_hf,
     "qwen2_lora": convert_qwen3_lora_to_hf,
     "qwen3_moe_lora": convert_qwen3_moe_lora_to_hf,
+    "qwen2_5_vl": convert_qwen2_5_vl_to_hf,
     "qwen3_moe": convert_qwen3moe_to_hf,
     "qwen2": convert_qwen2_to_hf,
     "qwen3": convert_qwen2_to_hf,
@@ -784,6 +942,7 @@ def convert_to_hf(
     param: Parameter | Tensor | FP8BlockwiseTensorHelper,
     quantization_config: dict[str, int | str | list[str]] | None = None,
     fp8_direct_convert: bool = False,
+    hf_config=None,
 ):
     """Convert Megatron parameter to HuggingFace format, optionally with FP8 quantization.
 
@@ -799,6 +958,8 @@ def convert_to_hf(
             - weight_block_size: Optional tuple/list of [block_m, block_n] for blockwise quantization
         fp8_direct_convert: If True, directly convert TE FP8 tensors to PyTorch FP8 format.
             If False, dequantize TE FP8 to bf16 first, then quantize to PyTorch FP8.
+        hf_config: Optional HuggingFace PretrainedConfig. Required for VLM models
+            that need vision_config for weight conversion (e.g., vision QKV reordering).
 
     Returns:
         List of (name, tensor) tuples in HuggingFace format. For FP8 quantization,
@@ -806,7 +967,13 @@ def convert_to_hf(
     """
     for key, conversion_fn in _CONVERSION_FN_REGISTRY.items():
         if key in model_name:
-            converted_named_tensors = conversion_fn(tf_config, name, param)
+            # Pass hf_config to converters that accept it (e.g., VLM models)
+            if _accepts_hf_config(conversion_fn):
+                converted_named_tensors = conversion_fn(
+                    tf_config, name, param, hf_config=hf_config
+                )
+            else:
+                converted_named_tensors = conversion_fn(tf_config, name, param)
             if quantization_config:
                 if fp8_direct_convert:
                     return convert_fp8_helper_to_pytorch_fp8(converted_named_tensors)
@@ -852,7 +1019,14 @@ def get_named_parameters(model_module, num_experts):
             if not name.startswith("module.module."):
                 name = "module." + name
 
-            decoder_layers_pattern = r"module\.module\.decoder\.layers\.(\d+)\.(.+)"
+            # Match either text-only (module.module.decoder.layers.X) or VLM
+            # (module.module.language_model.decoder.layers.X) — both share the
+            # same layer_offset (here `config` is the language_model config).
+            # Vision blocks (module.module.vision_model.decoder.layers.X) are
+            # intentionally not matched: vision is not PP-split.
+            decoder_layers_pattern = (
+                r"module\.module\.(language_model\.)?decoder\.layers\.(\d+)\.(.+)"
+            )
             match = re.match(decoder_layers_pattern, name)
             if not match:
                 mtp_layers_pattern = r"module\.module\.mtp\.layers\.(\d+)\.(.+)"
@@ -877,7 +1051,8 @@ def get_named_parameters(model_module, num_experts):
                 )
                 continue
 
-            layer_idx, rest = match.groups()
+            lm_prefix, layer_idx, rest = match.groups()
+            lm_prefix = lm_prefix or ""
             layer_idx = int(layer_idx) + layer_offset
 
             # this is hardcoded for te grouped matmul
@@ -887,11 +1062,14 @@ def get_named_parameters(model_module, num_experts):
                 rest, expert_idx = match.groups()
                 expert_idx = int(expert_idx) + expert_offset
                 yield (
-                    f"module.module.decoder.layers.{layer_idx}.mlp.experts.{rest}.weight{expert_idx}",
+                    f"module.module.{lm_prefix}decoder.layers.{layer_idx}.mlp.experts.{rest}.weight{expert_idx}",
                     param,
                 )
             else:
-                yield f"module.module.decoder.layers.{layer_idx}.{rest}", param
+                yield (
+                    f"module.module.{lm_prefix}decoder.layers.{layer_idx}.{rest}",
+                    param,
+                )
 
         # treat expert bias as normal parameters
         for name, buffer in single_module.named_buffers():
@@ -901,14 +1079,20 @@ def get_named_parameters(model_module, num_experts):
             if not name.startswith("module.module."):
                 name = "module." + name
 
-            decoder_layers_pattern = r"module\.module\.decoder\.layers\.(\d+)\.(.+)"
+            decoder_layers_pattern = (
+                r"module\.module\.(language_model\.)?decoder\.layers\.(\d+)\.(.+)"
+            )
             match = re.match(decoder_layers_pattern, name)
             if not match:
                 yield name, buffer
             else:
-                layer_idx, rest = match.groups()
+                lm_prefix, layer_idx, rest = match.groups()
+                lm_prefix = lm_prefix or ""
                 layer_idx = int(layer_idx) + layer_offset
-                yield f"module.module.decoder.layers.{layer_idx}.{rest}", buffer
+                yield (
+                    f"module.module.{lm_prefix}decoder.layers.{layer_idx}.{rest}",
+                    buffer,
+                )
 
     if isinstance(model_module, (list, tuple)):
         try:

--- a/areal/engine/megatron_utils/megatron.py
+++ b/areal/engine/megatron_utils/megatron.py
@@ -411,7 +411,14 @@ def convert_qwen2_5_vl_to_hf(
         lm_name = "module.module." + name[len(_LM_PREFIX) :]
         return convert_qwen2_to_hf(tf_config, lm_name, param)
 
-    # --- Vision model direct mappings ---
+    # --- megatron-bridge: vision tower stored in HF format under self.visual.* ---
+    # (vs mbridge's self.vision_model.* in mcore format). Just strip the
+    # "module.module." prefix and emit the HF name directly.
+    _MB_VISUAL_PREFIX = "module.module.visual."
+    if name.startswith(_MB_VISUAL_PREFIX):
+        return [(name[len("module.module.") :], param)]
+
+    # --- mbridge vision tower (mcore format) — direct mappings ---
     _VISION_DIRECT = {
         "module.module.vision_model.patch_embed.proj.weight": "visual.patch_embed.proj.weight",
         "module.module.vision_model.decoder.final_layernorm.weight": "visual.merger.ln_q.weight",

--- a/areal/engine/megatron_utils/packed_context_parallel.py
+++ b/areal/engine/megatron_utils/packed_context_parallel.py
@@ -163,13 +163,36 @@ def postprocess_packed_seqs_context_parallel(
     return output_new
 
 
+_VLM_FORWARD_KEYS = ("pixel_values", "image_grid_thw", "video_grid_thw")
+
+
+def extract_vision_from_multi_modal(
+    mb: dict[str, Any], padded_mb: dict[str, Any]
+) -> None:
+    """Extract pixel_values, image_grid_thw, video_grid_thw from multi_modal_input.
+
+    Mirrors the logic in FSDPEngine._prepare_mb_list. After extraction, vision
+    tensors are placed as top-level keys in both ``mb`` and ``padded_mb``.
+    """
+    if "multi_modal_input" not in mb:
+        return
+    multi_modal_input = mb["multi_modal_input"]
+    for key in _VLM_FORWARD_KEYS:
+        items = [item[key] for item in multi_modal_input if key in item]
+        if items:
+            concatenated = torch.cat(items, dim=0)
+            mb[key] = concatenated
+            padded_mb[key] = concatenated
+
+
 def packed_context_parallel_forward(
     model: torch.nn.Module,
     input_: dict[str, Any],
     gather_cp_output: bool = True,
+    is_vision_model: bool = False,
 ):
     input_ids = input_["input_ids"]
-    position_ids = input_["position_ids"]
+    position_ids = input_.get("position_ids", None)
     cu_seqlens = input_.get("cu_seqlens", None)
     # `attention_mask`: dense torch.Tensor (flex attention with Megatron) or None.
     # `tree_triton_data`: read from a separate key; takes priority over
@@ -178,21 +201,66 @@ def packed_context_parallel_forward(
     tree_triton_data = input_.get("tree_triton_data", None)
     packed_seq_params = None
 
+    is_vision = is_vision_model and any(key in input_ for key in _VLM_FORWARD_KEYS)
+
+    # Track whether we reconstructed 2D batch form for vision
+    vision_repack_info = None
+
     if cu_seqlens is not None:
-        if attention_mask is not None or tree_triton_data is not None:
-            raise ValueError(
-                "Attention mask should be None when using packed sequences."
+        if not is_vision:
+            if attention_mask is not None or tree_triton_data is not None:
+                raise ValueError(
+                    "Attention mask should be None when using packed sequences."
+                )
+            input_ids, packed_seq_params = preprocess_packed_seqs_context_parallel(
+                input_ids, cu_seqlens
             )
-        input_ids, packed_seq_params = preprocess_packed_seqs_context_parallel(
-            input_ids, cu_seqlens
-        )
-        input_ids = input_ids.contiguous()
+            input_ids = input_ids.contiguous()
+        else:
+            # VLM models expect batch-form [B, S] input_ids for mRoPE position
+            # computation and vision token embedding replacement. Reconstruct
+            # padded 2D tensors from packed 1D using cu_seqlens via boolean
+            # masking — avoids per-sample Python loop and GPU-CPU sync.
+            batch_size = cu_seqlens.shape[0] - 1
+            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+            max_seqlen = int(seq_lens.max().item())
+            # int64 for input_ids: mbridge's get_rope_index uses input_ids.dtype
+            # for position_ids, and some kernels (_index_put_impl_) require int64.
+            # Upcast to torch.long so the scatter `input_ids_2d[mask] = input_ids`
+            # below has matching source/dest dtypes (data pipeline may emit int32).
+            if input_ids.dtype != torch.long:
+                input_ids = input_ids.to(torch.long)
+            attention_mask = (
+                torch.arange(max_seqlen, device=input_ids.device)[None, :]
+                < seq_lens[:, None]
+            )
+            input_ids_2d = torch.zeros(
+                batch_size, max_seqlen, dtype=torch.long, device=input_ids.device
+            )
+            input_ids_2d[attention_mask] = input_ids
+            input_ids = input_ids_2d
+            vision_repack_info = (cu_seqlens, seq_lens, max_seqlen)
 
     # Pass tree_triton_data as attention_mask if present (for Triton tree attention)
     # Otherwise use the attention_mask from input (could be dense tensor for flex attention)
-    final_attention_mask = (
-        tree_triton_data if tree_triton_data is not None else attention_mask
-    )
+    # For VLM: pass None — the model's get_rope_index uses the 2D attention_mask
+    # internally for correct mRoPE positions. Each batch slot holds one sequence
+    # with trailing padding, so causal attention yields correct outputs at
+    # non-padding positions; padding outputs are discarded during repack.
+    if is_vision:
+        final_attention_mask = None
+    else:
+        final_attention_mask = (
+            tree_triton_data if tree_triton_data is not None else attention_mask
+        )
+
+    # VLM: pass vision inputs through to model forward. The VLM model computes
+    # mRoPE position_ids internally, so position_ids remains None for VLM.
+    vlm_kwargs: dict[str, Any] = {}
+    if is_vision:
+        for key in _VLM_FORWARD_KEYS:
+            if key in input_:
+                vlm_kwargs[key] = input_[key]
 
     try:
         output = model(
@@ -200,6 +268,7 @@ def packed_context_parallel_forward(
             attention_mask=final_attention_mask,
             position_ids=position_ids,
             packed_seq_params=packed_seq_params,
+            **vlm_kwargs,
         )
     except Exception as e:
         raise RuntimeError(
@@ -211,6 +280,22 @@ def packed_context_parallel_forward(
     is_pipeline_last_stage = mpu.is_pipeline_last_stage(
         ignore_virtual=False, vp_stage=model_vp_stage
     )
+
+    # Repack vision output to packed [total_len, ...] for the last PP stage only.
+    # Intermediate stages must return their output unchanged so the pipeline
+    # send/recv shapes match what the next stage expects (megatron-core's
+    # `_communicate_shapes` negotiates based on this return value).
+    #
+    # On the last PP stage, megatron-core GPTModel returns logits already
+    # transposed to [B, S, V] (gpt_model.py: `return logits.transpose(0, 1).contiguous()`),
+    # so a boolean mask of valid positions selects the packed sequence.
+    if vision_repack_info is not None and is_pipeline_last_stage:
+        _, repack_seq_lens, repack_max_seqlen = vision_repack_info
+        mask = (
+            torch.arange(repack_max_seqlen, device=output.device)[None, :]
+            < repack_seq_lens[:, None]
+        )
+        output = output[mask]
     output = postprocess_packed_seqs_context_parallel(
         output, cu_seqlens, is_pipeline_last_stage, gather_output=gather_cp_output
     )

--- a/areal/models/mcore/hf_load.py
+++ b/areal/models/mcore/hf_load.py
@@ -78,14 +78,14 @@ def _load_fused_qkv_weight(
     tp_rank: int,
     tp_size: int,
 ) -> torch.Tensor:
-    """Load fused QKV weight for Lightning Attention, with format conversion and TP slicing.
+    """Load fused QKV weight/bias with format conversion and TP slicing.
 
-    HF stores Lightning Attention QKV in concatenated format:
+    HF stores fused QKV in concatenated format:
         [Q_all, K_all, V_all] along dim 0, i.e., [q0,...,qH, k0,...,kH, v0,...,vH].
     Megatron-core expects interleaved format:
         [H, 3, D] along dim 0, i.e., [q0,k0,v0, q1,k1,v1, ...].
 
-    This function converts from HF concatenated to mcore interleaved, then TP-slices.
+    Handles both 2D weights [qkv_size, hidden] and 1D biases [qkv_size].
     """
     assert len(hf_weights_safe_slice) == 1
     x = hf_weights_safe_slice[0]
@@ -94,29 +94,45 @@ def _load_fused_qkv_weight(
     num_heads = hf_config.num_attention_heads
     num_kv_heads = getattr(hf_config, "num_key_value_heads", num_heads)
     head_dim = x.shape[0] // (num_heads + 2 * num_kv_heads)
-    hidden = x.shape[1]
+    is_bias = x.dim() == 1
 
-    # Split concatenated [Q_all(H*D), K_all(Kv*D), V_all(Kv*D)] into separate Q, K, V
-    q = x[: num_heads * head_dim].view(num_heads, head_dim, hidden)
-    k = x[num_heads * head_dim : (num_heads + num_kv_heads) * head_dim].view(
-        num_kv_heads, head_dim, hidden
-    )
-    v = x[(num_heads + num_kv_heads) * head_dim :].view(num_kv_heads, head_dim, hidden)
-
-    # For Lightning Attention, num_kv_heads == num_heads (no GQA)
+    # num_kv_heads == num_heads (no GQA) for this path
     assert num_kv_heads == num_heads, (
-        f"Lightning Attention requires num_kv_heads == num_heads (no GQA), "
+        f"_load_fused_qkv_weight requires num_kv_heads == num_heads (no GQA), "
         f"got num_kv_heads={num_kv_heads}, num_heads={num_heads}"
     )
-    # Convert to interleaved: [H, 3, D, hidden] -> [H*3*D, hidden]
-    x = torch.stack([q, k, v], dim=1)  # [H, 3, D, hidden]
-    x = x.reshape(-1, hidden)  # [H*3*D, hidden]
 
-    if tp_size > 1:
-        heads_per_tp = num_heads // tp_size
-        x = x.view(num_heads, 3 * head_dim, hidden)
-        x = x[tp_rank * heads_per_tp : (tp_rank + 1) * heads_per_tp]
-        x = x.reshape(-1, hidden)
+    if is_bias:
+        # 1D bias: [Q_all(H*D), K_all(Kv*D), V_all(Kv*D)]
+        q = x[: num_heads * head_dim].view(num_heads, head_dim)
+        k = x[num_heads * head_dim : (num_heads + num_kv_heads) * head_dim].view(
+            num_kv_heads, head_dim
+        )
+        v = x[(num_heads + num_kv_heads) * head_dim :].view(num_kv_heads, head_dim)
+        x = torch.stack([q, k, v], dim=1)  # [H, 3, D]
+        x = x.reshape(-1)  # [H*3*D]
+        if tp_size > 1:
+            heads_per_tp = num_heads // tp_size
+            x = x.view(num_heads, 3 * head_dim)
+            x = x[tp_rank * heads_per_tp : (tp_rank + 1) * heads_per_tp]
+            x = x.reshape(-1)
+    else:
+        # 2D weight: [Q_all(H*D), K_all(Kv*D), V_all(Kv*D), hidden]
+        hidden = x.shape[1]
+        q = x[: num_heads * head_dim].view(num_heads, head_dim, hidden)
+        k = x[num_heads * head_dim : (num_heads + num_kv_heads) * head_dim].view(
+            num_kv_heads, head_dim, hidden
+        )
+        v = x[(num_heads + num_kv_heads) * head_dim :].view(
+            num_kv_heads, head_dim, hidden
+        )
+        x = torch.stack([q, k, v], dim=1)  # [H, 3, D, hidden]
+        x = x.reshape(-1, hidden)  # [H*3*D, hidden]
+        if tp_size > 1:
+            heads_per_tp = num_heads // tp_size
+            x = x.view(num_heads, 3 * head_dim, hidden)
+            x = x[tp_rank * heads_per_tp : (tp_rank + 1) * heads_per_tp]
+            x = x.reshape(-1, hidden)
 
     return x.contiguous()
 
@@ -176,6 +192,62 @@ def _slice_generic_weight(
         ]
 
 
+def _convert_vision_qkv_hf_to_mcore(
+    hf_config,
+    mcore_weights_name: str,
+    mcore_param_shape: list,
+    hf_weights_safe_slice: list,
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    """Convert vision encoder QKV from HF format to mcore format.
+
+    HF format: grouped [Q_all | K_all | V_all] (3 sections of num_heads*head_dim rows).
+    mcore format: per-head interleaved [head_0(q,k,v) | head_1(q,k,v) | ...].
+    Both have the same total shape but different internal ordering.
+
+    Mirrors mbridge Qwen2_5VLBridge._weight_to_mcore_format for vision QKV.
+    """
+    # If 3 separate Q, K, V tensors, concatenate first into HF grouped format
+    if len(hf_weights_safe_slice) == 3:
+        parts = [
+            w[:] if not isinstance(w, torch.Tensor) else w
+            for w in hf_weights_safe_slice
+        ]
+        x = torch.cat(parts, dim=0)
+    else:
+        x = hf_weights_safe_slice[0]
+        x = x[:] if not isinstance(x, torch.Tensor) else x
+
+    vision_config = getattr(hf_config, "vision_config", None)
+    if vision_config is None:
+        # No vision_config means no special conversion is needed
+        return _slice_generic_weight(mcore_param_shape, [x], tp_rank, tp_size)
+
+    num_heads = vision_config.num_heads
+    hidden_size = vision_config.hidden_size
+    head_dim = hidden_size // num_heads
+    is_bias = ".bias" in mcore_weights_name
+
+    # Reshape from HF grouped format to mcore per-head interleaved format.
+    # HF: [3, num_heads, head_dim, hidden_size] (weight) or [3, num_heads, head_dim] (bias)
+    # mcore: [num_heads, 3*head_dim, hidden_size] (weight) or [num_heads, 3*head_dim] (bias)
+    in_shape = (
+        [3, num_heads, -1, head_dim, hidden_size] if not is_bias else [3, num_heads, -1]
+    )
+    q, k, v = x.view(*in_shape)
+
+    head_shape = [num_heads, head_dim, -1] if not is_bias else [num_heads, head_dim]
+    q = q.view(*head_shape)
+    k = k.view(*head_shape)
+    v = v.view(*head_shape)
+
+    out_shape = [-1, hidden_size] if not is_bias else [-1]
+    fused = torch.cat([q, k, v], dim=1).view(*out_shape).contiguous()
+
+    return _slice_generic_weight(mcore_param_shape, [fused], tp_rank, tp_size)
+
+
 def _weight_to_mcore_tp(
     hf_config,
     mcore_weights_name: str,
@@ -197,21 +269,65 @@ def _weight_to_mcore_tp(
         "self_attention.linear_qkv." in mcore_weights_name
         and "layer_norm" not in mcore_weights_name
     ):
-        if len(hf_weights_safe_slice) == 3:
+        if (
+            len(hf_weights_safe_slice) == 3
+            and "vision_model." not in mcore_weights_name
+        ):
             res = _merge_qkv_weights(
                 hf_config, mcore_weights_name, hf_weights_safe_slice, tp_rank, tp_size
             )
-        else:
-            # Fused QKV weight (e.g., Lightning Attention query_key_value)
-            # Already in megatron interleaved format [H, 3, D] — just TP-slice
-            res = _load_fused_qkv_weight(
-                hf_config, hf_weights_safe_slice, tp_rank, tp_size
+        elif "vision_model." in mcore_weights_name:
+            # Vision encoder QKV: no GQA (num_heads == num_kv_heads). HF stores
+            # QKV in grouped layout [Q_all | K_all | V_all] while mcore uses
+            # per-head interleaved [head_0(q,k,v) | head_1(q,k,v) | ...].
+            # Must convert between these formats (same shape, different ordering).
+            res = _convert_vision_qkv_hf_to_mcore(
+                hf_config,
+                mcore_weights_name,
+                mcore_param_shape,
+                hf_weights_safe_slice,
+                tp_rank,
+                tp_size,
             )
+        else:
+            num_kv_heads = getattr(
+                hf_config, "num_key_value_heads", hf_config.num_attention_heads
+            )
+            if num_kv_heads == hf_config.num_attention_heads:
+                # Fused QKV weight (e.g., Lightning Attention query_key_value)
+                # Already in megatron interleaved format [H, 3, D] — just TP-slice
+                res = _load_fused_qkv_weight(
+                    hf_config, hf_weights_safe_slice, tp_rank, tp_size
+                )
+            else:
+                # Fused QKV with GQA (e.g., Qwen2.5-VL language model qkv_proj)
+                # Split into separate Q, K, V then merge into mcore format.
+                x = hf_weights_safe_slice[0]
+                x = x[:] if not isinstance(x, torch.Tensor) else x
+                num_heads = hf_config.num_attention_heads
+                head_dim = x.shape[0] // (num_heads + 2 * num_kv_heads)
+                q = x[: num_heads * head_dim]
+                k = x[num_heads * head_dim : (num_heads + num_kv_heads) * head_dim]
+                v = x[(num_heads + num_kv_heads) * head_dim :]
+                res = _merge_qkv_weights(
+                    hf_config,
+                    mcore_weights_name,
+                    [q, k, v],
+                    tp_rank,
+                    tp_size,
+                )
     elif (
         "linear_fc1.weight" in mcore_weights_name
         or "linear_fc1.bias" in mcore_weights_name
     ):
-        res = _merge_gate_up_weights(hf_weights_safe_slice, tp_rank, tp_size)
+        if len(hf_weights_safe_slice) == 2:
+            # SwiGLU: merge separate gate_proj + up_proj
+            res = _merge_gate_up_weights(hf_weights_safe_slice, tp_rank, tp_size)
+        else:
+            # Single fc1 weight (e.g., vision encoder MLP without gate/up split)
+            res = _slice_generic_weight(
+                mcore_param_shape, hf_weights_safe_slice, tp_rank, tp_size
+            )
     elif "mlp.experts.linear_fc2.weight" in mcore_weights_name:
         res = _slice_moe_expert_weight(hf_weights_safe_slice, tp_rank, tp_size)
     else:

--- a/areal/models/mcore/registry.py
+++ b/areal/models/mcore/registry.py
@@ -93,13 +93,22 @@ def _replace_output_layer_with_value_head(
 
 
 def unwrap_to_gpt_model(model: torch.nn.Module) -> GPTModel:
-    """Unwraps a model to the underlying GPTModel instance."""
+    """Unwraps a model to the underlying GPTModel instance.
+
+    Handles both plain GPTModel (possibly wrapped in DDP) and VLM models
+    (e.g., Qwen2_5VLModel) where GPTModel lives at ``model.language_model``.
+    """
     _model = model
     while not isinstance(_model, GPTModel) and hasattr(_model, "module"):
         _model = _model.module
-    if not isinstance(_model, GPTModel):
-        raise TypeError(f"Model could not be unwrapped to GPTModel. Got {type(_model)}")
-    return _model
+    if isinstance(_model, GPTModel):
+        return _model
+    # VLM models wrap GPTModel as language_model (e.g., Qwen2_5VLModel)
+    if hasattr(_model, "language_model") and isinstance(
+        _model.language_model, GPTModel
+    ):
+        return _model.language_model
+    raise TypeError(f"Model could not be unwrapped to GPTModel. Got {type(_model)}")
 
 
 # Model registry for different architectures

--- a/tests/test_megatron_engine_vlm.py
+++ b/tests/test_megatron_engine_vlm.py
@@ -1,0 +1,587 @@
+"""Tests for Megatron engine VLM (Vision-Language Model) support.
+
+Unit tests (CPU-only) test the helper functions and logic changes.
+Integration tests (GPU-required) run via torchrun as subprocesses to avoid
+device memory leaks in the parent pytest process, allowing the full
+suite to run on just 2 GPUs.
+"""
+
+import os
+import pathlib
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+_TORCHRUN_SCRIPT = (
+    pathlib.Path(__file__).parent / "torchrun" / "run_megatron_engine_vlm.py"
+).resolve()
+
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Unit tests: CPU-only, no GPU or model weights required
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestUnwrapToGptModel:
+    """Test unwrap_to_gpt_model with VLM model structures."""
+
+    def test_plain_gpt_model_unwraps(self):
+        """Plain GPTModel (no wrapping) should return itself."""
+        from megatron.core.models.gpt.gpt_model import GPTModel
+
+        from areal.models.mcore.registry import unwrap_to_gpt_model
+
+        mock_gpt = MagicMock(spec=GPTModel)
+        mock_gpt.__class__ = GPTModel
+        result = unwrap_to_gpt_model(mock_gpt)
+        assert result is mock_gpt
+
+    def test_ddp_wrapped_gpt_model_unwraps(self):
+        """GPTModel wrapped in DDP (via .module) should unwrap correctly."""
+        from megatron.core.models.gpt.gpt_model import GPTModel
+
+        from areal.models.mcore.registry import unwrap_to_gpt_model
+
+        mock_gpt = MagicMock(spec=GPTModel)
+        mock_gpt.__class__ = GPTModel
+        wrapper = MagicMock()
+        wrapper.__class__ = type("DDPWrapper", (), {})
+        wrapper.module = mock_gpt
+        result = unwrap_to_gpt_model(wrapper)
+        assert result is mock_gpt
+
+    def test_vlm_model_with_language_model_unwraps(self):
+        """VLM model (e.g. Qwen2_5VLModel) with .language_model attribute unwraps."""
+        from megatron.core.models.gpt.gpt_model import GPTModel
+
+        from areal.models.mcore.registry import unwrap_to_gpt_model
+
+        mock_gpt = MagicMock(spec=GPTModel)
+        mock_gpt.__class__ = GPTModel
+
+        # VLM model: no .module, but has .language_model
+        vlm_model = MagicMock()
+        vlm_model.__class__ = type("Qwen2_5VLModel", (), {})
+        del vlm_model.module  # ensure no .module attribute
+        vlm_model.language_model = mock_gpt
+
+        result = unwrap_to_gpt_model(vlm_model)
+        assert result is mock_gpt
+
+    def test_ddp_wrapped_vlm_model_unwraps(self):
+        """VLM model wrapped in DDP should unwrap to language_model."""
+        from megatron.core.models.gpt.gpt_model import GPTModel
+
+        from areal.models.mcore.registry import unwrap_to_gpt_model
+
+        mock_gpt = MagicMock(spec=GPTModel)
+        mock_gpt.__class__ = GPTModel
+
+        vlm_model = MagicMock()
+        vlm_model.__class__ = type("Qwen2_5VLModel", (), {})
+        del vlm_model.module
+        vlm_model.language_model = mock_gpt
+
+        wrapper = MagicMock()
+        wrapper.__class__ = type("DDPWrapper", (), {})
+        wrapper.module = vlm_model
+
+        result = unwrap_to_gpt_model(wrapper)
+        assert result is mock_gpt
+
+    def test_unsupported_model_raises_type_error(self):
+        """Model with neither GPTModel nor .language_model should raise TypeError."""
+        from areal.models.mcore.registry import unwrap_to_gpt_model
+
+        unsupported = MagicMock()
+        unsupported.__class__ = type("RandomModel", (), {})
+        del unsupported.module
+        del unsupported.language_model
+
+        with pytest.raises(TypeError, match="could not be unwrapped"):
+            unwrap_to_gpt_model(unsupported)
+
+
+class TestExtractVisionFromMultiModal:
+    """Test _extract_vision_from_multi_modal helper."""
+
+    def test_extracts_pixel_values_and_grid(self):
+        """Should extract and concatenate pixel_values and image_grid_thw."""
+        from areal.engine.megatron_utils.packed_context_parallel import (
+            extract_vision_from_multi_modal,
+        )
+
+        mb: dict[str, Any] = {
+            "multi_modal_input": [
+                {
+                    "pixel_values": torch.randn(10, 3, 14, 14),
+                    "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                },
+                {
+                    "pixel_values": torch.randn(5, 3, 14, 14),
+                    "image_grid_thw": torch.tensor([[1, 1, 1]]),
+                },
+            ]
+        }
+        padded_mb: dict[str, Any] = dict(mb)
+
+        extract_vision_from_multi_modal(mb, padded_mb)
+
+        assert "pixel_values" in mb
+        assert mb["pixel_values"].shape[0] == 15  # 10 + 5
+        assert "image_grid_thw" in mb
+        assert mb["image_grid_thw"].shape[0] == 2  # 2 grids
+        # Same values in padded_mb
+        assert torch.equal(mb["pixel_values"], padded_mb["pixel_values"])
+        assert torch.equal(mb["image_grid_thw"], padded_mb["image_grid_thw"])
+
+    def test_handles_video_grid_thw(self):
+        """Should extract video_grid_thw when present."""
+        from areal.engine.megatron_utils.packed_context_parallel import (
+            extract_vision_from_multi_modal,
+        )
+
+        mb: dict[str, Any] = {
+            "multi_modal_input": [
+                {
+                    "pixel_values": torch.randn(4, 3, 14, 14),
+                    "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                    "video_grid_thw": torch.tensor([[2, 2, 2]]),
+                },
+            ]
+        }
+        padded_mb: dict[str, Any] = dict(mb)
+
+        extract_vision_from_multi_modal(mb, padded_mb)
+
+        assert "video_grid_thw" in mb
+        assert mb["video_grid_thw"].shape[0] == 1
+
+    def test_no_multi_modal_input_is_noop(self):
+        """Should do nothing if multi_modal_input not in dict."""
+        from areal.engine.megatron_utils.packed_context_parallel import (
+            extract_vision_from_multi_modal,
+        )
+
+        mb: dict[str, Any] = {"input_ids": torch.tensor([1, 2, 3])}
+        padded_mb: dict[str, Any] = dict(mb)
+
+        extract_vision_from_multi_modal(mb, padded_mb)
+
+        assert "pixel_values" not in mb
+        assert "image_grid_thw" not in mb
+
+    def test_empty_multi_modal_input_is_noop(self):
+        """Should not add keys if multi_modal_input items have no vision data."""
+        from areal.engine.megatron_utils.packed_context_parallel import (
+            extract_vision_from_multi_modal,
+        )
+
+        mb: dict[str, Any] = {"multi_modal_input": [{}]}
+        padded_mb: dict[str, Any] = dict(mb)
+
+        extract_vision_from_multi_modal(mb, padded_mb)
+
+        assert "pixel_values" not in mb
+
+
+class TestVisionModelDetection:
+    """Test is_valid_vision_model detection."""
+
+    def test_qwen2_5_vl_detected(self):
+        from areal.engine.core.model import is_valid_vision_model
+
+        assert is_valid_vision_model("qwen2_5_vl") is True
+
+    def test_qwen2_vl_detected(self):
+        from areal.engine.core.model import is_valid_vision_model
+
+        assert is_valid_vision_model("qwen2_vl") is True
+
+    def test_qwen3_not_detected(self):
+        from areal.engine.core.model import is_valid_vision_model
+
+        assert is_valid_vision_model("qwen3") is False
+
+    def test_text_model_not_detected(self):
+        from areal.engine.core.model import is_valid_vision_model
+
+        assert is_valid_vision_model("llama") is False
+
+
+class TestConvertQwen25VLToHF:
+    """Test mcore→HF weight name conversion for Qwen2.5-VL."""
+
+    @pytest.fixture()
+    def tf_config(self):
+        """Mock TransformerConfig with Qwen2.5-VL-3B values."""
+        cfg = MagicMock()
+        cfg.hidden_size = 2048
+        cfg.num_attention_heads = 16
+        cfg.num_query_groups = 2
+        cfg.kv_channels = 128
+        return cfg
+
+    @pytest.fixture()
+    def hf_config(self):
+        """Mock HF config with vision_config for Qwen2.5-VL-3B."""
+        cfg = MagicMock()
+        cfg.vision_config.num_heads = 16
+        cfg.vision_config.hidden_size = 1280
+        return cfg
+
+    # --- Registry dispatch ---
+
+    def test_registry_dispatches_qwen2_5_vl_before_qwen2(self, tf_config, hf_config):
+        """convert_to_hf with model_name='qwen2_5_vl' must use the VLM converter."""
+        from areal.engine.megatron_utils.megatron import convert_to_hf
+
+        param = torch.randn(2048)
+        result = convert_to_hf(
+            tf_config,
+            "qwen2_5_vl",
+            "module.module.vision_model.decoder.final_layernorm.weight",
+            param,
+            hf_config=hf_config,
+        )
+        assert result[0][0] == "visual.merger.ln_q.weight"
+
+    # --- Language model delegation ---
+
+    def test_language_model_embedding_delegates(self, tf_config):
+        """language_model.embedding should strip prefix and delegate to qwen2."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(151936, 2048)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.language_model.embedding.word_embeddings.weight",
+            param,
+        )
+        assert len(result) == 1
+        assert result[0][0] == "model.embed_tokens.weight"
+
+    def test_language_model_output_layer_delegates(self, tf_config):
+        """language_model.output_layer should map to lm_head."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(151936, 2048)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.language_model.output_layer.weight",
+            param,
+        )
+        assert result[0][0] == "lm_head.weight"
+
+    def test_language_model_decoder_layer_qkv_delegates(self, tf_config):
+        """language_model decoder QKV should split into q/k/v projections."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        # Qwen2.5-VL-3B: num_query_groups=2, value_num_per_group=8, kv_channels=128
+        # QKV weight shape: (num_query_groups * (value_num_per_group + 2) * kv_channels, hidden)
+        qkv_dim = tf_config.num_query_groups * (8 + 1 + 1) * tf_config.kv_channels
+        param = torch.randn(qkv_dim, tf_config.hidden_size)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.5.self_attention.linear_qkv.weight",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.layers.5.self_attn.q_proj.weight" in names
+        assert "model.layers.5.self_attn.k_proj.weight" in names
+        assert "model.layers.5.self_attn.v_proj.weight" in names
+
+    def test_language_model_mlp_fc1_splits_gate_up(self, tf_config):
+        """language_model MLP fc1 should split into gate_proj and up_proj."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(22016, 2048)  # gate + up stacked
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc1.weight",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.layers.0.mlp.gate_proj.weight" in names
+        assert "model.layers.0.mlp.up_proj.weight" in names
+
+    # --- Vision model direct mappings ---
+
+    def test_vision_patch_embed(self, tf_config):
+        """vision_model.patch_embed maps to visual.patch_embed."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(1280, 3, 2, 14, 14)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.patch_embed.proj.weight",
+            param,
+        )
+        assert result == [("visual.patch_embed.proj.weight", param)]
+
+    def test_vision_merger_ln(self, tf_config):
+        """vision final layernorm maps to visual.merger.ln_q."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(1280)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.final_layernorm.weight",
+            param,
+        )
+        assert result[0][0] == "visual.merger.ln_q.weight"
+
+    def test_vision_merger_mlp(self, tf_config):
+        """vision projection MLP maps to visual.merger.mlp."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(5120, 5120)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.projection.encoder.linear_fc1.weight",
+            param,
+        )
+        assert result[0][0] == "visual.merger.mlp.0.weight"
+
+    # --- Vision model per-layer params ---
+
+    def test_vision_layer_attn_qkv(self, tf_config, hf_config):
+        """Vision attention QKV maps to visual.blocks.<idx>.attn.qkv with reordering."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(3840, 1280)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.7.self_attention.linear_qkv.weight",
+            param,
+            hf_config=hf_config,
+        )
+        assert result[0][0] == "visual.blocks.7.attn.qkv.weight"
+        assert result[0][1].shape == param.shape  # same shape, different ordering
+
+    def test_vision_layer_attn_proj(self, tf_config):
+        """Vision attention proj maps to visual.blocks.<idx>.attn.proj."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(1280, 1280)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.3.self_attention.linear_proj.weight",
+            param,
+        )
+        assert result[0][0] == "visual.blocks.3.attn.proj.weight"
+
+    def test_vision_layer_norm1(self, tf_config):
+        """Vision input layernorm maps to visual.blocks.<idx>.norm1."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(1280)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.0.self_attention.linear_qkv.layer_norm_weight",
+            param,
+        )
+        assert result[0][0] == "visual.blocks.0.norm1.weight"
+
+    def test_vision_layer_mlp_fc1_splits_gate_up(self, tf_config):
+        """Vision MLP fc1 splits into gate_proj and up_proj."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(6840, 1280)  # gate + up stacked
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.2.mlp.linear_fc1.weight",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "visual.blocks.2.mlp.gate_proj.weight" in names
+        assert "visual.blocks.2.mlp.up_proj.weight" in names
+
+    def test_vision_layer_mlp_fc2(self, tf_config):
+        """Vision MLP fc2 maps to visual.blocks.<idx>.mlp.down_proj."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(1280, 3420)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.10.mlp.linear_fc2.weight",
+            param,
+        )
+        assert result[0][0] == "visual.blocks.10.mlp.down_proj.weight"
+
+    def test_vision_layer_norm2(self, tf_config):
+        """Vision post-attention layernorm maps to visual.blocks.<idx>.norm2."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        param = torch.randn(1280)
+        result = convert_qwen2_5_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.1.mlp.linear_fc1.layer_norm_weight",
+            param,
+        )
+        assert result[0][0] == "visual.blocks.1.norm2.weight"
+
+    # --- Error handling ---
+
+    def test_unknown_param_raises_value_error(self, tf_config):
+        """Unknown parameter name should raise ValueError."""
+        from areal.engine.megatron_utils.megatron import convert_qwen2_5_vl_to_hf
+
+        with pytest.raises(ValueError, match="Unknown parameter name"):
+            convert_qwen2_5_vl_to_hf(
+                tf_config,
+                "module.module.some_unknown.weight",
+                torch.randn(10),
+            )
+
+
+class TestRemovePaddingVLM:
+    """Test remove_padding handles VLM language_model prefixed params."""
+
+    def test_vlm_embedding_padding_removed(self):
+        """VLM language_model embedding should be trimmed to vocab_size."""
+        from areal.engine.megatron_utils.megatron import remove_padding
+
+        vocab_size = 151936
+        padded = torch.randn(vocab_size + 64, 2048)  # padded for TP alignment
+        result = remove_padding(
+            "module.module.language_model.embedding.word_embeddings.weight",
+            padded,
+            vocab_size,
+        )
+        assert result.shape[0] == vocab_size
+
+    def test_vlm_output_layer_padding_removed(self):
+        """VLM language_model output_layer should be trimmed to vocab_size."""
+        from areal.engine.megatron_utils.megatron import remove_padding
+
+        vocab_size = 151936
+        padded = torch.randn(vocab_size + 64, 2048)
+        result = remove_padding(
+            "module.module.language_model.output_layer.weight",
+            padded,
+            vocab_size,
+        )
+        assert result.shape[0] == vocab_size
+
+    def test_non_embedding_param_unchanged(self):
+        """Non-embedding params should pass through unchanged."""
+        from areal.engine.megatron_utils.megatron import remove_padding
+
+        param = torch.randn(1280)
+        result = remove_padding(
+            "module.module.vision_model.decoder.final_layernorm.weight",
+            param,
+            151936,
+        )
+        assert result is param
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Integration tests: subprocess-based to avoid device memory leaks
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _run_vlm_test(
+    test_type: str,
+    output_path: str,
+    *,
+    backend: str = "megatron:d1p1t1",
+    nproc: int = 1,
+    extra_args: list[str] | None = None,
+    timeout: int = 300,
+):
+    """Launch a VLM integration test via torchrun subprocess.
+
+    Each test runs in its own process, ensuring complete device memory
+    cleanup between tests. This allows the full suite to run on just 2 devices.
+    """
+    from areal.utils.network import find_free_ports
+
+    port = find_free_ports(1)[0]
+
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(nproc))
+
+    cmd = [
+        "torchrun",
+        f"--nproc_per_node={nproc}",
+        "--nnodes=1",
+        "--master-addr=localhost",
+        f"--master_port={port}",
+        str(_TORCHRUN_SCRIPT),
+        f"--backend={backend}",
+        f"--test_type={test_type}",
+        f"--output={output_path}",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    try:
+        subprocess.run(
+            cmd,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.CalledProcessError as e:
+        if "out of memory" in (e.stderr or "").lower():
+            pytest.skip(f"OOM: 3B VLM {test_type} requires more memory")
+        pytest.fail(
+            f"VLM {test_type} test failed:\nstdout: {e.stdout}\nstderr: {e.stderr}"
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"VLM {test_type} test timed out ({timeout}s)")
+
+    with open(output_path) as f:
+        result = f.read().strip()
+    if result == "OOM":
+        pytest.skip(f"OOM: 3B VLM {test_type} requires more memory than single device")
+    assert result == "Passed", f"VLM {test_type} test failed: {result}"
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+def test_vlm_engine_initializes(tmp_path_factory):
+    """Verify VLM engine detects vision model and loads processor."""
+    output = str(tmp_path_factory.mktemp("vlm_test") / "init.out")
+    _run_vlm_test("init", output)
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+def test_vlm_simple_forward(tmp_path_factory):
+    """Verify forward pass with VLM inputs completes."""
+    output = str(tmp_path_factory.mktemp("vlm_test") / "forward.out")
+    _run_vlm_test("forward", output)
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+def test_vlm_hf_save_load_weights(tmp_path_factory):
+    """Verify save/load preserves VLM weights and saves processor."""
+    save_dir = str(tmp_path_factory.mktemp("vlm_save"))
+    output = str(tmp_path_factory.mktemp("vlm_test") / "save_load.out")
+    _run_vlm_test("save_load", output, extra_args=[f"--save_dir={save_dir}"])
+
+
+@pytest.mark.gpu
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+def test_vlm_train_tensor_parallel(tmp_path_factory):
+    """VLM training with TP=2 to avoid single-device OOM."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("VLM TP training requires at least 2 GPUs")
+    output = str(tmp_path_factory.mktemp("vlm_test") / "train_tp2.out")
+    _run_vlm_test("train", output, backend="megatron:d1p1t2", nproc=2)

--- a/tests/torchrun/run_megatron_engine_vlm.py
+++ b/tests/torchrun/run_megatron_engine_vlm.py
@@ -1,0 +1,247 @@
+"""Torchrun script for Megatron VLM integration tests.
+
+Launched via torchrun from test_megatron_engine_vlm.py. All integration
+tests run as subprocesses so the parent pytest process never allocates
+GPU memory, allowing the full suite to run on just 2 GPUs.
+"""
+
+import argparse
+import os
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from tests.utils import get_model_path
+
+from areal.api import FinetuneSpec, SaveLoadMeta
+from areal.api.alloc_mode import ModelAllocation
+from areal.api.cli_args import (
+    MegatronEngineConfig,
+    MicroBatchSpec,
+    OptimizerConfig,
+    TrainEngineConfig,
+)
+from areal.engine import MegatronEngine
+from areal.utils.data import broadcast_tensor_container
+
+VLM_MODEL_PATH = get_model_path(
+    os.environ.get(
+        "QWEN25_VL_MODEL_PATH",
+        "/storage/openpsi/models/Qwen__Qwen2.5-VL-3B-Instruct/",
+    ),
+    "Qwen/Qwen2.5-VL-3B-Instruct",
+)
+
+
+def write_result(path: str, result: str):
+    with open(path, "w") as f:
+        f.write(result)
+
+
+def mock_vlm_input(device: str) -> dict[str, Any]:
+    """Create mock VLM input with vision tokens."""
+    PATCH_DIM = 3 * 2 * 14 * 14  # 1176
+    SPATIAL_MERGE_SIZE = 2
+    IMAGE_TOKEN_ID = 151655
+
+    grid_t, grid_h, grid_w = 1, 4, 4
+    total_patches = grid_t * grid_h * grid_w
+    num_image_tokens = (
+        grid_t * (grid_h // SPATIAL_MERGE_SIZE) * (grid_w // SPATIAL_MERGE_SIZE)
+    )
+
+    batch_size = 1
+    num_text_tokens = 16
+    seq_len = num_text_tokens + num_image_tokens
+
+    text_tokens = torch.randint(0, 1000, (num_text_tokens,), dtype=torch.long)
+    image_tokens = torch.full((num_image_tokens,), IMAGE_TOKEN_ID, dtype=torch.long)
+    input_ids = torch.cat([text_tokens, image_tokens]).unsqueeze(0).to(device)
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.bool, device=device)
+
+    pixel_values = torch.randn(
+        total_patches, PATCH_DIM, dtype=torch.float32, device=device
+    )
+    image_grid_thw = torch.tensor(
+        [[grid_t, grid_h, grid_w]], dtype=torch.long, device=device
+    )
+
+    return {
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
+        "multi_modal_input": [
+            {"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}
+        ],
+    }
+
+
+def make_vlm_engine(backend: str, init_optimizer: bool = False) -> MegatronEngine:
+    config = TrainEngineConfig(
+        backend=backend,
+        experiment_name="test-vlm",
+        trial_name="test",
+        path=VLM_MODEL_PATH,
+        mb_spec=MicroBatchSpec(max_tokens_per_mb=4096),
+        optimizer=OptimizerConfig() if init_optimizer else None,
+        megatron=MegatronEngineConfig(),
+        gradient_checkpointing=True,
+    )
+    alloc_mode = ModelAllocation.from_str(backend)
+    ft_spec = FinetuneSpec(total_train_epochs=1, dataset_size=32, train_batch_size=2)
+    engine = MegatronEngine(config)
+    engine.create_process_group(parallel_strategy=alloc_mode.parallel)
+    engine.initialize(addr=None, ft_spec=ft_spec)
+    return engine
+
+
+def _make_input(engine: MegatronEngine) -> dict[str, Any]:
+    """Create mock input and broadcast across model-parallel ranks."""
+    input_ = mock_vlm_input(device=engine.device)
+    return broadcast_tensor_container(
+        input_,
+        src_rank=engine.current_data_parallel_head(),
+        group=engine.context_and_model_parallel_group,
+    )
+
+
+def _cleanup(engine: MegatronEngine):
+    torch.cuda.synchronize()
+    dist.barrier()
+    engine.destroy()
+
+
+def test_vlm_init(backend: str, output: str | None = None):
+    """Test VLM engine initialization: model detection and processor loading."""
+    rank = int(os.environ["RANK"])
+    engine = make_vlm_engine(backend, init_optimizer=False)
+
+    assert engine.is_vision_model, "Engine should detect VLM model"
+    assert engine.processor is not None, "Processor should be loaded for VLM"
+    assert engine.tokenizer is not None, "Tokenizer should be loaded"
+
+    _cleanup(engine)
+    if rank == 0 and output is not None:
+        write_result(output, "Passed")
+    print(f"rank {rank}: test_vlm_init({backend}) Done.")
+
+
+def test_vlm_forward(backend: str, output: str | None = None):
+    """Test VLM eval forward pass."""
+    rank = int(os.environ["RANK"])
+    engine = make_vlm_engine(backend, init_optimizer=False)
+    bcasted_input = _make_input(engine)
+
+    engine.eval()
+    result = engine.forward(bcasted_input)
+    assert result is not None, "Forward pass should return a result"
+
+    _cleanup(engine)
+    if rank == 0 and output is not None:
+        write_result(output, "Passed")
+    print(f"rank {rank}: test_vlm_forward({backend}) Done.")
+
+
+def test_vlm_save_load(backend: str, save_dir: str, output: str | None = None):
+    """Test VLM save/load weight round-trip."""
+    rank = int(os.environ["RANK"])
+    engine = make_vlm_engine(backend, init_optimizer=False)
+    bcasted_input = _make_input(engine)
+
+    engine.eval()
+    with torch.no_grad():
+        old = engine.forward(bcasted_input)
+
+        meta = SaveLoadMeta(
+            path=Path(save_dir),
+            weight_format="hf",
+            tokenizer=engine.tokenizer,
+            processor=engine.processor,
+            with_optim=False,
+            base_model_path=None,
+        )
+        engine.save(meta)
+
+        if rank == 0:
+            has_processor = (Path(save_dir) / "preprocessor_config.json").exists() or (
+                Path(save_dir) / "processor_config.json"
+            ).exists()
+            assert has_processor, "Processor config should be saved"
+
+        for param in engine.model.parameters():
+            param.zero_()
+        engine.load(meta)
+
+        new = engine.forward(bcasted_input)
+        torch.testing.assert_close(old, new)
+
+    _cleanup(engine)
+    if rank == 0 and output is not None:
+        write_result(output, "Passed")
+    print(f"rank {rank}: test_vlm_save_load({backend}) Done.")
+
+
+def test_vlm_train(backend: str, output: str | None = None):
+    """Test VLM training step."""
+    rank = int(os.environ["RANK"])
+
+    try:
+        engine = make_vlm_engine(backend, init_optimizer=True)
+        bcasted_input = _make_input(engine)
+
+        engine.train()
+        train_result = engine.train_batch(
+            input_=bcasted_input,
+            loss_fn=lambda logprobs, entropy, input_data, **kwargs: torch.mean(
+                logprobs
+            ),
+            loss_weight_fn=lambda x: torch.tensor(1.0, device=engine.device),
+        )
+
+        assert "grad_norm" in train_result, f"Missing grad_norm: {train_result}"
+        assert "lr" in train_result, f"Missing lr: {train_result}"
+        print(f"rank {rank} train_result: {train_result}")
+
+        _cleanup(engine)
+        if rank == 0 and output is not None:
+            write_result(output, "Passed")
+    except RuntimeError as e:
+        if "out of memory" in str(e).lower():
+            if rank == 0 and output is not None:
+                write_result(output, "OOM")
+            print(f"rank {rank}: OOM during training")
+            return
+        raise
+
+    print(f"rank {rank}: test_vlm_train({backend}) Done.")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", type=str, default="megatron:d1p1t2")
+    parser.add_argument("--output", type=str, default=None)
+    parser.add_argument("--save_dir", type=str, default=None)
+    parser.add_argument(
+        "--test_type",
+        type=str,
+        choices=["init", "forward", "save_load", "train"],
+        default="train",
+    )
+    args = parser.parse_args()
+
+    if args.test_type == "init":
+        test_vlm_init(args.backend, output=args.output)
+    elif args.test_type == "forward":
+        test_vlm_forward(args.backend, output=args.output)
+    elif args.test_type == "save_load":
+        assert args.save_dir is not None, "--save_dir required for save_load test"
+        test_vlm_save_load(args.backend, args.save_dir, output=args.output)
+    elif args.test_type == "train":
+        test_vlm_train(args.backend, output=args.output)
+    else:
+        raise NotImplementedError(f"Unknown test type: {args.test_type}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/torchrun/run_megatron_engine_vlm.py
+++ b/tests/torchrun/run_megatron_engine_vlm.py
@@ -78,6 +78,7 @@ def mock_vlm_input(device: str) -> dict[str, Any]:
 
 
 def make_vlm_engine(backend: str, init_optimizer: bool = False) -> MegatronEngine:
+    bridge_type = os.environ.get("AREAL_TEST_BRIDGE_TYPE", "mbridge")
     config = TrainEngineConfig(
         backend=backend,
         experiment_name="test-vlm",
@@ -85,7 +86,7 @@ def make_vlm_engine(backend: str, init_optimizer: bool = False) -> MegatronEngin
         path=VLM_MODEL_PATH,
         mb_spec=MicroBatchSpec(max_tokens_per_mb=4096),
         optimizer=OptimizerConfig() if init_optimizer else None,
-        megatron=MegatronEngineConfig(),
+        megatron=MegatronEngineConfig(bridge_type=bridge_type),
         gradient_checkpointing=True,
     )
     alloc_mode = ModelAllocation.from_str(backend)


### PR DESCRIPTION
## Description

Adds Megatron training support for **Qwen2.5-VL** (Vision-Language Model) under the existing `MegatronEngine`, ported from our Ascend NPU branch and validated end-to-end on H100 with vLLM rollout (geometry3k-grpo).

### Supported parallelism (VLM)

| | TP | PP | CP |
|---|---|---|---|
| Qwen2.5-VL | ✅ | ✅ | ❌ |

CP > 1 is intentionally **not supported** for VLM in this PR — `MegatronEngine.initialize` raises `NotImplementedError` early if `context_parallel_size > 1` with a VLM model. Reason: the VLM forward path reconstructs a 2D `[B, S]` input and bypasses `preprocess_packed_seqs_context_parallel`'s CP-shard split entirely, so CP gather on the output side would mis-shape. Enabling CP for VLM is left to a follow-up.

Verified weight-conversion at TP/PP=1×1, 1×2, 2×1, 2×2 against mbridge's save path: zero mismatches. Plus 35-case pytest suite (31 CPU + 4 GPU) all green.

This PR contains **two commits**:

### 1. `feat(engine): add Megatron VLM support for Qwen2.5-VL`

- Vision-tower wiring through `mbridge.AutoBridge` for the Qwen2.5-VL bridge.
- VLM input handling: `multi_modal_input` extraction, packed forward pass with vectorized 2D batch reconstruction, last-PP-stage vision-output repack.
- HF↔mcore weight conversion for Qwen2.5-VL (vision-QKV per-head→grouped reorder, language MLP stride fix, merger projection).
- `get_named_parameters` regex extended to apply `layer_offset` to VLM language layers (`module.module.language_model.decoder.layers.X`) — without this, PP>1 + VLM would silently send mis-indexed layers to vLLM.
- Engine-init guard for CP+VLM (raises `NotImplementedError`).
- New unit + torchrun integration tests (`tests/test_megatron_engine_vlm.py`, `tests/torchrun/run_megatron_engine_vlm.py`): 35 cases (31 CPU + 4 GPU), all passing.

### 2. `fix(engine): restore GLU linear_fc1 de-interleave for TP weight sync`

A pre-existing TP-weight-sync bug that silently corrupts every SwiGLU MLP weight at TP≥2:

- **Regression introduced in `bf9b3c3b`** (`chore(deps): bump sglang, vllm, megatron-core`, megatron-core 0.13→0.16). The earlier unconditional `chunk(2)` de-interleave inside `_all_gather_and_concat` was replaced with a `partition_stride > 1` guard.
- **Why the guard never fires**: mcore/TE sets `partition_stride=1` on `linear_fc1` even when `gated_linear_unit=True`, but the per-rank storage is still `[gate_local | up_local]`. After all-gather at TP=N this produces `[gate_r0 | up_r0 | gate_r1 | up_r1 | …]`; downstream `chunk(2)` in `convert_*_to_hf` then mislabels mixed halves as `gate_proj` / `up_proj`, sending corrupted weights to vLLM/SGLang on every rollout-engine update.
- **Fix**: shape-based GLU detection at engine init. `MegatronEngine.initialize()` scans every module for `fc1.weight.shape[0] == 2 * fc2.weight.shape[1]` and records the matching parameter names (with layer indices stripped so the set is PP-invariant) in `_glu_fc1_names`. `_collect_param` then threads `gated_linear_unit=True` through `all_gather_param` / `_all_gather_and_concat`, which override the bogus `partition_stride=1` and force the correct stride-2 de-interleave. Model-agnostic — does not rely on config flags (which can be inconsistent between language and vision towers).
- **Validated**: TP=1/2 × PP=1/2 all match mbridge's save path with zero diff.
- **Scope**: affects all SwiGLU models (Qwen2 / Qwen3 dense / Qwen3-Coder / MoE, MiniMax, Llama, …) whenever `update_weights` is called via the XCCL, awex, or disk paths at TP≥2.

## Dependencies

- **Upgraded mbridge required** (already in `main`): relies on `mbridge` ≥ commit `dc1321b` (`_get_mcore_config_by_name` for VLM projection lookup), pulled in by #1258 (`4629c4ef chore(deps): upgrade mbridge from 0.15.1 to 310e8fb`). Without that upgrade, mbridge's save path reports the merger projection as GLU and de-interleaves a non-GLU weight.
- **Fetch-buffer leak fix required for sustained training** ([#1209](https://github.com/inclusionAI/AReaL/issues/1209)): long-running multimodal jobs hit a slow CPU memory leak in the RPC `_fetch_buffer` layer, manifesting as `actor/N failed with exit code 0` after a few dozen steps (sooner with low DP). The leak is **not** addressed by this PR; once #1209 is fixed, this PR's VLM workflow trains cleanly without time/step bound. Until then, training will abort once the per-rank leaked-sample threshold is crossed.

## Related Issue

#1209

## Type of Change

- [x] ✨ New feature (Megatron VLM support for Qwen2.5-VL)
- [x] 🐛 Bug fix (GLU `linear_fc1` TP de-interleave regression from `bf9b3c3b`)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

The GLU fix is independent of VLM and is also a prerequisite for any SwiGLU-model TP≥2 weight sync — splitting it out of this PR is also acceptable; let me know if reviewers prefer that.

### Training Reward Example
Image: ghcr.io/inclusionai/areal-runtime:v1.0.3-vllm with mbridge upgraded according to #1258
Dataset: Geometry3k
Model: Qwen2.5-VL-3B
Scheduler: Slurm
Actor backend: 
- TP=1 + PP=1 (mbridge)
- TP=2 + PP=2 (mbridge)
- TP=2 + PP=2 (megatron-bridge)
<img width="2848" height="1130" alt="image" src="https://github.com/user-attachments/assets/0ab536a2-7821-44b7-8a14-5136543de63d" />
 



