### PR TITLE
fix(infra): gate RTensor.remotize on DP-head to plug _storage leak

### DIFF
--- a/areal/infra/rpc/guard/engine_blueprint.py
+++ b/areal/infra/rpc/guard/engine_blueprint.py
@@ -572,10 +572,27 @@ def call_engine_method():
                 500,
             )
 
-        # Convert all tensors to RTensors and store locally
-        state = get_state()
-        result = RTensor.remotize(result, node_addr=state.node_addr)
-        serialized_result = serialize_value(result)
+        # Convert all tensors to RTensors and store locally — but ONLY on DP
+        # heads. The controller's ``_collect_results`` filter discards
+        # non-DP-head results (see train_controller.py:595), and
+        # ``clear_batches`` only walks ``rollout_batch``/``adv_batch`` which
+        # contain shard ids from DP-head results. Remotizing on non-DP-head
+        # ranks therefore stores tensors in the local ``_storage`` that NO
+        # cleanup path will ever reach — RSS leaks ~per-batch-payload-size
+        # per training step on every non-DP-head rank (see #1209 follow-up).
+        is_dp_head = (
+            isinstance(engine, TrainEngine)
+            and getattr(engine, "process_group_initialized", False)
+            and engine.is_data_parallel_head()
+        )
+        if is_dp_head or not isinstance(engine, TrainEngine):
+            state = get_state()
+            result = RTensor.remotize(result, node_addr=state.node_addr)
+            serialized_result = serialize_value(result)
+        else:
+            # Non-DP-head: result is discarded by controller. Skip remotize
+            # (no _storage growth) and return a sentinel.
+            serialized_result = serialize_value(None)
         return jsonify({"status": "success", "result": serialized_result})
 
     except Exception as e:

--- a/areal/infra/rpc/guard/engine_blueprint.py
+++ b/areal/infra/rpc/guard/engine_blueprint.py
@@ -588,7 +588,7 @@ def call_engine_method():
         # not yet defined) keep the original remotize path so setup-time
         # calls behave identically to before this gate.
         is_train = isinstance(engine, TrainEngine)
-        is_init = getattr(engine, "process_group_initialized", False)
+        is_init = is_train and engine.initialized
         if not is_train or not is_init or engine.is_data_parallel_head():
             state = get_state()
             result = RTensor.remotize(result, node_addr=state.node_addr)

--- a/areal/infra/rpc/guard/engine_blueprint.py
+++ b/areal/infra/rpc/guard/engine_blueprint.py
@@ -580,12 +580,16 @@ def call_engine_method():
         # ranks therefore stores tensors in the local ``_storage`` that NO
         # cleanup path will ever reach — RSS leaks ~per-batch-payload-size
         # per training step on every non-DP-head rank (see #1209 follow-up).
-        is_dp_head = (
-            isinstance(engine, TrainEngine)
-            and getattr(engine, "process_group_initialized", False)
-            and engine.is_data_parallel_head()
-        )
-        if is_dp_head or not isinstance(engine, TrainEngine):
+        #
+        # Skip remotize only when we are *certain* the result will be
+        # discarded — i.e. for an initialized TrainEngine on a non-DP-head
+        # rank. Non-TrainEngine workers (e.g. inference backends) and
+        # pre-init TrainEngine RPCs (where ``is_data_parallel_head()`` is
+        # not yet defined) keep the original remotize path so setup-time
+        # calls behave identically to before this gate.
+        is_train = isinstance(engine, TrainEngine)
+        is_init = getattr(engine, "process_group_initialized", False)
+        if not is_train or not is_init or engine.is_data_parallel_head():
             state = get_state()
             result = RTensor.remotize(result, node_addr=state.node_addr)
             serialized_result = serialize_value(result)


### PR DESCRIPTION
## Description

Skip `RTensor.remotize` on non-DP-head `TrainEngine` ranks and return a `None` sentinel; their results are discarded by the controller's `_collect_results` filter anyway, so storing them in node-local `_storage` just leaks. DP-head ranks and non-`TrainEngine` workers (e.g. inference backends) continue remotizing as before.

## Related Issue

Fixes #1296

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

See #1296 for the full diagnosis (per-step leak rates, MEMDIAG numbers, architectural mirror of #1209/#1282).

The gate is conservative — three conditions must all hold to skip remotize:
1. `engine` is a `TrainEngine` (inference backends are unaffected),
2. its process group has been initialized (otherwise `is_data_parallel_head()` would crash),
3. it reports as a non-DP-head.

Otherwise the original remotize path runs unchanged.

Validated on a Qwen2.5-VL-32B `megatron:d4p2t4` run that previously leaked ~411 MB / step per non-DP-head rank (73 GB at step 168). Post-fix RSS is flat across the same workload.
