### PR TITLE
perf(archon): parallelize inference controller initialization

### DIFF
--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -314,19 +314,6 @@ class RolloutControllerV2:
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        """Launch all servers as worker processes via the scheduler.
-
-        In both cases we create ``dp_size`` RPCGuard workers and fork
-        services onto them:
-
-        * **server_infos is None** — fork SGLang server + data proxy on
-          every worker; fork router + gateway on worker 0.
-        * **server_infos is not None** — SGLang servers already exist so
-          we only fork data proxy on every worker; fork router + gateway
-          on worker 0.
-        * **external_mode** — skip inference servers entirely; data proxies
-          start with an empty ``--backend-addr``.
-        """
         from dataclasses import asdict
 
         from areal.api.cli_args import SchedulingSpec, SchedulingStrategy
@@ -363,8 +350,6 @@ class RolloutControllerV2:
             gpus_per_worker = instance_size // nnodes_per_instance
 
             if server_infos is not None:
-                # Pre-existing inference servers — only need dp_size workers
-                # for CPU services (data proxy, router, gateway), no GPUs.
                 total_workers = dp_size
                 inf_spec.gpu = 0
             else:
@@ -374,7 +359,6 @@ class RolloutControllerV2:
                 if inf_spec.gpu > 0:
                     inf_spec.gpu = gpus_per_worker
 
-            # Override cmd to launch RPCGuard instead of RPC server
             inf_spec.cmd = "python -m areal.experimental.inference_service.guard"
 
         inf_role = f"{self._worker_role}{self._INF_SUFFIX}"
@@ -401,219 +385,11 @@ class RolloutControllerV2:
         if self._shutdown_requested.is_set():
             return
 
