### PR TITLE
chore: migrate repo references from InclusionAI to areal-project

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -80,12 +80,12 @@ git remote add fork https://github.com/<username>/AReaL.git
 **Store for later use:**
 
 - `PUSH_REMOTE`: The remote to push to (e.g., `origin` or `fork`)
-- `UPSTREAM_REPO`: The upstream repo for PR target (e.g., `inclusionAI/AReaL`)
+- `UPSTREAM_REPO`: The upstream repo for PR target (e.g., `areal-project/AReaL`)
 - `FORK_OWNER`: Fork owner username (for `--head` parameter if needed)
 
 ```bash
 # Example detection script
-UPSTREAM_REPO="inclusionAI/AReaL"
+UPSTREAM_REPO="areal-project/AReaL"
 PUSH_REMOTE=""
 
 # Check if we can push to origin
@@ -386,7 +386,7 @@ Files changed:
 
 Commands to execute:
 1. git push -f -u <fork-remote> feat/vision-rlvr
-2. gh pr create --repo inclusionAI/AReaL --head <username>:feat/vision-rlvr --base main --title "..." --body "..." [--draft]
+2. gh pr create --repo areal-project/AReaL --head <username>:feat/vision-rlvr --base main --title "..." --body "..." [--draft]
 ─────────────────────────────────────────────────
 ```
 
@@ -485,7 +485,7 @@ Add `--draft` flag if requested.
 
 ```
 ✓ PR created/updated successfully!
-https://github.com/inclusionAI/AReaL/pull/123
+https://github.com/areal-project/AReaL/pull/123
 ```
 
 ## Examples

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,20 +1,20 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 GitHub Discussions
-    url: https://github.com/inclusionAI/AReaL/discussions
+    url: https://github.com/areal-project/AReaL/discussions
     about: Ask questions, share ideas, or discuss features before opening an issue
   - name: 📖 Documentation
-    url: https://inclusionai.github.io/AReaL/
+    url: https://areal-project.github.io/AReaL/
     about: Check our comprehensive documentation for guides and tutorials
   - name: 🚀 Quickstart Guide
-    url: https://inclusionai.github.io/AReaL/en/tutorial/quickstart.html
+    url: https://areal-project.github.io/AReaL/en/tutorial/quickstart.html
     about: New to AReaL? Start here for installation and basic usage
   - name: 🐛 Debugging Guide
-    url: https://inclusionai.github.io/AReaL/en/best_practices/debugging.html
+    url: https://areal-project.github.io/AReaL/en/best_practices/debugging.html
     about: Tips for debugging common issues
   - name: 💾 Handling OOM Issues
-    url: https://inclusionai.github.io/AReaL/en/best_practices/handling_oom.html
+    url: https://areal-project.github.io/AReaL/en/best_practices/handling_oom.html
     about: Solutions for out-of-memory errors
   - name: 💬 WeChat Community
-    url: https://github.com/inclusionAI/AReaL/blob/main/assets/wechat_qrcode.png
+    url: https://github.com/areal-project/AReaL/blob/main/assets/wechat_qrcode.png
     about: Join our WeChat group for community support (微信群)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,4 +44,4 @@ Fixes #(issue)
 ______________________________________________________________________
 
 **Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
