### PR TITLE
feat(engine): add Qwen3-VL dense support to Megatron path

### DIFF
--- a/areal/engine/core/model.py
+++ b/areal/engine/core/model.py
@@ -30,6 +30,18 @@ def is_qwen_vl_model(model_type: str) -> bool:
     return is_qwen2_vl_model(model_type) or is_qwen3_vl_model(model_type)
 
 
+def lang_config(hf_config):
+    """Return the language-model side of a (possibly nested) HF config.
+
+    Qwen3-VL and similar VLMs nest text-model attributes (vocab_size,
+    num_attention_heads, num_key_value_heads, hidden_size, head_dim) under
+    ``hf_config.text_config``. Qwen2.5-VL and pure text models keep them
+    flat. Use this anywhere the caller wants a language-side attribute and
+    doesn't know the model family up front.
+    """
+    return getattr(hf_config, "text_config", hf_config)
+
+
 def is_gemma3_model(model_type: str) -> bool:
     return model_type in ["gemma3"]
 

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -56,7 +56,11 @@ from areal.engine.core.distributed import (
     init_custom_process_group,
     warmup_process_groups,
 )
-from areal.engine.core.model import disable_dropout_in_model, is_valid_vision_model
+from areal.engine.core.model import (
+    disable_dropout_in_model,
+    is_valid_vision_model,
+    lang_config,
+)
 from areal.engine.megatron_utils.checkpointer import MegatronCheckpointManager
 from areal.engine.megatron_utils.deterministic import set_deterministic_algorithms
 from areal.engine.megatron_utils.fp8 import FP8BlockwiseTensorHelper
@@ -1463,12 +1467,7 @@ class MegatronEngine(TrainEngine):
             duplicated_param_names=self._duplicated_param_names,
             gated_linear_unit=is_glu,
         )
-        # VLMs like Qwen3-VL nest text-model params under hf_config.text_config;
-        # Qwen2.5-VL and pure text models keep them flat. Pad-removal targets the
-        # language-model embedding/output_layer, so always pull vocab_size from
-        # the text-side config when present.
-        text_cfg = getattr(self.hf_config, "text_config", self.hf_config)
-        param = remove_padding(name, param, text_cfg.vocab_size)
+        param = remove_padding(name, param, lang_config(self.hf_config).vocab_size)
 
         if isinstance(param, FP8BlockwiseTensorHelper):
             # FP8 is stored as uint8, so element_size is 1 byte

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1463,7 +1463,12 @@ class MegatronEngine(TrainEngine):
             duplicated_param_names=self._duplicated_param_names,
             gated_linear_unit=is_glu,
         )
-        param = remove_padding(name, param, self.hf_config.vocab_size)
+        # VLMs like Qwen3-VL nest text-model params under hf_config.text_config;
+        # Qwen2.5-VL and pure text models keep them flat. Pad-removal targets the
+        # language-model embedding/output_layer, so always pull vocab_size from
+        # the text-side config when present.
+        text_cfg = getattr(self.hf_config, "text_config", self.hf_config)
+        param = remove_padding(name, param, text_cfg.vocab_size)
 
         if isinstance(param, FP8BlockwiseTensorHelper):
             # FP8 is stored as uint8, so element_size is 1 byte

