### PR TITLE
fix(tree_attn): skip transition logprob for last node in sequence

### DIFF
--- a/areal/models/tree_attn/functional.py
+++ b/areal/models/tree_attn/functional.py
@@ -298,15 +298,14 @@ def _gather_packed_tree_logprobs(
                 logprob_parts.append(internal_logprobs)
 
             # Compute or retrieve cached transition logprob to next node
-            next_start = 0
             if i + 1 < len(indices):
                 next_start, _ = indices[i + 1]
-            trans_key = (end, next_start)
-            if trans_key not in transition_cache:
-                transition_cache[trans_key] = _compute_transition_logprob(
-                    logits, input_ids, end, next_start, temperature, tp_group
-                )
-            logprob_parts.append(transition_cache[trans_key].unsqueeze(0))
+                trans_key = (end, next_start)
+                if trans_key not in transition_cache:
+                    transition_cache[trans_key] = _compute_transition_logprob(
+                        logits, input_ids, end, next_start, temperature, tp_group
+                    )
+                logprob_parts.append(transition_cache[trans_key].unsqueeze(0))
 
         if logprob_parts:
             results[seq_id] = torch.cat(logprob_parts, dim=0)
@@ -388,17 +387,16 @@ def _gather_packed_tree_logprobs_entropy(
                 entropy_parts.append(internal_entropy)
 
             # Compute or retrieve cached transition results to next node
-            next_start = 0
             if i + 1 < len(indices):
                 next_start, _ = indices[i + 1]
-            trans_key = (end, next_start)
-            if trans_key not in transition_cache:
-                transition_cache[trans_key] = _compute_transition_logprob_entropy(
-                    logits, input_ids, end, next_start, temperature, tp_group
-                )
-            trans_lp, trans_ent = transition_cache[trans_key]
-            logprob_parts.append(trans_lp.unsqueeze(0))
-            entropy_parts.append(trans_ent.unsqueeze(0))
+                trans_key = (end, next_start)
+                if trans_key not in transition_cache:
+                    transition_cache[trans_key] = _compute_transition_logprob_entropy(
+                        logits, input_ids, end, next_start, temperature, tp_group
+                    )
+                trans_lp, trans_ent = transition_cache[trans_key]
+                logprob_parts.append(trans_lp.unsqueeze(0))
+                entropy_parts.append(trans_ent.unsqueeze(0))
 
         if logprob_parts:
             logprobs_results[seq_id] = torch.cat(logprob_parts, dim=0)


### PR DESCRIPTION
## Summary

Fixes #1308

The transition logprob between trie nodes was unconditionally computed and appended even for the **last node** of a sequence, where `next_start` defaulted to `0`. This caused `logits[end]` to predict `input_ids[0]` (the packed tree root token), producing a semantically meaningless logprob.

## Root Cause

In both `_gather_packed_tree_logprobs` and `_gather_packed_tree_logprobs_entropy`, lines computing `trans_key` and appending the transition logprob were outside the `if i + 1 < len(indices):` guard:

```python
# Before (buggy)
next_start = 0
if i + 1 < len(indices):
    next_start, _ = indices[i + 1]
trans_key = (end, next_start)  # always runs, even for last node
...
logprob_parts.append(...)       # appends garbage logprob for last node
```

## Fix

Moved all transition logic inside the guard:

```python
# After (fixed)
if i + 1 < len(indices):
    next_start, _ = indices[i + 1]
    trans_key = (end, next_start)
    if trans_key not in transition_cache:
        transition_cache[trans_key] = _compute_transition_logprob(...)
    logprob_parts.append(transition_cache[trans_key].unsqueeze(0))
```

## Impact

Previously each sequence got one extra garbage logprob at the end, causing incorrect logprob vector lengths and corrupted PPO/GRPO advantage computation.