-[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions)!
+[GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!

--- a/.github/workflows/bake-gcp-image.yml
+++ b/.github/workflows/bake-gcp-image.yml
@@ -83,7 +83,7 @@ jobs:
           IMAGE_TAG=$(curl -fsSL -H "$METADATA_HEADER" "$METADATA_URL/image_tag")
           GHCR_TOKEN=$(curl -fsSL -H "$METADATA_HEADER" "$METADATA_URL/ghcr_token" 2>/dev/null || true)
 
-          IMAGE_REPO="ghcr.io/inclusionai/areal-runtime"
+          IMAGE_REPO="ghcr.io/areal-project/areal-runtime"
 
           # Wait for Docker daemon to be ready
           echo "Waiting for Docker daemon..."
@@ -101,7 +101,7 @@ jobs:
 
           # Authenticate to GHCR if token is available
           if [ -n "${GHCR_TOKEN:-}" ]; then
-            echo "$GHCR_TOKEN" | docker login ghcr.io -u inclusionai --password-stdin
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u areal-project --password-stdin
             echo "Authenticated to GHCR."
           fi
 
@@ -274,7 +274,7 @@ jobs:
           |---|---|
           | **New Image** | \`${IMAGE_NAME}\` |
           | **Base Image** | \`${BASE_IMAGE}\` |
-          | **Pre-pulled** | \`ghcr.io/inclusionai/areal-runtime:${IMAGE_TAG}-sglang\`, \`ghcr.io/inclusionai/areal-runtime:${IMAGE_TAG}-vllm\` |
+          | **Pre-pulled** | \`ghcr.io/areal-project/areal-runtime:${IMAGE_TAG}-sglang\`, \`ghcr.io/areal-project/areal-runtime:${IMAGE_TAG}-vllm\` |
 
           ### Next Steps
           Update \`GCP_OS_IMAGE\` in \`.github/workflows/test-areal.yml\`:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -15,7 +15,7 @@ env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   VALIDATOR_LABELS: gcp-docker-validator
   RUNNER_VERSION: '2.332.0'
-  IMAGE_NAME: ghcr.io/inclusionai/areal-runtime
+  IMAGE_NAME: ghcr.io/areal-project/areal-runtime
   IMAGE_TAG: test
 
 jobs:
@@ -129,7 +129,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: inclusionai
+          username: areal-project
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push sglang image
@@ -196,12 +196,12 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: inclusionai
+          username: areal-project
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Pull test image and push as dev
         env:
-          IMAGE_NAME: ghcr.io/inclusionai/areal-runtime
+          IMAGE_NAME: ghcr.io/areal-project/areal-runtime
         run: |
           docker pull $IMAGE_NAME:test-${{ matrix.variant }}
           docker tag $IMAGE_NAME:test-${{ matrix.variant }} $IMAGE_NAME:dev-${{ matrix.variant }}
@@ -239,12 +239,12 @@ jobs:
           TAG="test-${{ matrix.variant }}"
           # Get the package version ID for the test tag
           PACKAGE_VERSION_ID=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/orgs/inclusionai/packages/container/$PACKAGE_NAME/versions?per_page=100" \
+            "https://api.github.com/orgs/areal-project/packages/container/$PACKAGE_NAME/versions?per_page=100" \
             | jq -r ".[] | select(.metadata.container.tags[] == \"$TAG\") | .id")
 
           if [ -n "$PACKAGE_VERSION_ID" ] && [ "$PACKAGE_VERSION_ID" != "null" ]; then
             curl -X DELETE -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/orgs/inclusionai/packages/container/$PACKAGE_NAME/versions/$PACKAGE_VERSION_ID"
+              "https://api.github.com/orgs/areal-project/packages/container/$PACKAGE_NAME/versions/$PACKAGE_VERSION_ID"
             echo "✅ Deleted ${{ matrix.variant }} test image from registry"
           else
             echo "⚠️ ${{ matrix.variant }} test image not found or already deleted"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -147,7 +147,7 @@ jobs:
         variant: [sglang, vllm]
     name: Install test (Docker ${{ matrix.variant }} image)
     container:
-      image: ghcr.io/inclusionai/areal-runtime:dev-${{ matrix.variant }}
+      image: ghcr.io/areal-project/areal-runtime:dev-${{ matrix.variant }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tag-release-image.yml
+++ b/.github/workflows/tag-release-image.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  IMAGE_NAME: ghcr.io/inclusionai/areal-runtime
+  IMAGE_NAME: ghcr.io/areal-project/areal-runtime
 
 jobs:
   start-builder:
@@ -152,7 +152,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: inclusionai
+          username: areal-project
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push sglang image

--- a/.github/workflows/test-areal.yml
+++ b/.github/workflows/test-areal.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         variant: ${{ fromJson(needs.determine-variants.outputs.matrix) }}
     env:
-      CONTAINER_IMAGE: ghcr.io/inclusionai/areal-runtime:${{ inputs.image_tag || 'dev' }}-${{ matrix.variant }}
+      CONTAINER_IMAGE: ghcr.io/areal-project/areal-runtime:${{ inputs.image_tag || 'dev' }}-${{ matrix.variant }}
       RUNNER_LABELS: gcp-a2-highgpu-2g,variant-${{ matrix.variant }}
     steps:
       - name: Set instance variables

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ areal/                     Core Python package
 |-- utils/                 Cross-cutting helpers (logging, data, checkpoints, RL ops)
 +-- workflow/              RolloutWorkflow implementations (RLVR, multi-turn, vision)
 
-docs/                      Jupyter Book docs (https://inclusionai.github.io/AReaL/)
+docs/                      Jupyter Book docs (https://areal-project.github.io/AReaL/)
 examples/                  Training scripts and launcher recipes
 ```
 
@@ -250,7 +250,7 @@ ______________________________________________________________________
 
 ## Reference material
 
-- **Docs portal**: <https://inclusionai.github.io/AReaL/>
+- **Docs portal**: <https://areal-project.github.io/AReaL/>
 - **Quickstart**: `docs/tutorial/quickstart.md`
 - **Architecture**: `docs/tutorial/gsm8k_grpo.md`
 - **Customization**: `docs/customization/*.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating and
 1. **Install Development Dependencies:**
 
    Check our
-   [installation guide](https://inclusionai.github.io/AReaL/en/tutorial/installation.html)
+   [installation guide](https://areal-project.github.io/AReaL/en/tutorial/installation.html)
    for detailed setup instructions.
 
 1. **Set Up Pre-commit Hooks:**
@@ -41,11 +41,11 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating and
 1. **Find an Issue:**
 
    - Browse
-     [good first issues](https://github.com/inclusionAI/AReaL/labels/good%20first%20issue)
-   - Check [help wanted](https://github.com/inclusionAI/AReaL/labels/help%20wanted)
+     [good first issues](https://github.com/areal-project/AReaL/labels/good%20first%20issue)
+   - Check [help wanted](https://github.com/areal-project/AReaL/labels/help%20wanted)
      issues
    - Or create a new issue using our
-     [issue templates](https://github.com/inclusionAI/AReaL/issues/new/choose)
+     [issue templates](https://github.com/areal-project/AReaL/issues/new/choose)
 
 1. **Make Your Changes:**
 
@@ -98,7 +98,7 @@ waste your effort.
 ## Tips for Using AI-Assisted Coding
 
 See the full
-[AI-Assisted Development Guide](https://inclusionai.github.io/AReaL/en/reference/ai_assisted_dev.html)
+[AI-Assisted Development Guide](https://areal-project.github.io/AReaL/en/reference/ai_assisted_dev.html)
 for detailed documentation.
 
 ## CI/CD

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 </h1>
 
 <p align="center">
-| <a href="https://arxiv.org/pdf/2505.24298"><b>Paper</b></a> | <a href="https://inclusionai.github.io/AReaL/"><b>Documentation</b></a> | <a href="https://inclusionai.github.io/AReaL/zh/"><b>中文文档</b></a> | <a href="https://deepwiki.com/inclusionAI/AReaL"><b>Ask DeepWiki</b></a> | <a href="https://huggingface.co/collections/inclusionAI/"><b>🤗 Models & Data</b></a> |
+| <a href="https://arxiv.org/pdf/2505.24298"><b>Paper</b></a> | <a href="https://areal-project.github.io/AReaL/"><b>Documentation</b></a> | <a href="https://areal-project.github.io/AReaL/zh/"><b>中文文档</b></a> | <a href="https://deepwiki.com/areal-project/AReaL"><b>Ask DeepWiki</b></a> | <a href="https://huggingface.co/collections/inclusionAI/"><b>🤗 Models & Data</b></a> |
 <a href="./assets/figures/wechat_qrcode.png" target="_blank"><img src="./assets/figures/wechat_icon.png" width="20" style="vertical-align: middle;"> <b>WeChat (微信) Group</b></a> |
-  <a href="https://gitcgr.com/inclusionAI/AReaL">
-    <img src="https://gitcgr.com/badge/inclusionAI/AReaL.svg" alt="gitcgr" />
+  <a href="https://gitcgr.com/areal-project/AReaL">
+    <img src="https://gitcgr.com/badge/areal-project/AReaL.svg" alt="gitcgr" />
   </a>
 </p>
 
@@ -29,7 +29,7 @@ cost-effective** for a broad community of developers and researchers.
 **AReaL Highlights**
 
 - ⚡ **Flexibility**: Seamless customization for
-  [agentic RL](https://inclusionai.github.io/AReaL/en/tutorial/agentic_rl.html) and
+  [agentic RL](https://areal-project.github.io/AReaL/en/tutorial/agentic_rl.html) and
   [online RL training](https://www.inclusion-ai.org/AReaL/en/tutorial/online_proxy.html)
   for **black-box agent applications** by simply replacing the `base_url`.
 - 📈 **Scalability**: **Stable** fully asynchronous RL training with **industry-leading
@@ -43,7 +43,7 @@ cost-effective** for a broad community of developers and researchers.
 **\[2026/04/23\]** 🚀 We’re excited to release our integration with
 [Scaffoldings](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tensorrt_llm/scaffolding)
 for agentic RL training - now live in our
-[examples](https://github.com/inclusionAI/AReaL/tree/main/examples/scaffolding)! Huge
+[examples](https://github.com/areal-project/AReaL/tree/main/examples/scaffolding)! Huge
 shoutout to @narutolhy and @WeiHaocheng for making this happen 🙌. The modular design of
 the Scaffoldings enables it to achieve a thorough decoupling of agent execution, reward
 calculation, and trajectory acquisition. This enables developers to reuse existing
@@ -53,7 +53,7 @@ innovative modules.
 **\[2026/04/18\]** We are thrilled to announce that **AReaL's first Community Biweekly
 Meeting** was successfully held! Thank you to everyone who joined us. Meeting materials
 are now available
-[here](https://github.com/inclusionAI/AReaL/tree/main/assets/community). Our next
+[here](https://github.com/areal-project/AReaL/tree/main/assets/community). Our next
 meeting is scheduled for **2026/05/01** and will also be conducted in Chinese;
 English-language meetings will be scheduled in the future. We warmly welcome everyone to
 participate! See [Community](./assets/community/README.md) for more details.
@@ -71,7 +71,7 @@ and achieves comparable performance with Gemini 3.0 Pro on $\\tau^2$-bench! Chec
 the [paper](https://arxiv.org/pdf/2601.22607),
 [model](https://huggingface.co/inclusionAI/AReaL-SEA-235B-A22B),
 [data](https://huggingface.co/datasets/inclusionAI/AReaL-tau2-data), and
-[code](https://github.com/inclusionAI/AReaL/tree/main/examples/tau2).
+[code](https://github.com/areal-project/AReaL/tree/main/examples/tau2).
 
 **\[2026/01/15\]** Congrats to our friends at [CAMEL-AI](https://www.camel-ai.org/) for
 open-sourcing [SETA](https://github.com/camel-ai/seta), their terminal agent RL project
@@ -82,8 +82,8 @@ and the [announcement on X](https://x.com/guohao_li/status/2009678513574408636).
 **\[2026/01/01\]** Happy New Year! Thanks to the outstanding contribution from
 @HwVanICI, we are excited to officially announce stable support for AReaL training on
 **Ascend NPU devices**! The code is actively maintained and continuously updated in the
-[`ascend` branch](https://github.com/inclusionAI/AReaL/tree/ascend). Check out
-[our documentation](https://inclusionai.github.io/AReaL/en/tutorial/installation_npu.html)
+[`ascend` branch](https://github.com/areal-project/AReaL/tree/ascend). Check out
+[our documentation](https://areal-project.github.io/AReaL/en/tutorial/installation_npu.html)
 to get started, and feel free to report any issues!
 
 **\[2025/08/30\]** Introducing ASearcher, a state-of-the-art search agent built with
@@ -96,7 +96,7 @@ features an **algorithm-first** API design that prioritizes ease of use and algo
 development, while natively supporting **fully asynchronous agentic RL**. With 80% fewer
 lines of code, AReaL-lite maintains 90% of AReaL's performance and core functionality.
 Check out [our AReaL-lite design documentation](/areal/README.md) and
-[the quickstart guide](https://inclusionai.github.io/AReaL/en/tutorial/quickstart.html)
+[the quickstart guide](https://areal-project.github.io/AReaL/en/tutorial/quickstart.html)
 to begin your journey with **AReaL-lite**!
 
 **\[2025/06/03\] (v0.3, boba²)** We release **boba²** (double-boba) for fully
@@ -122,7 +122,7 @@ state-of-the-art 7B and 32B models for mathematical reasoning. Check out our
 First, install the package:
 
 ```bash
-git clone https://github.com/inclusionAI/AReaL
+git clone https://github.com/areal-project/AReaL
 cd AReaL
 pip install uv
 # Install flash-attn pre-built wheel first to avoid compiling from source
@@ -150,7 +150,7 @@ python3 examples/math/gsm8k_rl.py --config examples/math/gsm8k_grpo.yaml \
 ```
 
 For comprehensive setup instructions, see
-[our quickstart guide](https://inclusionai.github.io/AReaL/en/tutorial/quickstart.html).
+[our quickstart guide](https://areal-project.github.io/AReaL/en/tutorial/quickstart.html).
 
 ## 📚 Examples
 
@@ -322,7 +322,7 @@ git push
 ## 🗺️ Future Roadmap
 
 - **[Full Roadmap](ROADMAP.md)**
-- **[2026 Q1 Roadmap](https://github.com/inclusionAI/AReaL/issues/907)**
+- **[2026 Q1 Roadmap](https://github.com/areal-project/AReaL/issues/907)**
 
 AReaL is under active development with planned minor releases weekly and major releases
 monthly. We warmly welcome community engagement and contributions. We are also

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,12 +4,12 @@ This roadmap outlines the planned features and improvements for AReaL in the nex
 quarter. We welcome community feedback and contributions to help shape the future
 direction of the project.
 
-**Latest Release:** Check [releases](https://github.com/inclusionAI/AReaL/releases) for
-the most recent version.
+**Latest Release:** Check [releases](https://github.com/areal-project/AReaL/releases)
+for the most recent version.
 
 ## 2026 Q1 Roadmap (due April 30, 2026)
 
-[GitHub Issue #907](https://github.com/inclusionAI/AReaL/issues/907).
+[GitHub Issue #907](https://github.com/areal-project/AReaL/issues/907).
 
 This roadmap tracks major planned enhancements through April 30, 2026. Items are
 organized into two categories:
@@ -64,7 +64,7 @@ organized into two categories:
 
 ### 2025 Q4
 
-[GitHub Issue #542](https://github.com/inclusionAI/AReaL/issues/542).
+[GitHub Issue #542](https://github.com/areal-project/AReaL/issues/542).
 
 **Backends**
 
@@ -119,7 +119,7 @@ Carried over to Q1 2026:
 
 ### 2025 Q3
 
-[GitHub Issue #257](https://github.com/inclusionAI/AReaL/issues/257).
+[GitHub Issue #257](https://github.com/areal-project/AReaL/issues/257).
 
 **Backends**
 
@@ -170,13 +170,13 @@ We value community input! Here's how you can help shape AReaL's future:
 ### 💡 Propose New Features
 
 1. **Check Existing Issues:** Search
-   [issues](https://github.com/inclusionAI/AReaL/issues) and
-   [discussions](https://github.com/inclusionAI/AReaL/discussions) to see if your idea
+   [issues](https://github.com/areal-project/AReaL/issues) and
+   [discussions](https://github.com/areal-project/AReaL/discussions) to see if your idea
    already exists
 1. **Create a Feature Request:** Use our
-   [feature request template](https://github.com/inclusionAI/AReaL/issues/new?template=feature.md)
+   [feature request template](https://github.com/areal-project/AReaL/issues/new?template=feature.md)
 1. **Discuss in GitHub Discussions:** Post in
-   [Ideas category](https://github.com/inclusionAI/AReaL/discussions/categories/ideas)
+   [Ideas category](https://github.com/areal-project/AReaL/discussions/categories/ideas)
    for early feedback
 1. **Vote on Features:** Use 👍 reactions on issues to show support
 
@@ -210,5 +210,5 @@ ______________________________________________________________________
 **Last Updated:** 2026-02-06
 
 **Questions about the roadmap?** Open a discussion in
-[GitHub Discussions](https://github.com/inclusionAI/AReaL/discussions) or ask in our
+[GitHub Discussions](https://github.com/areal-project/AReaL/discussions) or ask in our
 [WeChat group](./assets/figures/wechat_qrcode.png).

--- a/areal/api/alloc_mode.py
+++ b/areal/api/alloc_mode.py
@@ -1129,7 +1129,7 @@ class _LLMParallelParser:
             err_hint = """
 Hints:
 1. The parsing logic requires colons instead of dots to separate backends from dimensions, e.g., use "sglang:d4+fsdp:d4" instead of "sglang.d4+fsdp.d4".
-2. Check https://inclusionai.github.io/AReaL/en/tutorial/megatron.html for allowed syntax and examples with complex MoE models.
+2. Check https://areal-project.github.io/AReaL/en/tutorial/megatron.html for allowed syntax and examples with complex MoE models.
 """
             raise ValueError(f"Parsing error: {e}\n{err_hint}")
 

--- a/areal/infra/controller/train_controller.py
+++ b/areal/infra/controller/train_controller.py
@@ -813,7 +813,7 @@ class TrainController:
     def clear_batches(self, *targets: dict[str, RTensor]):
         """Clear distributed batch shards from workers to free memory.
 
-        Two fan-outs — see inclusionAI/AReaL#1209:
+        Two fan-outs — see areal-project/AReaL#1209:
 
         1. ``_async_clear_batches``: HTTP DELETE to each storage node,
            dropping ``_storage`` entries (and the owner's ``_fetch_buffer``

--- a/areal/infra/rpc/rtensor.py
+++ b/areal/infra/rpc/rtensor.py
@@ -626,7 +626,7 @@ def remove(shard_id: str) -> int:
     goes through the HTTP backend (even for a self-local shard) and caches
     the fetched tensor. Without this pop, RSS grows unboundedly across steps
     on any worker that both stores and localizes the same shard — see
-    inclusionAI/AReaL#1209.
+    areal-project/AReaL#1209.
     """
     global _storage, _storage_lock, _storage_stats
     with _fetch_buffer_lock:

--- a/areal/trainer/dpo_trainer.py
+++ b/areal/trainer/dpo_trainer.py
@@ -303,7 +303,7 @@ class DPOTrainer:
                     self.actor.clear_batches(batch)
                     # ref DP heads also localized `batch` in compute_logp —
                     # drain their per-process fetch buffers. See
-                    # inclusionAI/AReaL#1209.
+                    # areal-project/AReaL#1209.
                     if self.ref is not None:
                         self.ref.clear_batches(batch)
                     if self.data_controller is not None:

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -786,7 +786,7 @@ class PPOTrainer:
                 # process-local ``_fetch_buffer``; one HTTP DELETE to the
                 # storage owner clears ``_storage`` but not per-consumer
                 # caches. Fan out ``clear_batches`` to every role that
-                # localized the batch — see inclusionAI/AReaL#1209.
+                # localized the batch — see areal-project/AReaL#1209.
                 # SPMD mode never populates ``_fetch_buffer`` (no RTensor
                 # round-trip), so the fan-out is single-controller only.
                 if is_single_controller():

--- a/blog/AReaL_v0_2.md
+++ b/blog/AReaL_v0_2.md
@@ -40,7 +40,7 @@ using only 200 data samples, replicating **QwQ-32B's** inference performance on 
 <span id="eval_detail"></span> We declare that the reported numbers are based on our
 re-testing, with each number representing the average results of 32 sampling responses.
 The evaluation code was available in the `evaluation/` folder. Please roll back to
-[commit f55fe68](https://github.com/inclusionAI/AReaL/commit/f55fe685c661b0117d888fcae47d6f46e9a85087)
+[commit f55fe68](https://github.com/areal-project/AReaL/commit/f55fe685c661b0117d888fcae47d6f46e9a85087)
 (Feb 4, 2026) or earlier.
 
 For the baselines and the SFT model AReaL-boba-SFT-32B, we follow the recommended

--- a/blog/AReaL_v0_3.md
+++ b/blog/AReaL_v0_3.md
@@ -291,7 +291,7 @@ either entirely correct or entirely incorrect.
     [14B-code](https://huggingface.co/inclusionAI/AReaL-boba-2-14B),
     [8B-code-open](https://huggingface.co/inclusionAI/AReaL-boba-2-8B-subset),
     [14B-code-open](https://huggingface.co/inclusionAI/AReaL-boba-2-14B-subset)
-  - [Evaluation Guide](https://inclusionai.github.io/AReaL/en/tutorial/eval.html)
-  - [Training configs](https://github.com/inclusionAI/AReaL/tree/main/examples/configs/v0.3-qwen3-code)
+  - [Evaluation Guide](https://areal-project.github.io/AReaL/en/tutorial/eval.html)
+  - [Training configs](https://github.com/areal-project/AReaL/tree/main/examples/configs/v0.3-qwen3-code)
     and instructions (`reference/reproduce.html`, revert to a version before v0.5.1 to
     see the reproduction guide)

--- a/docs/_config.yml.backup
+++ b/docs/_config.yml.backup
@@ -18,7 +18,7 @@ latex:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/inclusionAI/AReaL  # Online location of your book
+  url: https://github.com/areal-project/AReaL  # Online location of your book
   path_to_book: docs  # Optional path to your book, relative to the repository root
   branch: main  # Which branch of the repository should be used when creating links (optional)
 

--- a/docs/en/_config.yml
+++ b/docs/en/_config.yml
@@ -12,7 +12,7 @@ latex:
     targetname: book.tex
 
 repository:
-  url: https://github.com/inclusionAI/AReaL
+  url: https://github.com/areal-project/AReaL
   path_to_book: docs
   branch: main
 

--- a/docs/en/customization/dataset.md
+++ b/docs/en/customization/dataset.md
@@ -83,7 +83,7 @@ dispatched to multiple concurrent executions of workflows, where each dispatched
 corresponds to a single episode.
 
 In the following sections, we take
-[`RLVRWorkflow`](https://github.com/inclusionAI/AReaL/blob/main/areal/workflow/rlvr.py)
+[`RLVRWorkflow`](https://github.com/areal-project/AReaL/blob/main/areal/workflow/rlvr.py)
 as an example. Agent workflows have the same pattern of using input data. You are free
 to modify the customized dataset to include any keys as long as they accord with your
 workflow implementation.

--- a/docs/en/reference/ai_assisted_dev.md
+++ b/docs/en/reference/ai_assisted_dev.md
@@ -211,5 +211,5 @@ We welcome contributions to both the codebase and AI development configurations:
 - **OpenCode configs**: Edit files in `.opencode/`
 - **Claude Code configs**: Edit files in `.claude/`
 
-See [CONTRIBUTING.md](https://github.com/inclusionAI/AReaL/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/areal-project/AReaL/blob/main/CONTRIBUTING.md)
 for guidelines.

--- a/docs/en/reference/checkpointing.md
+++ b/docs/en/reference/checkpointing.md
@@ -62,7 +62,7 @@ PPOTrainer.train()
 
 ## Saver: HuggingFace Model Export
 
-The [`Saver`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/saver.py)
+The [`Saver`](https://github.com/areal-project/AReaL/blob/main/areal/utils/saver.py)
 periodically exports model weights in HuggingFace format for evaluation or deployment.
 
 ### Save Mode
@@ -133,7 +133,7 @@ tokenizer = AutoTokenizer.from_pretrained(
 ## RecoverHandler: Fault Tolerance
 
 The
-[`RecoverHandler`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/recover.py)
+[`RecoverHandler`](https://github.com/areal-project/AReaL/blob/main/areal/utils/recover.py)
 enables resuming training after failures by saving complete training state.
 
 ### Configuration

--- a/docs/en/reference/lora.md
+++ b/docs/en/reference/lora.md
@@ -14,7 +14,7 @@ In AReaL, this is especially useful for:
   and shipped,
 - \[Future\] fine-tune multiple LoRA adapters more efficiently in parallel for better
   hardware utilization (see RFC
-  [#609](https://github.com/inclusionAI/AReaL/issues/609)).
+  [#609](https://github.com/areal-project/AReaL/issues/609)).
 
 This guide explains how to enable LoRA in RL training and configure the related
 parameters.

--- a/docs/en/reference/metrics_tracking.md
+++ b/docs/en/reference/metrics_tracking.md
@@ -243,7 +243,7 @@ RolloutController.export_stats()                 │
 ## StatsLogger: Logging Backends
 
 The
-[`StatsLogger`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/stats_logger.py)
+[`StatsLogger`](https://github.com/areal-project/AReaL/blob/main/areal/utils/stats_logger.py)
 sends aggregated metrics to external logging backends. It is automatically managed by
 `PPOTrainer` and runs only on rank 0 to avoid duplicate logging.
 

--- a/docs/en/tutorial/agentic_rl.md
+++ b/docs/en/tutorial/agentic_rl.md
@@ -40,7 +40,7 @@ AReaL addresses these limitations by providing:
    for each query.
 
 We demonstrate several concrete examples below. More examples can be found in the
-[`workflow/` directory](https://github.com/inclusionAI/AReaL/tree/main/areal/workflow).
+[`workflow/` directory](https://github.com/areal-project/AReaL/tree/main/areal/workflow).
 
 > **Scheduler Compatibility**: Agent workflows with the proxy approach are supported on
 > `local` and `slurm` schedulers only. The `ray` scheduler is not supported because
@@ -148,7 +148,7 @@ if __name__ == "__main__":
 ```
 
 The full working OpenAI Agents training example is located in
-[**`examples/agent_workflow/`**](https://github.com/inclusionAI/AReaL/blob/main/examples/agent_workflow/).
+[**`examples/agent_workflow/`**](https://github.com/areal-project/AReaL/blob/main/examples/agent_workflow/).
 To run the example on a single node:
 
 ```bash
@@ -318,7 +318,7 @@ workflow = CamelRLVRWorkflow(
 ```
 
 See the
-[complete train script](https://github.com/inclusionAI/AReaL/blob/main/examples/camel/train.py)
+[complete train script](https://github.com/areal-project/AReaL/blob/main/examples/camel/train.py)
 for a full working implementation.
 
 ### More Examples
@@ -328,12 +328,12 @@ frameworks and SDKs:
 
 - **Claude Agent SDK**: Train agents using Anthropic's Claude Agent SDK with MCP tools.
   See the
-  [Claude example](https://github.com/inclusionAI/AReaL/blob/main/areal/workflow/anthropic/claude_math_agent.py)
+  [Claude example](https://github.com/areal-project/AReaL/blob/main/areal/workflow/anthropic/claude_math_agent.py)
   for a math agent with calculator tools.
 
 - **LangChain**: Integrate LangChain agents with AReaL's training infrastructure. See
   the
-  [LangChain example](https://github.com/inclusionAI/AReaL/blob/main/areal/workflow/langchain/math_agent.py)
+  [LangChain example](https://github.com/areal-project/AReaL/blob/main/areal/workflow/langchain/math_agent.py)
   for details.
 
 ## Online Mode
@@ -344,8 +344,8 @@ exposes an OpenAI-compatible HTTP API that any application can connect to, and a
 interactions are automatically collected as RL training data.
 
 See the [Online RL Training Guide](online_proxy.md) for a complete walkthrough, and the
-[OpenClaw example](https://github.com/inclusionAI/AReaL/tree/main/examples/openclaw) for
-a working end-to-end demo.
+[OpenClaw example](https://github.com/areal-project/AReaL/tree/main/examples/openclaw)
+for a working end-to-end demo.
 
 ## Under the Hood
 

--- a/docs/en/tutorial/eval.md
+++ b/docs/en/tutorial/eval.md
@@ -113,7 +113,7 @@ GPUs.
 ## Implementation
 
 See
-[`examples/math/gsm8k_eval.py`](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_eval.py)
+[`examples/math/gsm8k_eval.py`](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_eval.py)
 for a complete example. The key pattern:
 
 ```python

--- a/docs/en/tutorial/gsm8k_grpo.md
+++ b/docs/en/tutorial/gsm8k_grpo.md
@@ -2,9 +2,9 @@
 
 This guide walks you through how AReaL runs the GRPO algorithm on the GSM8K dataset.
 We'll use the example training script
-[`examples/math/gsm8k_rl.py`](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_rl.py)
+[`examples/math/gsm8k_rl.py`](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_rl.py)
 and configuration file
-[`examples/math/gsm8k_grpo.yaml`](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
+[`examples/math/gsm8k_grpo.yaml`](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
 to explain the key concepts step by step.
 
 ## Overview: How AReaL Works
@@ -142,7 +142,7 @@ that runs on the controller node.
 ### Configuration Files
 
 Configuration files are YAML files that specify options from
-[`areal/api/cli_args.py`](https://github.com/inclusionAI/AReaL/blob/main/areal/api/cli_args.py).
+[`areal/api/cli_args.py`](https://github.com/areal-project/AReaL/blob/main/areal/api/cli_args.py).
 You can override settings via CLI:
 
 ```bash
@@ -166,7 +166,7 @@ See [CLI Reference](../cli_reference.md) for all available options.
 ## The Training Script: Entry Point
 
 The training script
-([`examples/math/gsm8k_rl.py`](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_rl.py))
+([`examples/math/gsm8k_rl.py`](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_rl.py))
 follows this pattern:
 
 ```python
@@ -207,7 +207,7 @@ See [CLI Reference](../cli_reference.md) for configuration options, and
 ## The PPOTrainer: Controller-Based Training
 
 The
-[`PPOTrainer`](https://github.com/inclusionAI/AReaL/blob/main/areal/trainer/rl_trainer.py)
+[`PPOTrainer`](https://github.com/areal-project/AReaL/blob/main/areal/trainer/rl_trainer.py)
 orchestrates distributed training by initializing the scheduler and creating controllers
 for actors (policy/critic) and rollout workers.
 
@@ -254,7 +254,7 @@ trainer.train(
 ### RLVRWorkflow: Single-Turn Reward Learning
 
 The
-[`RLVRWorkflow`](https://github.com/inclusionAI/AReaL/blob/main/areal/workflow/rlvr.py)
+[`RLVRWorkflow`](https://github.com/areal-project/AReaL/blob/main/areal/workflow/rlvr.py)
 defines how prompts become training samples. Each trajectory goes through these steps:
 
 1. **Tokenize input**: Apply chat template to messages
@@ -268,7 +268,7 @@ defines how prompts become training samples. Each trajectory goes through these 
    - `rewards`: Scalar reward
 
 **GSM8K Reward**: Binary reward (1.0 for correct answer, 0.0 otherwise). See
-[`gsm8k_reward_fn`](https://github.com/inclusionAI/AReaL/blob/main/areal/reward/gsm8k.py).
+[`gsm8k_reward_fn`](https://github.com/areal-project/AReaL/blob/main/areal/reward/gsm8k.py).
 
 **NOTE:** This workflow adopts the low-level API of inference engines --- the
 `agenerate` API. It is preferable if you want more fine-grained control over token IDs.
@@ -313,7 +313,7 @@ Key: Generation and training happen SIMULTANEOUSLY on different GPUs
 #### Three Levels of Concurrency
 
 **Level 1 - Controller Thread**:
-[`BatchTaskDispatcher`](https://github.com/inclusionAI/AReaL/blob/main/areal/core/workflow_executor.py)
+[`BatchTaskDispatcher`](https://github.com/areal-project/AReaL/blob/main/areal/core/workflow_executor.py)
 runs in a background thread, continuously submitting rollout requests to workers via
 HTTP:
 
@@ -325,7 +325,7 @@ As such, **rollout and training happen simultaneously** in AReaL, even though th
 looks like a synchronous orchestration.
 
 **Level 2 - Worker RPC Server**: Each rollout worker runs a Flask HTTP server
-([`rpc_server.py`](https://github.com/inclusionAI/AReaL/blob/main/areal/infra/rpc/rpc_server.py))
+([`rpc_server.py`](https://github.com/areal-project/AReaL/blob/main/areal/infra/rpc/rpc_server.py))
 on **CPU**:
 
 - Accepts concurrent HTTP requests (multi-threaded Flask)
@@ -372,7 +372,7 @@ return concat_padded_tensors(results)  # Shape: [batch_size, seq_len]
 ```
 
 **Staleness Control**:
-[`StalenessManager`](https://github.com/inclusionAI/AReaL/blob/main/areal/infra/staleness_manager.py)
+[`StalenessManager`](https://github.com/areal-project/AReaL/blob/main/areal/infra/staleness_manager.py)
 limits concurrent inflight requests:
 
 - `max_concurrent_rollouts`: Maximum inflight trajectories
@@ -387,7 +387,7 @@ results are merged back.
 
 ### TrainController: Dispatch Mechanism
 
-[`TrainController`](https://github.com/inclusionAI/AReaL/blob/main/areal/infra/controller/train_controller.py)
+[`TrainController`](https://github.com/areal-project/AReaL/blob/main/areal/infra/controller/train_controller.py)
 provides the core RPC dispatch:
 
 1. `_dispatch_inputs()`: Splits batches using FFD load balancing across workers
@@ -426,7 +426,7 @@ directly from rollout workers, avoiding controller memory overhead.
 ### Training Workers: Algorithm Implementation
 
 On each training worker,
-[`FSDPPPOActor`](https://github.com/inclusionAI/AReaL/blob/main/areal/trainer/ppo/actor.py)
+[`FSDPPPOActor`](https://github.com/areal-project/AReaL/blob/main/areal/trainer/ppo/actor.py)
 implements the GRPO/PPO algorithm:
 
 **Algorithm Methods:**
@@ -458,7 +458,7 @@ Each worker processes its shard, then synchronizes gradients via NCCL.
 ### The Training Loop
 
 The `trainer.train()` method orchestrates the complete loop. See
-[`PPOTrainer.train()`](https://github.com/inclusionAI/AReaL/blob/main/areal/trainer/rl_trainer.py)
+[`PPOTrainer.train()`](https://github.com/areal-project/AReaL/blob/main/areal/trainer/rl_trainer.py)
 for the full implementation:
 
 ```python
@@ -516,7 +516,7 @@ The weight sync process in `PPOTrainer.train()` follows this pattern:
 1. Resume rollout with updated weights with re-computed KV cache
 
 See
-[`PPOTrainer.train()`](https://github.com/inclusionAI/AReaL/blob/main/areal/trainer/rl_trainer.py)
+[`PPOTrainer.train()`](https://github.com/areal-project/AReaL/blob/main/areal/trainer/rl_trainer.py)
 lines 861-874 for the full implementation.
 
 ## Monitoring and Utilities
@@ -528,10 +528,10 @@ metrics tracking. These are automatically orchestrated during training.
 
 AReaL provides two checkpointing mechanisms:
 
-| Component                                                                                 | Purpose                          | Format        | Configuration    |
-| ----------------------------------------------------------------------------------------- | -------------------------------- | ------------- | ---------------- |
-| [`Saver`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/saver.py)            | Export for evaluation/deployment | HuggingFace   | `config.saver`   |
-| [`RecoverHandler`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/recover.py) | Resume after failures            | DCP (sharded) | `config.recover` |
+| Component                                                                                   | Purpose                          | Format        | Configuration    |
+| ------------------------------------------------------------------------------------------- | -------------------------------- | ------------- | ---------------- |
+| [`Saver`](https://github.com/areal-project/AReaL/blob/main/areal/utils/saver.py)            | Export for evaluation/deployment | HuggingFace   | `config.saver`   |
+| [`RecoverHandler`](https://github.com/areal-project/AReaL/blob/main/areal/utils/recover.py) | Resume after failures            | DCP (sharded) | `config.recover` |
 
 **Saver** creates HuggingFace-compatible checkpoints that can be loaded with
 `transformers` or published to HuggingFace Hub. Each save creates a new directory.
@@ -546,7 +546,7 @@ Both are called automatically during `trainer.train()`. For details, see the
 ### Evaluation
 
 The
-[`Evaluator`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/evaluator.py)
+[`Evaluator`](https://github.com/areal-project/AReaL/blob/main/areal/utils/evaluator.py)
 runs periodic evaluations on validation sets. Configure via `config.evaluation`. Called
 automatically in `trainer.train()`.
 
@@ -555,7 +555,7 @@ automatically in `trainer.train()`.
 AReaL uses a two-component metrics system:
 
 **`stats_tracker`**
-([source](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/stats_tracker.py)):
+([source](https://github.com/areal-project/AReaL/blob/main/areal/utils/stats_tracker.py)):
 Collects statistics with two paradigms optimized for different use cases:
 
 - **Streaming metrics** for rollout workers: Each workflow logs scalars individually
@@ -573,7 +573,7 @@ stats_tracker.stat(advantages=tensor, denominator="n_valid_tokens")
 ```
 
 **`StatsLogger`**
-([source](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/stats_logger.py)):
+([source](https://github.com/areal-project/AReaL/blob/main/areal/utils/stats_logger.py)):
 Sends aggregated metrics to logging backends (Weights & Biases, SwanLab, TensorBoard)
 from rank 0. At each training step, `PPOTrainer` collects metrics from all components
 and commits them:

--- a/docs/en/tutorial/installation.md
+++ b/docs/en/tutorial/installation.md
@@ -24,7 +24,7 @@ The following hardware configuration has been extensively tested:
 | Git LFS                  | Required for downloading models, datasets, and AReaL code. See [installation guide](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) |
 | Docker                   |                                                                                                 27.5.1                                                                                                 |
 | NVIDIA Container Toolkit |                                         See [installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)                                          |
-| AReaL Image              |                                    `ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang` (default) or `v1.0.4-vllm`. Includes runtime dependencies and Ray components.                                     |
+| AReaL Image              |                                   `ghcr.io/areal-project/areal-runtime:v1.0.4-sglang` (default) or `v1.0.4-vllm`. Includes runtime dependencies and Ray components.                                    |
 
 **Note**: This tutorial does not cover the installation of NVIDIA Drivers, CUDA, or
 shared storage mounting, as these depend on your specific node configuration and system
@@ -42,19 +42,19 @@ We recommend using Docker with our provided image. The Dockerfile is available i
 top-level directory of the AReaL repository.
 
 ```bash
-docker pull ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang
+docker pull ghcr.io/areal-project/areal-runtime:v1.0.4-sglang
 docker run -it --name areal-node1 \
    --privileged --gpus all --network host \
    --shm-size 700g -v /path/to/mount:/path/to/mount \
-   ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang \
+   ghcr.io/areal-project/areal-runtime:v1.0.4-sglang \
    /bin/bash
-git clone https://github.com/inclusionAI/AReaL /path/to/mount/AReaL
+git clone https://github.com/areal-project/AReaL /path/to/mount/AReaL
 cd /path/to/mount/AReaL
 uv pip install -e . --no-deps
 ```
 
 A vLLM variant of the Docker image is also available at
-`ghcr.io/inclusionai/areal-runtime:v1.0.4-vllm`. Replace the image tag in the commands
+`ghcr.io/areal-project/areal-runtime:v1.0.4-vllm`. Replace the image tag in the commands
 above if you prefer vLLM as the inference backend.
 
 ### Option 2: Custom Environment Installation
@@ -64,7 +64,7 @@ above if you prefer vLLM as the inference backend.
 1. Clone the repo:
 
 ```bash
-git clone https://github.com/inclusionAI/AReaL
+git clone https://github.com/areal-project/AReaL
 cd AReaL
 ```
 
@@ -215,7 +215,7 @@ fused Adam kernel), install them manually after running `uv sync --extra cuda`:
 | grouped_gemm      | MoE model support in Megatron            | `uv pip install --no-build-isolation git+https://github.com/fanshiqing/grouped_gemm@v1.1.4`                                                                       |
 | NVIDIA apex       | Fused Adam, etc. in Megatron             | `NVCC_APPEND_FLAGS="--threads 4" APEX_PARALLEL_BUILD=8 APEX_CPP_EXT=1 APEX_CUDA_EXT=1 uv pip install --no-build-isolation git+https://github.com/NVIDIA/apex.git` |
 | TransformerEngine | FP8 training, optimized GEMM in Megatron | `uv pip install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@stable`                                                                  |
-| flash-attn-3      | Flash Attention v3 (Hopper)              | Built from source, see [Dockerfile](https://github.com/inclusionAI/AReaL/blob/main/Dockerfile)                                                                    |
+| flash-attn-3      | Flash Attention v3 (Hopper)              | Built from source, see [Dockerfile](https://github.com/areal-project/AReaL/blob/main/Dockerfile)                                                                  |
 
 **Important**: These packages require `--no-build-isolation` because they need access to
 the already-installed PyTorch for CUDA compilation. Install PyTorch first via
@@ -226,7 +226,7 @@ the already-installed PyTorch for CUDA compilation. Install PyTorch first via
 For running DeepSeek-V3 style MoE models with optimal performance, the Docker image also
 includes the following packages. These packages have complex build requirements and GPU
 architecture constraints. **Refer to the
-[Dockerfile](https://github.com/inclusionAI/AReaL/blob/main/Dockerfile) for the exact
+[Dockerfile](https://github.com/areal-project/AReaL/blob/main/Dockerfile) for the exact
 installation commands and environment variables.**
 
 | Package                | Purpose                                     | GPU Requirement |
@@ -305,7 +305,7 @@ sky check
 
 If `GCP: enabled` or `Kubernetes: enabled` are shown, you're ready to use SkyPilot with
 AReaL. See the
-[SkyPilot example](https://github.com/inclusionAI/AReaL/blob/main/examples/skypilot/README.md)
+[SkyPilot example](https://github.com/areal-project/AReaL/blob/main/examples/skypilot/README.md)
 for a detailed guide on running AReaL with SkyPilot. For more options and details, see
 the official
 [SkyPilot installation guide](https://docs.skypilot.co/en/latest/getting-started/installation.html).

--- a/docs/en/tutorial/installation_npu.md
+++ b/docs/en/tutorial/installation_npu.md
@@ -98,7 +98,7 @@ be out of date. We recommend removing it and installing AReaL from source.
 ```bash
 rm -rf /AReaL
 
-git clone https://github.com/inclusionAI/AReaL
+git clone https://github.com/areal-project/AReaL
 cd AReaL
 
 # Checkout to ascend branch

--- a/docs/en/tutorial/online_proxy.md
+++ b/docs/en/tutorial/online_proxy.md
@@ -361,8 +361,8 @@ rollout:
 
 ## See Also
 
-- [OpenClaw Example](https://github.com/inclusionAI/AReaL/tree/main/examples/openclaw) -
-  Complete end-to-end example with ZeroClaw
+- [OpenClaw Example](https://github.com/areal-project/AReaL/tree/main/examples/openclaw)
+  \- Complete end-to-end example with ZeroClaw
 - [Agentic RL Tutorial](agentic_rl.md) - Agent framework integration (inline/subproc
   modes)
 - [Custom Agent Workflows](../customization/agent.md) - Creating custom agent workflows

--- a/docs/en/tutorial/quickstart.md
+++ b/docs/en/tutorial/quickstart.md
@@ -10,9 +10,9 @@ function-based rewards. Ensure you've completed
 To run the experiment, you will need:
 
 - Training script:
-  [examples/math/gsm8k_rl.py](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_rl.py)
+  [examples/math/gsm8k_rl.py](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_rl.py)
 - Config YAML:
-  [examples/math/gsm8k_grpo.yaml](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
+  [examples/math/gsm8k_grpo.yaml](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
 
 Our training scripts will automatically download the dataset (openai/gsm8k) and model
 (Qwen/Qwen2-1.5B-Instruct). To run the example with default configuration, execute from
@@ -28,11 +28,11 @@ python3 examples/math/gsm8k_rl.py --config examples/math/gsm8k_grpo.yaml schedul
 ## Modifying configuration
 
 All available configuration options are listed in
-[areal/api/cli_args.py](https://github.com/inclusionAI/AReaL/blob/main/areal/api/cli_args.py).
+[areal/api/cli_args.py](https://github.com/areal-project/AReaL/blob/main/areal/api/cli_args.py).
 To customize the experiment (models, resources, algorithm options), you can:
 
 1. Edit the YAML file directly at
-   [examples/math/gsm8k_grpo.yaml](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_grpo.yaml).
+   [examples/math/gsm8k_grpo.yaml](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_grpo.yaml).
 1. Add command-line options:
    - For existing options in the YAML file, directly add the option:
      `actor.path=Qwen/Qwen3-1.7B`.
@@ -105,7 +105,7 @@ python3 examples/math/gsm8k_rl.py \
 Additional references:
 
 - For more options for schedulers, check `SchedulerConfig` in
-  [areal/api/cli_args.py](https://github.com/inclusionAI/AReaL/blob/main/areal/api/cli_args.py).
+  [areal/api/cli_args.py](https://github.com/areal-project/AReaL/blob/main/areal/api/cli_args.py).
 - Ray cluster setup guide (see installation.md for distributed setup) for a guide on how
   to set up a ray cluster.
 
@@ -158,7 +158,7 @@ sky launch -c areal-test examples/skypilot/ray_cluster.sky.yaml --infra k8s
 ```
 
 Check
-[Running AReaL with SkyPilot](https://github.com/inclusionAI/AReaL/blob/main/examples/skypilot/README.md),
+[Running AReaL with SkyPilot](https://github.com/areal-project/AReaL/blob/main/examples/skypilot/README.md),
 for more details about the examples. Check
 [SkyPilot Documentation](https://docs.skypilot.co/en/latest/docs/index.html) for more
 information about SkyPilot.

--- a/docs/en/version_history.md
+++ b/docs/en/version_history.md
@@ -6,7 +6,7 @@ development history, highlighting the key contributions of each version release.
 ## AReaL-lite (July 2025): Simplifying RL for Everyone
 
 *📖
-[Step-by-step Tutorial](https://inclusionai.github.io/AReaL/en/tutorial/gsm8k_grpo.html)*
+[Step-by-step Tutorial](https://areal-project.github.io/AReaL/en/tutorial/gsm8k_grpo.html)*
 
 AReaL-lite represents a fundamental rethinking of how researchers interact with
 reinforcement learning systems. Born from the recognition that AReaL's system-first
@@ -31,7 +31,8 @@ the first place.
 
 ## AReaL v0.3 (August 2025): Breaking the Speed Barrier
 
-*📖 [Full Blog Post](https://github.com/inclusionAI/AReaL/blob/main/blog/AReaL_v0_3.md)*
+*📖
+[Full Blog Post](https://github.com/areal-project/AReaL/blob/main/blog/AReaL_v0_3.md)*
 
 Version 0.3 marked AReaL's boldest architectural leap: completely decoupling generation
 from training across separate GPU clusters. This wasn't just an incremental
@@ -57,7 +58,8 @@ workflows, opening new possibilities for complex reasoning applications.
 
 ## AReaL v0.2 (March 2025): Engineering Excellence Meets SOTA Performance
 
-*📖 [Full Blog Post](https://github.com/inclusionAI/AReaL/blob/main/blog/AReaL_v0_2.md)*
+*📖
+[Full Blog Post](https://github.com/areal-project/AReaL/blob/main/blog/AReaL_v0_2.md)*
 
 The second major release focused on transforming AReaL from a promising research
 prototype into a production-ready system. At the heart of v0.2 was the transition from
@@ -89,7 +91,8 @@ improvement** that made large-scale experiments accessible to more research team
 
 ## AReaL v0.1 (February 2025): The Foundation That Started It All
 
-*📖 [Full Blog Post](https://github.com/inclusionAI/AReaL/blob/main/blog/AReaL_v0_1.md)*
+*📖
+[Full Blog Post](https://github.com/areal-project/AReaL/blob/main/blog/AReaL_v0_1.md)*
 
 At its initial release, AReaL's 1.5B model surpassed o1-Preview on mathematical
 reasoning in just 40 hours of training. v0.1 also demonstrated emergent thinking

--- a/docs/zh/_config.yml
+++ b/docs/zh/_config.yml
@@ -12,7 +12,7 @@ latex:
     targetname: book.tex
 
 repository:
-  url: https://github.com/inclusionAI/AReaL
+  url: https://github.com/areal-project/AReaL
   path_to_book: docs
   branch: main
 

--- a/docs/zh/customization/dataset.md
+++ b/docs/zh/customization/dataset.md
@@ -75,7 +75,7 @@ for global_step in range(start_step, max_steps):
 Workflow 的多个并发执行中，其中每个分派的数据对应一个单独的 episode。
 
 在以下部分中，我们以
-[`RLVRWorkflow`](https://github.com/inclusionAI/AReaL/blob/main/areal/workflow/rlvr.py)
+[`RLVRWorkflow`](https://github.com/areal-project/AReaL/blob/main/areal/workflow/rlvr.py)
 为例。Agent Workflow 使用输入数据的模式相同。只要符合您的 Workflow 实现，您可以随意修改自定义数据集以包含任何键。
 
 `RLVRWorkflow` 实现从数据字典中提取 "messages" 字段作为生成响应的提示。此外，此数据作为关键字参数传递给

--- a/docs/zh/reference/ai_assisted_dev.md
+++ b/docs/zh/reference/ai_assisted_dev.md
@@ -201,5 +201,5 @@ AReaL/
 - **OpenCode 配置**：编辑 `.opencode/` 中的文件
 - **Claude Code 配置**：编辑 `.claude/` 中的文件
 
-参见 [CONTRIBUTING.md](https://github.com/inclusionAI/AReaL/blob/main/CONTRIBUTING.md)
+参见 [CONTRIBUTING.md](https://github.com/areal-project/AReaL/blob/main/CONTRIBUTING.md)
 获取指南。

--- a/docs/zh/reference/checkpointing.md
+++ b/docs/zh/reference/checkpointing.md
@@ -58,7 +58,7 @@ PPOTrainer.train()
 
 ## Saver：HuggingFace 模型导出
 
-[`Saver`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/saver.py) 定期以
+[`Saver`](https://github.com/areal-project/AReaL/blob/main/areal/utils/saver.py) 定期以
 HuggingFace 格式导出模型权重，用于评估或部署。
 
 ### 保存模式
@@ -126,7 +126,7 @@ tokenizer = AutoTokenizer.from_pretrained(
 
 ## RecoverHandler：容错
 
-[`RecoverHandler`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/recover.py)
+[`RecoverHandler`](https://github.com/areal-project/AReaL/blob/main/areal/utils/recover.py)
 通过保存完整训练状态实现故障后恢复训练。
 
 ### 配置

--- a/docs/zh/reference/lora.md
+++ b/docs/zh/reference/lora.md
@@ -9,7 +9,7 @@ RL 微调在硬件资源有限的条件下也更具可行性。
 - 由于显存压力更低，可以支持更大的 batch size，
 - 模型迁移与部署更加简单，因为只需要保存和分发 LoRA adapter，
 - \[Future\] 更高效地并行微调多个 LoRA adapter，以提升硬件利用率（参见 RFC
-  [#609](https://github.com/inclusionAI/AReaL/issues/609)）。
+  [#609](https://github.com/areal-project/AReaL/issues/609)）。
 
 本文档说明如何在 RL 训练中启用 LoRA，并配置相关参数。
 

--- a/docs/zh/reference/metrics_tracking.md
+++ b/docs/zh/reference/metrics_tracking.md
@@ -236,7 +236,7 @@ RolloutController.export_stats()                 │
 
 ## StatsLogger：日志后端
 
-[`StatsLogger`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/stats_logger.py)
+[`StatsLogger`](https://github.com/areal-project/AReaL/blob/main/areal/utils/stats_logger.py)
 将聚合指标发送到外部日志后端。它由 `PPOTrainer` 自动管理，仅在 rank 0 运行以避免重复日志。
 
 ### 支持的后端

--- a/docs/zh/tutorial/agentic_rl.md
+++ b/docs/zh/tutorial/agentic_rl.md
@@ -26,7 +26,7 @@ AReaL 通过提供以下功能来解决这些限制：
 1. **并行轨迹收集**：AReaL 的工作流系统支持多个智能体实例的并发执行，允许您为每个查询收集多样化的轨迹。
 
 我们在下面演示了几个具体示例。更多示例可以在
-[`workflow/` 目录](https://github.com/inclusionAI/AReaL/tree/main/areal/workflow)中找到。
+[`workflow/` 目录](https://github.com/areal-project/AReaL/tree/main/areal/workflow)中找到。
 
 > **调度器兼容性**：使用代理方法的智能体工作流仅在 `local` 和 `slurm` 调度器上受支持。`ray` 调度器不支持，因为 Ray 的基于 actor
 > 的编程模型与需要 worker 之间持久连接的 HTTP 代理服务器本质上不兼容。
@@ -130,7 +130,7 @@ if __name__ == "__main__":
 ```
 
 完整的 OpenAI Agents 训练示例位于
-[**`examples/agent_workflow/`**](https://github.com/inclusionAI/AReaL/blob/main/examples/agent_workflow/)。要在单节点上运行示例：
+[**`examples/agent_workflow/`**](https://github.com/areal-project/AReaL/blob/main/examples/agent_workflow/)。要在单节点上运行示例：
 
 ```bash
 python3 examples/agent_workflow/train.py \
@@ -290,17 +290,17 @@ workflow = CamelRLVRWorkflow(
 # AReaL 将为每个批次调用 workflow.arun_episode()
 ```
 
-查看[完整的训练脚本](https://github.com/inclusionAI/AReaL/blob/main/examples/camel/train.py)以获取完整的工作实现。
+查看[完整的训练脚本](https://github.com/areal-project/AReaL/blob/main/examples/camel/train.py)以获取完整的工作实现。
 
 ### 更多示例
 
 除了上述两个示例外，AReaL 还支持与各种其他智能体框架和 SDK 的集成：
 
 - **Claude Agent SDK**：使用 Anthropic 的 Claude Agent SDK 和 MCP
-  工具训练智能体。请参阅[Claude 示例](https://github.com/inclusionAI/AReaL/blob/main/areal/workflow/anthropic/claude_math_agent.py)，了解带有计算器工具的数学智能体。
+  工具训练智能体。请参阅[Claude 示例](https://github.com/areal-project/AReaL/blob/main/areal/workflow/anthropic/claude_math_agent.py)，了解带有计算器工具的数学智能体。
 
 - **LangChain**：将 LangChain 智能体与 AReaL 的训练基础设施集成。请参阅
-  [LangChain 示例](https://github.com/inclusionAI/AReaL/blob/main/areal/workflow/langchain/math_agent.py)了解详情。
+  [LangChain 示例](https://github.com/areal-project/AReaL/blob/main/areal/workflow/langchain/math_agent.py)了解详情。
 
 ## 底层原理
 

--- a/docs/zh/tutorial/eval.md
+++ b/docs/zh/tutorial/eval.md
@@ -107,7 +107,7 @@ Controller Process
 ## 实现
 
 有关完整示例，请参阅
-[`examples/math/gsm8k_eval.py`](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_eval.py)。关键模式如下：
+[`examples/math/gsm8k_eval.py`](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_eval.py)。关键模式如下：
 
 ```python
 from areal.api.alloc_mode import ModelAllocation

--- a/docs/zh/tutorial/gsm8k_grpo.md
+++ b/docs/zh/tutorial/gsm8k_grpo.md
@@ -1,9 +1,9 @@
 # 在 GSM8K 数据集上运行 GRPO
 
 本指南将逐步介绍 AReaL 如何在 GSM8K 数据集上运行 GRPO 算法。我们将使用示例训练脚本
-[`examples/math/gsm8k_rl.py`](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_rl.py)
+[`examples/math/gsm8k_rl.py`](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_rl.py)
 和配置文件
-[`examples/math/gsm8k_grpo.yaml`](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
+[`examples/math/gsm8k_grpo.yaml`](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
 逐步解释关键概念。
 
 ## 概述：AReaL 如何工作
@@ -131,7 +131,7 @@ python examples/math/gsm8k_rl.py --config examples/math/gsm8k_grpo.yaml schedule
 ### 配置文件
 
 配置文件是 YAML 文件，指定来自
-[`areal/api/cli_args.py`](https://github.com/inclusionAI/AReaL/blob/main/areal/api/cli_args.py)
+[`areal/api/cli_args.py`](https://github.com/areal-project/AReaL/blob/main/areal/api/cli_args.py)
 的选项。您可以通过 CLI 覆盖设置：
 
 ```bash
@@ -155,7 +155,7 @@ config: GRPOConfig
 ## 训练脚本：入口点
 
 训练脚本
-（[`examples/math/gsm8k_rl.py`](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_rl.py)）
+（[`examples/math/gsm8k_rl.py`](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_rl.py)）
 遵循以下模式：
 
 ```python
@@ -194,7 +194,7 @@ def main(args):
 
 ## PPOTrainer：基于控制器的训练
 
-[`PPOTrainer`](https://github.com/inclusionAI/AReaL/blob/main/areal/trainer/rl_trainer.py)
+[`PPOTrainer`](https://github.com/areal-project/AReaL/blob/main/areal/trainer/rl_trainer.py)
 通过初始化调度器并为 actor（策略/评论家）和 rollout 工作进程创建控制器来编排分布式训练。
 
 ### 控制器架构
@@ -237,7 +237,7 @@ trainer.train(
 
 ### RLVRWorkflow：单轮奖励学习
 
-[`RLVRWorkflow`](https://github.com/inclusionAI/AReaL/blob/main/areal/workflow/rlvr.py)
+[`RLVRWorkflow`](https://github.com/areal-project/AReaL/blob/main/areal/workflow/rlvr.py)
 定义了 prompts 如何转化为训练样本。每个轨迹经历以下步骤：
 
 1. **Tokenize 输入**：将聊天模板应用于消息
@@ -251,7 +251,7 @@ trainer.train(
    - `rewards`：标量奖励
 
 **GSM8K 奖励**：二元奖励（正确答案 1.0，否则 0.0）。请参阅
-[`gsm8k_reward_fn`](https://github.com/inclusionAI/AReaL/blob/main/areal/reward/gsm8k.py)。
+[`gsm8k_reward_fn`](https://github.com/areal-project/AReaL/blob/main/areal/reward/gsm8k.py)。
 
 **注意**：此工作流采用推理引擎的低级 API —— `agenerate` API。如果您想更细粒度地控制 token IDs，这是更好的选择。`agenerate` 将
 token IDs 输入推理服务器，并输出 token IDs 供用户处理。我们还提供了高级 API 用于便捷的 agent 工作流编排。请参阅
@@ -293,7 +293,7 @@ TrainController           训练工作进程
 #### 三个并发级别
 
 **级别 1 - 控制器线程**：
-[`BatchTaskDispatcher`](https://github.com/inclusionAI/AReaL/blob/main/areal/core/workflow_executor.py)
+[`BatchTaskDispatcher`](https://github.com/areal-project/AReaL/blob/main/areal/core/workflow_executor.py)
 在后台线程中运行，通过 HTTP 持续向工作进程提交 rollout 请求：
 
 - 轮流向 rollout 工作进程提交任务
@@ -303,7 +303,7 @@ TrainController           训练工作进程
 因此，**在 AReaL 中 rollout 和训练同时进行**，尽管代码看起来像是同步编排。
 
 **级别 2 - 工作进程 RPC 服务器**：每个 rollout 工作进程在 **CPU** 上运行 Flask HTTP 服务器
-（[`rpc_server.py`](https://github.com/inclusionAI/AReaL/blob/main/areal/infra/rpc/rpc_server.py)）：
+（[`rpc_server.py`](https://github.com/areal-project/AReaL/blob/main/areal/infra/rpc/rpc_server.py)）：
 
 - 接受并发 HTTP 请求（多线程 Flask）
 - **引擎线程**：串行处理引擎操作（NCCL 兼容性）
@@ -349,7 +349,7 @@ return concat_padded_tensors(results)  # 形状：[batch_size, seq_len]
 ```
 
 **过期管理**：
-[`StalenessManager`](https://github.com/inclusionAI/AReaL/blob/main/areal/infra/staleness_manager.py)
+[`StalenessManager`](https://github.com/areal-project/AReaL/blob/main/areal/infra/staleness_manager.py)
 限制并发 inflight 请求：
 
 - `max_concurrent_rollouts`：最大 inflight 轨迹数
@@ -362,7 +362,7 @@ return concat_padded_tensors(results)  # 形状：[batch_size, seq_len]
 
 ### TrainController：分发机制
 
-[`TrainController`](https://github.com/inclusionAI/AReaL/blob/main/areal/infra/controller/train_controller.py)
+[`TrainController`](https://github.com/areal-project/AReaL/blob/main/areal/infra/controller/train_controller.py)
 提供核心 RPC 分发：
 
 1. `_dispatch_inputs()`：使用 FFD 负载平衡跨工作进程分割批次
@@ -400,7 +400,7 @@ return concat_padded_tensors(results)  # 形状：[batch_size, seq_len]
 ### 训练工作进程：算法实现
 
 在每个训练工作进程上，
-[`FSDPPPOActor`](https://github.com/inclusionAI/AReaL/blob/main/areal/trainer/ppo/actor.py)
+[`FSDPPPOActor`](https://github.com/areal-project/AReaL/blob/main/areal/trainer/ppo/actor.py)
 实现了 GRPO/PPO 算法：
 
 **算法方法**：
@@ -431,7 +431,7 @@ GPU 3: SGLang         GPU 7: FSDP rank 3  ─┘
 ### 训练循环
 
 `trainer.train()` 方法编排完整循环。请参阅
-[`PPOTrainer.train()`](https://github.com/inclusionAI/AReaL/blob/main/areal/trainer/rl_trainer.py)
+[`PPOTrainer.train()`](https://github.com/areal-project/AReaL/blob/main/areal/trainer/rl_trainer.py)
 获取完整实现：
 
 ```python
@@ -487,7 +487,7 @@ for global_step in range(start_step, max_steps):
 1. 使用重新计算的 KV 缓存恢复 rollout
 
 请参阅
-[`PPOTrainer.train()`](https://github.com/inclusionAI/AReaL/blob/main/areal/trainer/rl_trainer.py)
+[`PPOTrainer.train()`](https://github.com/areal-project/AReaL/blob/main/areal/trainer/rl_trainer.py)
 第 861-874 行获取完整实现。
 
 ## 监控和工具
@@ -498,10 +498,10 @@ AReaL 提供由 `PPOTrainer` 管理的工具，用于检查点保存、评估和
 
 AReaL 提供两种检查点机制：
 
-| 组件                                                                                      | 用途              | 格式        | 配置             |
-| ----------------------------------------------------------------------------------------- | ----------------- | ----------- | ---------------- |
-| [`Saver`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/saver.py)            | 导出用于评估/部署 | HuggingFace | `config.saver`   |
-| [`RecoverHandler`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/recover.py) | 故障后恢复        | DCP（分片） | `config.recover` |
+| 组件                                                                                        | 用途              | 格式        | 配置             |
+| ------------------------------------------------------------------------------------------- | ----------------- | ----------- | ---------------- |
+| [`Saver`](https://github.com/areal-project/AReaL/blob/main/areal/utils/saver.py)            | 导出用于评估/部署 | HuggingFace | `config.saver`   |
+| [`RecoverHandler`](https://github.com/areal-project/AReaL/blob/main/areal/utils/recover.py) | 故障后恢复        | DCP（分片） | `config.recover` |
 
 **Saver** 创建与 HuggingFace 兼容的检查点，可以使用 `transformers` 加载或发布到 HuggingFace Hub。每次保存创建一个新目录。
 
@@ -511,7 +511,7 @@ AReaL 提供两种检查点机制：
 
 ### 评估
 
-[`Evaluator`](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/evaluator.py)
+[`Evaluator`](https://github.com/areal-project/AReaL/blob/main/areal/utils/evaluator.py)
 在验证集上运行定期评估。通过 `config.evaluation` 配置。在 `trainer.train()` 中自动调用。
 
 ### 指标跟踪
@@ -519,7 +519,7 @@ AReaL 提供两种检查点机制：
 AReaL 使用两组件指标系统：
 
 **`stats_tracker`**
-（[源码](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/stats_tracker.py)）：
+（[源码](https://github.com/areal-project/AReaL/blob/main/areal/utils/stats_tracker.py)）：
 以两种针对不同用例优化的范式收集统计信息：
 
 - **流式指标**用于 rollout 工作进程：每个工作流单独记录标量（例如 `reward`），由控制器跨工作进程聚合
@@ -535,7 +535,7 @@ stats_tracker.stat(advantages=tensor, denominator="n_valid_tokens")
 ```
 
 **`StatsLogger`**
-（[源码](https://github.com/inclusionAI/AReaL/blob/main/areal/utils/stats_logger.py)）：
+（[源码](https://github.com/areal-project/AReaL/blob/main/areal/utils/stats_logger.py)）：
 将聚合指标从 rank 0 发送到日志后端（Weights & Biases、SwanLab、TensorBoard）。在每个训练步骤中，`PPOTrainer`
 从所有组件收集指标并提交：
 

--- a/docs/zh/tutorial/installation.md
+++ b/docs/zh/tutorial/installation.md
@@ -24,7 +24,7 @@
 | Git LFS                  | 用于下载模型、数据集和 AReaL 代码。请参阅[安装指南](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) |
 | Docker                   |                                                                                 27.5.1                                                                                 |
 | NVIDIA Container Toolkit |                             请参阅[安装指南](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)                              |
-| AReaL 镜像               |                                 `ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang`（默认）或 `v1.0.4-vllm`。包含运行时依赖和 Ray 组件。                                 |
+| AReaL 镜像               |                                `ghcr.io/areal-project/areal-runtime:v1.0.4-sglang`（默认）或 `v1.0.4-vllm`。包含运行时依赖和 Ray 组件。                                |
 
 **注意**：本教程不涵盖 NVIDIA 驱动、CUDA 或共享存储挂载的安装，因为这些取决于您具体的节点配置和系统版本。请独立完成这些安装。
 
@@ -37,18 +37,18 @@
 我们推荐使用 Docker 和提供的镜像。Dockerfile 位于 AReaL 仓库的顶级目录。
 
 ```bash
-docker pull ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang
+docker pull ghcr.io/areal-project/areal-runtime:v1.0.4-sglang
 docker run -it --name areal-node1 \
    --privileged --gpus all --network host \
    --shm-size 700g -v /path/to/mount:/path/to/mount \
-   ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang \
+   ghcr.io/areal-project/areal-runtime:v1.0.4-sglang \
    /bin/bash
-git clone https://github.com/inclusionAI/AReaL /path/to/mount/AReaL
+git clone https://github.com/areal-project/AReaL /path/to/mount/AReaL
 cd /path/to/mount/AReaL
 uv pip install -e . --no-deps
 ```
 
-vLLM 变体的 Docker 镜像也可使用： `ghcr.io/inclusionai/areal-runtime:v1.0.4-vllm`。如果您偏好使用 vLLM
+vLLM 变体的 Docker 镜像也可使用： `ghcr.io/areal-project/areal-runtime:v1.0.4-vllm`。如果您偏好使用 vLLM
 作为推理后端，请将上述命令中的镜像标签替换为该变体。
 
 ### 方式 2：自定义环境安装
@@ -58,7 +58,7 @@ vLLM 变体的 Docker 镜像也可使用： `ghcr.io/inclusionai/areal-runtime:v
 1. 克隆仓库：
 
 ```bash
-git clone https://github.com/inclusionAI/AReaL
+git clone https://github.com/areal-project/AReaL
 cd AReaL
 ```
 
@@ -186,7 +186,7 @@ Docker）且需要这些包的优化（例如 FP8 训练、融合 Adam 内核）
 | grouped_gemm      | Megatron 中的 MoE 模型支持        | `uv pip install --no-build-isolation git+https://github.com/fanshiqing/grouped_gemm@v1.1.4`                                                                       |
 | NVIDIA apex       | Megatron 中的融合 Adam 等         | `NVCC_APPEND_FLAGS="--threads 4" APEX_PARALLEL_BUILD=8 APEX_CPP_EXT=1 APEX_CUDA_EXT=1 uv pip install --no-build-isolation git+https://github.com/NVIDIA/apex.git` |
 | TransformerEngine | Megatron 中的 FP8 训练、优化 GEMM | `uv pip install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@stable`                                                                  |
-| flash-attn-3      | Flash Attention v3（Hopper）      | 从源码构建，请参阅 [Dockerfile](https://github.com/inclusionAI/AReaL/blob/main/Dockerfile)                                                                        |
+| flash-attn-3      | Flash Attention v3（Hopper）      | 从源码构建，请参阅 [Dockerfile](https://github.com/areal-project/AReaL/blob/main/Dockerfile)                                                                      |
 
 **重要**：这些包需要 `--no-build-isolation`，因为它们需要访问已安装的 PyTorch 进行 CUDA 编译。先通过
 `uv sync --extra cuda` 安装 PyTorch，然后再尝试安装这些包。
@@ -194,7 +194,7 @@ Docker）且需要这些包的优化（例如 FP8 训练、融合 Adam 内核）
 ### DeepSeek-V3 优化包（可选）
 
 为了以最佳性能运行 DeepSeek-V3 风格的 MoE 模型，Docker 镜像还包含以下包。这些包有复杂的构建要求和 GPU 架构约束。**请参阅
-[Dockerfile](https://github.com/inclusionAI/AReaL/blob/main/Dockerfile)
+[Dockerfile](https://github.com/areal-project/AReaL/blob/main/Dockerfile)
 获取确切的安装命令和环境变量。**
 
 | 包                     | 用途                             | GPU 要求       |
@@ -268,7 +268,7 @@ sky check
 ```
 
 如果显示 `GCP: enabled` 或 `Kubernetes: enabled`，您就可以将 SkyPilot 与 AReaL 一起使用了。请参阅
-[SkyPilot 示例](https://github.com/inclusionAI/AReaL/blob/main/examples/skypilot/README.md)
+[SkyPilot 示例](https://github.com/areal-project/AReaL/blob/main/examples/skypilot/README.md)
 获取运行 AReaL 的详细指南。更多选项和详细信息，请参阅官方
 [SkyPilot 安装指南](https://docs.skypilot.co/en/latest/getting-started/installation.html)。
 

--- a/docs/zh/tutorial/installation_npu.md
+++ b/docs/zh/tutorial/installation_npu.md
@@ -91,7 +91,7 @@ ${IMAGE}  \
 ```bash
 rm -rf /AReaL
 
-git clone https://github.com/inclusionAI/AReaL
+git clone https://github.com/areal-project/AReaL
 cd AReaL
 
 # 切换到 ascend 分支

--- a/docs/zh/tutorial/online_proxy.md
+++ b/docs/zh/tutorial/online_proxy.md
@@ -330,7 +330,7 @@ rollout:
 
 ## 另请参阅
 
-- [OpenClaw 示例](https://github.com/inclusionAI/AReaL/tree/main/examples/openclaw) - 使用
+- [OpenClaw 示例](https://github.com/areal-project/AReaL/tree/main/examples/openclaw) - 使用
   ZeroClaw 的完整端到端示例
 - [智能体 RL 教程](agentic_rl.md) - 智能体框架集成（inline/subproc 模式）
 - [自定义智能体工作流](../customization/agent.md) - 创建自定义智能体工作流

--- a/docs/zh/tutorial/quickstart.md
+++ b/docs/zh/tutorial/quickstart.md
@@ -8,9 +8,9 @@ GSM8K。在继续之前，请确保已完成[安装和环境设置](installation
 要运行实验，您需要：
 
 - 训练脚本：
-  [examples/math/gsm8k_rl.py](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_rl.py)
+  [examples/math/gsm8k_rl.py](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_rl.py)
 - 配置文件 YAML：
-  [examples/math/gsm8k_grpo.yaml](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
+  [examples/math/gsm8k_grpo.yaml](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)
 
 我们的训练脚本会自动下载数据集（openai/gsm8k）和模型（Qwen/Qwen2-1.5B-Instruct）。要使用默认配置运行示例，请从仓库目录执行：
 
@@ -23,10 +23,10 @@ python3 examples/math/gsm8k_rl.py --config examples/math/gsm8k_grpo.yaml schedul
 ## 修改配置
 
 所有可用的配置选项都列在
-[areal/api/cli_args.py](https://github.com/inclusionAI/AReaL/blob/main/areal/api/cli_args.py)中。要自定义实验（模型、资源、算法选项），您可以：
+[areal/api/cli_args.py](https://github.com/areal-project/AReaL/blob/main/areal/api/cli_args.py)中。要自定义实验（模型、资源、算法选项），您可以：
 
 1. 直接编辑 YAML 文件
-   [examples/math/gsm8k_grpo.yaml](https://github.com/inclusionAI/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)。
+   [examples/math/gsm8k_grpo.yaml](https://github.com/areal-project/AReaL/blob/main/examples/math/gsm8k_grpo.yaml)。
 1. 添加命令行选项：
    - 对于 YAML 文件中已存在的选项，直接添加： `actor.path=Qwen/Qwen3-1.7B`。
    - 对于 `cli_args.py` 中存在但不在 YAML 文件中的选项，使用前缀 "+" 添加：
@@ -93,7 +93,7 @@ python3 examples/math/gsm8k_rl.py \
 其他参考：
 
 - 有关调度器的更多选项，请查看
-  [areal/api/cli_args.py](https://github.com/inclusionAI/AReaL/blob/main/areal/api/cli_args.py)中的
+  [areal/api/cli_args.py](https://github.com/areal-project/AReaL/blob/main/areal/api/cli_args.py)中的
   `SchedulerConfig`。
 - 有关如何设置 Ray 集群的指南，请参阅安装文档中的分布式设置部分。
 
@@ -140,7 +140,7 @@ sky launch -c areal-test examples/skypilot/ray_cluster.sky.yaml --infra k8s
 ```
 
 查看
-[使用 SkyPilot 运行 AReaL](https://github.com/inclusionAI/AReaL/blob/main/examples/skypilot/README.md)
+[使用 SkyPilot 运行 AReaL](https://github.com/areal-project/AReaL/blob/main/examples/skypilot/README.md)
 了解更多示例详情。查看 [SkyPilot 文档](https://docs.skypilot.co/en/latest/docs/index.html) 了解更多关于
 SkyPilot 的信息。
 

--- a/docs/zh/version_history.md
+++ b/docs/zh/version_history.md
@@ -4,7 +4,7 @@
 
 ## AReaL-lite（2025年7月）：让 RL 触手可及
 
-*📖 [分步教程](https://inclusionai.github.io/AReaL/zh/tutorial/gsm8k_grpo.html)*
+*📖 [分步教程](https://areal-project.github.io/AReaL/zh/tutorial/gsm8k_grpo.html)*
 
 AReaL-lite 代表了对研究人员与强化学习系统交互方式的根本性重新思考。源于认识到 AReaL 的系统优先架构为 AI
 研究人员设置了障碍，这个轻量级版本将算法开发置于基础设施复杂性之上。
@@ -19,7 +19,7 @@ PyTorch -centric API。该架构遵循熟悉的 SPMD 模式，同时为异步训
 
 ## AReaL v0.3（2025年8月）：突破速度壁垒
 
-*📖 [完整博客文章](https://github.com/inclusionAI/AReaL/blob/main/blog/AReaL_v0_3.md)*
+*📖 [完整博客文章](https://github.com/areal-project/AReaL/blob/main/blog/AReaL_v0_3.md)*
 
 0.3 版本标志着 AReaL 最大胆的架构飞跃：在不同的 GPU 集群上完全解耦生成和训练。这不仅仅是增量改进——它从根本上重新想象了 RL
 系统可以扩展的方式，实现了令人瞩目的 **2.77 倍加速**，同时保持训练稳定性。
@@ -37,7 +37,7 @@ PyTorch -centric API。该架构遵循熟悉的 SPMD 模式，同时为异步训
 
 ## AReaL v0.2（2025年3月）：工程卓越与 SOTA 性能
 
-*📖 [完整博客文章](https://github.com/inclusionAI/AReaL/blob/main/blog/AReaL_v0_2.md)*
+*📖 [完整博客文章](https://github.com/areal-project/AReaL/blob/main/blog/AReaL_v0_2.md)*
 
 第二个主要版本专注于将 AReaL 从一个有前途的研究原型转变为生产就绪的系统。v0.2 的核心是从 vLLM 过渡到 SGLang
 v0.4.0，带来了复杂的基数注意力机制，显著提高了多响应采样场景的吞吐量——这正是 RL 训练所要求的。
@@ -58,7 +58,7 @@ AReaL v0.2 产生了当时 **性能最好的 7B 数学推理模型**，在 AIME 
 
 ## AReaL v0.1（2025年2月）：奠定基石
 
-*📖 [完整博客文章](https://github.com/inclusionAI/AReaL/blob/main/blog/AReaL_v0_1.md)*
+*📖 [完整博客文章](https://github.com/areal-project/AReaL/blob/main/blog/AReaL_v0_1.md)*
 
 在最初发布时，AReaL 的 1.5B 模型在仅 40 小时的训练中就在数学推理方面超越了 o1-Preview。v0.1 还通过 R1-Zero 风格的训练在
 Qwen2.5-7B

--- a/examples/countdown/README.md
+++ b/examples/countdown/README.md
@@ -24,7 +24,7 @@ for this puzzle.
 Before you begin, ensure you have met the following requirements:
 
 - You have installed **AReaL**. Please follow the official
-  [AReaL installation guide](https://inclusionai.github.io/AReaL/en/tutorial/installation.html).
+  [AReaL installation guide](https://areal-project.github.io/AReaL/en/tutorial/installation.html).
 - You have access to the `Qwen/Qwen2.5-3B-Instruct` model on the Hugging Face Hub (or
   have it downloaded locally).
 

--- a/examples/experimental/inference_service/README.md
+++ b/examples/experimental/inference_service/README.md
@@ -20,7 +20,7 @@ debugging agent behaviour.
 #### AReaL
 
 Follow the
-[AReaL installation guide](https://inclusionai.github.io/AReaL/en/tutorial/installation.html).
+[AReaL installation guide](https://areal-project.github.io/AReaL/en/tutorial/installation.html).
 
 #### Tau2
 
@@ -96,7 +96,7 @@ following procedure:
 ### Prerequisites
 
 - **AReaL installed** — follow the
-  [installation guide](https://inclusionai.github.io/AReaL/en/tutorial/installation.html).
+  [installation guide](https://areal-project.github.io/AReaL/en/tutorial/installation.html).
 - **zeroclaw installed** — any OpenAI-compatible CLI that supports
   `--session-state-file` can be substituted; the demo uses zeroclaw for convenience.
 - **A zeroclaw config at `~/.zeroclaw/config.toml`** with at least a `default_provider`

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -32,7 +32,7 @@ strict permission rules and an isolated execution environment for your agent run
 # Install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 # Clone and install AReaL
-git clone https://github.com/inclusionAI/AReaL.git
+git clone https://github.com/areal-project/AReaL.git
 cd AReaL
 uv sync --all-extras
 ```

--- a/examples/scaffolding/README.md
+++ b/examples/scaffolding/README.md
@@ -225,4 +225,4 @@ class CustomTrajectoryMaker(Controller):
 
 - [TensorRT-LLM Scaffolding README](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tensorrt_llm/scaffolding)
 - [AReaL Workflow Documentation](../../docs/customization/workflow.md)
-- [RFC: Scaffolding Integration](https://github.com/inclusionAI/AReaL/issues/818)
+- [RFC: Scaffolding Integration](https://github.com/areal-project/AReaL/issues/818)

--- a/examples/skypilot/README.md
+++ b/examples/skypilot/README.md
@@ -25,7 +25,7 @@ resources:
   cpus: 8+
   memory: 32GB+
   disk_size: 256GB
-  image_id: docker:ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang
+  image_id: docker:ghcr.io/areal-project/areal-runtime:v1.0.4-sglang
 
 num_nodes: 1
 
@@ -78,7 +78,7 @@ Specify the resources and image used to run the experiment.
 ```yaml
 resources:
   accelerators: A100:8
-  image_id: docker:ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang
+  image_id: docker:ghcr.io/areal-project/areal-runtime:v1.0.4-sglang
   memory: 256+
   cpus: 32+
 

--- a/examples/skypilot/ray_cluster.sky.yaml
+++ b/examples/skypilot/ray_cluster.sky.yaml
@@ -1,7 +1,7 @@
 
 resources:
   accelerators: A100:8
-  image_id: docker:ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang
+  image_id: docker:ghcr.io/areal-project/areal-runtime:v1.0.4-sglang
   memory: 32+
   cpus: 8+
 

--- a/examples/skypilot/single_node.sky.yaml
+++ b/examples/skypilot/single_node.sky.yaml
@@ -8,7 +8,7 @@ resources:
   cpus: 8+
   memory: 32GB+
   disk_size: 256GB
-  image_id: docker:ghcr.io/inclusionai/areal-runtime:v1.0.4-sglang
+  image_id: docker:ghcr.io/areal-project/areal-runtime:v1.0.4-sglang
 
 num_nodes: 1
 

--- a/examples/tau2/README.md
+++ b/examples/tau2/README.md
@@ -25,7 +25,7 @@ with user's request by both using agent tools and guiding users using their tool
 ### Prerequisites
 
 Please make sure AReaL is setup and working following the
-[installation guide](https://inclusionai.github.io/AReaL/en/tutorial/installation.html).
+[installation guide](https://areal-project.github.io/AReaL/en/tutorial/installation.html).
 
 1. Install the (forked) tau2-bench package:
 
@@ -82,7 +82,7 @@ NOTE: Following commands should be executed from root directory of this reposito
 #### Single Node (1.7B Model)
 
 On a single 8x GPU node with our offical image
-(ghcr.io/inclusionai/areal-runtime:latest), run:
+(ghcr.io/areal-project/areal-runtime:latest), run:
 
 ```bash
 python3 examples/tau2/train.py \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,10 +185,10 @@ sandbox = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/inclusionAI/AReaL"
-"Repository" = "https://github.com/inclusionAI/AReaL"
-"Documentation" = "https://inclusionai.github.io/AReaL/en/intro.html"
-"Bug Tracker" = "https://github.com/inclusionAI/AReaL/issues"
+"Homepage" = "https://github.com/areal-project/AReaL"
+"Repository" = "https://github.com/areal-project/AReaL"
+"Documentation" = "https://areal-project.github.io/AReaL/en/intro.html"
+"Bug Tracker" = "https://github.com/areal-project/AReaL/issues"
 
 [dependency-groups]
 dev = [

--- a/pyproject.vllm.toml
+++ b/pyproject.vllm.toml
@@ -196,10 +196,10 @@ sandbox = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/inclusionAI/AReaL"
-"Repository" = "https://github.com/inclusionAI/AReaL"
-"Documentation" = "https://inclusionai.github.io/AReaL/en/intro.html"
-"Bug Tracker" = "https://github.com/inclusionAI/AReaL/issues"
+"Homepage" = "https://github.com/areal-project/AReaL"
+"Repository" = "https://github.com/areal-project/AReaL"
+"Documentation" = "https://areal-project.github.io/AReaL/en/intro.html"
+"Bug Tracker" = "https://github.com/areal-project/AReaL/issues"
 
 [dependency-groups]
 dev = [

--- a/tests/experimental/openai/test_streaming_chat_completions.py
+++ b/tests/experimental/openai/test_streaming_chat_completions.py
@@ -4,7 +4,7 @@ The proxy rollout server's ``chat_completions`` handler must correctly return a
 ``StreamingResponse`` (SSE) when ``stream=True`` is requested, and a plain JSON
 ``ChatCompletion`` otherwise.
 
-Ref: https://github.com/inclusionAI/AReaL/issues/1046
+Ref: https://github.com/areal-project/AReaL/issues/1046
 """
 
 from __future__ import annotations

--- a/tests/test_rtensor.py
+++ b/tests/test_rtensor.py
@@ -1061,7 +1061,7 @@ class TestFetchBuffer:
     def test_remove_pops_both_storage_and_fetch_buffer(self):
         """remove() drops the shard from both _storage and _fetch_buffer.
 
-        Regression guard for inclusionAI/AReaL#1209: on a worker that is both
+        Regression guard for areal-project/AReaL#1209: on a worker that is both
         storage owner and consumer, ``to_local()`` caches the tensor in
         ``_fetch_buffer``; without this pop, RSS grows unboundedly across
         training steps.


### PR DESCRIPTION
## Description

Migrate all internal URLs and org references after moving the repository from `InclusionAI/AReaL` to `areal-project/AReaL`.

60 files updated across documentation, CI workflows, configs, and code comments. All pre-commit hooks pass.

## Related Issue

Part of org migration from InclusionAI to areal-project.

## Type of Change

- [x] ♻️ Refactoring

## What Changed

| Pattern | Before | After | Files |
|---------|--------|-------|-------|
| GitHub repo URLs | `github.com/inclusionAI/AReaL` | `github.com/areal-project/AReaL` | 42 |
| GitHub Pages docs | `inclusionai.github.io/AReaL` | `areal-project.github.io/AReaL` | 13 |
| GHCR Docker images | `ghcr.io/inclusionai/` | `ghcr.io/areal-project/` | 11 |
| CI usernames | `username: inclusionai` | `username: areal-project` | 3 |
| GitHub API org | `api.github.com/orgs/inclusionai/` | `api.github.com/orgs/areal-project/` | 1 |
| DeepWiki | `deepwiki.com/inclusionAI/AReaL` | `deepwiki.com/areal-project/AReaL` | 1 |
| Badge URLs | `gitcgr.com/inclusionAI/AReaL` | `gitcgr.com/areal-project/AReaL` | 1 |
| Issue refs in comments | `inclusionAI/AReaL#NNN` | `areal-project/AReaL#NNN` | 5 |

## Intentionally Unchanged

- **HuggingFace URLs** (`huggingface.co/inclusionAI/...`) — HF org not migrated
- **Vendored directories** (`sglang-src/`, `Megatron-LM/`, `Megatron-Bridge/`) — upstream-managed
- **asystem-awex/** — separate repo, not part of this migration
- **`github.com/inclusionAI/ASearcher`** — different repository

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Branch is up to date with `main`
- [x] This PR was created by a coding agent via `/create-pr`

## Additional Context

Also performed:
- Reset git origin remote to `https://github.com/areal-project/AReaL.git`
- Updated repository ruleset (`main-protection`) via `gh api`