-        # ==================================================================
-        # Step 1: Launch inference servers (skip in external mode or when pre-existing)
-        # ==================================================================
-        if self.external_mode:
-            logger.info("External mode — skipping inference server launch")
-        elif server_infos is not None:
-            # Pre-existing servers — just record their addresses
-            self.server_infos = server_infos
-            self._inf_addrs = [
-                f"http://{format_hostport(info.host, info.port)}"
-                for info in server_infos
-            ]
-            logger.info(
-                "Using %d pre-existing server_infos, skipping inference server fork",
-                len(server_infos),
-            )
-        else:
-            tp_size = alloc.parallel.tp_size
-
-            # Build backend-specific launch command builder
-            if inf_backend == "sglang":
-                from areal.api.cli_args import SGLangConfig
-
-                sglang_config = SGLangConfig()
-                if server_args:
-                    sglang_config = copy.deepcopy(sglang_config)
-                    for k, v in server_args.items():
-                        if hasattr(sglang_config, k):
-                            setattr(sglang_config, k, v)
-                        else:
-                            logger.warning(
-                                "SGLangConfig has no attribute %r, ignoring "
-                                "server_args entry (value=%r)",
-                                k,
-                                v,
-                            )
-
-                def _build_launch_cmd(
-                    host: str | None,
-                    port: int | None,
-                    n_nodes: int = 1,
-                    node_rank: int = 0,
-                    dist_init_addr: str | None = None,
-                ) -> list[str]:
-                    return SGLangConfig.build_cmd(
-                        sglang_config=sglang_config,
-                        tp_size=tp_size,
-                        pp_size=alloc.parallel.pp_size,
-                        base_gpu_id=0,
-                        host=host,
-                        port=port,
-                        dist_init_addr=dist_init_addr,
-                        n_nodes=n_nodes,
-                        node_rank=node_rank,
-                    )
-
-            elif inf_backend == "vllm":
-                from areal.api.cli_args import vLLMConfig
-
-                vllm_config = vLLMConfig()
-                if server_args:
-                    vllm_config = copy.deepcopy(vllm_config)
-                    for k, v in server_args.items():
-                        if hasattr(vllm_config, k):
-                            setattr(vllm_config, k, v)
-                        else:
-                            logger.warning(
-                                "vLLMConfig has no attribute %r, ignoring "
-                                "server_args entry (value=%r)",
-                                k,
-                                v,
-                            )
-
-                def _build_launch_cmd(
-                    host: str | None,
-                    port: int | None,
-                    n_nodes: int = 1,
-                    node_rank: int = 0,
-                    dist_init_addr: str | None = None,
-                ) -> list[str]:
-                    return vLLMConfig.build_cmd(
-                        vllm_config=vllm_config,
-                        tp_size=tp_size,
-                        pp_size=alloc.parallel.pp_size,
-                        host=host,
-                        port=port,
-                        dist_init_addr=dist_init_addr,
-                        n_nodes=n_nodes,
-                        node_rank=node_rank,
-                    )
-
-            else:
-                raise ValueError(f"Unsupported inference backend: {inf_backend!r}")
-
-            # For each inference instance group: alloc ports, build cmd, fork servers
-            for group_idx in range(dp_size):
-                group_workers = inf_workers[
-                    group_idx * nnodes_per_instance : (group_idx + 1)
-                    * nnodes_per_instance
-                ]
-                head_worker = group_workers[0]
-                head_guard_addr = f"http://{format_hostport(head_worker.ip, int(head_worker.worker_ports[0]))}"
-
-                # Allocate rendezvous port on head node for distributed init
-                dist_init_addr = None
-                if nnodes_per_instance > 1:
-                    resp = self._sync_client.post(
-                        f"{head_guard_addr}/alloc_ports",
-                        json={"count": 1},
-                    )
-                    resp.raise_for_status()
-                    rendezvous_data = resp.json()
-                    rendezvous_host = rendezvous_data["host"]
-                    rendezvous_port = rendezvous_data["ports"][0]
-                    dist_init_addr = format_hostport(rendezvous_host, rendezvous_port)
-
-                head_inf_host = None
-                head_inf_port = None
-
-                for node_rank, worker in enumerate(group_workers):
-                    guard_addr = f"http://{format_hostport(worker.ip, int(worker.worker_ports[0]))}"
-
-                    # Allocate port for inference server on this node
-                    resp = self._sync_client.post(
-                        f"{guard_addr}/alloc_ports",
-                        json={"count": 1},
-                    )
-                    resp.raise_for_status()
-                    port_data = resp.json()
-                    inf_host = port_data["host"]
-                    inf_port = port_data["ports"][0]
-
-                    # Worker nodes (rank > 0) don't need to serve HTTP,
-                    # but we still pass host/port for the server to bind
-                    cmd = _build_launch_cmd(
-                        host=inf_host,
-                        port=inf_port,
-                        n_nodes=nnodes_per_instance,
-                        node_rank=node_rank,
-                        dist_init_addr=dist_init_addr,
-                    )
-
-                    fork_payload: dict[str, Any] = {
-                        "role": "inf-server",
-                        "worker_index": group_idx * nnodes_per_instance + node_rank,
-                        "raw_cmd": cmd,
-                    }
-                    if inf_backend == "vllm":
-                        from areal.infra.utils.launcher import (
-                            TRITON_CACHE_PATH as _TRITON_CACHE,
-                        )
-                        from areal.infra.utils.launcher import (
-                            VLLM_CACHE_ROOT as _VLLM_CACHE,
-                        )
-
-                        fork_payload["env"] = {
-                            "TRITON_CACHE_PATH": os.path.join(
-                                os.environ.get("TRITON_CACHE_PATH", _TRITON_CACHE),
-                                str(uuid.uuid4()),
-                            ),
-                            "VLLM_CACHE_ROOT": os.path.join(
-                                os.environ.get("VLLM_CACHE_ROOT", _VLLM_CACHE),
-                                str(uuid.uuid4()),
-                            ),
-                            "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True",
-                        }
-
-                    resp = self._sync_client.post(
-                        f"{guard_addr}/fork",
-                        json=fork_payload,
-                    )
-                    resp.raise_for_status()
-                    self._forked_services.append(
-                        (
-                            guard_addr,
-                            "inf-server",
-                            group_idx * nnodes_per_instance + node_rank,
-                        )
-                    )
-
-                    if node_rank == 0:
-                        head_inf_host = inf_host
-                        head_inf_port = inf_port
-
-                if head_inf_host is None or head_inf_port is None:
-                    raise RuntimeError(
-                        f"No head worker resolved for group {group_idx}; "
-                        f"expected {nnodes_per_instance} workers per group"
-                    )
-
-                # Only record the head node's address as the inference endpoint
-                addr = f"http://{format_hostport(head_inf_host, head_inf_port)}"
-                self._inf_addrs.append(addr)
-                self.server_infos.append(
-                    LocalInfServerInfo(
-                        host=head_inf_host,
-                        port=head_inf_port,
-                        process=None,  # type: ignore[arg-type]  # RPCGuard manages process
-                    )
-                )
-
-            # Wait for inference servers to be healthy (only head nodes)
-            for i, addr in enumerate(self._inf_addrs):
-                self._wait_for_service(
-                    f"{addr}/health", f"InfServer-{i}", timeout=cfg.setup_timeout
-                )
-        logger.info("Inference servers: %s", self._inf_addrs)
-
-        if self._shutdown_requested.is_set():
-            return
+        guard_addr_0 = f"http://{format_hostport(self.workers[0].ip, int(self.workers[0].worker_ports[0]))}"
 
         # ==================================================================
