### PR TITLE
feat(engine): add Qwen3-VL dense and MoE support to Megatron path

### DIFF
--- a/areal/engine/core/model.py
+++ b/areal/engine/core/model.py
@@ -6,6 +6,7 @@ VALID_VISION_MODELS = [
     "qwen2_vl",
     "qwen2_5_vl",
     "qwen3_vl",
+    "qwen3_vl_moe",
     "gemma3",
 ]
 # This registry is used to check if a model is a vision model that we have checked it works with AReaL.
@@ -23,7 +24,19 @@ def is_qwen2_vl_model(model_type: str) -> bool:
 
 
 def is_qwen3_vl_model(model_type: str) -> bool:
-    return model_type in ["qwen3_vl"]
+    """True for the Qwen3-VL family (dense and MoE).
+
+    Existing call sites in ``fsdp_engine``, ``fsdp_utils/parallel``, and
+    ``awex/fsdp_adapter`` gate family-level behaviour (mRoPE index,
+    attention-mask handling) that is identical for dense and MoE, so this
+    helper covers both. Use ``is_qwen3_vl_moe_model`` when the MoE-vs-dense
+    distinction matters.
+    """
+    return model_type in ("qwen3_vl", "qwen3_vl_moe")
+
+
+def is_qwen3_vl_moe_model(model_type: str) -> bool:
+    return model_type == "qwen3_vl_moe"
 
 
 def is_qwen_vl_model(model_type: str) -> bool:
@@ -48,6 +61,7 @@ def is_gemma3_model(model_type: str) -> bool:
 
 VALID_MOE_MODELS = [
     "qwen3_moe",
+    "qwen3_vl_moe",
     "qwen3_5_moe",
     "qwen3_5_moe_text",
     "bailing_moe_v2",

--- a/areal/engine/core/model.py
+++ b/areal/engine/core/model.py
@@ -30,6 +30,18 @@ def is_qwen_vl_model(model_type: str) -> bool:
     return is_qwen2_vl_model(model_type) or is_qwen3_vl_model(model_type)
 
 
+def lang_config(hf_config):
+    """Return the language-model side of a (possibly nested) HF config.
+
+    Qwen3-VL and similar VLMs nest text-model attributes (vocab_size,
+    num_attention_heads, num_key_value_heads, hidden_size, head_dim) under
+    ``hf_config.text_config``. Qwen2.5-VL and pure text models keep them
+    flat. Use this anywhere the caller wants a language-side attribute and
+    doesn't know the model family up front.
+    """
+    return getattr(hf_config, "text_config", hf_config)
+
+
 def is_gemma3_model(model_type: str) -> bool:
     return model_type in ["gemma3"]
 

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -56,7 +56,11 @@ from areal.engine.core.distributed import (
     init_custom_process_group,
     warmup_process_groups,
 )
-from areal.engine.core.model import disable_dropout_in_model, is_valid_vision_model
+from areal.engine.core.model import (
+    disable_dropout_in_model,
+    is_valid_vision_model,
+    lang_config,
+)
 from areal.engine.megatron_utils.checkpointer import MegatronCheckpointManager
 from areal.engine.megatron_utils.deterministic import set_deterministic_algorithms
 from areal.engine.megatron_utils.fp8 import FP8BlockwiseTensorHelper
@@ -1463,7 +1467,7 @@ class MegatronEngine(TrainEngine):
             duplicated_param_names=self._duplicated_param_names,
             gated_linear_unit=is_glu,
         )
-        param = remove_padding(name, param, self.hf_config.vocab_size)
+        param = remove_padding(name, param, lang_config(self.hf_config).vocab_size)
 
         if isinstance(param, FP8BlockwiseTensorHelper):
             # FP8 is stored as uint8, so element_size is 1 byte

