### PR TITLE
Add mbridge weight save as an option in Megatron

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -923,6 +923,13 @@ class MegatronEngineConfig:
         },
     )
 
+    use_mbridge_cpu_save: bool = field(
+        default=False,
+        metadata={
+            "help": "Use CPU-based save instead of all-gather to save device memory."
+        },
+    )
+
 
 class SchedulingStrategyType(str, Enum):
     separation = "separation"

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -923,10 +923,10 @@ class MegatronEngineConfig:
         },
     )
 
-    use_mbridge_cpu_save: bool = field(
+    use_mbridge_save: bool = field(
         default=False,
         metadata={
-            "help": "Use CPU-based save instead of all-gather to save device memory."
+            "help": "Use mbridge's save method to save gpu memory when saving weights."
         },
     )
 

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -79,7 +79,10 @@ from areal.engine.megatron_utils.pipeline_parallel import (
 from areal.infra.dist_rollout import DistRolloutCoordinator
 from areal.infra.platforms import current_platform
 from areal.models.mcore.hf_load import load_weights_from_hf_with_mbridge_fast
-from areal.models.mcore.hf_save import save_weights_to_hf_with_mbridge_fast
+from areal.models.mcore.hf_save import (
+    save_critic_value_head,
+    save_weights_to_hf_with_mbridge_fast,
+)
 from areal.models.mcore.registry import make_hf_and_mcore_config, make_mcore_model
 from areal.models.tree_attn.functional import (
     _gather_packed_tree_logprobs,
@@ -1767,16 +1770,23 @@ class MegatronEngine(TrainEngine):
                     source_path=base_model_path,
                 )
         else:
-            save_weights_to_hf_with_mbridge_fast(
-                bridge=self.bridge,
-                models=self.model,
-                weights_path=path,
-                base_model_path=base_model_path,
-                max_shard_size_byte=int(3e9),
-                max_workers=None,
-                is_critic=self.config.is_critic,
-                fp8_direct_convert=self.fp8_direct_convert,
-            )
+            if self.mcore_config.use_mbridge_cpu_save:
+                self.bridge.save_weights(
+                    models=self.model, weights_path=path, memory_efficient=True
+                )
+                if self.config.is_critic:
+                    save_critic_value_head(self.model, path)
+            else:
+                save_weights_to_hf_with_mbridge_fast(
+                    bridge=self.bridge,
+                    models=self.model,
+                    weights_path=path,
+                    base_model_path=base_model_path,
+                    max_shard_size_byte=int(3e9),
+                    max_workers=None,
+                    is_critic=self.config.is_critic,
+                    fp8_direct_convert=self.fp8_direct_convert,
+                )
 
         if dist.get_rank() == 0:
             if tokenizer is not None:

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1770,10 +1770,8 @@ class MegatronEngine(TrainEngine):
                     source_path=base_model_path,
                 )
         else:
-            if self.mcore_config.use_mbridge_cpu_save:
-                self.bridge.save_weights(
-                    models=self.model, weights_path=path, memory_efficient=True
-                )
+            if self.mcore_config.use_mbridge_save:
+                self.bridge.save_weights(models=self.model, weights_path=path)
             else:
                 save_weights_to_hf_with_mbridge_fast(
                     bridge=self.bridge,

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1771,6 +1771,14 @@ class MegatronEngine(TrainEngine):
                 )
         else:
             if self.mcore_config.use_mbridge_save:
+                # when loading model using AreaL's fast hf load, the safetensor_io is never set
+                if (
+                    not hasattr(self.bridge, "safetensor_io")
+                    or self.bridge.safetensor_io is None
+                ):
+                    self.bridge.safetensor_io = self.bridge._get_safetensor_io(
+                        self.config.path
+                    )
                 self.bridge.save_weights(models=self.model, weights_path=path)
             else:
                 save_weights_to_hf_with_mbridge_fast(

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -1774,8 +1774,6 @@ class MegatronEngine(TrainEngine):
                 self.bridge.save_weights(
                     models=self.model, weights_path=path, memory_efficient=True
                 )
-                if self.config.is_critic:
-                    save_critic_value_head(self.model, path)
             else:
                 save_weights_to_hf_with_mbridge_fast(
                     bridge=self.bridge,
@@ -1784,9 +1782,11 @@ class MegatronEngine(TrainEngine):
                     base_model_path=base_model_path,
                     max_shard_size_byte=int(3e9),
                     max_workers=None,
-                    is_critic=self.config.is_critic,
                     fp8_direct_convert=self.fp8_direct_convert,
                 )
+
+            if self.config.is_critic:
+                save_critic_value_head(self.model, path)
 
         if dist.get_rank() == 0:
             if tokenizer is not None:

--- a/areal/models/mcore/hf_save.py
+++ b/areal/models/mcore/hf_save.py
@@ -587,7 +587,13 @@ def save_weights_to_hf_with_mbridge_fast(
             _patch_saved_config(base_model_path, weights_path)
 
     # 8. Save ValueHead weights separately for critic models.
-    if is_critic and mpu.is_pipeline_last_stage():
+    if is_critic:
+        save_critic_value_head(models, weights_path)
+
+
+def save_critic_value_head(models, weights_path):
+    # 8. Save ValueHead weights separately for critic models.
+    if mpu.is_pipeline_last_stage():
         is_tp_first = mpu.get_tensor_model_parallel_rank() == 0
         is_dp_first = mpu.get_data_parallel_rank(with_context_parallel=True) == 0
         should_save_value_head = is_tp_first and is_dp_first

--- a/areal/models/mcore/hf_save.py
+++ b/areal/models/mcore/hf_save.py
@@ -230,7 +230,6 @@ def save_weights_to_hf_with_mbridge_fast(
     base_model_path: str | None = None,
     max_shard_size_byte: int = int(3e9),
     max_workers: int | None = None,
-    is_critic: bool = False,
     fp8_direct_convert: bool = False,
 ):
     # 1. Prepare some global metadata required for saving the model.
@@ -585,10 +584,6 @@ def save_weights_to_hf_with_mbridge_fast(
         if base_model_path is not None:
             copy_hf_configs(base_model_path, weights_path)
             _patch_saved_config(base_model_path, weights_path)
-
-    # 8. Save ValueHead weights separately for critic models.
-    if is_critic:
-        save_critic_value_head(models, weights_path)
 
 
 def save_critic_value_head(models, weights_path):

--- a/areal/models/mcore/hf_save.py
+++ b/areal/models/mcore/hf_save.py
@@ -587,7 +587,6 @@ def save_weights_to_hf_with_mbridge_fast(
 
 
 def save_critic_value_head(models, weights_path):
-    # 8. Save ValueHead weights separately for critic models.
     if mpu.is_pipeline_last_stage():
         is_tp_first = mpu.get_tensor_model_parallel_rank() == 0
         is_dp_first = mpu.get_data_parallel_rank(with_context_parallel=True) == 0

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -1088,7 +1088,7 @@ Refer to Megatron-LM documentation for implementation details.
 | `moe_permute_fusion`                       | boolean                                                              | `False`      | Fuse token rearrangement ops during token dispatching.                                                                                                                                            |
 | `fp8_config`                               | [`FP8EngineConfig`](section-fp8-engine) \| None                      | `None`       | -                                                                                                                                                                                                 |
 | `bridge_type`                              | string                                                               | `"mbridge"`  | Bridge backend for MegatronEngine. Choices: 'mbridge' or 'megatron-bridge'. **Choices:** `mbridge`, `megatron-bridge`                                                                             |
-| `use_mbridge_cpu_save`                     | bool                                                                 | `False`      | Use CPU-based save instead of all-gather to save device memory.                                                                                                                                   |
+| `use_mbridge_save`                         | bool                                                                 | `False`      | Use mbridge's save method to save gpu memory when saving weights.                                                                                                                                 |
 
 (section-memory-profiler)=
 

--- a/docs/en/cli_reference.md
+++ b/docs/en/cli_reference.md
@@ -1088,6 +1088,7 @@ Refer to Megatron-LM documentation for implementation details.
 | `moe_permute_fusion`                       | boolean                                                              | `False`      | Fuse token rearrangement ops during token dispatching.                                                                                                                                            |
 | `fp8_config`                               | [`FP8EngineConfig`](section-fp8-engine) \| None                      | `None`       | -                                                                                                                                                                                                 |
 | `bridge_type`                              | string                                                               | `"mbridge"`  | Bridge backend for MegatronEngine. Choices: 'mbridge' or 'megatron-bridge'. **Choices:** `mbridge`, `megatron-bridge`                                                                             |
+| `use_mbridge_cpu_save`                     | bool                                                                 | `False`      | Use CPU-based save instead of all-gather to save device memory.                                                                                                                                   |
 
 (section-memory-profiler)=
 

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -1086,7 +1086,7 @@ Refer to Megatron-LM documentation for implementation details.
 | `moe_permute_fusion`                       | boolean                                                              | `False`      | Fuse token rearrangement ops during token dispatching.                                                                                                                                            |
 | `fp8_config`                               | [`FP8EngineConfig`](section-fp8-engine) \| None                      | `None`       | -                                                                                                                                                                                                 |
 | `bridge_type`                              | string                                                               | `"mbridge"`  | Bridge backend for MegatronEngine. Choices: 'mbridge' or 'megatron-bridge'. **Choices:** `mbridge`, `megatron-bridge`                                                                             |
-| `use_mbridge_cpu_save`                     | bool                                                                 | `False`      | Use CPU-based save instead of all-gather to save device memory.                                                                                                                                   |
+| `use_mbridge_save`                         | bool                                                                 | `False`      | Use mbridge's save method to save gpu memory when saving weights.                                                                                                                                 |
 
 (section-memory-profiler)=
 

--- a/docs/zh/cli_reference.md
+++ b/docs/zh/cli_reference.md
@@ -1086,6 +1086,7 @@ Refer to Megatron-LM documentation for implementation details.
 | `moe_permute_fusion`                       | boolean                                                              | `False`      | Fuse token rearrangement ops during token dispatching.                                                                                                                                            |
 | `fp8_config`                               | [`FP8EngineConfig`](section-fp8-engine) \| None                      | `None`       | -                                                                                                                                                                                                 |
 | `bridge_type`                              | string                                                               | `"mbridge"`  | Bridge backend for MegatronEngine. Choices: 'mbridge' or 'megatron-bridge'. **Choices:** `mbridge`, `megatron-bridge`                                                                             |
+| `use_mbridge_cpu_save`                     | bool                                                                 | `False`      | Use CPU-based save instead of all-gather to save device memory.                                                                                                                                   |
 
 (section-memory-profiler)=
 


### PR DESCRIPTION
## Description

This PR adds an option to use `mbridge.bridge.save_weights` over `save_weights_to_hf_with_mbridge_fast`. `save_weights_to_hf_with_mbridge_fast` performs an all-gather operation of weight shards in TP within a PP stage, which can result in high memory pressure for very large models. The mbridge implementation buckets this gather operation to reduce memory pressure.
## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