-        # Step 2: Fork Router on worker 0
+        # Step 1+2: Launch inference servers AND fork Router in PARALLEL
+        # Router does not depend on inference servers.
         # ==================================================================
         router_cmd = [
             sys.executable,
@@ -628,14 +404,41 @@ class RolloutControllerV2:
             "--log-level",
             _DEFAULT_SERVICE_LOG_LEVEL,
         ]
-
-        guard_addr_0 = f"http://{format_hostport(self.workers[0].ip, int(self.workers[0].worker_ports[0]))}"
-        router_host, router_port = self._fork_on_guard(
-            guard_addr=guard_addr_0,
-            role="router",
-            worker_index=0,
-            raw_cmd=router_cmd,
+        router_task = asyncio.ensure_future(
+            self._async_fork_on_guard(
+                guard_addr=guard_addr_0,
+                role="router",
+                worker_index=0,
+                raw_cmd=router_cmd,
+            )
         )
+
+        if self.external_mode:
+            logger.info("External mode — skipping inference server launch")
+        elif server_infos is not None:
+            self.server_infos = server_infos
+            self._inf_addrs = [
+                f"http://{format_hostport(info.host, info.port)}"
+                for info in server_infos
+            ]
+            logger.info(
+                "Using %d pre-existing server_infos, skipping inference server fork",
+                len(server_infos),
+            )
+        else:
+            assert alloc is not None and inf_backend is not None
+            await self._async_fork_inf_servers(
+                cfg,
+                alloc,
+                inf_backend,
+                inf_workers,
+                dp_size,
+                nnodes_per_instance,
+                server_args,
+            )
+        logger.info("Inference servers: %s", self._inf_addrs)
+
+        router_host, router_port = await router_task
         self._router_addr = f"http://{format_hostport(router_host, router_port)}"
         logger.info("Router: %s", self._router_addr)
 
@@ -643,7 +446,8 @@ class RolloutControllerV2:
             return
 
         # ==================================================================
-        # Step 3: Fork Data Proxies on all workers (raw_cmd mode)
+        # Step 3+4: Fork Data Proxies AND Gateway in PARALLEL
+        # Data Proxies need _inf_addrs (ready); Gateway needs _router_addr (ready).
         # ==================================================================
         data_proxy_base_cmd = [
             sys.executable,
@@ -674,7 +478,7 @@ class RolloutControllerV2:
                 str(agent_cfg.engine_max_tokens),
             ]
 
-        for group_idx in range(dp_size):
+        async def _fork_data_proxy(group_idx: int) -> tuple[str, int]:
             if self.external_mode:
                 head_worker = inf_workers[group_idx]
             else:
@@ -684,34 +488,22 @@ class RolloutControllerV2:
                     else group_idx * nnodes_per_instance
                 ]
             guard_addr = f"http://{format_hostport(head_worker.ip, int(head_worker.worker_ports[0]))}"
-            # Each data proxy connects to its group's head inference server
             if self.external_mode:
-                data_proxy_cmd = data_proxy_base_cmd + ["--backend-addr", ""]
+                dp_cmd = data_proxy_base_cmd + ["--backend-addr", ""]
             else:
