### PR TITLE
fix: Add error detection function and test for ZeroDivisionError and other errors alike

### DIFF
--- a/areal/experimental/openai/proxy/proxy_rollout_server.py
+++ b/areal/experimental/openai/proxy/proxy_rollout_server.py
@@ -283,9 +283,7 @@ def _setup_openai_client():
         # any attacker who can reach this port can call admin endpoints
         # (grant_capacity, start_session, export_trajectories, ...).
         loopback_hosts = {"127.0.0.1", "::1", "localhost"}
-        allow_override = (
-            os.environ.get("AREAL_ALLOW_DEFAULT_ADMIN_KEY", "0") == "1"
-        )
+        allow_override = os.environ.get("AREAL_ALLOW_DEFAULT_ADMIN_KEY", "0") == "1"
         if _server_host in loopback_hosts or allow_override:
             logger.warning(
                 "Using default admin API key. Change 'admin_api_key' in "

--- a/examples/tir/tests/test_tir.py
+++ b/examples/tir/tests/test_tir.py
@@ -54,9 +54,41 @@ async def test_tool_manager():
         )
         assert empty_status == ToolCallStatus.ERROR
         assert "Error" in empty_result
+
+        # Test Python execution of code that raises an error.
+        zero_result, zero_status = await python_manager.aexecute_tool_call(
+            "```python\n1 / 0\n```"
+        )
+        print(f"Zero division result: {zero_result}, status: {zero_status}")
+        assert zero_status == ToolCallStatus.ERROR
+        assert (
+            "ZeroDivisionError" in zero_result
+            or "division by zero" in zero_result.lower()
+        )
     finally:
         await python_manager.acleanup()
         await calc_manager.acleanup()
+
+
+@pytest.mark.asyncio
+async def test_tool_manager_error_handling():
+    """Test tool manager error handling with real execution"""
+    python_manager = ToolManager(timeout=10, enabled_tools="python", debug_mode=False)
+
+    try:
+        # Test ZeroDivisionError
+        zero_result, zero_status = await python_manager.aexecute_tool_call(
+            "```python\n1 / 0\n```"
+        )
+        print(f"Zero division result: {zero_result}, status: {zero_status}")
+        assert zero_status == ToolCallStatus.ERROR
+        assert (
+            "division by zero" in zero_result.lower()
+            or "zerodivisionerror" in zero_result.lower()
+        )
+
+    finally:
+        await python_manager.acleanup()
 
 
 @pytest.mark.asyncio

--- a/examples/tir/tests/test_tir.py
+++ b/examples/tir/tests/test_tir.py
@@ -54,17 +54,6 @@ async def test_tool_manager():
         )
         assert empty_status == ToolCallStatus.ERROR
         assert "Error" in empty_result
-
-        # Test Python execution of code that raises an error.
-        zero_result, zero_status = await python_manager.aexecute_tool_call(
-            "```python\n1 / 0\n```"
-        )
-        print(f"Zero division result: {zero_result}, status: {zero_status}")
-        assert zero_status == ToolCallStatus.ERROR
-        assert (
-            "ZeroDivisionError" in zero_result
-            or "division by zero" in zero_result.lower()
-        )
     finally:
         await python_manager.acleanup()
         await calc_manager.acleanup()

--- a/examples/tir/tools/python_tool.py
+++ b/examples/tir/tools/python_tool.py
@@ -256,9 +256,14 @@ class PythonTool(BaseTool):
 
         try:
             # Directly call apply to avoid using ProcessPool in async environment
-            result = self.python_executor.apply(code)
-            logger.debug(f"Python execution completed: {str(result)[:100]}...")
-            return str(result), ToolCallStatus.SUCCESS
+            res, report = self.python_executor.apply(code)
+
+            if report != "Done":
+                logger.error(f"Error in Python execution: {report}")
+                return f"Error: {report}", ToolCallStatus.ERROR
+
+            logger.debug(f"Python execution completed: {str(res)[:100]}...")
+            return str(res), ToolCallStatus.SUCCESS
         except Exception as e:
             logger.error(f"Python execution error: {e}")
             return f"Error: {str(e)}", ToolCallStatus.ERROR


### PR DESCRIPTION
## Description

### Fix Python tool error handling to properly report execution failures

Currently, PythonTool.execute() always returns ToolCallStatus.SUCCESS even when code execution fails (e.g., ZeroDivisionError, syntax errors). This led to the problem of the AsyncTaskRunner crash issue during training when agent code has ZeroDivisionError.

This PR fixes the issue by:

- Returning ToolCallStatus.ERROR when report != "Done"

- Adding comprehensive unit tests for error scenarios

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #1333


## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