--- a/areal/engine/megatron_utils/megatron.py
+++ b/areal/engine/megatron_utils/megatron.py
@@ -382,6 +382,14 @@ def _vision_qkv_mcore_to_hf(param: Tensor, vision_num_heads: int) -> Tensor:
     """
     hidden_vision = param.shape[0] // 3
     head_dim = hidden_vision // vision_num_heads
+    # Vision encoders for both Qwen2.5-VL and Qwen3-VL set
+    # num_query_groups == num_attention_heads (no GQA on the vision side); a
+    # future VLM that breaks this would silently miscompile vision QKV here.
+    assert head_dim * vision_num_heads * 3 == param.shape[0], (
+        f"_vision_qkv_mcore_to_hf assumes vision has no GQA "
+        f"(num_kv_heads == num_heads). Got param.shape[0]={param.shape[0]}, "
+        f"vision_num_heads={vision_num_heads}, derived head_dim={head_dim}."
+    )
     is_bias = param.ndim == 1
 
     if is_bias:
@@ -483,6 +491,217 @@ def convert_qwen2_5_vl_to_hf(
             return [(f"visual.blocks.{layer_idx}.norm2.weight", param)]
 
     raise ValueError(f"Unknown parameter name: {name}")
+
+
+def convert_qwen3_vl_to_hf(
+    tf_config: TransformerConfig,
+    name: str,
+    param: Parameter | Tensor | FP8BlockwiseTensorHelper,
+    hf_config=None,
+):
+    """Convert Qwen3-VL Megatron parameters to HuggingFace format.
+
+    Handles dense Qwen3-VL only; Qwen3-VL-MoE is a follow-up.
+
+    HF naming differs from Qwen2.5-VL:
+    - Vision: ``model.visual.*`` (extra ``model.`` prefix)
+    - Language: ``model.language_model.layers.*`` (extra ``language_model``)
+    - Text Q/K norms: ``self_attn.{q,k}_norm.weight`` (vs Qwen2's missing q/k norm)
+    - Vision MLP is non-gated: ``linear_fc1`` / ``linear_fc2`` map 1:1 (no chunk).
+    - Vision norms have bias; vision merger uses ``patch_norm`` and
+      ``linear_fc{1,2}`` directly (no separate projection encoder).
+    - New tensors: ``model.visual.pos_embed``, ``patch_embed.proj.bias``,
+      ``deepstack_merger_list.{i}.{norm,linear_fc1,linear_fc2}``.
+
+    The mapping mirrors mbridge.models.qwen3_vl.Qwen3VLBridge (the source of
+    truth used by ``update_weights``).
+    """
+
+    # ---- Language model (Qwen3 text) ----
+    _LM_PREFIX = "module.module.language_model."
+    if name == "module.module.language_model.embedding.word_embeddings.weight":
+        return [("model.language_model.embed_tokens.weight", param)]
+    if name == "module.module.language_model.decoder.final_layernorm.weight":
+        return [("model.language_model.norm.weight", param)]
+    if name == "module.module.language_model.output_layer.weight":
+        return [("lm_head.weight", param)]
+
+    # Early-raise on Qwen3-VL-MoE expert / router params before they fall
+    # through to the dense "Unknown Qwen3-VL language-model parameter" branch.
+    # `_CONVERSION_FN_REGISTRY` dispatches via substring matching, so once a
+    # `qwen3_vl_moe` model_type exists it will route here unless `qwen3_vl_moe`
+    # is registered BEFORE `qwen3_vl`.
+    if name.startswith(_LM_PREFIX) and (
+        ".mlp.experts." in name
+        or ".mlp.router." in name
+        or ".pre_mlp_layernorm." in name
+    ):
+        raise NotImplementedError(
+            "Qwen3-VL-MoE is not supported by convert_qwen3_vl_to_hf. "
+            "Implement convert_qwen3_vl_moe_to_hf and register it BEFORE "
+            "'qwen3_vl' in _CONVERSION_FN_REGISTRY (substring matching "
+            "dispatches the first hit)."
+        )
+
+    if name.startswith(_LM_PREFIX):
+        match = re.match(
+            r"module\.module\.language_model\.decoder\.layers\.(\d+)\.(.+)",
+            name,
+        )
+        if match:
+            layer_idx, rest = match.groups()
+            if tf_config.num_query_groups is None:
+                raise ValueError("Qwen3-VL text model requires num_query_groups")
+            kv_channels = getattr(tf_config, "kv_channels", None)
+            if kv_channels is not None:
+                head_dim = kv_channels
+            else:
+                head_dim = tf_config.hidden_size // tf_config.num_attention_heads
+            value_num_per_group = (
+                tf_config.num_attention_heads // tf_config.num_query_groups
+            )
+
+            base = f"model.language_model.layers.{layer_idx}"
+
+            if rest == "self_attention.linear_proj.weight":
+                return [(f"{base}.self_attn.o_proj.weight", param)]
+            if rest == "self_attention.linear_qkv.weight":
+                p = param.view(
+                    tf_config.num_query_groups, -1, head_dim, tf_config.hidden_size
+                )
+                q, k, v = torch.split(
+                    p, split_size_or_sections=[value_num_per_group, 1, 1], dim=1
+                )
+                return [
+                    (
+                        f"{base}.self_attn.q_proj.weight",
+                        q.reshape(-1, tf_config.hidden_size),
+                    ),
+                    (
+                        f"{base}.self_attn.k_proj.weight",
+                        k.reshape(-1, tf_config.hidden_size),
+                    ),
+                    (
+                        f"{base}.self_attn.v_proj.weight",
+                        v.reshape(-1, tf_config.hidden_size),
+                    ),
+                ]
+            if rest == "self_attention.linear_qkv.bias":
+                p = param.view(tf_config.num_query_groups, -1)
+                q, k, v = torch.split(
+                    p,
+                    split_size_or_sections=[
+                        value_num_per_group * head_dim,
+                        head_dim,
+                        head_dim,
+                    ],
+                    dim=1,
+                )
+                return [
+                    (f"{base}.self_attn.q_proj.bias", q.contiguous().flatten()),
+                    (f"{base}.self_attn.k_proj.bias", k.contiguous().flatten()),
+                    (f"{base}.self_attn.v_proj.bias", v.contiguous().flatten()),
+                ]
+            if rest == "self_attention.linear_qkv.layer_norm_weight":
+                return [(f"{base}.input_layernorm.weight", param)]
+            if rest == "self_attention.q_layernorm.weight":
+                return [(f"{base}.self_attn.q_norm.weight", param)]
+            if rest == "self_attention.k_layernorm.weight":
+                return [(f"{base}.self_attn.k_norm.weight", param)]
+            if rest == "mlp.linear_fc1.weight":
+                gate, up = param.chunk(2, dim=0)
+                return [
+                    (f"{base}.mlp.gate_proj.weight", gate),
+                    (f"{base}.mlp.up_proj.weight", up),
+                ]
+            if rest == "mlp.linear_fc1.layer_norm_weight":
+                return [(f"{base}.post_attention_layernorm.weight", param)]
+            if rest == "mlp.linear_fc2.weight":
+                return [(f"{base}.mlp.down_proj.weight", param)]
+
+        raise ValueError(f"Unknown Qwen3-VL language-model parameter: {name}")
+
+    # ---- Vision model (mbridge mcore format) ----
+    _VISION_DIRECT = {
+        "module.module.vision_model.patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
+        "module.module.vision_model.patch_embed.proj.bias": "model.visual.patch_embed.proj.bias",
+        "module.module.vision_model.pos_embed.weight": "model.visual.pos_embed.weight",
+        "module.module.vision_model.merger.patch_norm.weight": "model.visual.merger.norm.weight",
+        "module.module.vision_model.merger.patch_norm.bias": "model.visual.merger.norm.bias",
+        "module.module.vision_model.merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
+        "module.module.vision_model.merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
+        "module.module.vision_model.merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
+        "module.module.vision_model.merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
+    }
+    if name in _VISION_DIRECT:
+        return [(_VISION_DIRECT[name], param)]
+
+    # Vision blocks
+    match = re.match(
+        r"module\.module\.vision_model\.decoder\.layers\.(\d+)\.(.+)", name
+    )
+    if match:
+        layer_idx, rest = match.groups()
+        base = f"model.visual.blocks.{layer_idx}"
+
+        if rest in (
+            "self_attention.linear_qkv.weight",
+            "self_attention.linear_qkv.bias",
+        ):
+            vision_num_heads = getattr(
+                getattr(hf_config, "vision_config", None), "num_heads", None
+            )
+            if vision_num_heads is None:
+                raise ValueError(
+                    "hf_config.vision_config.num_heads is required for vision QKV "
+                    "conversion. Pass hf_config to convert_to_hf()."
+                )
+            param = _vision_qkv_mcore_to_hf(param, vision_num_heads)
+            kind = "weight" if rest.endswith("weight") else "bias"
+            return [(f"{base}.attn.qkv.{kind}", param)]
+        if rest == "self_attention.linear_proj.weight":
+            return [(f"{base}.attn.proj.weight", param)]
+        if rest == "self_attention.linear_proj.bias":
+            return [(f"{base}.attn.proj.bias", param)]
+        if rest == "self_attention.linear_qkv.layer_norm_weight":
+            return [(f"{base}.norm1.weight", param)]
+        if rest == "self_attention.linear_qkv.layer_norm_bias":
+            return [(f"{base}.norm1.bias", param)]
+        # Qwen3-VL vision MLP is non-gated: 1:1 mapping (no chunk)
+        if rest == "mlp.linear_fc1.weight":
+            return [(f"{base}.mlp.linear_fc1.weight", param)]
+        if rest == "mlp.linear_fc1.bias":
+            return [(f"{base}.mlp.linear_fc1.bias", param)]
+        if rest == "mlp.linear_fc2.weight":
+            return [(f"{base}.mlp.linear_fc2.weight", param)]
+        if rest == "mlp.linear_fc2.bias":
+            return [(f"{base}.mlp.linear_fc2.bias", param)]
+        if rest == "mlp.linear_fc1.layer_norm_weight":
+            return [(f"{base}.norm2.weight", param)]
+        if rest == "mlp.linear_fc1.layer_norm_bias":
+            return [(f"{base}.norm2.bias", param)]
+
+    # Deepstack mergers
+    match = re.match(
+        r"module\.module\.vision_model\.decoder\.deepstack_merger_list\.(\d+)\.(.+)",
+        name,
+    )
+    if match:
+        idx, rest = match.groups()
+        base = f"model.visual.deepstack_merger_list.{idx}"
+        if rest == "patch_norm.weight":
+            return [(f"{base}.norm.weight", param)]
+        if rest == "patch_norm.bias":
+            return [(f"{base}.norm.bias", param)]
+        if rest in (
+            "linear_fc1.weight",
+            "linear_fc1.bias",
+            "linear_fc2.weight",
+            "linear_fc2.bias",
+        ):
+            return [(f"{base}.{rest}", param)]
+
+    raise ValueError(f"Unknown Qwen3-VL parameter: {name}")
 
 
 # Adapted from slime
@@ -932,6 +1151,7 @@ _CONVERSION_FN_REGISTRY = {
     "qwen2_lora": convert_qwen3_lora_to_hf,
     "qwen3_moe_lora": convert_qwen3_moe_lora_to_hf,
     "qwen2_5_vl": convert_qwen2_5_vl_to_hf,
+    "qwen3_vl": convert_qwen3_vl_to_hf,
     "qwen3_moe": convert_qwen3moe_to_hf,
     "qwen2": convert_qwen2_to_hf,
     "qwen3": convert_qwen2_to_hf,

--- a/areal/engine/megatron_utils/megatron.py
+++ b/areal/engine/megatron_utils/megatron.py
@@ -493,135 +493,92 @@ def convert_qwen2_5_vl_to_hf(
     raise ValueError(f"Unknown parameter name: {name}")
 
 
-def convert_qwen3_vl_to_hf(
-    tf_config: TransformerConfig,
-    name: str,
-    param: Parameter | Tensor | FP8BlockwiseTensorHelper,
-    hf_config=None,
-):
-    """Convert Qwen3-VL Megatron parameters to HuggingFace format.
+_QWEN3_VL_LM_PREFIX = "module.module.language_model."
+_QWEN3_VL_LM_LAYER_RE = re.compile(
+    r"module\.module\.language_model\.decoder\.layers\.(\d+)\.(.+)"
+)
+_QWEN3_VL_VISION_LAYER_RE = re.compile(
+    r"module\.module\.vision_model\.decoder\.layers\.(\d+)\.(.+)"
+)
+_QWEN3_VL_VISION_DEEPSTACK_RE = re.compile(
+    r"module\.module\.vision_model\.decoder\.deepstack_merger_list\.(\d+)\.(.+)"
+)
 
-    Handles dense Qwen3-VL only; Qwen3-VL-MoE is a follow-up.
 
-    HF naming differs from Qwen2.5-VL:
-    - Vision: ``model.visual.*`` (extra ``model.`` prefix)
-    - Language: ``model.language_model.layers.*`` (extra ``language_model``)
-    - Text Q/K norms: ``self_attn.{q,k}_norm.weight`` (vs Qwen2's missing q/k norm)
-    - Vision MLP is non-gated: ``linear_fc1`` / ``linear_fc2`` map 1:1 (no chunk).
-    - Vision norms have bias; vision merger uses ``patch_norm`` and
-      ``linear_fc{1,2}`` directly (no separate projection encoder).
-    - New tensors: ``model.visual.pos_embed``, ``patch_embed.proj.bias``,
-      ``deepstack_merger_list.{i}.{norm,linear_fc1,linear_fc2}``.
+def _convert_qwen3_vl_lm_global(name, param):
+    """Top-level language-model tensors (embeddings, final norm, lm_head).
 
-    The mapping mirrors mbridge.models.qwen3_vl.Qwen3VLBridge (the source of
-    truth used by ``update_weights``).
+    Returns the converted name list if matched, else ``None``.
     """
-
-    # ---- Language model (Qwen3 text) ----
-    _LM_PREFIX = "module.module.language_model."
     if name == "module.module.language_model.embedding.word_embeddings.weight":
         return [("model.language_model.embed_tokens.weight", param)]
     if name == "module.module.language_model.decoder.final_layernorm.weight":
         return [("model.language_model.norm.weight", param)]
     if name == "module.module.language_model.output_layer.weight":
         return [("lm_head.weight", param)]
+    return None
 
-    # Early-raise on Qwen3-VL-MoE expert / router params before they fall
-    # through to the dense "Unknown Qwen3-VL language-model parameter" branch.
-    # `_CONVERSION_FN_REGISTRY` dispatches via substring matching, so once a
-    # `qwen3_vl_moe` model_type exists it will route here unless `qwen3_vl_moe`
-    # is registered BEFORE `qwen3_vl`.
-    if name.startswith(_LM_PREFIX) and (
-        ".mlp.experts." in name
-        or ".mlp.router." in name
-        or ".pre_mlp_layernorm." in name
-    ):
-        raise NotImplementedError(
-            "Qwen3-VL-MoE is not supported by convert_qwen3_vl_to_hf. "
-            "Implement convert_qwen3_vl_moe_to_hf and register it BEFORE "
-            "'qwen3_vl' in _CONVERSION_FN_REGISTRY (substring matching "
-            "dispatches the first hit)."
+
+def _convert_qwen3_vl_lm_attention(tf_config, layer_idx, rest, param):
+    """Per-layer attention block shared by Qwen3-VL dense and MoE.
+
+    Returns the converted name list if ``rest`` matches an attention key,
+    else ``None`` so the caller can fall through to dense or MoE MLP logic.
+    """
+    if tf_config.num_query_groups is None:
+        raise ValueError("Qwen3-VL text model requires num_query_groups")
+    kv_channels = getattr(tf_config, "kv_channels", None)
+    head_dim = (
+        kv_channels
+        if kv_channels is not None
+        else tf_config.hidden_size // tf_config.num_attention_heads
+    )
+    value_num_per_group = tf_config.num_attention_heads // tf_config.num_query_groups
+    base = f"model.language_model.layers.{layer_idx}"
+
+    if rest == "self_attention.linear_proj.weight":
+        return [(f"{base}.self_attn.o_proj.weight", param)]
+    if rest == "self_attention.linear_qkv.weight":
+        p = param.view(tf_config.num_query_groups, -1, head_dim, tf_config.hidden_size)
+        q, k, v = torch.split(
+            p, split_size_or_sections=[value_num_per_group, 1, 1], dim=1
         )
-
-    if name.startswith(_LM_PREFIX):
-        match = re.match(
-            r"module\.module\.language_model\.decoder\.layers\.(\d+)\.(.+)",
-            name,
+        return [
+            (f"{base}.self_attn.q_proj.weight", q.reshape(-1, tf_config.hidden_size)),
+            (f"{base}.self_attn.k_proj.weight", k.reshape(-1, tf_config.hidden_size)),
+            (f"{base}.self_attn.v_proj.weight", v.reshape(-1, tf_config.hidden_size)),
+        ]
+    if rest == "self_attention.linear_qkv.bias":
+        p = param.view(tf_config.num_query_groups, -1)
+        q, k, v = torch.split(
+            p,
+            split_size_or_sections=[
+                value_num_per_group * head_dim,
+                head_dim,
+                head_dim,
+            ],
+            dim=1,
         )
-        if match:
-            layer_idx, rest = match.groups()
-            if tf_config.num_query_groups is None:
-                raise ValueError("Qwen3-VL text model requires num_query_groups")
-            kv_channels = getattr(tf_config, "kv_channels", None)
-            if kv_channels is not None:
-                head_dim = kv_channels
-            else:
-                head_dim = tf_config.hidden_size // tf_config.num_attention_heads
-            value_num_per_group = (
-                tf_config.num_attention_heads // tf_config.num_query_groups
-            )
+        return [
+            (f"{base}.self_attn.q_proj.bias", q.contiguous().flatten()),
+            (f"{base}.self_attn.k_proj.bias", k.contiguous().flatten()),
+            (f"{base}.self_attn.v_proj.bias", v.contiguous().flatten()),
+        ]
+    if rest == "self_attention.linear_qkv.layer_norm_weight":
+        return [(f"{base}.input_layernorm.weight", param)]
+    if rest == "self_attention.q_layernorm.weight":
+        return [(f"{base}.self_attn.q_norm.weight", param)]
+    if rest == "self_attention.k_layernorm.weight":
+        return [(f"{base}.self_attn.k_norm.weight", param)]
+    return None
 
-            base = f"model.language_model.layers.{layer_idx}"
 
-            if rest == "self_attention.linear_proj.weight":
-                return [(f"{base}.self_attn.o_proj.weight", param)]
-            if rest == "self_attention.linear_qkv.weight":
-                p = param.view(
-                    tf_config.num_query_groups, -1, head_dim, tf_config.hidden_size
-                )
-                q, k, v = torch.split(
-                    p, split_size_or_sections=[value_num_per_group, 1, 1], dim=1
-                )
-                return [
-                    (
-                        f"{base}.self_attn.q_proj.weight",
-                        q.reshape(-1, tf_config.hidden_size),
-                    ),
-                    (
-                        f"{base}.self_attn.k_proj.weight",
-                        k.reshape(-1, tf_config.hidden_size),
-                    ),
-                    (
-                        f"{base}.self_attn.v_proj.weight",
-                        v.reshape(-1, tf_config.hidden_size),
-                    ),
-                ]
-            if rest == "self_attention.linear_qkv.bias":
-                p = param.view(tf_config.num_query_groups, -1)
-                q, k, v = torch.split(
-                    p,
-                    split_size_or_sections=[
-                        value_num_per_group * head_dim,
-                        head_dim,
-                        head_dim,
-                    ],
-                    dim=1,
-                )
-                return [
-                    (f"{base}.self_attn.q_proj.bias", q.contiguous().flatten()),
-                    (f"{base}.self_attn.k_proj.bias", k.contiguous().flatten()),
-                    (f"{base}.self_attn.v_proj.bias", v.contiguous().flatten()),
-                ]
-            if rest == "self_attention.linear_qkv.layer_norm_weight":
-                return [(f"{base}.input_layernorm.weight", param)]
-            if rest == "self_attention.q_layernorm.weight":
-                return [(f"{base}.self_attn.q_norm.weight", param)]
-            if rest == "self_attention.k_layernorm.weight":
-                return [(f"{base}.self_attn.k_norm.weight", param)]
-            if rest == "mlp.linear_fc1.weight":
-                gate, up = param.chunk(2, dim=0)
-                return [
-                    (f"{base}.mlp.gate_proj.weight", gate),
-                    (f"{base}.mlp.up_proj.weight", up),
-                ]
-            if rest == "mlp.linear_fc1.layer_norm_weight":
-                return [(f"{base}.post_attention_layernorm.weight", param)]
-            if rest == "mlp.linear_fc2.weight":
-                return [(f"{base}.mlp.down_proj.weight", param)]
+def _convert_qwen3_vl_vision_to_hf(name, param, hf_config):
+    """Vision tower + deepstack merger conversion shared by dense and MoE.
 
-        raise ValueError(f"Unknown Qwen3-VL language-model parameter: {name}")
-
-    # ---- Vision model (mbridge mcore format) ----
+    Mirrors mbridge.models.qwen3_vl.Qwen3VBaseBridge mappings.
+    Raises ``ValueError`` if ``name`` does not match any vision-side tensor.
+    """
     _VISION_DIRECT = {
         "module.module.vision_model.patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
         "module.module.vision_model.patch_embed.proj.bias": "model.visual.patch_embed.proj.bias",
@@ -636,10 +593,7 @@ def convert_qwen3_vl_to_hf(
     if name in _VISION_DIRECT:
         return [(_VISION_DIRECT[name], param)]
 
-    # Vision blocks
-    match = re.match(
-        r"module\.module\.vision_model\.decoder\.layers\.(\d+)\.(.+)", name
-    )
+    match = _QWEN3_VL_VISION_LAYER_RE.match(name)
     if match:
         layer_idx, rest = match.groups()
         base = f"model.visual.blocks.{layer_idx}"
@@ -681,11 +635,7 @@ def convert_qwen3_vl_to_hf(
         if rest == "mlp.linear_fc1.layer_norm_bias":
             return [(f"{base}.norm2.bias", param)]
 
-    # Deepstack mergers
-    match = re.match(
-        r"module\.module\.vision_model\.decoder\.deepstack_merger_list\.(\d+)\.(.+)",
-        name,
-    )
+    match = _QWEN3_VL_VISION_DEEPSTACK_RE.match(name)
     if match:
         idx, rest = match.groups()
         base = f"model.visual.deepstack_merger_list.{idx}"
@@ -702,6 +652,149 @@ def convert_qwen3_vl_to_hf(
             return [(f"{base}.{rest}", param)]
 
     raise ValueError(f"Unknown Qwen3-VL parameter: {name}")
+
+
+def convert_qwen3_vl_to_hf(
+    tf_config: TransformerConfig,
+    name: str,
+    param: Parameter | Tensor | FP8BlockwiseTensorHelper,
+    hf_config=None,
+):
+    """Convert dense Qwen3-VL Megatron parameters to HuggingFace format.
+
+    Qwen3-VL-MoE is handled by ``convert_qwen3_vl_moe_to_hf``; the registry
+    in ``_CONVERSION_FN_REGISTRY`` MUST register ``qwen3_vl_moe`` BEFORE
+    ``qwen3_vl`` (substring matching dispatches the first hit).
+
+    HF naming differs from Qwen2.5-VL:
+    - Vision: ``model.visual.*`` (extra ``model.`` prefix)
+    - Language: ``model.language_model.layers.*`` (extra ``language_model``)
+    - Text Q/K norms: ``self_attn.{q,k}_norm.weight`` (vs Qwen2's missing q/k norm)
+    - Vision MLP is non-gated: ``linear_fc1`` / ``linear_fc2`` map 1:1 (no chunk).
+    - Vision norms have bias; vision merger uses ``patch_norm`` and
+      ``linear_fc{1,2}`` directly (no separate projection encoder).
+    - New tensors: ``model.visual.pos_embed``, ``patch_embed.proj.bias``,
+      ``deepstack_merger_list.{i}.{norm,linear_fc1,linear_fc2}``.
+
+    The mapping mirrors mbridge.models.qwen3_vl.Qwen3VLBridge (the source of
+    truth used by ``update_weights``).
+    """
+
+    converted = _convert_qwen3_vl_lm_global(name, param)
+    if converted is not None:
+        return converted
+
+    if name.startswith(_QWEN3_VL_LM_PREFIX):
+        match = _QWEN3_VL_LM_LAYER_RE.match(name)
+        if match:
+            layer_idx, rest = match.groups()
+            attn = _convert_qwen3_vl_lm_attention(tf_config, layer_idx, rest, param)
+            if attn is not None:
+                return attn
+
+            base = f"model.language_model.layers.{layer_idx}"
+            if rest == "mlp.linear_fc1.weight":
+                gate, up = param.chunk(2, dim=0)
+                return [
+                    (f"{base}.mlp.gate_proj.weight", gate),
+                    (f"{base}.mlp.up_proj.weight", up),
+                ]
+            if rest == "mlp.linear_fc1.layer_norm_weight":
+                return [(f"{base}.post_attention_layernorm.weight", param)]
+            if rest == "mlp.linear_fc2.weight":
+                return [(f"{base}.mlp.down_proj.weight", param)]
+
+        raise ValueError(f"Unknown Qwen3-VL language-model parameter: {name}")
+
+    return _convert_qwen3_vl_vision_to_hf(name, param, hf_config)
+
+
+def convert_qwen3_vl_moe_to_hf(
+    tf_config: TransformerConfig,
+    name: str,
+    param: Parameter | Tensor | FP8BlockwiseTensorHelper,
+    hf_config=None,
+):
+    """Convert Qwen3-VL-MoE Megatron parameters to HuggingFace format.
+
+    Mirrors ``convert_qwen3moe_to_hf`` (per-expert flat HF keys, no transpose,
+    stateless) so the XCCL ``update_weights`` path to vLLM/SGLang reuses the
+    same shape contract that ships today for Qwen3-MoE. Vision tower + language
+    attention + global LM tensors share the dense Qwen3-VL converter helpers.
+
+    Differences from dense Qwen3-VL:
+    - Per-layer dense MLP (``mlp.linear_fc{1,2}``) is replaced by per-expert
+      ``mlp.experts.linear_fc{1,2}.weight{idx}``, plus router and pre-MLP layernorm.
+    - No shared experts (verified against mbridge ``Qwen3VLMoEBridge._MLP_MAPPING``).
+    - No router expert_bias (mbridge sets ``moe_router_load_balancing_type="none"``).
+
+    Registry MUST place ``qwen3_vl_moe`` before ``qwen3_vl``, ``qwen3_moe``, and
+    ``qwen3`` in ``_CONVERSION_FN_REGISTRY`` due to substring-match dispatch.
+    """
+
+    converted = _convert_qwen3_vl_lm_global(name, param)
+    if converted is not None:
+        return converted
+
+    if name.startswith(_QWEN3_VL_LM_PREFIX):
+        match = _QWEN3_VL_LM_LAYER_RE.match(name)
+        if match:
+            layer_idx, rest = match.groups()
+            attn = _convert_qwen3_vl_lm_attention(tf_config, layer_idx, rest, param)
+            if attn is not None:
+                return attn
+
+            base = f"model.language_model.layers.{layer_idx}"
+
+            expert_match = re.match(r"mlp\.experts\.(.+)\.weight(\d+)", rest)
+            if expert_match:
+                fc_kind, expert_idx = expert_match.groups()
+                if fc_kind == "linear_fc1":
+                    gate, up = param.chunk(2, dim=0)
+                    return [
+                        (
+                            f"{base}.mlp.experts.{expert_idx}.gate_proj.weight",
+                            gate,
+                        ),
+                        (
+                            f"{base}.mlp.experts.{expert_idx}.up_proj.weight",
+                            up,
+                        ),
+                    ]
+                if fc_kind == "linear_fc2":
+                    return [
+                        (
+                            f"{base}.mlp.experts.{expert_idx}.down_proj.weight",
+                            param,
+                        )
+                    ]
+                raise ValueError(f"Unknown Qwen3-VL-MoE expert parameter: {name}")
+
+            if rest == "mlp.router.weight":
+                return [(f"{base}.mlp.gate.weight", param)]
+            if rest == "pre_mlp_layernorm.weight":
+                return [(f"{base}.post_attention_layernorm.weight", param)]
+
+            # Dense MLP fallback for layers where ``decoder_sparse_step > 1``
+            # leaves some layers non-sparse. Qwen3-VL-30B-A3B-Instruct uses
+            # ``decoder_sparse_step=1`` so every layer is MoE and these branches
+            # are dead, but the same converter is expected to cover future
+            # variants with mixed dense/sparse layouts. Mirrors the dense-MLP
+            # tail of ``convert_qwen3moe_to_hf``.
+            if rest == "mlp.linear_fc1.weight":
+                gate, up = param.chunk(2, dim=0)
+                return [
+                    (f"{base}.mlp.gate_proj.weight", gate),
+                    (f"{base}.mlp.up_proj.weight", up),
+                ]
+            if rest == "mlp.linear_fc1.layer_norm_weight":
+                return [(f"{base}.post_attention_layernorm.weight", param)]
+            if rest == "mlp.linear_fc2.weight":
+                return [(f"{base}.mlp.down_proj.weight", param)]
+
+        raise ValueError(f"Unknown Qwen3-VL-MoE language-model parameter: {name}")
+
+    return _convert_qwen3_vl_vision_to_hf(name, param, hf_config)
 
 
 # Adapted from slime
@@ -1146,11 +1239,16 @@ def convert_bailingmoe_to_hf(
 
 # Adapted from slime
 # A registry for conversion functions is more extensible.
+# Ordering matters: ``convert_to_hf`` dispatches on the FIRST substring hit, so
+# longer/more-specific keys MUST come before shorter ones that are substrings of
+# them. In particular, ``qwen3_vl_moe`` must precede ``qwen3_vl``,
+# ``qwen3_moe``, and ``qwen3``.
 _CONVERSION_FN_REGISTRY = {
     "qwen3_lora": convert_qwen3_lora_to_hf,
     "qwen2_lora": convert_qwen3_lora_to_hf,
     "qwen3_moe_lora": convert_qwen3_moe_lora_to_hf,
     "qwen2_5_vl": convert_qwen2_5_vl_to_hf,
+    "qwen3_vl_moe": convert_qwen3_vl_moe_to_hf,
     "qwen3_vl": convert_qwen3_vl_to_hf,
     "qwen3_moe": convert_qwen3moe_to_hf,
     "qwen2": convert_qwen2_to_hf,

--- a/areal/models/mcore/hf_load.py
+++ b/areal/models/mcore/hf_load.py
@@ -170,6 +170,80 @@ def _slice_moe_expert_weight(
     return x[_get_tp_slice(shape, dim=partition_dim, tp_rank=tp_rank, tp_size=tp_size)]
 
 
+def _parse_local_expert_idx(mcore_weights_name: str) -> int:
+    """Extract the per-rank-local expert index from an mcore expert param name.
+
+    mcore weight names for grouped MoE end with ``weight{idx}`` where ``idx`` is
+    the rank-local expert index (0..num_experts_per_rank-1). The global expert
+    index is ``idx + (num_moe_experts // ep_size) * ep_rank``.
+    """
+    return int(mcore_weights_name.split(".weight")[-1])
+
+
+def _slice_moe_expert_fc1_stacked_gate_up(
+    hf_weights_safe_slice: list,
+    mcore_weights_name: str,
+    num_moe_experts: int,
+    ep_rank: int,
+    ep_size: int,
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    """Slice a per-expert ``linear_fc1.weight{idx}`` shard from a 3D stacked
+    HF ``gate_up_proj`` of shape ``[E, hidden, 2*expert_dim]``.
+
+    Used for Qwen3-VL-MoE-style MoE checkpoints whose HF format keeps experts
+    grouped under one tensor (vs Qwen3-MoE which exposes per-expert flat keys).
+    Mirrors mbridge ``Qwen3VBaseBridge._weight_to_mcore_format`` MoE branch
+    (``base_bridge.py:322-331``) plus AReaL's TP slicing of the gate/up halves.
+    """
+    assert len(hf_weights_safe_slice) == 1
+    stacked = hf_weights_safe_slice[0]
+    local_idx = _parse_local_expert_idx(mcore_weights_name)
+    num_experts_per_rank = num_moe_experts // ep_size
+    global_idx = local_idx + num_experts_per_rank * ep_rank
+    expert = stacked[global_idx]  # [hidden, 2*expert_dim]
+    if not isinstance(expert, torch.Tensor):
+        expert = expert[:]
+    expert_t = expert.T.contiguous()  # [2*expert_dim, hidden]
+    gate, up = expert_t.chunk(2, dim=0)  # each [expert_dim, hidden]
+    gate = gate[
+        _get_tp_slice(_get_shape(gate), dim=0, tp_rank=tp_rank, tp_size=tp_size)
+    ]
+    up = up[_get_tp_slice(_get_shape(up), dim=0, tp_rank=tp_rank, tp_size=tp_size)]
+    return torch.cat([gate, up], dim=0)
+
+
+def _slice_moe_expert_fc2_stacked_down(
+    hf_weights_safe_slice: list,
+    mcore_weights_name: str,
+    num_moe_experts: int,
+    ep_rank: int,
+    ep_size: int,
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    """Slice a per-expert ``linear_fc2.weight{idx}`` shard from a 3D stacked
+    HF ``down_proj`` of shape ``[E, expert_dim, hidden]``.
+
+    After expert slice + transpose the result is ``[hidden, expert_dim]``,
+    matching mcore's per-expert ``linear_fc2`` layout. TP shards along dim 1
+    (input/expert_dim axis), the same axis ``_slice_moe_expert_weight`` uses.
+    """
+    assert len(hf_weights_safe_slice) == 1
+    stacked = hf_weights_safe_slice[0]
+    local_idx = _parse_local_expert_idx(mcore_weights_name)
+    num_experts_per_rank = num_moe_experts // ep_size
+    global_idx = local_idx + num_experts_per_rank * ep_rank
+    expert = stacked[global_idx]  # [expert_dim, hidden]
+    if not isinstance(expert, torch.Tensor):
+        expert = expert[:]
+    expert_t = expert.T.contiguous()  # [hidden, expert_dim]
+    return expert_t[
+        _get_tp_slice(_get_shape(expert_t), dim=1, tp_rank=tp_rank, tp_size=tp_size)
+    ]
+
+
 def _slice_generic_weight(
     mcore_param_shape: list,
     hf_weights_safe_slice: list,
@@ -327,13 +401,45 @@ def _weight_to_mcore_tp(
         if len(hf_weights_safe_slice) == 2:
             # SwiGLU: merge separate gate_proj + up_proj
             res = _merge_gate_up_weights(hf_weights_safe_slice, tp_rank, tp_size)
+        elif (
+            "mlp.experts.linear_fc1.weight" in mcore_weights_name
+            and len(hf_weights_safe_slice) == 1
+            and len(_get_shape(hf_weights_safe_slice[0])) == 3
+        ):
+            # Stacked MoE expert (e.g., Qwen3-VL-MoE ``gate_up_proj`` shape
+            # ``[E, hidden, 2*expert_dim]``). Slice per-expert + transpose +
+            # gate/up TP-split. ``num_moe_experts`` lives on the bridge config.
+            res = _slice_moe_expert_fc1_stacked_gate_up(
+                hf_weights_safe_slice,
+                mcore_weights_name,
+                num_moe_experts=lang_config(hf_config).num_experts,
+                ep_rank=mpu.get_expert_model_parallel_rank(),
+                ep_size=mpu.get_expert_model_parallel_world_size(),
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            )
         else:
             # Single fc1 weight (e.g., vision encoder MLP without gate/up split)
             res = _slice_generic_weight(
                 mcore_param_shape, hf_weights_safe_slice, tp_rank, tp_size
             )
     elif "mlp.experts.linear_fc2.weight" in mcore_weights_name:
-        res = _slice_moe_expert_weight(hf_weights_safe_slice, tp_rank, tp_size)
+        if (
+            len(hf_weights_safe_slice) == 1
+            and len(_get_shape(hf_weights_safe_slice[0])) == 3
+        ):
+            # Stacked MoE expert ``down_proj`` shape ``[E, expert_dim, hidden]``.
+            res = _slice_moe_expert_fc2_stacked_down(
+                hf_weights_safe_slice,
+                mcore_weights_name,
+                num_moe_experts=lang_config(hf_config).num_experts,
+                ep_rank=mpu.get_expert_model_parallel_rank(),
+                ep_size=mpu.get_expert_model_parallel_world_size(),
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            )
+        else:
+            res = _slice_moe_expert_weight(hf_weights_safe_slice, tp_rank, tp_size)
     else:
         res = _slice_generic_weight(
             mcore_param_shape, hf_weights_safe_slice, tp_rank, tp_size

--- a/areal/models/mcore/hf_load.py
+++ b/areal/models/mcore/hf_load.py
@@ -14,6 +14,7 @@ from megatron.core import parallel_state as mpu
 from megatron.core.fp8_utils import is_float8tensor
 from safetensors import safe_open
 
+from areal.engine.core.model import lang_config
 from areal.engine.megatron_utils.fp8 import (
     FP8BlockwiseTensorHelper,
     dequantize_params,
@@ -51,10 +52,11 @@ def _merge_qkv_weights(
 ) -> torch.Tensor | FP8BlockwiseTensorHelper:
     """Merge Q, K, V weights into a single QKV weight tensor."""
     assert len(hf_weights_safe_slice) == 3
-    num_key_value_heads = hf_config.num_key_value_heads
-    hidden_dim = hf_config.hidden_size
-    num_attention_heads = hf_config.num_attention_heads
-    head_dim = getattr(hf_config, "head_dim", hidden_dim // num_attention_heads)
+    text_cfg = lang_config(hf_config)
+    num_key_value_heads = text_cfg.num_key_value_heads
+    hidden_dim = text_cfg.hidden_size
+    num_attention_heads = text_cfg.num_attention_heads
+    head_dim = getattr(text_cfg, "head_dim", hidden_dim // num_attention_heads)
     group_dim = head_dim * num_attention_heads // num_key_value_heads
     q, k, v = hf_weights_safe_slice
     # q k v might be tp split
@@ -91,8 +93,9 @@ def _load_fused_qkv_weight(
     x = hf_weights_safe_slice[0]
     x = x[:] if not isinstance(x, torch.Tensor) else x
 
-    num_heads = hf_config.num_attention_heads
-    num_kv_heads = getattr(hf_config, "num_key_value_heads", num_heads)
+    text_cfg = lang_config(hf_config)
+    num_heads = text_cfg.num_attention_heads
+    num_kv_heads = getattr(text_cfg, "num_key_value_heads", num_heads)
     head_dim = x.shape[0] // (num_heads + 2 * num_kv_heads)
     is_bias = x.dim() == 1
 
@@ -290,10 +293,11 @@ def _weight_to_mcore_tp(
                 tp_size,
             )
         else:
+            text_cfg = lang_config(hf_config)
             num_kv_heads = getattr(
-                hf_config, "num_key_value_heads", hf_config.num_attention_heads
+                text_cfg, "num_key_value_heads", text_cfg.num_attention_heads
             )
-            if num_kv_heads == hf_config.num_attention_heads:
+            if num_kv_heads == text_cfg.num_attention_heads:
                 # Fused QKV weight (e.g., Lightning Attention query_key_value)
                 # Already in megatron interleaved format [H, 3, D] — just TP-slice
                 res = _load_fused_qkv_weight(
@@ -304,7 +308,7 @@ def _weight_to_mcore_tp(
                 # Split into separate Q, K, V then merge into mcore format.
                 x = hf_weights_safe_slice[0]
                 x = x[:] if not isinstance(x, torch.Tensor) else x
-                num_heads = hf_config.num_attention_heads
+                num_heads = text_cfg.num_attention_heads
                 head_dim = x.shape[0] // (num_heads + 2 * num_kv_heads)
                 q = x[: num_heads * head_dim]
                 k = x[num_heads * head_dim : (num_heads + num_kv_heads) * head_dim]

--- a/areal/models/mcore/hf_save.py
+++ b/areal/models/mcore/hf_save.py
@@ -250,6 +250,196 @@ class McoreDistributedWeightSpec:
         return int(s)
 
 
+def _emit_stacked_moe_expert_sd(
+    bridge: Bridge,
+    expert_specs: list["McoreDistributedWeightSpec"],
+    *,
+    all_gather_outputs: dict,
+    etp_size: int,
+    ep_size: int,
+    ep_rank: int,
+    ep_group,
+    quantization_config,
+    fp8_direct_convert: bool,
+    weight_block_size: int,
+) -> dict:
+    """Stacked-MoE save path (e.g., Qwen3-VL-MoE).
+
+    mbridge buffers per-expert tensors and only emits the stacked HF tensor
+    once ``num_moe_experts`` have arrived. Each EP rank only owns
+    ``num_moe_experts / ep_size`` experts, so this helper EP-gathers merged
+    tensors per ``(layer, fc)`` group, feeds mbridge in global-index order so
+    its buffer fills exactly once, and consolidates writes onto ``ep_rank==0``.
+    Other EP ranks still participate in collectives but return an empty dict.
+
+    Stacked outputs are moved to CPU memory immediately to bound peak GPU
+    footprint by one stacked tensor at a time. Without this, all
+    ``num_layers × 2`` stacked tensors (~74 GB for Qwen3-VL-30B-A3B)
+    accumulate on the EP-rank-0 GPU and trigger CUDA OOM.
+    """
+    expert_sd: dict = {}
+    num_experts = bridge.config.num_moe_experts
+    num_experts_per_rank = num_experts // ep_size
+    assert num_experts_per_rank * ep_size == num_experts, (
+        f"num_moe_experts={num_experts} not divisible by ep_size={ep_size}"
+    )
+
+    # Group local specs by (layer_idx, fc_kind) and order by local-expert-id
+    # within each group. ``local_name`` carries the rank-local TEGroupedLinear
+    # suffix (``weight0..weight{num_experts_per_rank-1}``); ``global_name`` was
+    # rewritten by the caller to bake in the global expert id, but for sort
+    # order the local idx is sufficient and avoids the rank-dependent offset.
+    _expert_re = re.compile(
+        r"\.layers\.(\d+)\.mlp\.experts\.(linear_fc\d+)\.weight(\d+)$"
+    )
+    groups: dict[tuple[str, str], list[tuple[int, McoreDistributedWeightSpec]]] = {}
+    for s in expert_specs:
+        m = _expert_re.search(s.local_name)
+        if not m:
+            raise ValueError(
+                f"stacked-expert path: cannot parse layer/fc/expert "
+                f"from local_name={s.local_name!r}"
+            )
+        layer_idx, fc_kind, local_idx_str = m.groups()
+        local_id = int(local_idx_str)
+        groups.setdefault((layer_idx, fc_kind), []).append((local_id, s))
+    for k in groups:
+        groups[k].sort(key=lambda t: t[0])
+
+    # Invariant check across the EP group: every rank must see the same set of
+    # (layer, fc) groups with the same per-group expert count. Without this, a
+    # future refactor that injects a vision-tower expert spec on some ranks
+    # only — or a VPP layout where local layers differ across EP ranks — would
+    # silently mismatch the ``all_gather_into_tensor`` collective below and
+    # either hang or scramble tensors across layers. One cheap
+    # ``all_gather_object`` eliminates that class of
+    # silent-corruption-on-future-refactor failures.
+    group_keys = tuple(sorted(groups.keys()))
+    ep_keys: list[tuple | None] = [None] * ep_size
+    dist.all_gather_object(ep_keys, group_keys, group=ep_group)
+    assert all(k == group_keys for k in ep_keys), (
+        f"EP rank divergence in (layer, fc) groups: "
+        f"rank {ep_rank} sees {group_keys}, peers see {ep_keys}"
+    )
+    for k, specs_with_idx in groups.items():
+        assert len(specs_with_idx) == num_experts_per_rank, (
+            f"layer {k} has {len(specs_with_idx)} local experts on "
+            f"ep_rank {ep_rank}, expected {num_experts_per_rank}"
+        )
+
+    for (layer_idx, fc_kind), specs_with_idx in groups.items():
+        local_specs = [s for _, s in specs_with_idx]
+        # Pre-merge each spec's TP shard into a per-expert tensor.
+        merged_local: list[torch.Tensor] = []
+        for s in local_specs:
+            if etp_size > 1:
+                params = all_gather_outputs[s.global_name].chunk(etp_size, dim=0)
+            else:
+                params = [s.param]
+            params = _maybe_convert_from_te_fp8_params(
+                params, fp8_direct_convert, weight_block_size
+            )
+            merged = bridge._weight_merge_across_tp(s.global_name, params, s.param)
+            merged_local.append(merged.contiguous())
+
+        # EP all-gather: stack local-merged on dim 0, all-gather, split.
+        # All ranks contribute the same number of experts (uniform EP shard).
+        stacked_local = torch.stack(merged_local, dim=0)
+        gathered = torch.empty(
+            (ep_size,) + tuple(stacked_local.shape),
+            dtype=stacked_local.dtype,
+            device=stacked_local.device,
+        )
+        dist.all_gather_into_tensor(gathered, stacked_local, group=ep_group)
+        # gathered shape: [ep_size, num_experts_per_rank, *expert_shape].
+        # Flatten the first two dims to get global expert order:
+        # ep_rank0 [0..n-1], ep_rank1 [n..2n-1], ...
+        gathered = gathered.view(num_experts, *stacked_local.shape[1:])
+
+        # Feed mbridge in global expert order. Build the synthetic mcore name
+        # with the appropriate global index. mbridge's buffer fills after
+        # num_experts calls and emits the stacked HF tensor; intermediate
+        # calls return ``[], []``.
+        # Use the first local spec's name as the template — the prefix is
+        # rank-invariant, only the .weight{N} suffix varies per call.
+        name_prefix = local_specs[0].global_name.split(".weight")[0]
+        last_converted_names: list[str] = []
+        last_converted_params: list[torch.Tensor] = []
+        for global_idx in range(num_experts):
+            name = f"{name_prefix}.weight{global_idx}"
+            converted_names, converted_params = bridge._weight_to_hf_format(
+                name, gathered[global_idx]
+            )
+            if converted_names:
+                last_converted_names = converted_names
+                last_converted_params = converted_params
+        converted_names, converted_params = _maybe_convert_to_torch_fp8_params(
+            name_prefix,
+            last_converted_names,
+            last_converted_params,
+            quantization_config,
+            fp8_direct_convert,
+        )
+        # Only ep_rank==0 contributes to the on-disk shard; other EP ranks
+        # discard so their expert_sd stays empty (collectives have already
+        # happened above, so this is safe).
+        if ep_rank == 0:
+            for n, p in zip(converted_names, converted_params):
+                assert n not in expert_sd, n
+                if isinstance(p, torch.Tensor) and p.is_cuda:
+                    expert_sd[n] = p.detach().to(device="cpu", non_blocking=False)
+                else:
+                    expert_sd[n] = p
+        # Free the gathered buffer before the next group.
+        del gathered, stacked_local
+
+    return expert_sd
+
+
+def _emit_per_expert_flat_expert_sd(
+    bridge: Bridge,
+    expert_specs: list["McoreDistributedWeightSpec"],
+    *,
+    all_gather_outputs: dict,
+    etp_size: int,
+    quantization_config,
+    fp8_direct_convert: bool,
+    weight_block_size: int,
+) -> dict:
+    """Per-expert-flat save path (Qwen3-MoE, BailingMoeV2, DeepSeekV3).
+
+    HF format keys experts as ``mlp.experts.{idx}.{gate,up,down}_proj.weight``,
+    so each EP rank emits its local-experts subset independently and the
+    union across ranks forms the full set without any cross-EP gather.
+    """
+    expert_sd: dict = {}
+    for s in expert_specs:
+        param = s.param
+        if etp_size > 1:
+            params = all_gather_outputs[s.global_name].chunk(etp_size, dim=0)
+        else:
+            params = [param]
+
+        params = _maybe_convert_from_te_fp8_params(
+            params, fp8_direct_convert, weight_block_size
+        )
+        merge_params = bridge._weight_merge_across_tp(s.global_name, params, param)
+        converted_names, converted_params = bridge._weight_to_hf_format(
+            s.global_name, merge_params
+        )
+        converted_names, converted_params = _maybe_convert_to_torch_fp8_params(
+            s.global_name,
+            converted_names,
+            converted_params,
+            quantization_config,
+            fp8_direct_convert,
+        )
+        for n, p in zip(converted_names, converted_params):
+            assert n not in expert_sd, n
+            expert_sd[n] = p
+    return expert_sd
+
+
 def save_weights_to_hf_with_mbridge_fast(
     bridge: Bridge,
     models: list,
@@ -556,7 +746,6 @@ def save_weights_to_hf_with_mbridge_fast(
             global_expert_id = num_experts_per_rank * ep_rank + local_expert_id
             s.global_name = f"{name_prefix}.weight{global_expert_id}"
         # all-gather weights across the TP group and converts to HF format
-        expert_sd = {}
         _all_gather_specs = []
         all_gather_outputs = {}
         for s in expert_specs:
@@ -570,169 +759,28 @@ def save_weights_to_hf_with_mbridge_fast(
             for s, gathered_param in zip(_all_gather_specs, _all_gather_outputs):
                 all_gather_outputs[s.global_name] = gathered_param
         if stacked_experts and ep_size > 1:
-            # ── Stacked-MoE path (Qwen3-VL-MoE) ──
-            # mbridge buffers per-expert tensors and only emits the stacked
-            # HF tensor when num_moe_experts have arrived. Each rank only
-            # owns 1/ep_size of experts, so we EP-gather merged tensors per
-            # (layer, fc) group, feed mbridge in global-index order so its
-            # buffer fills exactly once, and consolidate writes on
-            # ep_rank==0. Other EP ranks still participate in collectives.
-            num_experts = bridge.config.num_moe_experts
-            num_experts_per_rank = num_experts // ep_size
-            assert num_experts_per_rank * ep_size == num_experts, (
-                f"num_moe_experts={num_experts} not divisible by ep_size={ep_size}"
+            expert_sd = _emit_stacked_moe_expert_sd(
+                bridge,
+                expert_specs,
+                all_gather_outputs=all_gather_outputs,
+                etp_size=etp_size,
+                ep_size=ep_size,
+                ep_rank=ep_rank,
+                ep_group=ep_group,
+                quantization_config=quantization_config,
+                fp8_direct_convert=fp8_direct_convert,
+                weight_block_size=weight_block_size,
             )
-
-            # Group local specs by (layer_idx, fc_kind) and order by
-            # local-expert-id within each group.
-            _expert_re = re.compile(
-                r"\.layers\.(\d+)\.mlp\.experts\.(linear_fc\d+)\.weight(\d+)$"
-            )
-            groups: dict[
-                tuple[str, str], list[tuple[int, McoreDistributedWeightSpec]]
-            ] = {}
-            for s in expert_specs:
-                m = _expert_re.search(s.local_name)
-                if not m:
-                    raise ValueError(
-                        f"stacked-expert path: cannot parse layer/fc/expert "
-                        f"from local_name={s.local_name!r}"
-                    )
-                layer_idx, fc_kind, local_idx_str = m.groups()
-                # ``local_name`` carries the rank-local TEGroupedLinear suffix
-                # (``weight0..weight{num_experts_per_rank-1}``). ``global_name``
-                # was rewritten above to bake in the global expert id; for the
-                # sort/iteration order within each (layer, fc) group the local
-                # idx is sufficient and avoids the rank-dependent offset.
-                local_id = int(local_idx_str)
-                groups.setdefault((layer_idx, fc_kind), []).append((local_id, s))
-            for k in groups:
-                groups[k].sort(key=lambda t: t[0])
-
-            # Invariant check across the EP group: every rank must see the same
-            # set of (layer, fc) groups with the same per-group expert count.
-            # Without this, a future refactor that injects a vision-tower expert
-            # spec on some ranks only — or a VPP layout where local layers
-            # differ across EP ranks — would silently mismatch the
-            # ``all_gather_into_tensor`` collective below and either hang or
-            # scramble tensors across layers. One cheap ``all_gather_object``
-            # eliminates that class of silent-corruption-on-future-refactor
-            # failures.
-            group_keys = tuple(sorted(groups.keys()))
-            ep_keys: list[tuple | None] = [None] * ep_size
-            dist.all_gather_object(ep_keys, group_keys, group=ep_group)
-            assert all(k == group_keys for k in ep_keys), (
-                f"EP rank divergence in (layer, fc) groups: "
-                f"rank {ep_rank} sees {group_keys}, peers see {ep_keys}"
-            )
-            for k, specs_with_idx in groups.items():
-                assert len(specs_with_idx) == num_experts_per_rank, (
-                    f"layer {k} has {len(specs_with_idx)} local experts on "
-                    f"ep_rank {ep_rank}, expected {num_experts_per_rank}"
-                )
-
-            for (layer_idx, fc_kind), specs_with_idx in groups.items():
-                local_specs = [s for _, s in specs_with_idx]
-                # Pre-merge each spec's TP shard into a per-expert tensor.
-                merged_local: list[torch.Tensor] = []
-                for s in local_specs:
-                    if etp_size > 1:
-                        params = all_gather_outputs[s.global_name].chunk(
-                            etp_size, dim=0
-                        )
-                    else:
-                        params = [s.param]
-                    params = _maybe_convert_from_te_fp8_params(
-                        params, fp8_direct_convert, weight_block_size
-                    )
-                    merged = bridge._weight_merge_across_tp(
-                        s.global_name, params, s.param
-                    )
-                    merged_local.append(merged.contiguous())
-
-                # EP all-gather: stack local-merged on dim 0, all-gather, split.
-                # All ranks contribute the same number of experts (uniform EP shard).
-                stacked_local = torch.stack(merged_local, dim=0)
-                gathered = torch.empty(
-                    (ep_size,) + tuple(stacked_local.shape),
-                    dtype=stacked_local.dtype,
-                    device=stacked_local.device,
-                )
-                dist.all_gather_into_tensor(gathered, stacked_local, group=ep_group)
-                # gathered shape: [ep_size, num_experts_per_rank, *expert_shape]
-                # Flatten the first two dims to get global expert order:
-                # ep_rank0 [0..n-1], ep_rank1 [n..2n-1], ...
-                gathered = gathered.view(num_experts, *stacked_local.shape[1:])
-
-                # Feed mbridge in global expert order. Build the synthetic
-                # mcore name with the appropriate global index. mbridge's
-                # buffer fills after num_experts calls and emits the stacked
-                # HF tensor; intermediate calls return ``[], []``.
-                # Use the first local spec's name as the template.
-                name_prefix = local_specs[0].global_name.split(".weight")[0]
-                last_converted_names: list[str] = []
-                last_converted_params: list[torch.Tensor] = []
-                for global_idx in range(num_experts):
-                    name = f"{name_prefix}.weight{global_idx}"
-                    converted_names, converted_params = bridge._weight_to_hf_format(
-                        name, gathered[global_idx]
-                    )
-                    if converted_names:
-                        last_converted_names = converted_names
-                        last_converted_params = converted_params
-                converted_names, converted_params = _maybe_convert_to_torch_fp8_params(
-                    name_prefix,
-                    last_converted_names,
-                    last_converted_params,
-                    quantization_config,
-                    fp8_direct_convert,
-                )
-                # Only ep_rank==0 contributes to the on-disk shard; other EP
-                # ranks discard so their expert_sd stays empty (collectives
-                # have already happened above, so this is safe).
-                # Move stacked outputs to CPU pinned memory immediately to bound
-                # GPU memory by one stacked tensor at a time. Without this, all
-                # ~num_layers × 2 stacked tensors (~74GB for Qwen3-VL-30B-A3B)
-                # accumulate on the EP-rank-0 GPU and trigger CUDA OOM.
-                if ep_rank == 0:
-                    for n, p in zip(converted_names, converted_params):
-                        assert n not in expert_sd, n
-                        if isinstance(p, torch.Tensor) and p.is_cuda:
-                            expert_sd[n] = p.detach().to(
-                                device="cpu", non_blocking=False
-                            )
-                        else:
-                            expert_sd[n] = p
-                # Free the gathered buffer before the next group.
-                del gathered, stacked_local
         else:
-            # ── Per-expert-flat path (Qwen3-MoE, BailingMoeV2, DeepSeekV3) ──
-            for s in expert_specs:
-                param = s.param
-                if etp_size > 1:
-                    params = all_gather_outputs[s.global_name].chunk(etp_size, dim=0)
-                else:
-                    params = [param]
-
-                params = _maybe_convert_from_te_fp8_params(
-                    params, fp8_direct_convert, weight_block_size
-                )
-                merge_params = bridge._weight_merge_across_tp(
-                    s.global_name, params, param
-                )
-                converted_names, converted_params = bridge._weight_to_hf_format(
-                    s.global_name, merge_params
-                )
-                converted_names, converted_params = _maybe_convert_to_torch_fp8_params(
-                    s.global_name,
-                    converted_names,
-                    converted_params,
-                    quantization_config,
-                    fp8_direct_convert,
-                )
-                for n, p in zip(converted_names, converted_params):
-                    assert n not in expert_sd, n
-                    expert_sd[n] = p
+            expert_sd = _emit_per_expert_flat_expert_sd(
+                bridge,
+                expert_specs,
+                all_gather_outputs=all_gather_outputs,
+                etp_size=etp_size,
+                quantization_config=quantization_config,
+                fp8_direct_convert=fp8_direct_convert,
+                weight_block_size=weight_block_size,
+            )
         # Stacked-MoE: only ep_rank==0 holds the consolidated expert_sd; other
         # EP ranks have empty dicts and must skip shard split/save (they still
         # participate in the weight_map collective below).

--- a/areal/models/mcore/hf_save.py
+++ b/areal/models/mcore/hf_save.py
@@ -599,12 +599,37 @@ def save_weights_to_hf_with_mbridge_fast(
                         f"from local_name={s.local_name!r}"
                     )
                 layer_idx, fc_kind, local_idx_str = m.groups()
-                # Recover the rank-local idx (0..num_experts_per_rank-1) from
-                # the global idx baked into global_name above.
-                local_id = int(local_idx_str) - num_experts_per_rank * ep_rank
+                # ``local_name`` carries the rank-local TEGroupedLinear suffix
+                # (``weight0..weight{num_experts_per_rank-1}``). ``global_name``
+                # was rewritten above to bake in the global expert id; for the
+                # sort/iteration order within each (layer, fc) group the local
+                # idx is sufficient and avoids the rank-dependent offset.
+                local_id = int(local_idx_str)
                 groups.setdefault((layer_idx, fc_kind), []).append((local_id, s))
             for k in groups:
                 groups[k].sort(key=lambda t: t[0])
+
+            # Invariant check across the EP group: every rank must see the same
+            # set of (layer, fc) groups with the same per-group expert count.
+            # Without this, a future refactor that injects a vision-tower expert
+            # spec on some ranks only — or a VPP layout where local layers
+            # differ across EP ranks — would silently mismatch the
+            # ``all_gather_into_tensor`` collective below and either hang or
+            # scramble tensors across layers. One cheap ``all_gather_object``
+            # eliminates that class of silent-corruption-on-future-refactor
+            # failures.
+            group_keys = tuple(sorted(groups.keys()))
+            ep_keys: list[tuple | None] = [None] * ep_size
+            dist.all_gather_object(ep_keys, group_keys, group=ep_group)
+            assert all(k == group_keys for k in ep_keys), (
+                f"EP rank divergence in (layer, fc) groups: "
+                f"rank {ep_rank} sees {group_keys}, peers see {ep_keys}"
+            )
+            for k, specs_with_idx in groups.items():
+                assert len(specs_with_idx) == num_experts_per_rank, (
+                    f"layer {k} has {len(specs_with_idx)} local experts on "
+                    f"ep_rank {ep_rank}, expected {num_experts_per_rank}"
+                )
 
             for (layer_idx, fc_kind), specs_with_idx in groups.items():
                 local_specs = [s for _, s in specs_with_idx]

--- a/areal/models/mcore/hf_save.py
+++ b/areal/models/mcore/hf_save.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -180,6 +181,32 @@ def _patch_saved_config(base_model_path, saved_path):
         logger.info(f"Patched config.json: {', '.join(patched_fields)}")
 
 
+def _bridge_uses_stacked_experts(bridge: Bridge) -> bool:
+    """Detect bridges whose HF format keeps experts grouped under a single
+    stacked tensor (e.g., Qwen3-VL-MoE ``mlp.experts.gate_up_proj`` shape
+    ``[E, hidden, 2*expert_dim]``) rather than per-expert flat keys.
+
+    Inferred from the bridge's ``_MLP_MAPPING``: per-expert-flat bridges (Qwen3-MoE,
+    BailingMoeV2, DeepSeekV3) map ``mlp.experts.linear_fc1.weight`` to HF names that
+    template ``{expert_id}``. Stacked bridges map to a single HF name without that
+    template, and their ``_weight_to_hf_format`` buffers per-expert tensors and
+    only emits the stacked output when ``num_moe_experts`` are accumulated. Under
+    EP>1 this means the caller must arrange to feed all ``num_moe_experts`` in a
+    single rank's loop — the per-EP-rank loop in the existing fast path leaves
+    the buffer permanently under-filled.
+    """
+    mapping = getattr(bridge, "_MLP_MAPPING", None)
+    if not mapping:
+        return False
+    for mcore_pat, hf_names in mapping.items():
+        if "mlp.experts.linear_fc" not in mcore_pat:
+            continue
+        for n in hf_names:
+            if "{expert_id}" not in n:
+                return True
+    return False
+
+
 def split_state_dict_into_shards(state_dict: dict, n_shards: int) -> list[dict]:
     if n_shards == 1:
         return [state_dict]
@@ -329,7 +356,21 @@ def save_weights_to_hf_with_mbridge_fast(
     expert_specs = list(
         filter(lambda s: ".mlp.experts.linear_fc" in s.global_name, weight_specs)
     )
-    expert_param_size = [s.full_param_size_byte() for s in expert_specs]
+    # Stacked-experts bridges (e.g., Qwen3-VL-MoE) emit a single stacked HF
+    # tensor per (layer, fc) that requires all ``num_moe_experts`` per-expert
+    # tensors to flow through ``bridge._weight_to_hf_format`` on the SAME rank
+    # so its internal buffer fills. Under EP>1 we EP-gather and consolidate
+    # writes onto ep_rank==0, so total expert shards == per-PP-stage count
+    # (no ``* ep_size`` multiplication; one rank writes them all).
+    stacked_experts = _bridge_uses_stacked_experts(bridge)
+    if stacked_experts:
+        # Total bytes after EP consolidation = local bytes × ep_size.
+        ep_size_for_size = mpu.get_expert_model_parallel_world_size()
+        expert_param_size = [
+            s.full_param_size_byte() * ep_size_for_size for s in expert_specs
+        ]
+    else:
+        expert_param_size = [s.full_param_size_byte() for s in expert_specs]
     expert_shards_this_stage = torch.tensor(
         min(
             len(expert_param_size),
@@ -347,8 +388,13 @@ def save_weights_to_hf_with_mbridge_fast(
         group=pp_group,
     )
     ep_size = mpu.get_expert_model_parallel_world_size()
-    # EP equally partition weights, so we simply multipy ep_size
-    pp_stage_expert_shards = [int(x) for x in pp_stage_expert_shards] * ep_size
+    # Per-expert-flat bridges: each EP rank writes its own disjoint shards →
+    # total shards across the EP group is ``per_rank * ep_size``.
+    # Stacked bridges: only ep_rank==0 writes after EP-gather → no multiplication.
+    if not stacked_experts:
+        pp_stage_expert_shards = [int(x) for x in pp_stage_expert_shards] * ep_size
+    else:
+        pp_stage_expert_shards = [int(x) for x in pp_stage_expert_shards]
     if len(expert_param_size) > 0:
         assert all(x >= 1 for x in pp_stage_expert_shards)
 
@@ -474,15 +520,23 @@ def save_weights_to_hf_with_mbridge_fast(
     if len(expert_param_size) > 0:
         ep_size = mpu.get_expert_model_parallel_world_size()
         ep_rank = mpu.get_expert_model_parallel_rank()
+        ep_group = mpu.get_expert_model_parallel_group()
         edp_size = dist.get_world_size(mpu.get_expert_data_parallel_group())
         edp_rank = mpu.get_expert_data_parallel_rank()
         etp_size: int = mpu.get_expert_tensor_parallel_world_size()
         etp_rank: int = mpu.get_expert_tensor_parallel_rank()
         etp_group = mpu.get_expert_tensor_parallel_group()
 
-        shard_offset = sum(pp_stage_non_expert_shards) + sum(
-            pp_stage_expert_shards[: ep_rank * pp_size + pp_rank]
-        )
+        # Stacked bridges consolidate all expert writes onto ep_rank==0 (per-PP
+        # stage), so the shard offset must NOT include ``ep_rank * pp_size``.
+        if stacked_experts:
+            shard_offset = sum(pp_stage_non_expert_shards) + sum(
+                pp_stage_expert_shards[:pp_rank]
+            )
+        else:
+            shard_offset = sum(pp_stage_non_expert_shards) + sum(
+                pp_stage_expert_shards[: ep_rank * pp_size + pp_rank]
+            )
         mesh_size = edp_size * etp_size
         mesh_idx = edp_rank * etp_size + etp_rank
         n_shards = int(expert_shards_this_stage)
@@ -515,32 +569,153 @@ def save_weights_to_hf_with_mbridge_fast(
             )
             for s, gathered_param in zip(_all_gather_specs, _all_gather_outputs):
                 all_gather_outputs[s.global_name] = gathered_param
-        for s in expert_specs:
-            param = s.param
-            if etp_size > 1:
-                params = all_gather_outputs[s.global_name].chunk(etp_size, dim=0)
-            else:
-                params = [param]
+        if stacked_experts and ep_size > 1:
+            # ── Stacked-MoE path (Qwen3-VL-MoE) ──
+            # mbridge buffers per-expert tensors and only emits the stacked
+            # HF tensor when num_moe_experts have arrived. Each rank only
+            # owns 1/ep_size of experts, so we EP-gather merged tensors per
+            # (layer, fc) group, feed mbridge in global-index order so its
+            # buffer fills exactly once, and consolidate writes on
+            # ep_rank==0. Other EP ranks still participate in collectives.
+            num_experts = bridge.config.num_moe_experts
+            num_experts_per_rank = num_experts // ep_size
+            assert num_experts_per_rank * ep_size == num_experts, (
+                f"num_moe_experts={num_experts} not divisible by ep_size={ep_size}"
+            )
 
-            params = _maybe_convert_from_te_fp8_params(
-                params, fp8_direct_convert, weight_block_size
+            # Group local specs by (layer_idx, fc_kind) and order by
+            # local-expert-id within each group.
+            _expert_re = re.compile(
+                r"\.layers\.(\d+)\.mlp\.experts\.(linear_fc\d+)\.weight(\d+)$"
             )
-            merge_params = bridge._weight_merge_across_tp(s.global_name, params, param)
-            converted_names, converted_params = bridge._weight_to_hf_format(
-                s.global_name, merge_params
-            )
-            converted_names, converted_params = _maybe_convert_to_torch_fp8_params(
-                s.global_name,
-                converted_names,
-                converted_params,
-                quantization_config,
-                fp8_direct_convert,
-            )
-            for n, p in zip(converted_names, converted_params):
-                assert n not in expert_sd, n
-                expert_sd[n] = p
-        # Split the state dict into shards and save the process's own shard.
-        shards = split_state_dict_into_shards(expert_sd, n_shards)
+            groups: dict[
+                tuple[str, str], list[tuple[int, McoreDistributedWeightSpec]]
+            ] = {}
+            for s in expert_specs:
+                m = _expert_re.search(s.local_name)
+                if not m:
+                    raise ValueError(
+                        f"stacked-expert path: cannot parse layer/fc/expert "
+                        f"from local_name={s.local_name!r}"
+                    )
+                layer_idx, fc_kind, local_idx_str = m.groups()
+                # Recover the rank-local idx (0..num_experts_per_rank-1) from
+                # the global idx baked into global_name above.
+                local_id = int(local_idx_str) - num_experts_per_rank * ep_rank
+                groups.setdefault((layer_idx, fc_kind), []).append((local_id, s))
+            for k in groups:
+                groups[k].sort(key=lambda t: t[0])
+
+            for (layer_idx, fc_kind), specs_with_idx in groups.items():
+                local_specs = [s for _, s in specs_with_idx]
+                # Pre-merge each spec's TP shard into a per-expert tensor.
+                merged_local: list[torch.Tensor] = []
+                for s in local_specs:
+                    if etp_size > 1:
+                        params = all_gather_outputs[s.global_name].chunk(
+                            etp_size, dim=0
+                        )
+                    else:
+                        params = [s.param]
+                    params = _maybe_convert_from_te_fp8_params(
+                        params, fp8_direct_convert, weight_block_size
+                    )
+                    merged = bridge._weight_merge_across_tp(
+                        s.global_name, params, s.param
+                    )
+                    merged_local.append(merged.contiguous())
+
+                # EP all-gather: stack local-merged on dim 0, all-gather, split.
+                # All ranks contribute the same number of experts (uniform EP shard).
+                stacked_local = torch.stack(merged_local, dim=0)
+                gathered = torch.empty(
+                    (ep_size,) + tuple(stacked_local.shape),
+                    dtype=stacked_local.dtype,
+                    device=stacked_local.device,
+                )
+                dist.all_gather_into_tensor(gathered, stacked_local, group=ep_group)
+                # gathered shape: [ep_size, num_experts_per_rank, *expert_shape]
+                # Flatten the first two dims to get global expert order:
+                # ep_rank0 [0..n-1], ep_rank1 [n..2n-1], ...
+                gathered = gathered.view(num_experts, *stacked_local.shape[1:])
+
+                # Feed mbridge in global expert order. Build the synthetic
+                # mcore name with the appropriate global index. mbridge's
+                # buffer fills after num_experts calls and emits the stacked
+                # HF tensor; intermediate calls return ``[], []``.
+                # Use the first local spec's name as the template.
+                name_prefix = local_specs[0].global_name.split(".weight")[0]
+                last_converted_names: list[str] = []
+                last_converted_params: list[torch.Tensor] = []
+                for global_idx in range(num_experts):
+                    name = f"{name_prefix}.weight{global_idx}"
+                    converted_names, converted_params = bridge._weight_to_hf_format(
+                        name, gathered[global_idx]
+                    )
+                    if converted_names:
+                        last_converted_names = converted_names
+                        last_converted_params = converted_params
+                converted_names, converted_params = _maybe_convert_to_torch_fp8_params(
+                    name_prefix,
+                    last_converted_names,
+                    last_converted_params,
+                    quantization_config,
+                    fp8_direct_convert,
+                )
+                # Only ep_rank==0 contributes to the on-disk shard; other EP
+                # ranks discard so their expert_sd stays empty (collectives
+                # have already happened above, so this is safe).
+                # Move stacked outputs to CPU pinned memory immediately to bound
+                # GPU memory by one stacked tensor at a time. Without this, all
+                # ~num_layers × 2 stacked tensors (~74GB for Qwen3-VL-30B-A3B)
+                # accumulate on the EP-rank-0 GPU and trigger CUDA OOM.
+                if ep_rank == 0:
+                    for n, p in zip(converted_names, converted_params):
+                        assert n not in expert_sd, n
+                        if isinstance(p, torch.Tensor) and p.is_cuda:
+                            expert_sd[n] = p.detach().to(
+                                device="cpu", non_blocking=False
+                            )
+                        else:
+                            expert_sd[n] = p
+                # Free the gathered buffer before the next group.
+                del gathered, stacked_local
+        else:
+            # ── Per-expert-flat path (Qwen3-MoE, BailingMoeV2, DeepSeekV3) ──
+            for s in expert_specs:
+                param = s.param
+                if etp_size > 1:
+                    params = all_gather_outputs[s.global_name].chunk(etp_size, dim=0)
+                else:
+                    params = [param]
+
+                params = _maybe_convert_from_te_fp8_params(
+                    params, fp8_direct_convert, weight_block_size
+                )
+                merge_params = bridge._weight_merge_across_tp(
+                    s.global_name, params, param
+                )
+                converted_names, converted_params = bridge._weight_to_hf_format(
+                    s.global_name, merge_params
+                )
+                converted_names, converted_params = _maybe_convert_to_torch_fp8_params(
+                    s.global_name,
+                    converted_names,
+                    converted_params,
+                    quantization_config,
+                    fp8_direct_convert,
+                )
+                for n, p in zip(converted_names, converted_params):
+                    assert n not in expert_sd, n
+                    expert_sd[n] = p
+        # Stacked-MoE: only ep_rank==0 holds the consolidated expert_sd; other
+        # EP ranks have empty dicts and must skip shard split/save (they still
+        # participate in the weight_map collective below).
+        write_shards = not (stacked_experts and ep_rank > 0)
+        if write_shards:
+            shards = split_state_dict_into_shards(expert_sd, n_shards)
+        else:
+            shards = []
 
         def _save_one_shard(x):
             i, shard = x
@@ -550,18 +725,21 @@ def save_weights_to_hf_with_mbridge_fast(
                 os.path.join(weights_path, output_filename.format(shard=shard_idx + 1)),
             )
 
-        _max_workers = max_workers
-        if _max_workers is None:
-            _max_workers = min(8, max(1, os.cpu_count() // dist.get_world_size()))
-        _max_workers = min(_max_workers, n_shards_per_gpu)
-        with ThreadPoolExecutor(max_workers=_max_workers) as executor:
-            results = executor.map(
-                _save_one_shard,
-                list(enumerate(shards[local_start : local_start + n_shards_per_gpu])),
-            )
-            # consume the result
-            for _ in results:
-                pass
+        if write_shards:
+            _max_workers = max_workers
+            if _max_workers is None:
+                _max_workers = min(8, max(1, os.cpu_count() // dist.get_world_size()))
+            _max_workers = min(_max_workers, max(1, n_shards_per_gpu))
+            with ThreadPoolExecutor(max_workers=_max_workers) as executor:
+                results = executor.map(
+                    _save_one_shard,
+                    list(
+                        enumerate(shards[local_start : local_start + n_shards_per_gpu])
+                    ),
+                )
+                # consume the result
+                for _ in results:
+                    pass
         # organize metadata
         for i, shard in enumerate(shards):
             shard_idx = shard_offset + i

--- a/areal/utils/testing_utils.py
+++ b/areal/utils/testing_utils.py
@@ -99,6 +99,14 @@ DENSE_MODEL_PATHS = {
         "/storage/openpsi/models/Qwen__Qwen3.5-0.8B/",
         "Qwen/Qwen3.5-0.8B",
     ),
+    "qwen2_5_vl": get_model_path(
+        "/storage/openpsi/models/Qwen__Qwen2.5-VL-3B-Instruct/",
+        "Qwen/Qwen2.5-VL-3B-Instruct",
+    ),
+    "qwen3_vl": get_model_path(
+        "/storage/openpsi/models/Qwen__Qwen3-VL-2B-Instruct/",
+        "Qwen/Qwen3-VL-2B-Instruct",
+    ),
 }
 
 # MoE models (slow to instantiate due to large number of experts)

--- a/areal/utils/testing_utils.py
+++ b/areal/utils/testing_utils.py
@@ -119,6 +119,10 @@ MOE_MODEL_PATHS = {
         "/storage/openpsi/models/Qwen__Qwen3.5-35B-A3B",
         "Qwen/Qwen3.5-35B-A3B",
     ),
+    "qwen3_vl_moe": get_model_path(
+        "/storage/openpsi/models/Qwen__Qwen3-VL-30B-A3B-Instruct/",
+        "Qwen/Qwen3-VL-30B-A3B-Instruct",
+    ),
 }
 
 # Combined for backward compatibility

--- a/tests/test_megatron_engine_vlm.py
+++ b/tests/test_megatron_engine_vlm.py
@@ -273,6 +273,20 @@ class TestVisionModelDetection:
 
         assert is_valid_vision_model("qwen3_vl") is True
 
+    def test_qwen3_vl_moe_detected(self):
+        from areal.engine.core.model import (
+            is_qwen3_vl_model,
+            is_qwen3_vl_moe_model,
+            is_valid_vision_model,
+        )
+
+        assert is_valid_vision_model("qwen3_vl_moe") is True
+        assert is_qwen3_vl_moe_model("qwen3_vl_moe") is True
+        # Family-level helper covers both dense and MoE.
+        assert is_qwen3_vl_model("qwen3_vl_moe") is True
+        assert is_qwen3_vl_model("qwen3_vl") is True
+        assert is_qwen3_vl_moe_model("qwen3_vl") is False
+
     def test_qwen3_not_detected(self):
         from areal.engine.core.model import is_valid_vision_model
 
@@ -929,6 +943,279 @@ class TestConvertQwen3VLToHF:
 
         with pytest.raises(ValueError, match="Unknown Qwen3-VL parameter"):
             convert_qwen3_vl_to_hf(
+                tf_config,
+                "module.module.some_unknown.weight",
+                torch.randn(10),
+            )
+
+
+class TestConvertQwen3VLMoEToHF:
+    """Test mcore→HF weight name conversion for Qwen3-VL-MoE.
+
+    Qwen3-VL-MoE shares vision tower + language attention with dense
+    Qwen3-VL; this class focuses on MoE-specific tensors (experts, router,
+    pre_mlp_layernorm) plus registry-ordering and a few cross-cutting
+    regression guards.
+    """
+
+    @pytest.fixture()
+    def tf_config(self):
+        """Mock TransformerConfig matching Qwen/Qwen3-VL-30B-A3B-Instruct text_config:
+        hidden=2048, attn_heads=32, kv_heads=4, head_dim=128.
+        """
+        cfg = MagicMock()
+        cfg.hidden_size = 2048
+        cfg.num_attention_heads = 32
+        cfg.num_query_groups = 4
+        cfg.kv_channels = 128
+        return cfg
+
+    @pytest.fixture()
+    def hf_config(self):
+        """Mock HF config matching Qwen/Qwen3-VL-30B-A3B-Instruct vision_config."""
+        cfg = MagicMock()
+        cfg.vision_config.num_heads = 16
+        cfg.vision_config.hidden_size = 1152
+        return cfg
+
+    # --- Registry dispatch (must hit MoE converter before dense) ---
+
+    def test_registry_dispatches_qwen3_vl_moe_before_qwen3_vl(
+        self, tf_config, hf_config
+    ):
+        """``qwen3_vl_moe`` model_name must dispatch to the MoE converter, not
+        fall through to ``qwen3_vl`` / ``qwen3_moe`` / ``qwen3`` (substring match
+        order). MoE-specific names like ``mlp.experts.linear_fc1.weight0`` would
+        otherwise raise ``Unknown Qwen3-VL language-model parameter``.
+        """
+        from areal.engine.megatron_utils.megatron import convert_to_hf
+
+        param = torch.randn(1536, 2048)  # 2 * expert_dim x hidden
+        result = convert_to_hf(
+            tf_config,
+            "qwen3_vl_moe",
+            "module.module.language_model.decoder.layers.0.mlp.experts.linear_fc1.weight5",
+            param,
+            hf_config=hf_config,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.0.mlp.experts.5.gate_proj.weight" in names
+        assert "model.language_model.layers.0.mlp.experts.5.up_proj.weight" in names
+
+    def test_registry_dense_still_routes_to_dense(self, tf_config, hf_config):
+        """Sanity: ``qwen3_vl`` model_name still dispatches to dense converter
+        even after MoE entry is inserted. Dense MLP fc1 must chunk gate/up.
+        """
+        from areal.engine.megatron_utils.megatron import convert_to_hf
+
+        param = torch.randn(12288, 2048)
+        result = convert_to_hf(
+            tf_config,
+            "qwen3_vl",
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc1.weight",
+            param,
+            hf_config=hf_config,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.0.mlp.gate_proj.weight" in names
+        assert "model.language_model.layers.0.mlp.up_proj.weight" in names
+
+    # --- Shared global / attention paths (regression guards on factoring) ---
+
+    def test_lm_global_embedding_shared_with_dense(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        param = torch.randn(151936, 2048)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.embedding.word_embeddings.weight",
+            param,
+        )
+        assert result == [("model.language_model.embed_tokens.weight", param)]
+
+    def test_lm_attention_qkv_split_shared_with_dense(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        # value_num_per_group = 32/4 = 8, head_dim = 128
+        qkv_dim = tf_config.num_query_groups * (8 + 1 + 1) * tf_config.kv_channels
+        param = torch.randn(qkv_dim, tf_config.hidden_size)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.4.self_attention.linear_qkv.weight",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.4.self_attn.q_proj.weight" in names
+        assert "model.language_model.layers.4.self_attn.k_proj.weight" in names
+        assert "model.language_model.layers.4.self_attn.v_proj.weight" in names
+
+    def test_lm_attention_q_norm_shared_with_dense(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        param = torch.randn(128)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.7.self_attention.q_layernorm.weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.7.self_attn.q_norm.weight", param)
+        ]
+
+    # --- MoE-specific: experts, router, pre_mlp_layernorm ---
+
+    def test_expert_fc1_chunks_gate_up_per_expert(self, tf_config):
+        """Per-expert ``linear_fc1.weight{idx}`` chunks into gate_proj and
+        up_proj at the per-expert HF path.
+        """
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        param = torch.randn(1536, 2048)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.3.mlp.experts.linear_fc1.weight12",
+            param,
+        )
+        assert len(result) == 2
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.3.mlp.experts.12.gate_proj.weight" in names
+        assert "model.language_model.layers.3.mlp.experts.12.up_proj.weight" in names
+
+    def test_expert_fc2_passthrough_per_expert(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        param = torch.randn(2048, 768)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.3.mlp.experts.linear_fc2.weight12",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.3.mlp.experts.12.down_proj.weight", param)
+        ]
+
+    def test_router_renamed_to_mlp_gate(self, tf_config):
+        """``mlp.router.weight`` → HF ``mlp.gate.weight`` (NOT ``mlp.router.weight``)."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        param = torch.randn(128, 2048)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.router.weight",
+            param,
+        )
+        assert result == [("model.language_model.layers.0.mlp.gate.weight", param)]
+
+    def test_pre_mlp_layernorm_renamed_to_post_attention(self, tf_config):
+        """``pre_mlp_layernorm.weight`` → HF ``post_attention_layernorm.weight``."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        param = torch.randn(2048)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.5.pre_mlp_layernorm.weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.5.post_attention_layernorm.weight", param)
+        ]
+
+    def test_dense_mlp_fallback_for_mixed_sparse_step(self, tf_config):
+        """Layers left non-sparse by ``decoder_sparse_step > 1`` keep the dense
+        MLP path. Qwen3-VL-30B-A3B-Instruct uses ``decoder_sparse_step=1`` so
+        these branches are dead for that checkpoint, but they must exist for
+        future variants with mixed dense/sparse layouts.
+        """
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        # linear_fc1: chunk gate/up
+        param = torch.randn(12288, 2048)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc1.weight",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.0.mlp.gate_proj.weight" in names
+        assert "model.language_model.layers.0.mlp.up_proj.weight" in names
+
+        # linear_fc1.layer_norm_weight: post_attention_layernorm
+        ln_param = torch.randn(2048)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc1.layer_norm_weight",
+            ln_param,
+        )
+        assert result == [
+            ("model.language_model.layers.0.post_attention_layernorm.weight", ln_param)
+        ]
+
+        # linear_fc2: down_proj passthrough
+        fc2_param = torch.randn(2048, 6144)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc2.weight",
+            fc2_param,
+        )
+        assert result == [
+            ("model.language_model.layers.0.mlp.down_proj.weight", fc2_param)
+        ]
+
+    # --- Vision tower (delegates to shared helper) ---
+
+    def test_vision_block_qkv_reordered_via_shared_helper(self, tf_config, hf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        # 3 * hidden_vision = 3 * 1152 = 3456
+        param = torch.randn(3456, 1152)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.7.self_attention.linear_qkv.weight",
+            param,
+            hf_config=hf_config,
+        )
+        assert result[0][0] == "model.visual.blocks.7.attn.qkv.weight"
+        assert result[0][1].shape == param.shape
+
+    def test_deepstack_merger_via_shared_helper(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        param = torch.randn(1152)
+        result = convert_qwen3_vl_moe_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.deepstack_merger_list.1.patch_norm.weight",
+            param,
+        )
+        assert result == [("model.visual.deepstack_merger_list.1.norm.weight", param)]
+
+    # --- Error handling ---
+
+    def test_unknown_lang_param_raises(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        with pytest.raises(ValueError, match="Unknown Qwen3-VL-MoE language-model"):
+            convert_qwen3_vl_moe_to_hf(
+                tf_config,
+                "module.module.language_model.decoder.layers.0.unknown.weight",
+                torch.randn(10),
+            )
+
+    def test_unknown_expert_kind_raises(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        with pytest.raises(ValueError, match="Unknown Qwen3-VL-MoE expert"):
+            convert_qwen3_vl_moe_to_hf(
+                tf_config,
+                "module.module.language_model.decoder.layers.0.mlp.experts.linear_fc99.weight0",
+                torch.randn(10),
+            )
+
+    def test_unknown_top_level_param_raises(self, tf_config):
+        """Non-LM, non-vision names should raise via the shared vision helper."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_moe_to_hf
+
+        with pytest.raises(ValueError, match="Unknown Qwen3-VL parameter"):
+            convert_qwen3_vl_moe_to_hf(
                 tf_config,
                 "module.module.some_unknown.weight",
                 torch.randn(10),

--- a/tests/test_megatron_engine_vlm.py
+++ b/tests/test_megatron_engine_vlm.py
@@ -1,30 +1,15 @@
-"""Tests for Megatron engine VLM (Vision-Language Model) support.
+"""CPU-only unit tests for Megatron engine VLM (Vision-Language Model) support.
 
-Unit tests (CPU-only) test the helper functions and logic changes.
-Integration tests (GPU-required) run via torchrun as subprocesses to avoid
-device memory leaks in the parent pytest process, allowing the full
-suite to run on just 2 GPUs.
+Distributed integration tests live in
+``tests/test_megatron_engine_vlm_distributed.py`` — they launch torchrun
+subprocesses and require GPUs.
 """
 
-import os
-import pathlib
-import subprocess
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 import torch
-
-_TORCHRUN_SCRIPT = (
-    pathlib.Path(__file__).parent / "torchrun" / "run_megatron_engine_vlm.py"
-).resolve()
-
-CUDA_AVAILABLE = torch.cuda.is_available()
-
-
-# ──────────────────────────────────────────────────────────────────────
-# Unit tests: CPU-only, no GPU or model weights required
-# ──────────────────────────────────────────────────────────────────────
 
 
 class TestUnwrapToGptModel:
@@ -283,6 +268,11 @@ class TestVisionModelDetection:
 
         assert is_valid_vision_model("qwen2_vl") is True
 
+    def test_qwen3_vl_detected(self):
+        from areal.engine.core.model import is_valid_vision_model
+
+        assert is_valid_vision_model("qwen3_vl") is True
+
     def test_qwen3_not_detected(self):
         from areal.engine.core.model import is_valid_vision_model
 
@@ -520,6 +510,431 @@ class TestConvertQwen25VLToHF:
             )
 
 
+class TestConvertQwen3VLToHF:
+    """Test mcore→HF weight name conversion for Qwen3-VL (dense)."""
+
+    @pytest.fixture()
+    def tf_config(self):
+        """Mock TransformerConfig matching Qwen/Qwen3-VL-2B-Instruct text_config:
+        hidden=2048, attn_heads=16, kv_heads=8, head_dim=128.
+        """
+        cfg = MagicMock()
+        cfg.hidden_size = 2048
+        cfg.num_attention_heads = 16
+        cfg.num_query_groups = 8
+        cfg.kv_channels = 128
+        return cfg
+
+    @pytest.fixture()
+    def hf_config(self):
+        """Mock HF config matching Qwen/Qwen3-VL-2B-Instruct vision_config:
+        hidden=1024, num_heads=16 (head_dim=64).
+        """
+        cfg = MagicMock()
+        cfg.vision_config.num_heads = 16
+        cfg.vision_config.hidden_size = 1024
+        return cfg
+
+    # --- Registry dispatch ---
+
+    def test_registry_dispatches_qwen3_vl_before_qwen3(self, tf_config, hf_config):
+        """convert_to_hf with model_name='qwen3_vl' must use the VLM converter,
+        not fall through to qwen3 (substring match order)."""
+        from areal.engine.megatron_utils.megatron import convert_to_hf
+
+        param = torch.randn(1024)
+        result = convert_to_hf(
+            tf_config,
+            "qwen3_vl",
+            "module.module.vision_model.merger.patch_norm.weight",
+            param,
+            hf_config=hf_config,
+        )
+        assert result[0][0] == "model.visual.merger.norm.weight"
+
+    # --- Language model (Qwen3-VL has model.language_model.* prefix) ---
+
+    def test_language_model_embedding_uses_language_model_prefix(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(151936, 2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.embedding.word_embeddings.weight",
+            param,
+        )
+        assert result == [("model.language_model.embed_tokens.weight", param)]
+
+    def test_language_model_final_norm(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.final_layernorm.weight",
+            param,
+        )
+        assert result == [("model.language_model.norm.weight", param)]
+
+    def test_language_model_output_layer(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(151936, 2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.output_layer.weight",
+            param,
+        )
+        assert result == [("lm_head.weight", param)]
+
+    def test_language_model_qkv_split(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        # value_num_per_group = 16/8 = 2, head_dim = 128
+        # qkv_dim = num_query_groups * (value_num_per_group + 2) * head_dim
+        qkv_dim = tf_config.num_query_groups * (2 + 1 + 1) * tf_config.kv_channels
+        param = torch.randn(qkv_dim, tf_config.hidden_size)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.5.self_attention.linear_qkv.weight",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.5.self_attn.q_proj.weight" in names
+        assert "model.language_model.layers.5.self_attn.k_proj.weight" in names
+        assert "model.language_model.layers.5.self_attn.v_proj.weight" in names
+
+    def test_language_model_qkv_bias_split(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        qkv_dim = tf_config.num_query_groups * (2 + 1 + 1) * tf_config.kv_channels
+        param = torch.randn(qkv_dim)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.self_attention.linear_qkv.bias",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.0.self_attn.q_proj.bias" in names
+        assert "model.language_model.layers.0.self_attn.k_proj.bias" in names
+        assert "model.language_model.layers.0.self_attn.v_proj.bias" in names
+
+    def test_language_model_q_norm(self, tf_config):
+        """Qwen3-specific q_layernorm → self_attn.q_norm."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(128)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.3.self_attention.q_layernorm.weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.3.self_attn.q_norm.weight", param)
+        ]
+
+    def test_language_model_k_norm(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(128)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.3.self_attention.k_layernorm.weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.3.self_attn.k_norm.weight", param)
+        ]
+
+    def test_language_model_o_proj(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048, 2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.self_attention.linear_proj.weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.0.self_attn.o_proj.weight", param)
+        ]
+
+    def test_language_model_input_layernorm(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.self_attention.linear_qkv.layer_norm_weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.0.input_layernorm.weight", param)
+        ]
+
+    def test_language_model_post_attention_layernorm(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc1.layer_norm_weight",
+            param,
+        )
+        assert result == [
+            ("model.language_model.layers.0.post_attention_layernorm.weight", param)
+        ]
+
+    def test_language_model_mlp_fc1_splits_gate_up(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(12288, 2048)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc1.weight",
+            param,
+        )
+        names = [n for n, _ in result]
+        assert "model.language_model.layers.0.mlp.gate_proj.weight" in names
+        assert "model.language_model.layers.0.mlp.up_proj.weight" in names
+
+    def test_language_model_mlp_fc2(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2048, 6144)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.language_model.decoder.layers.0.mlp.linear_fc2.weight",
+            param,
+        )
+        assert result == [("model.language_model.layers.0.mlp.down_proj.weight", param)]
+
+    # --- Vision model: direct mappings (model.visual.* prefix) ---
+
+    def test_vision_patch_embed_weight(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(1024, 3, 2, 16, 16)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.patch_embed.proj.weight",
+            param,
+        )
+        assert result == [("model.visual.patch_embed.proj.weight", param)]
+
+    def test_vision_patch_embed_bias(self, tf_config):
+        """Qwen3-VL adds patch_embed bias (Qwen2.5-VL was bias=False)."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(1024)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.patch_embed.proj.bias",
+            param,
+        )
+        assert result == [("model.visual.patch_embed.proj.bias", param)]
+
+    def test_vision_pos_embed(self, tf_config):
+        """Qwen3-VL has pos_embed (new vs Qwen2.5-VL)."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(2304, 1024)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.pos_embed.weight",
+            param,
+        )
+        assert result == [("model.visual.pos_embed.weight", param)]
+
+    def test_vision_merger_patch_norm(self, tf_config):
+        """merger.patch_norm.{weight,bias} → merger.norm.{weight,bias}."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind in ("weight", "bias"):
+            param = torch.randn(1024)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.merger.patch_norm.{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.merger.norm.{kind}", param)]
+
+    def test_vision_merger_linear_fc1_fc2(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for fc in ("linear_fc1", "linear_fc2"):
+            for kind in ("weight", "bias"):
+                param = (
+                    torch.randn(4096, 4096) if kind == "weight" else torch.randn(4096)
+                )
+                result = convert_qwen3_vl_to_hf(
+                    tf_config,
+                    f"module.module.vision_model.merger.{fc}.{kind}",
+                    param,
+                )
+                assert result == [(f"model.visual.merger.{fc}.{kind}", param)]
+
+    # --- Vision model: per-layer params ---
+
+    def test_vision_block_qkv_weight_reordered(self, tf_config, hf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        # 3 * hidden_vision = 3 * 1024 = 3072
+        param = torch.randn(3072, 1024)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.7.self_attention.linear_qkv.weight",
+            param,
+            hf_config=hf_config,
+        )
+        assert result[0][0] == "model.visual.blocks.7.attn.qkv.weight"
+        assert result[0][1].shape == param.shape
+
+    def test_vision_block_qkv_bias_reordered(self, tf_config, hf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(3072)
+        result = convert_qwen3_vl_to_hf(
+            tf_config,
+            "module.module.vision_model.decoder.layers.0.self_attention.linear_qkv.bias",
+            param,
+            hf_config=hf_config,
+        )
+        assert result[0][0] == "model.visual.blocks.0.attn.qkv.bias"
+        assert result[0][1].shape == param.shape
+
+    def test_vision_block_qkv_requires_hf_config(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        param = torch.randn(3072, 1024)
+        with pytest.raises(ValueError, match="vision_config.num_heads"):
+            convert_qwen3_vl_to_hf(
+                tf_config,
+                "module.module.vision_model.decoder.layers.0.self_attention.linear_qkv.weight",
+                param,
+            )
+
+    def test_vision_block_attn_proj(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind, shape in (("weight", (1024, 1024)), ("bias", (1024,))):
+            param = torch.randn(*shape)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.3.self_attention.linear_proj.{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.3.attn.proj.{kind}", param)]
+
+    def test_vision_block_norm1_weight_and_bias(self, tf_config):
+        """Qwen3-VL adds norm1.bias (Qwen2.5-VL was weight-only)."""
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind in ("weight", "bias"):
+            param = torch.randn(1024)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.0.self_attention.linear_qkv.layer_norm_{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.0.norm1.{kind}", param)]
+
+    def test_vision_block_norm2_weight_and_bias(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind in ("weight", "bias"):
+            param = torch.randn(1024)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.1.mlp.linear_fc1.layer_norm_{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.1.norm2.{kind}", param)]
+
+    def test_vision_block_mlp_is_NOT_gated(self, tf_config):
+        """Regression guard: Qwen3-VL vision MLP is NOT gated.
+
+        linear_fc1 must map 1:1 (no chunk into gate_proj/up_proj).
+        """
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind, shape in (("weight", (4096, 1024)), ("bias", (4096,))):
+            param = torch.randn(*shape)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.2.mlp.linear_fc1.{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.2.mlp.linear_fc1.{kind}", param)]
+
+    def test_vision_block_mlp_fc2(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind, shape in (("weight", (1024, 4096)), ("bias", (1024,))):
+            param = torch.randn(*shape)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.layers.10.mlp.linear_fc2.{kind}",
+                param,
+            )
+            assert result == [(f"model.visual.blocks.10.mlp.linear_fc2.{kind}", param)]
+
+    # --- Deepstack mergers (new in Qwen3-VL) ---
+
+    @pytest.mark.parametrize("idx", [0, 1, 2])
+    def test_deepstack_merger_norm(self, tf_config, idx):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for kind in ("weight", "bias"):
+            param = torch.randn(1024)
+            result = convert_qwen3_vl_to_hf(
+                tf_config,
+                f"module.module.vision_model.decoder.deepstack_merger_list.{idx}.patch_norm.{kind}",
+                param,
+            )
+            assert result == [
+                (f"model.visual.deepstack_merger_list.{idx}.norm.{kind}", param)
+            ]
+
+    @pytest.mark.parametrize("idx", [0, 1, 2])
+    def test_deepstack_merger_linear_fc(self, tf_config, idx):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        for fc in ("linear_fc1", "linear_fc2"):
+            for kind, shape in (("weight", (4096, 4096)), ("bias", (4096,))):
+                param = torch.randn(*shape)
+                result = convert_qwen3_vl_to_hf(
+                    tf_config,
+                    f"module.module.vision_model.decoder.deepstack_merger_list.{idx}.{fc}.{kind}",
+                    param,
+                )
+                assert result == [
+                    (f"model.visual.deepstack_merger_list.{idx}.{fc}.{kind}", param)
+                ]
+
+    # --- Error handling ---
+
+    def test_unknown_lang_param_raises(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        with pytest.raises(ValueError, match="Unknown Qwen3-VL language-model"):
+            convert_qwen3_vl_to_hf(
+                tf_config,
+                "module.module.language_model.decoder.layers.0.unknown.weight",
+                torch.randn(10),
+            )
+
+    def test_unknown_param_raises(self, tf_config):
+        from areal.engine.megatron_utils.megatron import convert_qwen3_vl_to_hf
+
+        with pytest.raises(ValueError, match="Unknown Qwen3-VL parameter"):
+            convert_qwen3_vl_to_hf(
+                tf_config,
+                "module.module.some_unknown.weight",
+                torch.randn(10),
+            )
+
+
 class TestRemovePaddingVLM:
     """Test remove_padding handles VLM language_model prefixed params."""
 
@@ -560,108 +975,3 @@ class TestRemovePaddingVLM:
             151936,
         )
         assert result is param
-
-
-# ──────────────────────────────────────────────────────────────────────
-# Integration tests: subprocess-based to avoid device memory leaks
-# ──────────────────────────────────────────────────────────────────────
-
-
-def _run_vlm_test(
-    test_type: str,
-    output_path: str,
-    *,
-    backend: str = "megatron:d1p1t1",
-    nproc: int = 1,
-    extra_args: list[str] | None = None,
-    timeout: int = 300,
-):
-    """Launch a VLM integration test via torchrun subprocess.
-
-    Each test runs in its own process, ensuring complete device memory
-    cleanup between tests. This allows the full suite to run on just 2 devices.
-    """
-    from areal.utils.network import find_free_ports
-
-    port = find_free_ports(1)[0]
-
-    env = os.environ.copy()
-    env["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(nproc))
-
-    cmd = [
-        "torchrun",
-        f"--nproc_per_node={nproc}",
-        "--nnodes=1",
-        "--master-addr=localhost",
-        f"--master_port={port}",
-        str(_TORCHRUN_SCRIPT),
-        f"--backend={backend}",
-        f"--test_type={test_type}",
-        f"--output={output_path}",
-    ]
-    if extra_args:
-        cmd.extend(extra_args)
-
-    try:
-        subprocess.run(
-            cmd,
-            env=env,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-    except subprocess.CalledProcessError as e:
-        if "out of memory" in (e.stderr or "").lower():
-            pytest.skip(f"OOM: 3B VLM {test_type} requires more memory")
-        pytest.fail(
-            f"VLM {test_type} test failed:\nstdout: {e.stdout}\nstderr: {e.stderr}"
-        )
-    except subprocess.TimeoutExpired:
-        pytest.fail(f"VLM {test_type} test timed out ({timeout}s)")
-
-    with open(output_path) as f:
-        result = f.read().strip()
-    if result == "OOM":
-        pytest.skip(f"OOM: 3B VLM {test_type} requires more memory than single device")
-    assert result == "Passed", f"VLM {test_type} test failed: {result}"
-
-
-@pytest.mark.gpu
-@pytest.mark.slow
-@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
-def test_vlm_engine_initializes(tmp_path_factory):
-    """Verify VLM engine detects vision model and loads processor."""
-    output = str(tmp_path_factory.mktemp("vlm_test") / "init.out")
-    _run_vlm_test("init", output)
-
-
-@pytest.mark.gpu
-@pytest.mark.slow
-@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
-def test_vlm_simple_forward(tmp_path_factory):
-    """Verify forward pass with VLM inputs completes."""
-    output = str(tmp_path_factory.mktemp("vlm_test") / "forward.out")
-    _run_vlm_test("forward", output)
-
-
-@pytest.mark.gpu
-@pytest.mark.slow
-@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
-def test_vlm_hf_save_load_weights(tmp_path_factory):
-    """Verify save/load preserves VLM weights and saves processor."""
-    save_dir = str(tmp_path_factory.mktemp("vlm_save"))
-    output = str(tmp_path_factory.mktemp("vlm_test") / "save_load.out")
-    _run_vlm_test("save_load", output, extra_args=[f"--save_dir={save_dir}"])
-
-
-@pytest.mark.gpu
-@pytest.mark.multi_gpu
-@pytest.mark.slow
-@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
-def test_vlm_train_tensor_parallel(tmp_path_factory):
-    """VLM training with TP=2 to avoid single-device OOM."""
-    if torch.cuda.device_count() < 2:
-        pytest.skip("VLM TP training requires at least 2 GPUs")
-    output = str(tmp_path_factory.mktemp("vlm_test") / "train_tp2.out")
-    _run_vlm_test("train", output, backend="megatron:d1p1t2", nproc=2)

--- a/tests/test_megatron_engine_vlm_distributed.py
+++ b/tests/test_megatron_engine_vlm_distributed.py
@@ -4,7 +4,8 @@
 
 All tests in this file launch ``tests/torchrun/run_megatron_engine_vlm_distributed.py``
 as a torchrun subprocess so the parent pytest process never allocates GPU
-memory. The full suite runs on as few as 2 devices.
+memory. The full suite runs on as few as 2 devices for the dense parametric
+tests; Qwen3-VL-MoE tests need 8.
 
 CPU-only unit tests for the converters / detection helpers live in
 ``tests/test_megatron_engine_vlm.py``.
@@ -20,7 +21,7 @@ import torch
 
 from areal.api.alloc_mode import ModelAllocation
 from areal.utils.network import find_free_ports
-from areal.utils.testing_utils import DENSE_MODEL_PATHS
+from areal.utils.testing_utils import DENSE_MODEL_PATHS, MOE_MODEL_PATHS
 
 _TORCHRUN_SCRIPT = (
     pathlib.Path(__file__).parent
@@ -117,6 +118,14 @@ _VLM_MODELS = [
         {"VLM_MODEL_PATH": DENSE_MODEL_PATHS["qwen3_vl"]},
         id="qwen3_vl",
     ),
+    pytest.param(
+        {"VLM_MODEL_PATH": MOE_MODEL_PATHS["qwen3_vl_moe"]},
+        id="qwen3_vl_moe",
+        marks=pytest.mark.skipif(
+            torch.cuda.device_count() < 8,
+            reason="Qwen3-VL-MoE-30B-A3B requires at least 8 GPUs",
+        ),
+    ),
 ]
 
 
@@ -171,4 +180,55 @@ def test_train_tensor_parallel(model_env, tmp_path_factory):
         output,
         backend="megatron:d1p1t2",
         env_overrides=model_env,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Qwen3-VL-MoE: 30B-A3B-Instruct under hybrid (attn|ffn) allocation.
+# CP > 1 is forbidden for VLMs (megatron_engine.py:347).
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+def test_qwen3vl_moe_expert_parallel(tmp_path_factory):
+    """Forward smoke test for Qwen3-VL-MoE under ``(attn:d2t4|ffn:d2e4)``.
+
+    Allocation: attn DP=2 TP=4 (8 GPUs); ffn DP=2 EP=4 (8 GPUs). World sizes
+    must match — earlier ``(attn:d2t2|ffn:d2e4)`` raised
+    ``InvalidAllocationModeError`` (attn=4 vs ffn=8). Validates the hybrid
+    attn/ffn parser, EP-aware weight init, and VLM forward path.
+    """
+    if torch.cuda.device_count() < 8:
+        pytest.skip("Qwen3-VL-MoE expert parallel requires 8 GPUs to run")
+    output = str(
+        tmp_path_factory.mktemp("test_output") / "qwen3vl_moe_expert_parallel.out"
+    )
+    _run_vlm_test(
+        "forward",
+        output,
+        backend="megatron:(attn:d2t4|ffn:d2e4)",
+        env_overrides={"VLM_MODEL_PATH": MOE_MODEL_PATHS["qwen3_vl_moe"]},
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+def test_qwen3vl_moe_dcp_save_load(tmp_path_factory):
+    """DCP save/load round-trip for Qwen3-VL-MoE under ``(attn:d2p1t4|ffn:d1p1t2e4)``.
+
+    Allocation: attn DP=2 PP=1 TP=4 (8 GPUs); ffn DP=1 PP=1 TP=2 EP=4 (8 GPUs).
+    Drops the ``cp=2`` segment from the dense Qwen3-MoE analog because VLM
+    forbids CP>1 (megatron_engine.py:347).
+    """
+    if torch.cuda.device_count() < 8:
+        pytest.skip("Qwen3-VL-MoE DCP save load requires 8 GPUs to run")
+    output = str(tmp_path_factory.mktemp("test_output") / "qwen3vl_moe_save_load.out")
+    _run_vlm_test(
+        "dcp_save_load",
+        output,
+        backend="megatron:(attn:d2p1t4|ffn:d1p1t2e4)",
+        env_overrides={"VLM_MODEL_PATH": MOE_MODEL_PATHS["qwen3_vl_moe"]},
     )

--- a/tests/test_megatron_engine_vlm_distributed.py
+++ b/tests/test_megatron_engine_vlm_distributed.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Distributed integration tests for the Megatron VLM path.
+
+All tests in this file launch ``tests/torchrun/run_megatron_engine_vlm_distributed.py``
+as a torchrun subprocess so the parent pytest process never allocates GPU
+memory. The full suite runs on as few as 2 devices.
+
+CPU-only unit tests for the converters / detection helpers live in
+``tests/test_megatron_engine_vlm.py``.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+import torch
+
+from areal.api.alloc_mode import ModelAllocation
+from areal.utils.network import find_free_ports
+from areal.utils.testing_utils import DENSE_MODEL_PATHS
+
+_TORCHRUN_SCRIPT = (
+    pathlib.Path(__file__).parent
+    / "torchrun"
+    / "run_megatron_engine_vlm_distributed.py"
+).resolve()
+
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+
+def _run_vlm_test(
+    test_type: str,
+    output_path: str,
+    *,
+    backend: str = "megatron:d1p1t1",
+    nproc: int | None = None,
+    extra_args: list[str] | None = None,
+    timeout: int = 1800,
+    env_overrides: dict[str, str] | None = None,
+):
+    """Launch a VLM integration test via torchrun subprocess.
+
+    ``nproc`` is inferred from ``ModelAllocation.from_str(backend).parallel.world_size``
+    when not provided, so asymmetric ``(attn:...|ffn:...)`` allocations work
+    without callers having to compute the rank count separately. Pass
+    ``env_overrides={"VLM_MODEL_PATH": ...}`` to switch the model under test.
+
+    Output is streamed to the parent's stdout/stderr (helpful for diagnosing
+    long distributed runs); OOM detection happens via the runner's own
+    ``write_result(output, "OOM")`` marker rather than stderr scraping.
+    """
+    if nproc is None:
+        nproc = ModelAllocation.from_str(backend).parallel.world_size
+
+    port = find_free_ports(1)[0]
+
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(nproc))
+    if env_overrides:
+        env.update(env_overrides)
+
+    cmd = [
+        "torchrun",
+        f"--nproc_per_node={nproc}",
+        "--nnodes=1",
+        "--master-addr=localhost",
+        f"--master_port={port}",
+        str(_TORCHRUN_SCRIPT),
+        f"--backend={backend}",
+        f"--test_type={test_type}",
+        f"--output={output_path}",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    output_path_obj = pathlib.Path(output_path)
+    try:
+        subprocess.run(
+            cmd,
+            env=env,
+            check=True,
+            stdout=sys.stdout,
+            stderr=sys.stdout,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.CalledProcessError as e:
+        if output_path_obj.exists() and output_path_obj.read_text().strip() == "OOM":
+            pytest.skip(f"OOM: VLM {test_type} requires more GPU memory")
+        pytest.fail(f"VLM {test_type} test failed (exit {e.returncode})")
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"VLM {test_type} test timed out ({timeout}s)")
+
+    result = output_path_obj.read_text().strip()
+    if result == "OOM":
+        pytest.skip(f"OOM: VLM {test_type} requires more GPU memory")
+    assert result == "Passed", f"VLM {test_type} test failed: {result}"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Per-model env fixtures.
+#
+# Each parametric scenario below runs once for every entry in _VLM_MODELS.
+# To add a new VLM, register the path in ``areal.utils.testing_utils`` and
+# append one tuple here — no test-body changes needed.
+# ──────────────────────────────────────────────────────────────────────
+
+_VLM_MODELS = [
+    pytest.param(
+        {"VLM_MODEL_PATH": DENSE_MODEL_PATHS["qwen2_5_vl"]},
+        id="qwen25_vl",
+    ),
+    pytest.param(
+        {"VLM_MODEL_PATH": DENSE_MODEL_PATHS["qwen3_vl"]},
+        id="qwen3_vl",
+    ),
+]
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+@pytest.mark.parametrize("model_env", _VLM_MODELS)
+def test_engine_initializes(model_env, tmp_path_factory):
+    """Verify VLM engine detects vision model and loads processor."""
+    output = str(tmp_path_factory.mktemp("vlm_test") / "init.out")
+    _run_vlm_test("init", output, env_overrides=model_env)
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+@pytest.mark.parametrize("model_env", _VLM_MODELS)
+def test_simple_forward(model_env, tmp_path_factory):
+    """Verify forward pass with VLM inputs completes."""
+    output = str(tmp_path_factory.mktemp("vlm_test") / "forward.out")
+    _run_vlm_test("forward", output, env_overrides=model_env)
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+@pytest.mark.parametrize("model_env", _VLM_MODELS)
+def test_hf_save_load_weights(model_env, tmp_path_factory):
+    """Verify save/load preserves VLM weights and saves processor."""
+    save_dir = str(tmp_path_factory.mktemp("vlm_save"))
+    output = str(tmp_path_factory.mktemp("vlm_test") / "save_load.out")
+    _run_vlm_test(
+        "save_load",
+        output,
+        extra_args=[f"--save_dir={save_dir}"],
+        env_overrides=model_env,
+    )
+
+
+@pytest.mark.gpu
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+@pytest.mark.parametrize("model_env", _VLM_MODELS)
+def test_train_tensor_parallel(model_env, tmp_path_factory):
+    """VLM training with TP=2 to avoid single-device OOM."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("VLM TP training requires at least 2 GPUs")
+    output = str(tmp_path_factory.mktemp("vlm_test") / "train_tp2.out")
+    _run_vlm_test(
+        "train",
+        output,
+        backend="megatron:d1p1t2",
+        env_overrides=model_env,
+    )

--- a/tests/torchrun/run_megatron_engine_vlm_distributed.py
+++ b/tests/torchrun/run_megatron_engine_vlm_distributed.py
@@ -3,6 +3,15 @@
 Launched via torchrun from test_megatron_engine_vlm.py. All integration
 tests run as subprocesses so the parent pytest process never allocates
 GPU memory, allowing the full suite to run on just 2 GPUs.
+
+Supports any registered VLM whose ``hf_config`` exposes ``vision_config``
+with ``patch_size``, ``temporal_patch_size``, ``spatial_merge_size``,
+``in_channels``, and ``image_token_id`` — ``mock_vlm_input`` reads patch
+geometry from ``engine.hf_config`` so this script works for both
+Qwen2.5-VL (patch=14) and Qwen3-VL (patch=16) without code-side
+branching. Pick the model via the ``VLM_MODEL_PATH`` env var; default
+is ``DENSE_MODEL_PATHS["qwen2_5_vl"]`` from ``areal.utils.testing_utils``
+(local path preferred, HF Hub fallback).
 """
 
 import argparse
@@ -12,8 +21,6 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-
-from tests.utils import get_model_path
 
 from areal.api import FinetuneSpec, SaveLoadMeta
 from areal.api.alloc_mode import ModelAllocation
@@ -25,14 +32,9 @@ from areal.api.cli_args import (
 )
 from areal.engine import MegatronEngine
 from areal.utils.data import broadcast_tensor_container
+from areal.utils.testing_utils import DENSE_MODEL_PATHS
 
-VLM_MODEL_PATH = get_model_path(
-    os.environ.get(
-        "QWEN25_VL_MODEL_PATH",
-        "/storage/openpsi/models/Qwen__Qwen2.5-VL-3B-Instruct/",
-    ),
-    "Qwen/Qwen2.5-VL-3B-Instruct",
-)
+VLM_MODEL_PATH = os.environ.get("VLM_MODEL_PATH", DENSE_MODEL_PATHS["qwen2_5_vl"])
 
 
 def write_result(path: str, result: str):
@@ -40,16 +42,26 @@ def write_result(path: str, result: str):
         f.write(result)
 
 
-def mock_vlm_input(device: str) -> dict[str, Any]:
-    """Create mock VLM input with vision tokens."""
-    PATCH_DIM = 3 * 2 * 14 * 14  # 1176
-    SPATIAL_MERGE_SIZE = 2
-    IMAGE_TOKEN_ID = 151655
+def mock_vlm_input(engine: "MegatronEngine") -> dict[str, Any]:
+    """Create mock VLM input with vision tokens.
+
+    Pulls patch geometry from ``engine.hf_config`` so this works for both
+    Qwen2.5-VL (patch_size=14) and Qwen3-VL (patch_size=16).
+    """
+    vc = engine.hf_config.vision_config
+    patch_size = getattr(vc, "patch_size", 14)
+    temporal_patch_size = getattr(vc, "temporal_patch_size", 2)
+    spatial_merge_size = getattr(vc, "spatial_merge_size", 2)
+    in_channels = getattr(vc, "in_channels", 3)
+    image_token_id = getattr(engine.hf_config, "image_token_id", 151655)
+    device = engine.device
+
+    patch_dim = in_channels * temporal_patch_size * patch_size * patch_size
 
     grid_t, grid_h, grid_w = 1, 4, 4
     total_patches = grid_t * grid_h * grid_w
     num_image_tokens = (
-        grid_t * (grid_h // SPATIAL_MERGE_SIZE) * (grid_w // SPATIAL_MERGE_SIZE)
+        grid_t * (grid_h // spatial_merge_size) * (grid_w // spatial_merge_size)
     )
 
     batch_size = 1
@@ -57,12 +69,12 @@ def mock_vlm_input(device: str) -> dict[str, Any]:
     seq_len = num_text_tokens + num_image_tokens
 
     text_tokens = torch.randint(0, 1000, (num_text_tokens,), dtype=torch.long)
-    image_tokens = torch.full((num_image_tokens,), IMAGE_TOKEN_ID, dtype=torch.long)
+    image_tokens = torch.full((num_image_tokens,), image_token_id, dtype=torch.long)
     input_ids = torch.cat([text_tokens, image_tokens]).unsqueeze(0).to(device)
     attention_mask = torch.ones(batch_size, seq_len, dtype=torch.bool, device=device)
 
     pixel_values = torch.randn(
-        total_patches, PATCH_DIM, dtype=torch.float32, device=device
+        total_patches, patch_dim, dtype=torch.float32, device=device
     )
     image_grid_thw = torch.tensor(
         [[grid_t, grid_h, grid_w]], dtype=torch.long, device=device
@@ -99,7 +111,7 @@ def make_vlm_engine(backend: str, init_optimizer: bool = False) -> MegatronEngin
 
 def _make_input(engine: MegatronEngine) -> dict[str, Any]:
     """Create mock input and broadcast across model-parallel ranks."""
-    input_ = mock_vlm_input(device=engine.device)
+    input_ = mock_vlm_input(engine)
     return broadcast_tensor_container(
         input_,
         src_rank=engine.current_data_parallel_head(),

--- a/tests/torchrun/run_megatron_engine_vlm_distributed.py
+++ b/tests/torchrun/run_megatron_engine_vlm_distributed.py
@@ -89,7 +89,20 @@ def mock_vlm_input(engine: "MegatronEngine") -> dict[str, Any]:
     }
 
 
-def make_vlm_engine(backend: str, init_optimizer: bool = False) -> MegatronEngine:
+def make_vlm_engine(
+    backend: str,
+    init_optimizer: bool = False,
+    wrap_with_ddp: bool = True,
+) -> MegatronEngine:
+    """Build a MegatronEngine for VLM tests.
+
+    ``wrap_with_ddp=False`` skips the DDP grad-buffer allocation (~2× model
+    bf16 bytes per rank). Forward-only / save-only paths don't need grads
+    and benefit from the memory headroom — important for 30B+ MoE models
+    where the grad buffer pushes per-GPU usage near 80 GB and tiny NCCL
+    coordination allocations can fail when other processes hold a few
+    hundred MB on the same device.
+    """
     bridge_type = os.environ.get("AREAL_TEST_BRIDGE_TYPE", "mbridge")
     config = TrainEngineConfig(
         backend=backend,
@@ -98,7 +111,9 @@ def make_vlm_engine(backend: str, init_optimizer: bool = False) -> MegatronEngin
         path=VLM_MODEL_PATH,
         mb_spec=MicroBatchSpec(max_tokens_per_mb=4096),
         optimizer=OptimizerConfig() if init_optimizer else None,
-        megatron=MegatronEngineConfig(bridge_type=bridge_type),
+        megatron=MegatronEngineConfig(
+            bridge_type=bridge_type, wrap_with_ddp=wrap_with_ddp
+        ),
         gradient_checkpointing=True,
     )
     alloc_mode = ModelAllocation.from_str(backend)
@@ -143,7 +158,9 @@ def test_vlm_init(backend: str, output: str | None = None):
 def test_vlm_forward(backend: str, output: str | None = None):
     """Test VLM eval forward pass."""
     rank = int(os.environ["RANK"])
-    engine = make_vlm_engine(backend, init_optimizer=False)
+    # No DDP grad buffer — forward is inference-only. Saves ~2× model bytes
+    # per rank and avoids NCCL OOMs at the GPU-memory boundary on 30B+ MoE.
+    engine = make_vlm_engine(backend, init_optimizer=False, wrap_with_ddp=False)
     bcasted_input = _make_input(engine)
 
     engine.eval()
@@ -195,6 +212,63 @@ def test_vlm_save_load(backend: str, save_dir: str, output: str | None = None):
     print(f"rank {rank}: test_vlm_save_load({backend}) Done.")
 
 
+def test_vlm_dcp_save_load(backend: str, output: str | None = None):
+    """Test VLM DCP save/load round-trip on parameters only.
+
+    Parameter-only round-trip (no forward), so it works for any registered
+    VLM regardless of input shape. Mirrors ``test_simple_dcp_save_load`` in
+    ``run_megatron_engine_distributed.py`` but uses ``make_vlm_engine`` to
+    pull processor/tokenizer through the engine init.
+    """
+    import copy
+    import tempfile
+
+    rank = int(os.environ["RANK"])
+    base_dir = tempfile.gettempdir()
+    save_path = Path(base_dir) / "megatron_vlm_simple_dcp_test"
+    if rank == 0:
+        save_path.mkdir(parents=True, exist_ok=True)
+    # No barrier here — the process group is not initialized yet;
+    # ``make_vlm_engine`` calls ``create_process_group`` + ``initialize``
+    # which barrier internally before any rank touches ``save_path``.
+
+    engine = make_vlm_engine(backend, init_optimizer=True)
+
+    meta = SaveLoadMeta(
+        path=save_path,
+        weight_format="dcp",
+        tokenizer=engine.tokenizer,
+        with_optim=False,
+        base_model_path=None,
+    )
+
+    with torch.no_grad():
+        engine.eval()
+        params = copy.deepcopy(dict(engine.model.named_parameters()))
+        engine.save(meta)
+
+        for p in engine.model.parameters():
+            p.data.zero_()
+
+        engine.load(meta)
+
+        succ = True
+        for name, param in engine.model.named_parameters():
+            if not torch.allclose(param, params[name]):
+                diff = torch.abs(params[name] - param)
+                print(
+                    f"rank {rank} diff of {name}: max={torch.max(diff)} "
+                    f"avg={torch.mean(diff)} count={torch.count_nonzero(diff)}"
+                )
+                succ = False
+        assert succ, "Weights should be identical after DCP save/load"
+
+    _cleanup(engine)
+    if rank == 0 and output is not None:
+        write_result(output, "Passed")
+    print(f"rank {rank}: test_vlm_dcp_save_load({backend}) Done.")
+
+
 def test_vlm_train(backend: str, output: str | None = None):
     """Test VLM training step."""
     rank = int(os.environ["RANK"])
@@ -238,7 +312,7 @@ def main():
     parser.add_argument(
         "--test_type",
         type=str,
-        choices=["init", "forward", "save_load", "train"],
+        choices=["init", "forward", "save_load", "dcp_save_load", "train"],
         default="train",
     )
     args = parser.parse_args()
@@ -250,6 +324,8 @@ def main():
     elif args.test_type == "save_load":
         assert args.save_dir is not None, "--save_dir required for save_load test"
         test_vlm_save_load(args.backend, args.save_dir, output=args.output)
+    elif args.test_type == "dcp_save_load":
+        test_vlm_dcp_save_load(args.backend, output=args.output)
     elif args.test_type == "train":
         test_vlm_train(args.backend, output=args.output)
     else:


### PR DESCRIPTION
## Description

Adds Qwen3-VL **dense** and **MoE** support to AReaL's Megatron engine via mbridge, so GRPO/PPO of any Qwen3-VL or Qwen3-VL-MoE checkpoint on the Megatron backend is unblocked. Resubmission of #1299 (closed) extended with Qwen3-VL-MoE in a second commit.

### Commits

1. `b2057e3` — **feat(engine): add Qwen3-VL dense support to Megatron path** (squash of the original #1299 + reorganized test layout)
2. `4434fea` — **feat(engine): add Qwen3-VL-MoE support to Megatron path** (new)

### Commit 1 — Qwen3-VL dense

- `areal/engine/megatron_utils/megatron.py`: new `convert_qwen3_vl_to_hf` registered before `"qwen3"` in `_CONVERSION_FN_REGISTRY` (mapping anchored on `mbridge.models.qwen3_vl.Qwen3VLBridge`). Carries an early-raise on Qwen3-VL-MoE param names so `qwen3_vl_moe` cannot silently dispatch to the dense converter via substring match. `_vision_qkv_mcore_to_hf` gains a no-GQA assertion that guards future vision-GQA VLMs.
- `areal/engine/core/model.py`: new `lang_config(hf_config)` helper — `getattr(hf_config, "text_config", hf_config)` — so callers can read language-side attrs (`vocab_size`, `num_attention_heads`, `num_key_value_heads`, `hidden_size`, `head_dim`) uniformly across Qwen3-VL (nested) and Qwen2.5-VL / pure text (flat).
- `areal/models/mcore/hf_load.py`: `_merge_qkv_weights`, `_load_fused_qkv_weight`, and the GQA branch of `_weight_to_mcore_tp` use the shared `lang_config` helper.
- `areal/engine/megatron_engine.py`: `_collect_param` uses `lang_config(self.hf_config).vocab_size` for `remove_padding`.
- **Test reorganization:** split `tests/test_megatron_engine_vlm.py` into CPU-only unit tests + a new `tests/test_megatron_engine_vlm_distributed.py` for torchrun-launched integration tests, mirroring the existing `test_megatron_engine_distributed.py` convention. Renamed `tests/torchrun/run_megatron_engine_vlm.py` → `run_megatron_engine_vlm_distributed.py`. Helper `_run_vlm_test` infers `nproc` from `ModelAllocation.from_str(backend).parallel.world_size`.
- `areal/utils/testing_utils.py`: register `qwen2_5_vl` and `qwen3_vl` in `DENSE_MODEL_PATHS` so parametric test fixtures consume one source of truth.

### Commit 2 — Qwen3-VL-MoE

End-to-end on `Qwen/Qwen3-VL-30B-A3B-Instruct`. Without this, RL is blocked at engine init: the dense converter raises on MoE-shaped param names, the HF loader's per-expert slicer assumes 2D HF tensors, and the HF saver's per-rank emission buffer never fills under EP>1.

**Conversion (mcore↔HF)**
- `areal/engine/megatron_utils/megatron.py`: factor the dense `convert_qwen3_vl_to_hf` body into `_convert_qwen3_vl_lm_global`, `_convert_qwen3_vl_lm_attention`, and `_convert_qwen3_vl_vision_to_hf` helpers. Add `convert_qwen3_vl_moe_to_hf` mirroring `convert_qwen3moe_to_hf`'s per-expert flat HF emission so the XCCL `update_weights` path to vLLM/SGLang reuses the proven shape contract. Insert `qwen3_vl_moe` into `_CONVERSION_FN_REGISTRY` **before** `qwen3_vl`, `qwen3_moe`, and `qwen3` (substring-match dispatch). Drop the dead `NotImplementedError` guard in the dense converter.
- `areal/engine/core/model.py`: register `qwen3_vl_moe` in `VALID_VISION_MODELS` and `VALID_MOE_MODELS`; add `is_qwen3_vl_moe_model`; broaden `is_qwen3_vl_model` to the family so `fsdp_engine`, `fsdp_utils/parallel`, and `awex/fsdp_adapter` call sites cover both dense and MoE without duplication.

**HF→mcore loader**
- `areal/models/mcore/hf_load.py`: add `_slice_moe_expert_fc1_stacked_gate_up` and `_slice_moe_expert_fc2_stacked_down` that unpack 3D stacked HF expert tensors (`[E, hidden, 2*expert_dim]` for `gate_up_proj`, `[E, expert_dim, hidden]` for `down_proj`) into mcore's per-expert 2D layout. Dispatch from `_weight_to_mcore_tp` when shape rank indicates the stacked HF format.

**HF saver under EP>1**
- `areal/models/mcore/hf_save.py`: add `_bridge_uses_stacked_experts` predicate (inferred from the bridge's `_MLP_MAPPING` per-expert template) plus a stacked-MoE branch in `save_weights_to_hf_with_mbridge_fast` that EP-all-gathers expert tensors per `(layer, fc)` group, feeds mbridge in global expert-index order so its internal buffer fills exactly once, consolidates writes on `ep_rank==0`, and offloads stacked outputs to CPU memory immediately to bound peak GPU footprint by one stacked tensor at a time. Adjust shard-count math to drop the `* ep_size` multiplication for stacked emission. Per-expert-flat bridges (Qwen3-MoE, BailingMoeV2, DeepSeekV3) keep the existing fast path unchanged.
- `areal/utils/testing_utils.py`: register `qwen3_vl_moe` in `MOE_MODEL_PATHS`.

### Tests added

**CPU unit tests** (`tests/test_megatron_engine_vlm.py`):
- `TestConvertQwen3VLToHF`: registry dispatch (`qwen3_vl` resolves before `qwen3` substring fallback), language model embedding/final-norm/output-layer prefixes, QKV weight + bias split with GQA, `q_norm`/`k_norm`/`o_proj`/`input_layernorm`/`post_attention_layernorm`, gated MLP fc1 split + fc2; vision direct mappings, vision per-block (QKV per-head→grouped reorder, attn proj, norm1/norm2 weight + bias, **non-gated MLP** regression guard, fc2); deepstack mergers parametrized over indices `[0, 1, 2]`; error handling.
- `TestConvertQwen3VLMoEToHF`: registry-ordering invariant, expert fc1 chunk, fc2 passthrough, router rename, `pre_mlp_layernorm` rename, dense MLP fallback (for future `decoder_sparse_step > 1` variants), shared vision tower delegation, unknown-name error paths.
- `TestVisionModelDetection`: extended for the qwen3-vl-moe family.

**Distributed integration tests** (`tests/test_megatron_engine_vlm_distributed.py`):
- Parametric `test_engine_initializes` / `test_simple_forward` / `test_hf_save_load_weights` / `test_train_tensor_parallel` over `_VLM_MODELS`; entries `qwen25_vl`, `qwen3_vl`, `qwen3_vl_moe`.
- `test_qwen3vl_moe_expert_parallel`: forward smoke under `(attn:d2t4|ffn:d2e4)`.
- `test_qwen3vl_moe_dcp_save_load`: parameter round-trip under `(attn:d2p1t4|ffn:d1p1t2e4)`.

### Validation

End-to-end on `Qwen/Qwen3-VL-30B-A3B-Instruct`:
- 84 CPU unit tests pass (incl. dense regression).
- `test_qwen3vl_moe_expert_parallel`: PASS.
- `test_qwen3vl_moe_dcp_save_load`: PASS.

### Scope

- `bridge_type: mbridge` only. The `bridge_type: megatron-bridge` path with Qwen3-VL + `gradient_checkpointing: true` crashes inside `Qwen3VLTransformerBlock._checkpointed_forward` with `TypeError: save_for_backward can only save variables, but argument 6 is of type list` — `deepstack_visual_embeds` is handed verbatim to `tensor_parallel.checkpoint`. Fixed upstream in megatron-bridge **v0.4.0**; this PR intentionally does **NOT** vendor-patch the megatron-bridge path so it lights up automatically when the dependency upgrade lands as #1206 plans to do.
- Context parallelism for VLM (`context_parallel_size > 1`) continues to raise `NotImplementedError` — matches Qwen2.5-VL state.
- mbridge 0.15.1+ already registers `Qwen3VLMoEBridge` for the `qwen3_vl_moe` model_type; AReaL just needs to feed it correctly under EP>1, which is what this PR does.
- Out of scope: `qwen3_vl_moe` LoRA path; `pixel_values_videos` plumbing for streaming video inputs.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

N/A — net-new feature support. Resubmission of #1299 (closed) extended with MoE.

## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A.

## Additional Context

Fix for #1298 is required to run integration tests or actual training. This PR was tested with a local patch which is not committed.

### Training Reward Example
Image: `ghcr.io/inclusionai/areal-runtime:v1.0.3-vllm` with mbridge upgraded according to #1258
Dataset: Geometry3k
Model: Qwen3-VL-3B-Instruct / Qwen3-VL-32B-Instruct / Qwen3-VL-30B-A3B-Instruct
Scheduler: Slurm

<img width="3141" height="1059" alt="image" src="https://github.com/user-attachments/assets/57f793db-c217-4581-bba7-af53c1359154" />
