### PR TITLE
fix(megatron): pass absolute total_train_steps as lr_decay_steps

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1292,7 +1292,16 @@ class MegatronEngine(TrainEngine):
             max_lr=self.optimizer_config.lr,
             min_lr=self.optimizer_config.min_lr_ratio * self.optimizer_config.lr,
             lr_warmup_steps=warmup_steps,
-            lr_decay_steps=ft_spec.total_train_steps - warmup_steps,
+            # Megatron Core treats `lr_decay_steps` as the absolute step at
+            # which decay ends (it subtracts `lr_warmup_steps` internally to
+            # get the decay-phase length). Previously this was passed as
+            # `total_train_steps - warmup_steps`, which caused Megatron to
+            # subtract warmup twice and the cosine schedule to reach min_lr
+            # ~one full warmup earlier than intended (e.g. lr=0 at step 198
+            # for a 220-step run). Pass the raw total so cosine spans
+            # [warmup_steps, total_train_steps], matching HF's
+            # get_cosine_schedule_with_warmup used by the FSDP engine.
+            lr_decay_steps=ft_spec.total_train_steps,
             lr_decay_style=self.optimizer_config.lr_scheduler_type,
             start_wd=self.optimizer_config.weight_decay,
             end_wd=self.optimizer_config.weight_decay,


### PR DESCRIPTION
## Summary

- Megatron Core's `OptimizerParamScheduler` treats `lr_decay_steps` as the **absolute step at which decay ends**, and internally subtracts `lr_warmup_steps` to get the decay-phase length.
- We were passing `total_train_steps - warmup_steps`, so warmup got subtracted twice. The cosine schedule hit `min_lr` roughly one full warmup phase earlier than intended (e.g. lr=0 at step 198 for a 220-step run with 22 warmup steps), wasting ~10% of training on zero lr.
- Fix: pass the raw `total_train_steps`. Cosine decay now spans `[warmup_steps, total_train_steps]`, matching HF's `get_cosine_schedule_with_warmup` used by the FSDP engine.

## Test plan

- [ ] Run a short Megatron training job and verify lr > 0 through the final step
- [ ] Confirm Megatron and FSDP engines produce matching lr schedules for identical `warmup_steps` / `total_train_steps`