--- a/areal/engine/megatron_utils/megatron.py
+++ b/areal/engine/megatron_utils/megatron.py
@@ -382,6 +382,14 @@ def _vision_qkv_mcore_to_hf(param: Tensor, vision_num_heads: int) -> Tensor:
     """
     hidden_vision = param.shape[0] // 3
     head_dim = hidden_vision // vision_num_heads
+    # Vision encoders for both Qwen2.5-VL and Qwen3-VL set
+    # num_query_groups == num_attention_heads (no GQA on the vision side); a
+    # future VLM that breaks this would silently miscompile vision QKV here.
+    assert head_dim * vision_num_heads * 3 == param.shape[0], (
+        f"_vision_qkv_mcore_to_hf assumes vision has no GQA "
+        f"(num_kv_heads == num_heads). Got param.shape[0]={param.shape[0]}, "
+        f"vision_num_heads={vision_num_heads}, derived head_dim={head_dim}."
+    )
     is_bias = param.ndim == 1
 
     if is_bias:
@@ -518,6 +526,23 @@ def convert_qwen3_vl_to_hf(
     if name == "module.module.language_model.output_layer.weight":
         return [("lm_head.weight", param)]
 
+    # Early-raise on Qwen3-VL-MoE expert / router params before they fall
+    # through to the dense "Unknown Qwen3-VL language-model parameter" branch.
+    # `_CONVERSION_FN_REGISTRY` dispatches via substring matching, so once a
+    # `qwen3_vl_moe` model_type exists it will route here unless `qwen3_vl_moe`
+    # is registered BEFORE `qwen3_vl`.
+    if name.startswith(_LM_PREFIX) and (
+        ".mlp.experts." in name
+        or ".mlp.router." in name
+        or ".pre_mlp_layernorm." in name
+    ):
+        raise NotImplementedError(
+            "Qwen3-VL-MoE is not supported by convert_qwen3_vl_to_hf. "
+            "Implement convert_qwen3_vl_moe_to_hf and register it BEFORE "
+            "'qwen3_vl' in _CONVERSION_FN_REGISTRY (substring matching "
+            "dispatches the first hit)."
+        )
+
     if name.startswith(_LM_PREFIX):
         match = re.match(
             r"module\.module\.language_model\.decoder\.layers\.(\d+)\.(.+)",
@@ -527,13 +552,10 @@ def convert_qwen3_vl_to_hf(
             layer_idx, rest = match.groups()
             if tf_config.num_query_groups is None:
                 raise ValueError("Qwen3-VL text model requires num_query_groups")
-            try:
-                head_dim = (
-                    tf_config.kv_channels
-                    if tf_config.kv_channels is not None
-                    else tf_config.hidden_size // tf_config.num_attention_heads
-                )
-            except (AttributeError, TypeError):
+            kv_channels = getattr(tf_config, "kv_channels", None)
+            if kv_channels is not None:
+                head_dim = kv_channels
+            else:
                 head_dim = tf_config.hidden_size // tf_config.num_attention_heads
             value_num_per_group = (
                 tf_config.num_attention_heads // tf_config.num_query_groups

--- a/areal/engine/megatron_utils/megatron.py
+++ b/areal/engine/megatron_utils/megatron.py
@@ -485,6 +485,203 @@ def convert_qwen2_5_vl_to_hf(
     raise ValueError(f"Unknown parameter name: {name}")
 
 
+def convert_qwen3_vl_to_hf(
+    tf_config: TransformerConfig,
+    name: str,
+    param: Parameter | Tensor | FP8BlockwiseTensorHelper,
+    hf_config=None,
+):
+    """Convert Qwen3-VL Megatron parameters to HuggingFace format.
+
+    Handles dense Qwen3-VL only; Qwen3-VL-MoE is a follow-up.
+
+    HF naming differs from Qwen2.5-VL:
+    - Vision: ``model.visual.*`` (extra ``model.`` prefix)
+    - Language: ``model.language_model.layers.*`` (extra ``language_model``)
+    - Text Q/K norms: ``self_attn.{q,k}_norm.weight`` (vs Qwen2's missing q/k norm)
+    - Vision MLP is non-gated: ``linear_fc1`` / ``linear_fc2`` map 1:1 (no chunk).
+    - Vision norms have bias; vision merger uses ``patch_norm`` and
+      ``linear_fc{1,2}`` directly (no separate projection encoder).
+    - New tensors: ``model.visual.pos_embed``, ``patch_embed.proj.bias``,
+      ``deepstack_merger_list.{i}.{norm,linear_fc1,linear_fc2}``.
+
+    The mapping mirrors mbridge.models.qwen3_vl.Qwen3VLBridge (the source of
+    truth used by ``update_weights``).
+    """
+
+    # ---- Language model (Qwen3 text) ----
+    _LM_PREFIX = "module.module.language_model."
+    if name == "module.module.language_model.embedding.word_embeddings.weight":
+        return [("model.language_model.embed_tokens.weight", param)]
+    if name == "module.module.language_model.decoder.final_layernorm.weight":
+        return [("model.language_model.norm.weight", param)]
+    if name == "module.module.language_model.output_layer.weight":
+        return [("lm_head.weight", param)]
+
+    if name.startswith(_LM_PREFIX):
+        match = re.match(
+            r"module\.module\.language_model\.decoder\.layers\.(\d+)\.(.+)",
+            name,
+        )
+        if match:
+            layer_idx, rest = match.groups()
+            if tf_config.num_query_groups is None:
+                raise ValueError("Qwen3-VL text model requires num_query_groups")
+            try:
+                head_dim = (
+                    tf_config.kv_channels
+                    if tf_config.kv_channels is not None
+                    else tf_config.hidden_size // tf_config.num_attention_heads
+                )
+            except (AttributeError, TypeError):
+                head_dim = tf_config.hidden_size // tf_config.num_attention_heads
+            value_num_per_group = (
+                tf_config.num_attention_heads // tf_config.num_query_groups
+            )
+
+            base = f"model.language_model.layers.{layer_idx}"
+
+            if rest == "self_attention.linear_proj.weight":
+                return [(f"{base}.self_attn.o_proj.weight", param)]
+            if rest == "self_attention.linear_qkv.weight":
+                p = param.view(
+                    tf_config.num_query_groups, -1, head_dim, tf_config.hidden_size
+                )
+                q, k, v = torch.split(
+                    p, split_size_or_sections=[value_num_per_group, 1, 1], dim=1
+                )
+                return [
+                    (
+                        f"{base}.self_attn.q_proj.weight",
+                        q.reshape(-1, tf_config.hidden_size),
+                    ),
+                    (
+                        f"{base}.self_attn.k_proj.weight",
+                        k.reshape(-1, tf_config.hidden_size),
+                    ),
+                    (
+                        f"{base}.self_attn.v_proj.weight",
+                        v.reshape(-1, tf_config.hidden_size),
+                    ),
+                ]
+            if rest == "self_attention.linear_qkv.bias":
+                p = param.view(tf_config.num_query_groups, -1)
+                q, k, v = torch.split(
+                    p,
+                    split_size_or_sections=[
+                        value_num_per_group * head_dim,
+                        head_dim,
+                        head_dim,
+                    ],
+                    dim=1,
+                )
+                return [
+                    (f"{base}.self_attn.q_proj.bias", q.contiguous().flatten()),
+                    (f"{base}.self_attn.k_proj.bias", k.contiguous().flatten()),
+                    (f"{base}.self_attn.v_proj.bias", v.contiguous().flatten()),
+                ]
+            if rest == "self_attention.linear_qkv.layer_norm_weight":
+                return [(f"{base}.input_layernorm.weight", param)]
+            if rest == "self_attention.q_layernorm.weight":
+                return [(f"{base}.self_attn.q_norm.weight", param)]
+            if rest == "self_attention.k_layernorm.weight":
+                return [(f"{base}.self_attn.k_norm.weight", param)]
+            if rest == "mlp.linear_fc1.weight":
+                gate, up = param.chunk(2, dim=0)
+                return [
+                    (f"{base}.mlp.gate_proj.weight", gate),
+                    (f"{base}.mlp.up_proj.weight", up),
+                ]
+            if rest == "mlp.linear_fc1.layer_norm_weight":
+                return [(f"{base}.post_attention_layernorm.weight", param)]
+            if rest == "mlp.linear_fc2.weight":
+                return [(f"{base}.mlp.down_proj.weight", param)]
+
+        raise ValueError(f"Unknown Qwen3-VL language-model parameter: {name}")
+
+    # ---- Vision model (mbridge mcore format) ----
+    _VISION_DIRECT = {
+        "module.module.vision_model.patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
+        "module.module.vision_model.patch_embed.proj.bias": "model.visual.patch_embed.proj.bias",
+        "module.module.vision_model.pos_embed.weight": "model.visual.pos_embed.weight",
+        "module.module.vision_model.merger.patch_norm.weight": "model.visual.merger.norm.weight",
+        "module.module.vision_model.merger.patch_norm.bias": "model.visual.merger.norm.bias",
+        "module.module.vision_model.merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
+        "module.module.vision_model.merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
+        "module.module.vision_model.merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
+        "module.module.vision_model.merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
+    }
+    if name in _VISION_DIRECT:
+        return [(_VISION_DIRECT[name], param)]
+
+    # Vision blocks
+    match = re.match(
+        r"module\.module\.vision_model\.decoder\.layers\.(\d+)\.(.+)", name
+    )
+    if match:
+        layer_idx, rest = match.groups()
+        base = f"model.visual.blocks.{layer_idx}"
+
+        if rest in (
+            "self_attention.linear_qkv.weight",
+            "self_attention.linear_qkv.bias",
+        ):
+            vision_num_heads = getattr(
+                getattr(hf_config, "vision_config", None), "num_heads", None
+            )
+            if vision_num_heads is None:
+                raise ValueError(
+                    "hf_config.vision_config.num_heads is required for vision QKV "
+                    "conversion. Pass hf_config to convert_to_hf()."
+                )
+            param = _vision_qkv_mcore_to_hf(param, vision_num_heads)
+            kind = "weight" if rest.endswith("weight") else "bias"
+            return [(f"{base}.attn.qkv.{kind}", param)]
+        if rest == "self_attention.linear_proj.weight":
+            return [(f"{base}.attn.proj.weight", param)]
+        if rest == "self_attention.linear_proj.bias":
+            return [(f"{base}.attn.proj.bias", param)]
+        if rest == "self_attention.linear_qkv.layer_norm_weight":
+            return [(f"{base}.norm1.weight", param)]
+        if rest == "self_attention.linear_qkv.layer_norm_bias":
+            return [(f"{base}.norm1.bias", param)]
+        # Qwen3-VL vision MLP is non-gated: 1:1 mapping (no chunk)
+        if rest == "mlp.linear_fc1.weight":
+            return [(f"{base}.mlp.linear_fc1.weight", param)]
+        if rest == "mlp.linear_fc1.bias":
+            return [(f"{base}.mlp.linear_fc1.bias", param)]
+        if rest == "mlp.linear_fc2.weight":
+            return [(f"{base}.mlp.linear_fc2.weight", param)]
+        if rest == "mlp.linear_fc2.bias":
+            return [(f"{base}.mlp.linear_fc2.bias", param)]
+        if rest == "mlp.linear_fc1.layer_norm_weight":
+            return [(f"{base}.norm2.weight", param)]
+        if rest == "mlp.linear_fc1.layer_norm_bias":
+            return [(f"{base}.norm2.bias", param)]
+
+    # Deepstack mergers
+    match = re.match(
+        r"module\.module\.vision_model\.decoder\.deepstack_merger_list\.(\d+)\.(.+)",
+        name,
+    )
+    if match:
+        idx, rest = match.groups()
+        base = f"model.visual.deepstack_merger_list.{idx}"
+        if rest == "patch_norm.weight":
+            return [(f"{base}.norm.weight", param)]
+        if rest == "patch_norm.bias":
+            return [(f"{base}.norm.bias", param)]
+        if rest in (
+            "linear_fc1.weight",
+            "linear_fc1.bias",
+            "linear_fc2.weight",
+            "linear_fc2.bias",
+        ):
+            return [(f"{base}.{rest}", param)]
+
+    raise ValueError(f"Unknown Qwen3-VL parameter: {name}")
+
+
 # Adapted from slime
 def convert_qwen2_to_hf(
     tf_config: TransformerConfig,
@@ -932,6 +1129,7 @@ _CONVERSION_FN_REGISTRY = {
     "qwen2_lora": convert_qwen3_lora_to_hf,
     "qwen3_moe_lora": convert_qwen3_moe_lora_to_hf,
     "qwen2_5_vl": convert_qwen2_5_vl_to_hf,
+    "qwen3_vl": convert_qwen3_vl_to_hf,
     "qwen3_moe": convert_qwen3moe_to_hf,
     "qwen2": convert_qwen2_to_hf,
     "qwen3": convert_qwen2_to_hf,

--- a/areal/models/mcore/hf_load.py
+++ b/areal/models/mcore/hf_load.py
@@ -33,6 +33,16 @@ def _get_tp_slice(shape, dim, tp_rank, tp_size) -> tuple:
     return tuple(res)
 
 
+def _lang_config(hf_config):
+    """Return the language-model side of an HF config.
+
+    Qwen3-VL (and similar) nest text-model params (num_attention_heads,
+    num_key_value_heads, hidden_size, head_dim) under ``hf_config.text_config``.
+    Qwen2.5-VL and pure text models keep them at the top level.
+    """
+    return getattr(hf_config, "text_config", hf_config)
+
+
 def _get_shape(obj) -> list:
     """Get shape from either a tensor or PySafeSlice object."""
     if isinstance(obj, torch.Tensor):
@@ -51,10 +61,11 @@ def _merge_qkv_weights(
 ) -> torch.Tensor | FP8BlockwiseTensorHelper:
     """Merge Q, K, V weights into a single QKV weight tensor."""
     assert len(hf_weights_safe_slice) == 3
-    num_key_value_heads = hf_config.num_key_value_heads
-    hidden_dim = hf_config.hidden_size
-    num_attention_heads = hf_config.num_attention_heads
-    head_dim = getattr(hf_config, "head_dim", hidden_dim // num_attention_heads)
+    text_cfg = _lang_config(hf_config)
+    num_key_value_heads = text_cfg.num_key_value_heads
+    hidden_dim = text_cfg.hidden_size
+    num_attention_heads = text_cfg.num_attention_heads
+    head_dim = getattr(text_cfg, "head_dim", hidden_dim // num_attention_heads)
     group_dim = head_dim * num_attention_heads // num_key_value_heads
     q, k, v = hf_weights_safe_slice
     # q k v might be tp split
@@ -91,8 +102,9 @@ def _load_fused_qkv_weight(
     x = hf_weights_safe_slice[0]
     x = x[:] if not isinstance(x, torch.Tensor) else x
 
-    num_heads = hf_config.num_attention_heads
-    num_kv_heads = getattr(hf_config, "num_key_value_heads", num_heads)
+    text_cfg = _lang_config(hf_config)
+    num_heads = text_cfg.num_attention_heads
+    num_kv_heads = getattr(text_cfg, "num_key_value_heads", num_heads)
     head_dim = x.shape[0] // (num_heads + 2 * num_kv_heads)
     is_bias = x.dim() == 1
 
@@ -290,10 +302,11 @@ def _weight_to_mcore_tp(
                 tp_size,
             )
         else:
+            text_cfg = _lang_config(hf_config)
             num_kv_heads = getattr(
-                hf_config, "num_key_value_heads", hf_config.num_attention_heads
+                text_cfg, "num_key_value_heads", text_cfg.num_attention_heads
             )
-            if num_kv_heads == hf_config.num_attention_heads:
+            if num_kv_heads == text_cfg.num_attention_heads:
                 # Fused QKV weight (e.g., Lightning Attention query_key_value)
                 # Already in megatron interleaved format [H, 3, D] — just TP-slice
                 res = _load_fused_qkv_weight(
@@ -304,7 +317,7 @@ def _weight_to_mcore_tp(
                 # Split into separate Q, K, V then merge into mcore format.
                 x = hf_weights_safe_slice[0]
                 x = x[:] if not isinstance(x, torch.Tensor) else x
-                num_heads = hf_config.num_attention_heads
+                num_heads = text_cfg.num_attention_heads
                 head_dim = x.shape[0] // (num_heads + 2 * num_kv_heads)
                 q = x[: num_heads * head_dim]
                 k = x[num_heads * head_dim : (num_heads + num_kv_heads) * head_dim]

--- a/areal/models/mcore/hf_load.py
+++ b/areal/models/mcore/hf_load.py
@@ -14,6 +14,7 @@ from megatron.core import parallel_state as mpu
 from megatron.core.fp8_utils import is_float8tensor
 from safetensors import safe_open
 
+from areal.engine.core.model import lang_config
 from areal.engine.megatron_utils.fp8 import (
     FP8BlockwiseTensorHelper,
     dequantize_params,
@@ -31,16 +32,6 @@ def _get_tp_slice(shape, dim, tp_rank, tp_size) -> tuple:
     res = [slice(None) for _ in range(dim)]
     res.append(slice(tp_rank * size_per_tp, (tp_rank + 1) * size_per_tp))
     return tuple(res)
-
-
-def _lang_config(hf_config):
-    """Return the language-model side of an HF config.
-
-    Qwen3-VL (and similar) nest text-model params (num_attention_heads,
-    num_key_value_heads, hidden_size, head_dim) under ``hf_config.text_config``.
-    Qwen2.5-VL and pure text models keep them at the top level.
-    """
-    return getattr(hf_config, "text_config", hf_config)
 
 
 def _get_shape(obj) -> list:
@@ -61,7 +52,7 @@ def _merge_qkv_weights(
 ) -> torch.Tensor | FP8BlockwiseTensorHelper:
     """Merge Q, K, V weights into a single QKV weight tensor."""
     assert len(hf_weights_safe_slice) == 3
-    text_cfg = _lang_config(hf_config)
+    text_cfg = lang_config(hf_config)
     num_key_value_heads = text_cfg.num_key_value_heads
     hidden_dim = text_cfg.hidden_size
     num_attention_heads = text_cfg.num_attention_heads
@@ -102,7 +93,7 @@ def _load_fused_qkv_weight(
     x = hf_weights_safe_slice[0]
     x = x[:] if not isinstance(x, torch.Tensor) else x
 
-    text_cfg = _lang_config(hf_config)
+    text_cfg = lang_config(hf_config)
     num_heads = text_cfg.num_attention_heads
     num_kv_heads = getattr(text_cfg, "num_key_value_heads", num_heads)
     head_dim = x.shape[0] // (num_heads + 2 * num_kv_heads)
@@ -302,7 +293,7 @@ def _weight_to_mcore_tp(
                 tp_size,
             )
         else:
-            text_cfg = _lang_config(hf_config)
+            text_cfg = lang_config(hf_config)
             num_kv_heads = getattr(
                 text_cfg, "num_key_value_heads", text_cfg.num_attention_heads
             )

--- a/tests/test_megatron_engine_vlm.py
+++ b/tests/test_megatron_engine_vlm.py
@@ -530,20 +530,24 @@ class TestConvertQwen3VLToHF:
 
     @pytest.fixture()
     def tf_config(self):
-        """Mock TransformerConfig with Qwen3-VL-2B-ish text values."""
+        """Mock TransformerConfig matching Qwen/Qwen3-VL-2B-Instruct text_config:
+        hidden=2048, attn_heads=16, kv_heads=8, head_dim=128.
+        """
         cfg = MagicMock()
         cfg.hidden_size = 2048
         cfg.num_attention_heads = 16
-        cfg.num_query_groups = 8  # Qwen3 less aggressive GQA
+        cfg.num_query_groups = 8
         cfg.kv_channels = 128
         return cfg
 
     @pytest.fixture()
     def hf_config(self):
-        """Mock HF config with vision_config for Qwen3-VL."""
+        """Mock HF config matching Qwen/Qwen3-VL-2B-Instruct vision_config:
+        hidden=1024, num_heads=16 (head_dim=64).
+        """
         cfg = MagicMock()
         cfg.vision_config.num_heads = 16
-        cfg.vision_config.hidden_size = 1152
+        cfg.vision_config.hidden_size = 1024
         return cfg
 
     # --- Registry dispatch ---
@@ -553,7 +557,7 @@ class TestConvertQwen3VLToHF:
         not fall through to qwen3 (substring match order)."""
         from areal.engine.megatron_utils.megatron import convert_to_hf
 
-        param = torch.randn(1152)
+        param = torch.randn(1024)
         result = convert_to_hf(
             tf_config,
             "qwen3_vl",
@@ -725,7 +729,7 @@ class TestConvertQwen3VLToHF:
     def test_vision_patch_embed_weight(self, tf_config):
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
-        param = torch.randn(1152, 3, 2, 16, 16)
+        param = torch.randn(1024, 3, 2, 16, 16)
         result = convert_qwen3_vl_to_hf(
             tf_config,
             "module.module.vision_model.patch_embed.proj.weight",
@@ -737,7 +741,7 @@ class TestConvertQwen3VLToHF:
         """Qwen3-VL adds patch_embed bias (Qwen2.5-VL was bias=False)."""
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
-        param = torch.randn(1152)
+        param = torch.randn(1024)
         result = convert_qwen3_vl_to_hf(
             tf_config,
             "module.module.vision_model.patch_embed.proj.bias",
@@ -749,7 +753,7 @@ class TestConvertQwen3VLToHF:
         """Qwen3-VL has pos_embed (new vs Qwen2.5-VL)."""
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
-        param = torch.randn(1024, 1152)
+        param = torch.randn(2304, 1024)
         result = convert_qwen3_vl_to_hf(
             tf_config,
             "module.module.vision_model.pos_embed.weight",
@@ -762,7 +766,7 @@ class TestConvertQwen3VLToHF:
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
         for kind in ("weight", "bias"):
-            param = torch.randn(1152)
+            param = torch.randn(1024)
             result = convert_qwen3_vl_to_hf(
                 tf_config,
                 f"module.module.vision_model.merger.patch_norm.{kind}",
@@ -790,8 +794,8 @@ class TestConvertQwen3VLToHF:
     def test_vision_block_qkv_weight_reordered(self, tf_config, hf_config):
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
-        # 3 * hidden_vision = 3 * 1152 = 3456
-        param = torch.randn(3456, 1152)
+        # 3 * hidden_vision = 3 * 1024 = 3072
+        param = torch.randn(3072, 1024)
         result = convert_qwen3_vl_to_hf(
             tf_config,
             "module.module.vision_model.decoder.layers.7.self_attention.linear_qkv.weight",
@@ -804,7 +808,7 @@ class TestConvertQwen3VLToHF:
     def test_vision_block_qkv_bias_reordered(self, tf_config, hf_config):
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
-        param = torch.randn(3456)
+        param = torch.randn(3072)
         result = convert_qwen3_vl_to_hf(
             tf_config,
             "module.module.vision_model.decoder.layers.0.self_attention.linear_qkv.bias",
@@ -817,7 +821,7 @@ class TestConvertQwen3VLToHF:
     def test_vision_block_qkv_requires_hf_config(self, tf_config):
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
-        param = torch.randn(3456, 1152)
+        param = torch.randn(3072, 1024)
         with pytest.raises(ValueError, match="vision_config.num_heads"):
             convert_qwen3_vl_to_hf(
                 tf_config,
@@ -828,7 +832,7 @@ class TestConvertQwen3VLToHF:
     def test_vision_block_attn_proj(self, tf_config):
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
-        for kind, shape in (("weight", (1152, 1152)), ("bias", (1152,))):
+        for kind, shape in (("weight", (1024, 1024)), ("bias", (1024,))):
             param = torch.randn(*shape)
             result = convert_qwen3_vl_to_hf(
                 tf_config,
@@ -842,7 +846,7 @@ class TestConvertQwen3VLToHF:
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
         for kind in ("weight", "bias"):
-            param = torch.randn(1152)
+            param = torch.randn(1024)
             result = convert_qwen3_vl_to_hf(
                 tf_config,
                 f"module.module.vision_model.decoder.layers.0.self_attention.linear_qkv.layer_norm_{kind}",
@@ -854,7 +858,7 @@ class TestConvertQwen3VLToHF:
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
         for kind in ("weight", "bias"):
-            param = torch.randn(1152)
+            param = torch.randn(1024)
             result = convert_qwen3_vl_to_hf(
                 tf_config,
                 f"module.module.vision_model.decoder.layers.1.mlp.linear_fc1.layer_norm_{kind}",
@@ -869,7 +873,7 @@ class TestConvertQwen3VLToHF:
         """
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
-        for kind, shape in (("weight", (4304, 1152)), ("bias", (4304,))):
+        for kind, shape in (("weight", (4096, 1024)), ("bias", (4096,))):
             param = torch.randn(*shape)
             result = convert_qwen3_vl_to_hf(
                 tf_config,
@@ -881,7 +885,7 @@ class TestConvertQwen3VLToHF:
     def test_vision_block_mlp_fc2(self, tf_config):
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
-        for kind, shape in (("weight", (1152, 4304)), ("bias", (1152,))):
+        for kind, shape in (("weight", (1024, 4096)), ("bias", (1024,))):
             param = torch.randn(*shape)
             result = convert_qwen3_vl_to_hf(
                 tf_config,
@@ -897,7 +901,7 @@ class TestConvertQwen3VLToHF:
         from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
 
         for kind in ("weight", "bias"):
-            param = torch.randn(1152)
+            param = torch.randn(1024)
             result = convert_qwen3_vl_to_hf(
                 tf_config,
                 f"module.module.vision_model.decoder.deepstack_merger_list.{idx}.patch_norm.{kind}",

--- a/tests/test_megatron_engine_vlm.py
+++ b/tests/test_megatron_engine_vlm.py
@@ -283,6 +283,11 @@ class TestVisionModelDetection:
 
         assert is_valid_vision_model("qwen2_vl") is True
 
+    def test_qwen3_vl_detected(self):
+        from areal.engine.core.model import is_valid_vision_model
+
+        assert is_valid_vision_model("qwen3_vl") is True
+
     def test_qwen3_not_detected(self):
         from areal.engine.core.model import is_valid_vision_model
 
@@ -520,6 +525,427 @@ class TestConvertQwen25VLToHF:
             )
 
 
+class TestConvertQwen3VLToHF:
+    """Test mcore→HF weight name conversion for Qwen3-VL (dense)."""
+
+    @pytest.fixture()
+    def tf_config(self):
+        """Mock TransformerConfig with Qwen3-VL-2B-ish text values."""
+        cfg = MagicMock()
+        cfg.hidden_size = 2048
+        cfg.num_attention_heads = 16
+        cfg.num_query_groups = 8  # Qwen3 less aggressive GQA
+        cfg.kv_channels = 128
+        return cfg
+
+    @pytest.fixture()
+    def hf_config(self):
+        """Mock HF config with vision_config for Qwen3-VL."""
+        cfg = MagicMock()
+        cfg.vision_config.num_heads = 16
+        cfg.vision_config.hidden_size = 1152
+        return cfg
+
+    # --- Registry dispatch ---
+
+    def test_registry_dispatches_qwen3_vl_before_qwen3(self, tf_config, hf_config):
+        """convert_to_hf with model_name='qwen3_vl' must use the VLM converter,
+        not fall through to qwen3 (substring match order)."""
+        from areal.engine.megatron_utils.megatron import convert_to_hf
+
+        param = torch.randn(1152)
+        result = convert_to_hf(
+            tf_config,
+            "qwen3_vl",
+            "module.module.vision_model.merger.patch_norm.weight",
+            param,
+            hf_config=hf_config,
+        )
+        assert result[0][0] == "model.visual.merger.norm.weight"
+
+    # --- Language model (Qwen3-VL has model.language_model.* prefix) ---
+
+    def test_language_model_embedding_uses_language_model_prefix(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(151936, 2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.embedding.word_embeddings.weight",
+            param,
+        )
+        assert result == [("model.language_model.embed_tokens.weight", param)]
+
+    def test_language_model_final_norm(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.final_layernorm.weight",
+            param,
+        )
+        assert result == [("model.language_model.norm.weight", param)]
+
+    def test_language_model_output_layer(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(151936, 2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.output_layer.weight",
+            param,
+        )
+        assert result == [("lm_head.weight", param)]
+
+    def test_language_model_qkv_split(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        # value_num_per_group = 16/8 = 2, head_dim = 128
+        # qkv_dim = num_query_groups * (value_num_per_group + 2) * head_dim
+        qkv_dim = tf_config.num_query_groups * (2 + 1 + 1) * tf_config.kv_channels
+        param = torch.randn(qkv_dim, tf_config.hidden_size)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.5.self_attention.linear_qkv.weight",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.5.self_attn.q_proj.weight" in names
+        assert "model.language_model.layers.5.self_attn.k_proj.weight" in names
+        assert "model.language_model.layers.5.self_attn.v_proj.weight" in names
+
+    def test_language_model_qkv_bias_split(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        qkv_dim = tf_config.num_query_groups * (2 + 1 + 1) * tf_config.kv_channels
+        param = torch.randn(qkv_dim)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.self_attention.linear_qkv.bias",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.0.self_attn.q_proj.bias" in names
+        assert "model.language_model.layers.0.self_attn.k_proj.bias" in names
+        assert "model.language_model.layers.0.self_attn.v_proj.bias" in names
+
+    def test_language_model_q_norm(self, tf_config):
+        """Qwen3-specific q_layernorm → self_attn.q_norm."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(128)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.3.self_attention.q_layernorm.weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.3.self_attn.q_norm.weight", param)
+        ]
+
+    def test_language_model_k_norm(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(128)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.3.self_attention.k_layernorm.weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.3.self_attn.k_norm.weight", param)
+        ]
+
+    def test_language_model_o_proj(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048, 2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.self_attention.linear_proj.weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.0.self_attn.o_proj.weight", param)
+        ]
+
+    def test_language_model_input_layernorm(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.self_attention.linear_qkv.layer_norm_weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.0.input_layernorm.weight", param)
+        ]
+
+    def test_language_model_post_attention_layernorm(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc1.layer_norm_weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.0.post_attention_layernorm.weight", param)
+        ]
+
+    def test_language_model_mlp_fc1_splits_gate_up(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(12288, 2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc1.weight",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.0.mlp.gate_proj.weight" in names
+        assert "model.language_model.layers.0.mlp.up_proj.weight" in names
+
+    def test_language_model_mlp_fc2(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048, 6144)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc2.weight",
+            param,
+        )
+        assert result == [("model.language_model.layers.0.mlp.down_proj.weight", param)]
+
+    # --- Vision model: direct mappings (model.visual.* prefix) ---
+
+    def test_vision_patch_embed_weight(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(1152, 3, 2, 16, 16)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.patch_embed.proj.weight",
+            param,
+        )
+        assert result == [("model.visual.patch_embed.proj.weight", param)]
+
+    def test_vision_patch_embed_bias(self, tf_config):
+        """Qwen3-VL adds patch_embed bias (Qwen2.5-VL was bias=False)."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(1152)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.patch_embed.proj.bias",
+            param,
+        )
+        assert result == [("model.visual.patch_embed.proj.bias", param)]
+
+    def test_vision_pos_embed(self, tf_config):
+        """Qwen3-VL has pos_embed (new vs Qwen2.5-VL)."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(1024, 1152)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.pos_embed.weight",
+            param,
+        )
+        assert result == [("model.visual.pos_embed.weight", param)]
+
+    def test_vision_merger_patch_norm(self, tf_config):
+        """merger.patch_norm.{weight,bias} → merger.norm.{weight,bias}."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind in ("weight", "bias"):
+            param = torch.randn(1152)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.merger.patch_norm.{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.merger.norm.{kind}", param)]
+
+    def test_vision_merger_linear_fc1_fc2(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for fc in ("linear_fc1", "linear_fc2"):
+            for kind in ("weight", "bias"):
+                param = (
+                    torch.randn(4096, 4096) if kind == "weight" else torch.randn(4096)
+                )
+                result = convert_qwen3_vl_to_hf(
+                    tf_config,
+                    f"module.module.vision_model.merger.{fc}.{kind}",
+                    param,
+                )
+                assert result == [(f"model.visual.merger.{fc}.{kind}", param)]
+
+    # --- Vision model: per-layer params ---
+
+    def test_vision_block_qkv_weight_reordered(self, tf_config, hf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        # 3 * hidden_vision = 3 * 1152 = 3456
+        param = torch.randn(3456, 1152)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.7.self_attention.linear_qkv.weight",
+            param,
+            hf_config=hf_config,
+        )
+        assert result[0][0] == "model.visual.blocks.7.attn.qkv.weight"
+        assert result[0][1].shape == param.shape
+
+    def test_vision_block_qkv_bias_reordered(self, tf_config, hf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(3456)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.0.self_attention.linear_qkv.bias",
+            param,
+            hf_config=hf_config,
+        )
+        assert result[0][0] == "model.visual.blocks.0.attn.qkv.bias"
+        assert result[0][1].shape == param.shape
+
+    def test_vision_block_qkv_requires_hf_config(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(3456, 1152)
+        with pytest.raises(ValueError, match="vision_config.num_heads"):
+            convert_qwen3_vl_to_hf(
+                tf_config,
+                "module.module.vision_model.decoder.layers.0.self_attention.linear_qkv.weight",
+                param,
+            )
+
+    def test_vision_block_attn_proj(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind, shape in (("weight", (1152, 1152)), ("bias", (1152,))):
+            param = torch.randn(*shape)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.3.self_attention.linear_proj.{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.3.attn.proj.{kind}", param)]
+
+    def test_vision_block_norm1_weight_and_bias(self, tf_config):
+        """Qwen3-VL adds norm1.bias (Qwen2.5-VL was weight-only)."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind in ("weight", "bias"):
+            param = torch.randn(1152)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.0.self_attention.linear_qkv.layer_norm_{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.0.norm1.{kind}", param)]
+
+    def test_vision_block_norm2_weight_and_bias(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind in ("weight", "bias"):
+            param = torch.randn(1152)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.1.mlp.linear_fc1.layer_norm_{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.1.norm2.{kind}", param)]
+
+    def test_vision_block_mlp_is_NOT_gated(self, tf_config):
+        """Regression guard: Qwen3-VL vision MLP is NOT gated.
+
+        linear_fc1 must map 1:1 (no chunk into gate_proj/up_proj).
+        """
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind, shape in (("weight", (4304, 1152)), ("bias", (4304,))):
+            param = torch.randn(*shape)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.2.mlp.linear_fc1.{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.2.mlp.linear_fc1.{kind}", param)]
+
+    def test_vision_block_mlp_fc2(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind, shape in (("weight", (1152, 4304)), ("bias", (1152,))):
+            param = torch.randn(*shape)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.10.mlp.linear_fc2.{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.10.mlp.linear_fc2.{kind}", param)]
+
+    # --- Deepstack mergers (new in Qwen3-VL) ---
+
+    @pytest.mark.parametrize("idx", [0, 1, 2])
+    def test_deepstack_merger_norm(self, tf_config, idx):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind in ("weight", "bias"):
+            param = torch.randn(1152)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.deepstack_merger_list.{idx}.patch_norm.{kind}",
+                param,
+            )
+            assert result == [
+                (f"model.visual.deepstack_merger_list.{idx}.norm.{kind}", param)
+            ]
+
+    @pytest.mark.parametrize("idx", [0, 1, 2])
+    def test_deepstack_merger_linear_fc(self, tf_config, idx):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for fc in ("linear_fc1", "linear_fc2"):
+            for kind, shape in (("weight", (4096, 4096)), ("bias", (4096,))):
+                param = torch.randn(*shape)
+                result = convert_qwen3_vl_to_hf(
+                    tf_config,
+                    f"module.module.vision_model.decoder.deepstack_merger_list.{idx}.{fc}.{kind}",
+                    param,
+                )
+                assert result == [
+                    (f"model.visual.deepstack_merger_list.{idx}.{fc}.{kind}", param)
+                ]
+
+    # --- Error handling ---
+
+    def test_unknown_lang_param_raises(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        with pytest.raises(ValueError, match="Unknown Qwen3-VL language-model"):
+            convert_qwen3_vl_to_hf(
+                tf_config,
+                "module.module.language_model.decoder.layers.0.unknown.weight",
+                torch.randn(10),
+            )
+
+    def test_unknown_param_raises(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        with pytest.raises(ValueError, match="Unknown Qwen3-VL parameter"):
+            convert_qwen3_vl_to_hf(
+                tf_config,
+                "module.module.some_unknown.weight",
+                torch.randn(10),
+            )
+
+
 class TestRemovePaddingVLM:
     """Test remove_padding handles VLM language_model prefixed params."""
 
@@ -575,11 +1001,15 @@ def _run_vlm_test(
     nproc: int = 1,
     extra_args: list[str] | None = None,
     timeout: int = 300,
+    env_overrides: dict[str, str] | None = None,
 ):
     """Launch a VLM integration test via torchrun subprocess.
 
     Each test runs in its own process, ensuring complete device memory
     cleanup between tests. This allows the full suite to run on just 2 devices.
+
+    Pass ``env_overrides`` to switch the model under test (e.g. set
+    ``VLM_MODEL_PATH`` for Qwen3-VL).
     """
     from areal.utils.network import find_free_ports
 
@@ -587,6 +1017,8 @@ def _run_vlm_test(
 
     env = os.environ.copy()
     env["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(nproc))
+    if env_overrides:
+        env.update(env_overrides)
 
     cmd = [
         "torchrun",
@@ -627,41 +1059,87 @@ def _run_vlm_test(
     assert result == "Passed", f"VLM {test_type} test failed: {result}"
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Per-model env fixtures.
+#
+# Each scenario below runs once for every entry in _VLM_MODELS. To add a new
+# VLM (e.g. qwen3_vl_moe), append one tuple — no test-body changes needed.
+# Override the local path with QWEN25_VL_MODEL_PATH / QWEN3_VL_MODEL_PATH if
+# the model is staged elsewhere on the test machine.
+# ──────────────────────────────────────────────────────────────────────
+
+_VLM_MODELS = [
+    pytest.param(
+        {
+            "VLM_MODEL_PATH": os.environ.get(
+                "QWEN25_VL_MODEL_PATH",
+                "/storage/openpsi/models/Qwen__Qwen2.5-VL-3B-Instruct/",
+            ),
+        },
+        id="qwen25_vl",
+    ),
+    pytest.param(
+        {
+            "VLM_MODEL_PATH": os.environ.get(
+                "QWEN3_VL_MODEL_PATH",
+                "/storage/openpsi/models/Qwen__Qwen3-VL-2B-Instruct/",
+            ),
+        },
+        id="qwen3_vl",
+    ),
+]
+
+
 @pytest.mark.gpu
 @pytest.mark.slow
 @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
-def test_vlm_engine_initializes(tmp_path_factory):
+@pytest.mark.parametrize("model_env", _VLM_MODELS)
+def test_engine_initializes(model_env, tmp_path_factory):
     """Verify VLM engine detects vision model and loads processor."""
     output = str(tmp_path_factory.mktemp("vlm_test") / "init.out")
-    _run_vlm_test("init", output)
+    _run_vlm_test("init", output, env_overrides=model_env)
 
 
 @pytest.mark.gpu
 @pytest.mark.slow
 @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
-def test_vlm_simple_forward(tmp_path_factory):
+@pytest.mark.parametrize("model_env", _VLM_MODELS)
+def test_simple_forward(model_env, tmp_path_factory):
     """Verify forward pass with VLM inputs completes."""
     output = str(tmp_path_factory.mktemp("vlm_test") / "forward.out")
-    _run_vlm_test("forward", output)
+    _run_vlm_test("forward", output, env_overrides=model_env)
 
 
 @pytest.mark.gpu
 @pytest.mark.slow
 @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
-def test_vlm_hf_save_load_weights(tmp_path_factory):
+@pytest.mark.parametrize("model_env", _VLM_MODELS)
+def test_hf_save_load_weights(model_env, tmp_path_factory):
     """Verify save/load preserves VLM weights and saves processor."""
     save_dir = str(tmp_path_factory.mktemp("vlm_save"))
     output = str(tmp_path_factory.mktemp("vlm_test") / "save_load.out")
-    _run_vlm_test("save_load", output, extra_args=[f"--save_dir={save_dir}"])
+    _run_vlm_test(
+        "save_load",
+        output,
+        extra_args=[f"--save_dir={save_dir}"],
+        env_overrides=model_env,
+    )
 
 
 @pytest.mark.gpu
 @pytest.mark.multi_gpu
 @pytest.mark.slow
 @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
-def test_vlm_train_tensor_parallel(tmp_path_factory):
+@pytest.mark.parametrize("model_env", _VLM_MODELS)
+def test_train_tensor_parallel(model_env, tmp_path_factory):
     """VLM training with TP=2 to avoid single-device OOM."""
     if torch.cuda.device_count() < 2:
         pytest.skip("VLM TP training requires at least 2 GPUs")
     output = str(tmp_path_factory.mktemp("vlm_test") / "train_tp2.out")
-    _run_vlm_test("train", output, backend="megatron:d1p1t2", nproc=2)
+    _run_vlm_test(
+        "train",
+        output,
+        backend="megatron:d1p1t2",
+        nproc=2,
+        env_overrides=model_env,
+    )

--- a/tests/torchrun/run_megatron_engine_vlm.py
+++ b/tests/torchrun/run_megatron_engine_vlm.py
@@ -3,6 +3,17 @@
 Launched via torchrun from test_megatron_engine_vlm.py. All integration
 tests run as subprocesses so the parent pytest process never allocates
 GPU memory, allowing the full suite to run on just 2 GPUs.
+
+Supports any registered VLM whose ``hf_config`` exposes ``vision_config``
+with ``patch_size``, ``temporal_patch_size``, ``spatial_merge_size``,
+``in_channels``, and ``image_token_id`` — ``mock_vlm_input`` reads patch
+geometry from ``engine.hf_config`` so this script works for both
+Qwen2.5-VL (patch=14) and Qwen3-VL (patch=16) without code-side
+branching. Select the model via the ``VLM_MODEL_PATH`` env var
+(preferred) or the legacy ``QWEN25_VL_MODEL_PATH``. The default is
+Qwen2.5-VL-3B-Instruct; the HF Hub fallback in ``get_model_path`` is a
+Qwen2.5-VL-3B safety net only and the model is expected to be
+pre-downloaded on the test machine.
 """
 
 import argparse
@@ -28,8 +39,11 @@ from areal.utils.data import broadcast_tensor_container
 
 VLM_MODEL_PATH = get_model_path(
     os.environ.get(
-        "QWEN25_VL_MODEL_PATH",
-        "/storage/openpsi/models/Qwen__Qwen2.5-VL-3B-Instruct/",
+        "VLM_MODEL_PATH",
+        os.environ.get(
+            "QWEN25_VL_MODEL_PATH",
+            "/storage/openpsi/models/Qwen__Qwen2.5-VL-3B-Instruct/",
+        ),
     ),
     "Qwen/Qwen2.5-VL-3B-Instruct",
 )
@@ -40,16 +54,26 @@ def write_result(path: str, result: str):
         f.write(result)
 
 
-def mock_vlm_input(device: str) -> dict[str, Any]:
-    """Create mock VLM input with vision tokens."""
-    PATCH_DIM = 3 * 2 * 14 * 14  # 1176
-    SPATIAL_MERGE_SIZE = 2
-    IMAGE_TOKEN_ID = 151655
+def mock_vlm_input(engine: "MegatronEngine") -> dict[str, Any]:
+    """Create mock VLM input with vision tokens.
+
+    Pulls patch geometry from ``engine.hf_config`` so this works for both
+    Qwen2.5-VL (patch_size=14) and Qwen3-VL (patch_size=16).
+    """
+    vc = engine.hf_config.vision_config
+    patch_size = getattr(vc, "patch_size", 14)
+    temporal_patch_size = getattr(vc, "temporal_patch_size", 2)
+    spatial_merge_size = getattr(vc, "spatial_merge_size", 2)
+    in_channels = getattr(vc, "in_channels", 3)
+    image_token_id = getattr(engine.hf_config, "image_token_id", 151655)
+    device = engine.device
+
+    patch_dim = in_channels * temporal_patch_size * patch_size * patch_size
 
     grid_t, grid_h, grid_w = 1, 4, 4
     total_patches = grid_t * grid_h * grid_w
     num_image_tokens = (
-        grid_t * (grid_h // SPATIAL_MERGE_SIZE) * (grid_w // SPATIAL_MERGE_SIZE)
+        grid_t * (grid_h // spatial_merge_size) * (grid_w // spatial_merge_size)
     )
 
     batch_size = 1
@@ -57,12 +81,12 @@ def mock_vlm_input(device: str) -> dict[str, Any]:
     seq_len = num_text_tokens + num_image_tokens
 
     text_tokens = torch.randint(0, 1000, (num_text_tokens,), dtype=torch.long)
-    image_tokens = torch.full((num_image_tokens,), IMAGE_TOKEN_ID, dtype=torch.long)
+    image_tokens = torch.full((num_image_tokens,), image_token_id, dtype=torch.long)
     input_ids = torch.cat([text_tokens, image_tokens]).unsqueeze(0).to(device)
     attention_mask = torch.ones(batch_size, seq_len, dtype=torch.bool, device=device)
 
     pixel_values = torch.randn(
-        total_patches, PATCH_DIM, dtype=torch.float32, device=device
+        total_patches, patch_dim, dtype=torch.float32, device=device
     )
     image_grid_thw = torch.tensor(
         [[grid_t, grid_h, grid_w]], dtype=torch.long, device=device
@@ -99,7 +123,7 @@ def make_vlm_engine(backend: str, init_optimizer: bool = False) -> MegatronEngin
 
 def _make_input(engine: MegatronEngine) -> dict[str, Any]:
     """Create mock input and broadcast across model-parallel ranks."""
-    input_ = mock_vlm_input(device=engine.device)
+    input_ = mock_vlm_input(engine)
     return broadcast_tensor_container(
         input_,
         src_rank=engine.current_data_parallel_head(),


### PR DESCRIPTION
## Description

Adds Qwen3-VL dense support to AReaL's Megatron engine via mbridge, so GRPO/PPO of any Qwen3-VL model on the Megatron backend is unblocked.

**Key changes:**
- `areal/engine/megatron_utils/megatron.py`: new `convert_qwen3_vl_to_hf` registered before `"qwen3"` in `_CONVERSION_FN_REGISTRY` (mapping anchored on `mbridge.models.qwen3_vl.Qwen3VLBridge`). Carries an early-raise on Qwen3-VL-MoE param names so `qwen3_vl_moe` cannot silently dispatch to the dense converter via substring match. `_vision_qkv_mcore_to_hf` gains a no-GQA assertion that guards future vision-GQA VLMs.
- `areal/engine/core/model.py`: new `lang_config(hf_config)` helper — `getattr(hf_config, "text_config", hf_config)` — so callers can read language-side attrs (`vocab_size`, `num_attention_heads`, `num_key_value_heads`, `hidden_size`, `head_dim`) uniformly across Qwen3-VL (nested) and Qwen2.5-VL / pure text (flat).
- `areal/models/mcore/hf_load.py`: `_merge_qkv_weights`, `_load_fused_qkv_weight`, and the GQA branch of `_weight_to_mcore_tp` use the shared `lang_config` helper.
- `areal/engine/megatron_engine.py`: `_collect_param` uses `lang_config(self.hf_config).vocab_size` for `remove_padding`.
- `tests/test_megatron_engine_vlm.py`: add `TestConvertQwen3VLToHF` and parametrize the VLM integration tests across `qwen25_vl` and `qwen3_vl` via `_VLM_MODELS` + `env_overrides`.
- `tests/torchrun/run_megatron_engine_vlm.py`: `mock_vlm_input` reads patch geometry from `engine.hf_config` so it works for both VLMs without code-side branching.

**Tests added:**
- `TestConvertQwen3VLToHF` (CPU unit tests for `convert_qwen3_vl_to_hf`):
  - Registry dispatch: `qwen3_vl` resolves before `qwen3` substring fallback.
  - Language model: embedding / final norm / output_layer prefixes; QKV weight + bias split with GQA; q_norm / k_norm / o_proj / input_layernorm / post_attention_layernorm; gated MLP fc1 split + fc2.
  - Vision direct mappings: patch_embed weight + bias, pos_embed, merger (`patch_norm`, `linear_fc1/2`).
  - Vision per-block: QKV per-head→grouped reorder for weight + bias; requires `hf_config.vision_config.num_heads`; attn proj; norm1 / norm2 weight + bias; **non-gated MLP** regression guard (linear_fc1 must NOT chunk); fc2.
  - Deepstack mergers: parametrized over indices `[0, 1, 2]` for `norm` and `linear_fc{1,2}`.
  - Error handling: unknown language-model and unknown vision parameter names.
- `test_qwen3_vl_detected` added to `TestVisionModelDetection`.
- The 4 existing `test_vlm_*` integration tests (`test_engine_initializes`, `test_simple_forward`, `test_hf_save_load_weights`, `test_train_tensor_parallel`) become parametrized over `_VLM_MODELS` so they run once per VLM (qwen25_vl, qwen3_vl). Adding a new VLM is a one-line addition to `_VLM_MODELS`.

**Scope:**
- `bridge_type: mbridge` only. The `bridge_type: megatron-bridge` path with Qwen3-VL + `gradient_checkpointing: true` crashes inside `Qwen3VLTransformerBlock._checkpointed_forward` with `TypeError: save_for_backward can only save variables, but argument 6 is of type list` — `deepstack_visual_embeds` is handed verbatim to `tensor_parallel.checkpoint`. Fixed upstream in megatron-bridge **v0.4.0** (variadic-flatten of `deepstack_visual_embeds`); this PR intentionally does **NOT** vendor-patch the megatron-bridge path so it lights up automatically when the dependency upgrade lands as #1206 plans to do.
- Context parallelism for VLM (`context_parallel_size > 1`) continues to raise `NotImplementedError` — matches Qwen2.5-VL state.
- Out of scope: Qwen3-VL MoE (`qwen3_vl_moe`), `pixel_values_videos` plumbing for streaming video inputs.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

N/A — net-new feature support.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A.

## Additional Context

Fix for #1298 is required to run integration tests or actual training. This PR was tested with a local patch which is not committed.

### Training Reward Example
Image: ghcr.io/inclusionai/areal-runtime:v1.0.3-vllm with mbridge upgraded according to #1258
Dataset: Geometry3k
Model: Qwen3-VL-3B-Instruct /  Qwen3-VL-32B-Instruct
Scheduler: Slurm
<img width="2145" height="937" alt="image" src="https://github.com/user-attachments/assets/518c17ad-9bb3-465e-9f99-9acbe247e1bd" />


