### PR TITLE
refactor: consolidate admin key validation into shared helper

### DIFF
--- a/areal/experimental/agent_service/gateway/__main__.py
+++ b/areal/experimental/agent_service/gateway/__main__.py
@@ -6,6 +6,8 @@ import argparse
 
 import uvicorn
 
+from areal.infra.utils.http import validate_admin_api_key
+
 from ..auth import DEFAULT_ADMIN_API_KEY
 from .app import create_gateway_app
 from .bridge import OpenResponsesBridge, mount_bridge
@@ -24,6 +26,10 @@ def main() -> None:
         "--log-level", choices=["debug", "info", "warning", "error"], default="warning"
     )
     args = parser.parse_args()
+
+    validate_admin_api_key(
+        args.host, args.admin_api_key, default_key=DEFAULT_ADMIN_API_KEY
+    )
 
     config = GatewayConfig(
         host=args.host,

--- a/areal/experimental/agent_service/router/__main__.py
+++ b/areal/experimental/agent_service/router/__main__.py
@@ -6,6 +6,8 @@ import argparse
 
 import uvicorn
 
+from areal.infra.utils.http import validate_admin_api_key
+
 from ..auth import DEFAULT_ADMIN_API_KEY
 from .app import create_router_app
 from .config import RouterConfig
@@ -22,6 +24,10 @@ def main() -> None:
         "--log-level", choices=["debug", "info", "warning", "error"], default="warning"
     )
     args = parser.parse_args()
+
+    validate_admin_api_key(
+        args.host, args.admin_api_key, default_key=DEFAULT_ADMIN_API_KEY
+    )
 
     config = RouterConfig(
         host=args.host,

--- a/areal/experimental/inference_service/data_proxy/__main__.py
+++ b/areal/experimental/inference_service/data_proxy/__main__.py
@@ -10,7 +10,10 @@ import uvicorn
 
 from areal.experimental.inference_service.data_proxy.app import create_app
 from areal.experimental.inference_service.data_proxy.config import DataProxyConfig
-from areal.infra.utils.http import get_default_uvicorn_kwargs
+from areal.infra.utils.http import (
+    get_default_uvicorn_kwargs,
+    validate_admin_api_key,
+)
 from areal.utils.logging import suppress_http_loggers
 from areal.utils.network import format_hostport
 
@@ -73,6 +76,8 @@ def main():
         choices=("hf", "concat"),
     )
     args, _ = parser.parse_known_args()
+
+    validate_admin_api_key(args.host, args.admin_api_key)
 
     # Resolve the actual serving host (replace 0.0.0.0 with real IP)
     from areal.utils.network import gethostip

--- a/areal/experimental/inference_service/gateway/__main__.py
+++ b/areal/experimental/inference_service/gateway/__main__.py
@@ -43,8 +43,13 @@ def main():
 
     from areal.experimental.inference_service.gateway.app import create_app
     from areal.experimental.inference_service.gateway.config import GatewayConfig
-    from areal.infra.utils.http import get_default_uvicorn_kwargs
+    from areal.infra.utils.http import (
+        get_default_uvicorn_kwargs,
+        validate_admin_api_key,
+    )
     from areal.utils.logging import suppress_http_loggers