-                data_proxy_cmd = data_proxy_base_cmd + [
+                dp_cmd = data_proxy_base_cmd + [
                     "--backend-addr",
                     self._inf_addrs[group_idx],
                     "--backend-type",
                     inf_backend or "sglang",
                 ]
-            data_proxy_host, data_proxy_port = self._fork_on_guard(
+            return await self._async_fork_on_guard(
                 guard_addr=guard_addr,
                 role="data-proxy",
                 worker_index=group_idx,
-                raw_cmd=data_proxy_cmd,
-            )
-            self._data_proxy_addrs.append(
-                f"http://{format_hostport(data_proxy_host, data_proxy_port)}"
+                raw_cmd=dp_cmd,
             )
 
-        logger.info("Data proxies: %s", self._data_proxy_addrs)
-
-        if self._shutdown_requested.is_set():
-            return
-
-        # ==================================================================
-        # Step 4: Fork Gateway on worker 0
-        # ==================================================================
         gw_cmd = [
             sys.executable,
             "-m",
@@ -726,14 +518,232 @@ class RolloutControllerV2:
             _DEFAULT_SERVICE_LOG_LEVEL,
         ]
 
-        gw_host, gw_port = self._fork_on_guard(
-            guard_addr=guard_addr_0,
-            role="gateway",
-            worker_index=0,
-            raw_cmd=gw_cmd,
+        all_results = await asyncio.gather(
+            *[_fork_data_proxy(i) for i in range(dp_size)],
+            self._async_fork_on_guard(
+                guard_addr=guard_addr_0,
+                role="gateway",
+                worker_index=0,
+                raw_cmd=gw_cmd,
+            ),
         )
+
+        for dp_host, dp_port in all_results[:-1]:
+            self._data_proxy_addrs.append(f"http://{format_hostport(dp_host, dp_port)}")
+        logger.info("Data proxies: %s", self._data_proxy_addrs)
+
+        gw_host, gw_port = all_results[-1]
         self._gateway_addr = f"http://{format_hostport(gw_host, gw_port)}"
         logger.info("Gateway: %s", self._gateway_addr)
+
+    async def _async_fork_inf_servers(
+        self,
+        cfg: Any,
+        alloc: Any,
+        inf_backend: str,
+        inf_workers: list,
+        dp_size: int,
+        nnodes_per_instance: int,
+        server_args: dict[str, Any] | None,
+    ) -> None:
+        """Fork inference server groups in parallel across all DP ranks."""
+        tp_size = alloc.parallel.tp_size
+        pp_size = alloc.parallel.pp_size
+
+        # Build backend-specific launch command builder
+        if inf_backend == "sglang":
+            from areal.api.cli_args import SGLangConfig
+
+            sglang_config = SGLangConfig()
+            if server_args:
+                sglang_config = copy.deepcopy(sglang_config)
+                for k, v in server_args.items():
+                    if hasattr(sglang_config, k):
+                        setattr(sglang_config, k, v)
+                    else:
+                        logger.warning(
+                            "SGLangConfig has no attribute %r, ignoring "
+                            "server_args entry (value=%r)",
+                            k,
+                            v,
+                        )
+
+            def _build_launch_cmd(
+                host: str | None,
+                port: int | None,
+                n_nodes: int = 1,
+                node_rank: int = 0,
+                dist_init_addr: str | None = None,
+            ) -> list[str]:
+                return SGLangConfig.build_cmd(
+                    sglang_config=sglang_config,
+                    tp_size=tp_size,
+                    pp_size=pp_size,
+                    base_gpu_id=0,
+                    host=host,
+                    port=port,
+                    dist_init_addr=dist_init_addr,
+                    n_nodes=n_nodes,
+                    node_rank=node_rank,
+                )
+
+        elif inf_backend == "vllm":
+            from areal.api.cli_args import vLLMConfig
+
+            vllm_config = vLLMConfig()
+            if server_args:
+                vllm_config = copy.deepcopy(vllm_config)
+                for k, v in server_args.items():
+                    if hasattr(vllm_config, k):
+                        setattr(vllm_config, k, v)
+                    else:
+                        logger.warning(
+                            "vLLMConfig has no attribute %r, ignoring "
+                            "server_args entry (value=%r)",
+                            k,
+                            v,
+                        )
+
+            def _build_launch_cmd(
+                host: str | None,
+                port: int | None,
+                n_nodes: int = 1,
+                node_rank: int = 0,
+                dist_init_addr: str | None = None,
+            ) -> list[str]:
+                return vLLMConfig.build_cmd(
+                    vllm_config=vllm_config,
+                    tp_size=tp_size,
+                    pp_size=pp_size,
+                    host=host,
+                    port=port,
+                    dist_init_addr=dist_init_addr,
+                    n_nodes=n_nodes,
+                    node_rank=node_rank,
+                )
+
+        else:
+            raise ValueError(f"Unsupported inference backend: {inf_backend!r}")
+
+        async def _fork_group(group_idx: int) -> tuple[str, int]:
+            group_workers = inf_workers[
+                group_idx * nnodes_per_instance : (group_idx + 1) * nnodes_per_instance
+            ]
+            head_worker = group_workers[0]
+            head_guard_addr = f"http://{format_hostport(head_worker.ip, int(head_worker.worker_ports[0]))}"
+            client = await self._get_async_client()
+
+            dist_init_addr = None
+            if nnodes_per_instance > 1:
+                resp = await client.post(
+                    f"{head_guard_addr}/alloc_ports",
+                    json={"count": 1},
+                    timeout=30.0,
+                )
+                resp.raise_for_status()
+                rendezvous_data = resp.json()
+                rendezvous_host = rendezvous_data["host"]
+                rendezvous_port = rendezvous_data["ports"][0]
+                dist_init_addr = format_hostport(rendezvous_host, rendezvous_port)
+
+            head_inf_host = None
+            head_inf_port = None
+
+            for node_rank, worker in enumerate(group_workers):
+                guard_addr = (
+                    f"http://{format_hostport(worker.ip, int(worker.worker_ports[0]))}"
+                )
+
+                resp = await client.post(
+                    f"{guard_addr}/alloc_ports",
+                    json={"count": 1},
+                    timeout=30.0,
+                )
+                resp.raise_for_status()
+                port_data = resp.json()
+                inf_host = port_data["host"]
+                inf_port = port_data["ports"][0]
+
+                cmd = _build_launch_cmd(
+                    host=inf_host,
+                    port=inf_port,
+                    n_nodes=nnodes_per_instance,
+                    node_rank=node_rank,
+                    dist_init_addr=dist_init_addr,
+                )
+
+                fork_payload: dict[str, Any] = {
+                    "role": "inf-server",
+                    "worker_index": group_idx * nnodes_per_instance + node_rank,
+                    "raw_cmd": cmd,
+                }
+                if inf_backend == "vllm":
+                    from areal.infra.utils.launcher import (
+                        TRITON_CACHE_PATH as _TRITON_CACHE,
+                    )
+                    from areal.infra.utils.launcher import (
+                        VLLM_CACHE_ROOT as _VLLM_CACHE,
+                    )
+
+                    fork_payload["env"] = {
+                        "TRITON_CACHE_PATH": os.path.join(
+                            os.environ.get("TRITON_CACHE_PATH", _TRITON_CACHE),
+                            str(uuid.uuid4()),
+                        ),
+                        "VLLM_CACHE_ROOT": os.path.join(
+                            os.environ.get("VLLM_CACHE_ROOT", _VLLM_CACHE),
+                            str(uuid.uuid4()),
+                        ),
+                        "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True",
+                    }
+
+                resp = await client.post(
+                    f"{guard_addr}/fork",
+                    json=fork_payload,
+                    timeout=30.0,
+                )
+                resp.raise_for_status()
+                self._forked_services.append(
+                    (
+                        guard_addr,
+                        "inf-server",
+                        group_idx * nnodes_per_instance + node_rank,
+                    )
+                )
+
+                if node_rank == 0:
+                    head_inf_host = inf_host
+                    head_inf_port = inf_port
+
+            if head_inf_host is None or head_inf_port is None:
+                raise RuntimeError(
+                    f"No head worker resolved for group {group_idx}; "
+                    f"expected {nnodes_per_instance} workers per group"
+                )
+            return (head_inf_host, head_inf_port)
+
+        group_results = await asyncio.gather(*[_fork_group(i) for i in range(dp_size)])
+
+        for host, port in group_results:
+            addr = f"http://{format_hostport(host, port)}"
+            self._inf_addrs.append(addr)
+            self.server_infos.append(
+                LocalInfServerInfo(
+                    host=host,
+                    port=port,
+                    process=None,  # type: ignore[arg-type]
+                )
+            )
+
+        # Wait for all inference servers to be healthy in parallel
+        await asyncio.gather(
+            *[
+                self._async_wait_for_service(
+                    f"{addr}/health", f"InfServer-{i}", timeout=cfg.setup_timeout
+                )
+                for i, addr in enumerate(self._inf_addrs)
+            ]
+        )
 
     # -- Service health checks & registration ------------------------------
 
@@ -752,6 +762,23 @@ class RolloutControllerV2:
             except httpx.HTTPError:
                 pass
             time.sleep(0.1)
+        raise TimeoutError(f"{name} did not become healthy at {url} within {timeout}s")
+
+    async def _async_wait_for_service(
+        self, url: str, name: str, timeout: float | None = None
+    ) -> None:
+        timeout = timeout or self.config.setup_timeout
+        deadline = time.monotonic() + timeout
+        client = await self._get_async_client()
+        while time.monotonic() < deadline:
+            try:
+                resp = await client.get(url, timeout=2.0)
+                if resp.status_code == 200:
+                    logger.info("%s is ready at %s", name, url)
+                    return
+            except Exception:
+                pass
+            await asyncio.sleep(0.1)
         raise TimeoutError(f"{name} did not become healthy at {url} within {timeout}s")
 
     def _register_data_proxies_in_router(self) -> None:
@@ -1749,6 +1776,40 @@ class RolloutControllerV2:
 
         addr = f"http://{format_hostport(host, port)}"
         self._wait_for_service(f"{addr}{health_path}", role)
+
+        return host, port
+
+    async def _async_fork_on_guard(
+        self,
+        guard_addr: str,
+        role: str,
+        worker_index: int,
+        raw_cmd: list[str],
+        health_path: str = "/health",
+    ) -> tuple[str, int]:
+        client = await self._get_async_client()
+        resp = await client.post(
+            f"{guard_addr}/alloc_ports", json={"count": 1}, timeout=30.0
+        )
+        resp.raise_for_status()
+        port_data = resp.json()
+        host = port_data["host"]
+        port = port_data["ports"][0]
+
+        cmd = list(raw_cmd) + ["--host", host, "--port", str(port)]
+        fork_payload: dict[str, Any] = {
+            "role": role,
+            "worker_index": worker_index,
+            "raw_cmd": cmd,
+        }
+
+        resp = await client.post(f"{guard_addr}/fork", json=fork_payload, timeout=30.0)
+        resp.raise_for_status()
+
+        self._forked_services.append((guard_addr, role, worker_index))
+
+        addr = f"http://{format_hostport(host, port)}"
+        await self._async_wait_for_service(f"{addr}{health_path}", role)
 
         return host, port
 

--- a/areal/experimental/inference_service/controller/controller.py
+++ b/areal/experimental/inference_service/controller/controller.py
@@ -439,6 +439,7 @@ class RolloutControllerV2:
         logger.info("Inference servers: %s", self._inf_addrs)
 
         router_host, router_port = await router_task
+        self._forked_services.append((guard_addr_0, "router", 0))
         self._router_addr = f"http://{format_hostport(router_host, router_port)}"
         logger.info("Router: %s", self._router_addr)
 
@@ -478,7 +479,7 @@ class RolloutControllerV2:
                 str(agent_cfg.engine_max_tokens),
             ]
 
-        async def _fork_data_proxy(group_idx: int) -> tuple[str, int]:
+        async def _fork_data_proxy(group_idx: int) -> tuple[str, int, str]:
             if self.external_mode:
                 head_worker = inf_workers[group_idx]
             else:
@@ -497,12 +498,13 @@ class RolloutControllerV2:
                     "--backend-type",
                     inf_backend or "sglang",
                 ]
-            return await self._async_fork_on_guard(
+            host, port = await self._async_fork_on_guard(
                 guard_addr=guard_addr,
                 role="data-proxy",
                 worker_index=group_idx,
                 raw_cmd=dp_cmd,
             )
+            return host, port, guard_addr
 
         gw_cmd = [
             sys.executable,
@@ -518,21 +520,26 @@ class RolloutControllerV2:
             _DEFAULT_SERVICE_LOG_LEVEL,
         ]
 
-        all_results = await asyncio.gather(
-            *[_fork_data_proxy(i) for i in range(dp_size)],
+        gw_task = asyncio.ensure_future(
             self._async_fork_on_guard(
                 guard_addr=guard_addr_0,
                 role="gateway",
                 worker_index=0,
                 raw_cmd=gw_cmd,
-            ),
+            )
+        )
+        dp_results = await asyncio.gather(
+            *[_fork_data_proxy(i) for i in range(dp_size)]
         )
 
-        for dp_host, dp_port in all_results[:-1]:
+        # Track data-proxies in group order, then gateway — deterministic cleanup.
+        for group_idx, (dp_host, dp_port, dp_guard) in enumerate(dp_results):
             self._data_proxy_addrs.append(f"http://{format_hostport(dp_host, dp_port)}")
+            self._forked_services.append((dp_guard, "data-proxy", group_idx))
         logger.info("Data proxies: %s", self._data_proxy_addrs)
 
-        gw_host, gw_port = all_results[-1]
+        gw_host, gw_port = await gw_task
+        self._forked_services.append((guard_addr_0, "gateway", 0))
         self._gateway_addr = f"http://{format_hostport(gw_host, gw_port)}"
         logger.info("Gateway: %s", self._gateway_addr)
 
@@ -625,7 +632,9 @@ class RolloutControllerV2:
         else:
             raise ValueError(f"Unsupported inference backend: {inf_backend!r}")
 
-        async def _fork_group(group_idx: int) -> tuple[str, int]:
+        async def _fork_group(
+            group_idx: int,
+        ) -> tuple[str, int, list[tuple[str, str, int]]]:
             group_workers = inf_workers[
                 group_idx * nnodes_per_instance : (group_idx + 1) * nnodes_per_instance
             ]
@@ -646,10 +655,7 @@ class RolloutControllerV2:
                 rendezvous_port = rendezvous_data["ports"][0]
                 dist_init_addr = format_hostport(rendezvous_host, rendezvous_port)
 
-            head_inf_host = None
-            head_inf_port = None
-
-            for node_rank, worker in enumerate(group_workers):
+            async def _fork_node(node_rank: int, worker: Any) -> tuple[str, int, str]:
                 guard_addr = (
                     f"http://{format_hostport(worker.ip, int(worker.worker_ports[0]))}"
                 )
@@ -661,8 +667,8 @@ class RolloutControllerV2:
                 )
                 resp.raise_for_status()
                 port_data = resp.json()
-                inf_host = port_data["host"]
-                inf_port = port_data["ports"][0]
+                inf_host: str = port_data["host"]
+                inf_port: int = port_data["ports"][0]
 
                 cmd = _build_launch_cmd(
                     host=inf_host,
@@ -703,28 +709,22 @@ class RolloutControllerV2:
                     timeout=30.0,
                 )
                 resp.raise_for_status()
-                self._forked_services.append(
-                    (
-                        guard_addr,
-                        "inf-server",
-                        group_idx * nnodes_per_instance + node_rank,
-                    )
-                )
+                return inf_host, inf_port, guard_addr
 
-                if node_rank == 0:
-                    head_inf_host = inf_host
-                    head_inf_port = inf_port
+            node_results = await asyncio.gather(
+                *[_fork_node(rank, w) for rank, w in enumerate(group_workers)]
+            )
 
-            if head_inf_host is None or head_inf_port is None:
-                raise RuntimeError(
-                    f"No head worker resolved for group {group_idx}; "
-                    f"expected {nnodes_per_instance} workers per group"
-                )
-            return (head_inf_host, head_inf_port)
+            head_inf_host, head_inf_port, _ = node_results[0]
+            forked: list[tuple[str, str, int]] = [
+                (guard_addr, "inf-server", group_idx * nnodes_per_instance + rank)
+                for rank, (_, _, guard_addr) in enumerate(node_results)
+            ]
+            return (head_inf_host, head_inf_port, forked)
 
         group_results = await asyncio.gather(*[_fork_group(i) for i in range(dp_size)])
 
-        for host, port in group_results:
+        for host, port, forked in group_results:
             addr = f"http://{format_hostport(host, port)}"
             self._inf_addrs.append(addr)
             self.server_infos.append(
@@ -734,6 +734,7 @@ class RolloutControllerV2:
                     process=None,  # type: ignore[arg-type]
                 )
             )
