### PR TITLE
refactor(inference-service): remove unused release_capacity endpoint

### DIFF
--- a/areal/experimental/inference_service/gateway/streaming.py
+++ b/areal/experimental/inference_service/gateway/streaming.py
@@ -222,34 +222,6 @@ async def grant_capacity_in_router(
         ) from exc
 
 
-async def release_capacity_in_router(
-    router_addr: str,
-    admin_api_key: str,
-    timeout: float,
-    *,
-    client: httpx.AsyncClient | None = None,
-) -> None:
-    """Return one capacity permit to the Router.
-
-    POST ``{router_addr}/release_capacity`` with admin key auth.
-    Best-effort: logs errors but never raises, since the caller is
-    already handling a failure path.
-    """
-    try:
-        async with _use_client(client, timeout) as c:
-            resp = await c.post(
-                f"{router_addr}/release_capacity",
-                headers={"Authorization": f"Bearer {admin_api_key}"},
-                timeout=timeout,
-            )
-        if resp.status_code != 200:
-            logger.warning(
-                "release_capacity returned %d: %s", resp.status_code, resp.text
-            )
-    except Exception as exc:
-        logger.warning("Failed to release capacity in router: %s", exc)
-
-
 async def get_all_worker_addrs(
     router_addr: str,
     admin_api_key: str,

--- a/areal/experimental/inference_service/router/app.py
+++ b/areal/experimental/inference_service/router/app.py
@@ -536,15 +536,7 @@ def create_app(config: RouterConfig) -> FastAPI:
         """Increment session capacity by 1."""
         _require_admin_key(request, config.admin_api_key)
         new_capacity = await capacity_manager.grant()
-        logger.info("Capacity granted — now %d", new_capacity)
-        return CapacityResponse(status="ok", capacity=new_capacity)
-
-    @app.post("/release_capacity", response_model=CapacityResponse)
-    async def release_capacity(request: Request):
-        """Return one previously acquired capacity permit."""
-        _require_admin_key(request, config.admin_api_key)
-        new_capacity = await capacity_manager.release()
-        logger.info("Capacity released — now %d", new_capacity)
+        logger.debug("Capacity granted — now %d", new_capacity)
         return CapacityResponse(status="ok", capacity=new_capacity)
 
     return app

--- a/areal/experimental/inference_service/router/state.py
+++ b/areal/experimental/inference_service/router/state.py
@@ -118,12 +118,6 @@ class CapacityManager:
             self._capacity -= 1
             return True
 
-    async def release(self) -> int:
-        """Return one previously acquired permit. Returns the new capacity value."""
-        async with self._lock:
-            self._capacity += 1
-            return self._capacity
-
     async def get_capacity(self) -> int:
         """Return current capacity (for health / debug endpoints)."""
         async with self._lock:


### PR DESCRIPTION
## Summary

- Remove the dead `release_capacity` code path from the inference service router, gateway streaming helper, and capacity manager state
- The `release_capacity_in_router` function, `CapacityManager.release()` method, and `/release_capacity` HTTP endpoint are never called — capacity is managed solely via `grant_capacity`
- Downgrade the `grant_capacity` log level from `info` to `debug` to reduce noise during normal operation

## Files Changed

| File | Change |
|------|--------|
| `areal/experimental/inference_service/gateway/streaming.py` | Remove `release_capacity_in_router` helper |
| `areal/experimental/inference_service/router/state.py` | Remove `CapacityManager.release()` method |
| `areal/experimental/inference_service/router/app.py` | Remove `/release_capacity` endpoint; downgrade grant log to debug |

## Testing

- Pre-commit hooks pass (ruff lint + format, trailing whitespace, conventional commit)
- No callers of removed code exist in the codebase