+
+    validate_admin_api_key(args.host, args.admin_api_key)
 
     config = GatewayConfig(
         host=args.host,

--- a/areal/experimental/inference_service/router/__main__.py
+++ b/areal/experimental/inference_service/router/__main__.py
@@ -44,8 +44,13 @@ def main():
 
     from areal.experimental.inference_service.router.app import create_app
     from areal.experimental.inference_service.router.config import RouterConfig
-    from areal.infra.utils.http import get_default_uvicorn_kwargs
+    from areal.infra.utils.http import (
+        get_default_uvicorn_kwargs,
+        validate_admin_api_key,
+    )
     from areal.utils.logging import suppress_http_loggers
+
+    validate_admin_api_key(args.host, args.admin_api_key)
 
     config = RouterConfig(
         host=args.host,

--- a/areal/experimental/openai/proxy/proxy_rollout_server.py
+++ b/areal/experimental/openai/proxy/proxy_rollout_server.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel
 from areal.api.cli_args import NameResolveConfig
 from areal.experimental.openai.client import ArealOpenAI
 from areal.infra.rpc.serialization import deserialize_value, serialize_value
+from areal.infra.utils.http import validate_admin_api_key
 from areal.utils import name_resolve, names, seeding
 from areal.utils.dynamic_import import import_from_string
 from areal.utils.hf_utils import load_hf_tokenizer
@@ -276,33 +277,19 @@ def _setup_openai_client():
     _session_timeout_seconds = agent_cfg.session_timeout_seconds
     # Validate admin API key BEFORE assigning it to the global, so a
     # failed validation cannot leave the default key live on the server.
-    requested_admin_key = agent_cfg.admin_api_key
-    if requested_admin_key == DEFAULT_ADMIN_API_KEY:
-        # The default admin key is publicly known. Refuse to use it when
-        # the server is reachable from outside the local host, otherwise
-        # any attacker who can reach this port can call admin endpoints
-        # (grant_capacity, start_session, export_trajectories, ...).
-        loopback_hosts = {"127.0.0.1", "::1", "localhost"}
-        allow_override = (
-            os.environ.get("AREAL_ALLOW_DEFAULT_ADMIN_KEY", "0") == "1"
-        )
-        if _server_host in loopback_hosts or allow_override:
-            logger.warning(
-                "Using default admin API key. Change 'admin_api_key' in "
-                "AgentConfig before exposing this server on a network."
-            )
-        else:
-            raise RuntimeError(
-                "Refusing to start proxy rollout server on non-loopback "
-                f"host {_server_host!r} with the default admin API key "
-                f"({DEFAULT_ADMIN_API_KEY!r}). Set 'admin_api_key' in "
-                "OpenAIProxyConfig to a unique secret, or set "
-                "AREAL_ALLOW_DEFAULT_ADMIN_KEY=1 to acknowledge the risk "
-                "in a trusted environment."
-            )
+    # The default admin key is publicly known; refuse to use it when the
+    # server is reachable from outside the local host (otherwise anyone
+    # who can reach this port can call admin endpoints such as
+    # grant_capacity, start_session, export_trajectories, ...).
+    validate_admin_api_key(
+        _server_host,
+        agent_cfg.admin_api_key,
+        default_key=DEFAULT_ADMIN_API_KEY,
+        config_field="AgentConfig.admin_api_key",
+    )
     # Only commit the key to the global after validation has passed.
     with _lock:
-        _admin_api_key = requested_admin_key
+        _admin_api_key = agent_cfg.admin_api_key
 
 
 @app.post("/configure")

--- a/areal/experimental/training_service/data_proxy/__main__.py
+++ b/areal/experimental/training_service/data_proxy/__main__.py
@@ -8,7 +8,10 @@ import uvicorn
 
 from areal.experimental.training_service.data_proxy.app import create_app
 from areal.experimental.training_service.data_proxy.config import TrainDataProxyConfig
-from areal.infra.utils.http import get_default_uvicorn_kwargs
+from areal.infra.utils.http import (
+    get_default_uvicorn_kwargs,
+    validate_admin_api_key,
+)
 from areal.utils.logging import suppress_http_loggers
 
 
@@ -27,6 +30,8 @@ def main():
         choices=["debug", "info", "warning", "error"],
     )
     args, _ = parser.parse_known_args()
+
+    validate_admin_api_key(args.host, args.admin_api_key)
 
     worker_addrs = [
         addr.strip() for addr in args.worker_addrs.split(",") if addr.strip()

--- a/areal/experimental/training_service/gateway/__main__.py
+++ b/areal/experimental/training_service/gateway/__main__.py
@@ -41,8 +41,13 @@ def main():
 
     from areal.experimental.training_service.gateway.app import create_app
     from areal.experimental.training_service.gateway.config import GatewayConfig
-    from areal.infra.utils.http import get_default_uvicorn_kwargs
+    from areal.infra.utils.http import (
+        get_default_uvicorn_kwargs,
+        validate_admin_api_key,
+    )
     from areal.utils.logging import suppress_http_loggers
+
+    validate_admin_api_key(args.host, args.admin_api_key)
 
     config = GatewayConfig(
         host=args.host,

--- a/areal/experimental/training_service/router/__main__.py
+++ b/areal/experimental/training_service/router/__main__.py
@@ -37,8 +37,13 @@ def main():
 
     from areal.experimental.training_service.router.app import create_app
     from areal.experimental.training_service.router.config import RouterConfig
-    from areal.infra.utils.http import get_default_uvicorn_kwargs
+    from areal.infra.utils.http import (
+        get_default_uvicorn_kwargs,
+        validate_admin_api_key,
+    )
     from areal.utils.logging import suppress_http_loggers
+
+    validate_admin_api_key(args.host, args.admin_api_key)
 
     config = RouterConfig(
         host=args.host,

--- a/areal/experimental/training_service/worker/__main__.py
+++ b/areal/experimental/training_service/worker/__main__.py
@@ -26,6 +26,9 @@ def main():
 
     from areal.experimental.training_service.worker.app import create_app
     from areal.experimental.training_service.worker.config import TrainWorkerConfig
+    from areal.infra.utils.http import validate_admin_api_key
+
+    validate_admin_api_key(args.host, args.admin_api_key)
 
     config = TrainWorkerConfig(
         host=args.host,

--- a/areal/experimental/weight_update/gateway/__main__.py
+++ b/areal/experimental/weight_update/gateway/__main__.py
@@ -38,8 +38,13 @@ def main():
 
     from areal.experimental.weight_update.gateway.app import create_app
     from areal.experimental.weight_update.gateway.config import WeightUpdateConfig
-    from areal.infra.utils.http import get_default_uvicorn_kwargs
+    from areal.infra.utils.http import (
+        get_default_uvicorn_kwargs,
+        validate_admin_api_key,
+    )
     from areal.utils.logging import suppress_http_loggers
+
+    validate_admin_api_key(args.host, args.admin_api_key)
 
     config = WeightUpdateConfig(
         host=args.host,

--- a/areal/infra/utils/http.py
+++ b/areal/infra/utils/http.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import os
 from http import HTTPStatus
 from typing import Any
 
@@ -14,10 +15,13 @@ from tenacity import (
 )
 
 from areal.utils import logging
-from areal.utils.network import format_hostport, split_hostport
+from areal.utils.network import format_hostport, gethostip, split_hostport
 
 DEFAULT_RETRIES = 1
 DEFAULT_REQUEST_TIMEOUT = 3600
+
+DEFAULT_ADMIN_API_KEY = "areal-admin-key"
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 # ---------------------------------------------------------------------------
 # Shared capacity defaults for httpx clients and uvicorn servers
@@ -55,6 +59,47 @@ def get_default_uvicorn_kwargs() -> dict[str, Any]:
         "backlog": UVICORN_BACKLOG,
         "limit_concurrency": UVICORN_LIMIT_CONCURRENCY,
     }
+
+
+def validate_admin_api_key(
+    host: str,
+    admin_api_key: str,
+    default_key: str = DEFAULT_ADMIN_API_KEY,
+    config_field: str = "admin_api_key",
+) -> None:
+    """Refuse to start an HTTP service on a non-loopback bind with the default admin key.
+
+    The default admin API key is publicly documented in the source tree, so
+    a server that listens on a routable interface with the default key
+    effectively has no admin authentication. Operators must either set a
+    unique ``admin_api_key`` or opt in via ``AREAL_ALLOW_DEFAULT_ADMIN_KEY=1``
+    when they knowingly accept the risk on a trusted network.
+
+    A non-default key, or a loopback-only bind, is always accepted.
+    """
+    if admin_api_key != default_key:
+        return
+
+    resolved_host = host
+    if host in ("0.0.0.0", "::"):
+        resolved_host = gethostip()
+
+    allow_override = os.environ.get("AREAL_ALLOW_DEFAULT_ADMIN_KEY", "0") == "1"
+    if resolved_host in _LOOPBACK_HOSTS or allow_override:
+        logger.warning(
+            "Using default admin API key. Change '%s' before exposing this "
+            "server on a network.",
+            config_field,
+        )
+        return
+
+    raise RuntimeError(
+        f"Refusing to start server on non-loopback host {resolved_host!r} "
+        f"with the default admin API key ({default_key!r}). Set "
+        f"'{config_field}' to a unique secret, or set "
+        "AREAL_ALLOW_DEFAULT_ADMIN_KEY=1 to acknowledge the risk in a "
+        "trusted environment."
+    )
 
 
 async_http_retry = retry(


### PR DESCRIPTION
## Description

Extract the loopback/override admin-key validation block introduced by #1323 from `proxy_rollout_server.py` into a reusable `validate_admin_api_key` helper in `areal.infra.utils.http`, and apply it to every other experimental HTTP service whose CLI ships with the publicly known default `admin_api_key`.

Without this follow-up, the inference / training / weight-update / agent gateways, routers, data proxies and worker entrypoints still share the same CWE-798 risk #1323 fixed for the proxy: listening on `0.0.0.0` with `areal-admin-key` lets any network peer hit admin endpoints. The helper centralises the loopback set, the `AREAL_ALLOW_DEFAULT_ADMIN_KEY=1` opt-out, and the `gethostip()` host resolution so every entrypoint behaves identically.

## Related Issue

Follows up on #1323.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A — existing callers that already set a non-default `admin_api_key` are unaffected. Loopback binds remain warning-only. Operators on a trusted network can keep the default key by exporting `AREAL_ALLOW_DEFAULT_ADMIN_KEY=1`.

## Additional Context

Key changes:
- `areal/infra/utils/http.py`: add `DEFAULT_ADMIN_API_KEY` and `validate_admin_api_key(host, admin_api_key, default_key, config_field)`. Resolves `0.0.0.0`/`::` via `gethostip()`, raises `RuntimeError` on non-loopback bind with the default key, warns on loopback, returns silently for any custom key.
- `areal/experimental/openai/proxy/proxy_rollout_server.py`: replace the inline 22-line loopback/override block from #1323 with a single helper call (behaviour preserved, including the `host=_server_host` in `uvicorn.run`).
- Call `validate_admin_api_key(args.host, args.admin_api_key)` before `uvicorn.run(...)` in every `__main__.py` that takes `--admin-api-key`:
  - `inference_service/{router,data_proxy,gateway}/__main__.py`
  - `training_service/{router,data_proxy,gateway,worker}/__main__.py`
  - `weight_update/gateway/__main__.py`
  - `agent_service/{router,gateway}/__main__.py` (passes the agent-specific default `"areal-agent-admin"`)
- Skipped: `*/guard/__main__.py` (no admin auth) and `agent_service/{worker,data_proxy}/__main__.py` (no `--admin-api-key` flag).

Refs: #1323