+            self._forked_services.extend(forked)
 
         # Wait for all inference servers to be healthy in parallel
         await asyncio.gather(
@@ -1787,6 +1788,12 @@ class RolloutControllerV2:
         raw_cmd: list[str],
         health_path: str = "/health",
     ) -> tuple[str, int]:
+        """Async fork a process on a RPCGuard worker via ``/fork``.
+
+        Returns ``(host, port)`` of the forked service.  The caller is
+        responsible for appending to ``_forked_services`` to maintain
+        deterministic cleanup ordering when multiple forks run concurrently.
+        """
         client = await self._get_async_client()
         resp = await client.post(
             f"{guard_addr}/alloc_ports", json={"count": 1}, timeout=30.0
@@ -1805,8 +1812,6 @@ class RolloutControllerV2:
 
         resp = await client.post(f"{guard_addr}/fork", json=fork_payload, timeout=30.0)
         resp.raise_for_status()
-
-        self._forked_services.append((guard_addr, role, worker_index))
 
         addr = f"http://{format_hostport(host, port)}"
         await self._async_wait_for_service(f"{addr}{health_path}", role)

--- a/tests/experimental/inference_service/test_controller.py
+++ b/tests/experimental/inference_service/test_controller.py
@@ -385,7 +385,7 @@ class TestRolloutControllerV2Construction:
         controller._callback_host = "127.0.0.1"
         controller._callback_port = 19000
 
-        with patch.object(controller, "_fork_on_guard") as mock_fork:
+        with patch.object(controller, "_async_fork_on_guard") as mock_fork:
             mock_fork.side_effect = [
                 ("127.0.0.1", 18081),
                 ("127.0.0.1", 18082),
@@ -401,7 +401,11 @@ class TestRolloutControllerV2Construction:
                 ],
             )
 
-        data_proxy_cmd = mock_fork.call_args_list[1].kwargs["raw_cmd"]
+        data_proxy_calls = [
+            c for c in mock_fork.call_args_list if c.kwargs.get("role") == "data-proxy"
+        ]
+        assert len(data_proxy_calls) == 1
+        data_proxy_cmd = data_proxy_calls[0].kwargs["raw_cmd"]
         assert "--set-reward-finish-timeout" in data_proxy_cmd
         assert "7.5" in data_proxy_cmd
         assert "--callback-server-addr" in data_proxy_cmd
@@ -732,7 +736,7 @@ class TestMultiNodeConfig:
         controller._callback_host = "127.0.0.1"
         controller._callback_port = 19000
 
-        with patch.object(controller, "_fork_on_guard") as mock_fork:
+        with patch.object(controller, "_async_fork_on_guard") as mock_fork:
             mock_fork.side_effect = [
                 ("127.0.0.1", 18081),  # router
                 ("127.0.0.1", 18082),  # data proxy (only 1, on head)
@@ -789,14 +793,15 @@ class TestMultiNodeConfig:
         controller._callback_host = "127.0.0.1"
         controller._callback_port = 19000
 
-        # Track requests.post calls to /alloc_ports and /fork
+        # Track async client .post calls to /alloc_ports and /fork
         alloc_port_counter = 0
         fork_calls = []
 
-        def mock_requests_post(url, json=None, timeout=None):
+        async def mock_async_post(url, json=None, timeout=None):
             nonlocal alloc_port_counter
             resp = MagicMock()
             resp.status_code = 200
+            resp.raise_for_status = MagicMock()
             if "/alloc_ports" in url:
                 alloc_port_counter += 1
                 resp.json.return_value = {
@@ -809,12 +814,15 @@ class TestMultiNodeConfig:
                 resp.json.return_value = {"status": "success"}
             return resp
 
+        mock_async_client = AsyncMock()
+        mock_async_client.post = mock_async_post
+
         with (
             patch.object(
-                controller._sync_client, "post", side_effect=mock_requests_post
-            ) as mock_post,
-            patch.object(controller, "_fork_on_guard") as mock_fork,
-            patch.object(controller, "_wait_for_service"),
+                controller, "_get_async_client", return_value=mock_async_client
+            ),
+            patch.object(controller, "_async_fork_on_guard") as mock_fork,
+            patch.object(controller, "_async_wait_for_service"),
             patch(
                 "areal.api.cli_args.pkg_version.is_version_greater_or_equal",
                 return_value=True,
@@ -837,13 +845,10 @@ class TestMultiNodeConfig:
         job = create_call.kwargs.get("job") or create_call.args[0]
         assert job.replicas == 2
 
-        # requests.post calls:
+        # Async client .post calls for inf server fork:
         # 1 rendezvous alloc (nnodes_per_instance > 1) + 2 node allocs + 2 forks = 5
-        post_calls = mock_post.call_args_list
-        alloc_calls = [c for c in post_calls if "/alloc_ports" in str(c)]
-        fork_post_calls = [c for c in post_calls if "/fork" in str(c)]
-        assert len(alloc_calls) == 3  # 1 rendezvous + 2 per-node
-        assert len(fork_post_calls) == 2  # 1 per node in the group
+        assert alloc_port_counter == 3  # 1 rendezvous + 2 per-node
+        assert len(fork_calls) == 2  # 1 per node in the group
 
         # Verify fork payloads have correct worker_index and role
         assert fork_calls[0]["role"] == "inf-server"

--- a/tests/test_sglang_pp_unit.py
+++ b/tests/test_sglang_pp_unit.py
@@ -354,6 +354,12 @@ class TestPPBridgeModule:
         bridge.bind()
 
 
+@pytest.mark.skipif(
+    not __import__("areal.utils.pkg_version", fromlist=["is_available"]).is_available(
+        "sglang"
+    ),
+    reason="sglang package not installed",
+)
 class TestLocalLaunchPPSizeThreading:
     """``rl_trainer.py`` and the local controller path
     must thread ``pp_size`` through to ``SGLangConfig.build_args`` /


### PR DESCRIPTION
## Summary

- Launch **router** and **inference servers** concurrently during `RolloutControllerV2` initialization (router does not depend on inference servers being ready)
- Fork **data proxies** and **gateway** concurrently in the next phase (both only need `router_addr` and `inf_addrs`, which are ready by then)
- Within inference server forking, all DP groups launch in **parallel** via `asyncio.gather` instead of a sequential loop
- Health checks for inference servers also run concurrently

## Changes

- **`_async_fork_on_guard()`** — async counterpart of the existing sync `_fork_on_guard()`, using the shared async httpx client
- **`_async_wait_for_service()`** — async health-check poller (non-blocking `asyncio.sleep` instead of `time.sleep`)
- **`_async_fork_inf_servers()`** — extracted inference server forking logic into a dedicated method; each DP group forks concurrently
- **`_async_initialize()`** — restructured into two parallel phases:
  1. Router + inference servers (concurrent)
  2. Data proxies + gateway (concurrent)

## Motivation

On clusters with `dp_size > 1` and multi-node instances, initialization was dominated by serial inference server launches and sequential health checks. This change reduces wall-clock init time proportional to `dp_size` for the inference fork phase, plus eliminates the serial router→data-proxy→gateway chain.

## Testing

- Pre-commit passes (ruff lint + format, license headers)
- No new dependencies introduced
- Existing `tests/test_rollout_controller.py` and integration tests cover `RolloutControllerV2` initialization paths