### PR TITLE
fix(infra): correct staleness capacity inflation after recovery

### DIFF
--- a/areal/infra/staleness_manager.py
+++ b/areal/infra/staleness_manager.py
@@ -112,6 +112,19 @@ class StalenessManager:
             capacity = min(concurrency_capacity, staleness_capacity)
             return capacity
 
+    def on_version_recovered(self, version: int) -> None:
+        """Adjust accepted count after checkpoint recovery.
+
+        When a checkpoint is recovered, the version jumps from 0 to the
+        recovered value. Without adjusting accepted, the capacity formula
+        yields (max_staleness + version + 1) * batch_size instead of the
+        intended (max_staleness + 1) * batch_size, causing a burst of
+        submissions and unbounded staleness growth.
+        """
+        with self.lock:
+            consumer_bs = max(1, self.consumer_batch_size)
+            self.rollout_stat.accepted = version * consumer_bs
+
     def on_rollout_enqueued(self) -> None:
         """Callback when a rollout is enqueued as a pending input task.
 

--- a/areal/infra/staleness_manager.py
+++ b/areal/infra/staleness_manager.py
@@ -120,6 +120,11 @@ class StalenessManager:
         yields (max_staleness + version + 1) * batch_size instead of the
         intended (max_staleness + 1) * batch_size, causing a burst of
         submissions and unbounded staleness growth.
+
+        Expected to be called during trainer init, before any rollouts are
+        submitted, so running == 0. If running > 0 (unlikely in practice),
+        accepted is still set correctly and the capacity formula remains
+        bounded — (max_staleness + 1) * consumer_bs - running.
         """
         with self.lock:
             consumer_bs = max(1, self.consumer_batch_size)

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -368,6 +368,17 @@ class PPOTrainer:
             weight_update_meta=self.weight_update_meta,
         )
 
+        # After recovery, sync the staleness manager so its capacity formula
+        # stays bounded despite the version jumping from 0 to recovery_version.
+        if self.recover_info is not None:
+            recovery_version = self.recover_info.last_step_info.global_step + 1
+            if is_single_controller():
+                sm = self.rollout._staleness_manager
+            else:
+                sm = self.rollout.workflow_executor._staleness_manager
+            if sm is not None:
+                sm.on_version_recovered(recovery_version)
+
         self._config_perf_tracer()
         self._apply_initial_offload_policy()
 

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -373,9 +373,9 @@ class PPOTrainer:
         if self.recover_info is not None:
             recovery_version = self.recover_info.last_step_info.global_step + 1
             if is_single_controller():
-                sm = self.rollout._staleness_manager
+                sm = self.rollout.staleness_manager
             else:
-                sm = self.rollout.workflow_executor._staleness_manager
+                sm = self.rollout.workflow_executor.staleness_manager
             if sm is not None:
                 sm.on_version_recovered(recovery_version)
 

--- a/tests/test_staleness_manager.py
+++ b/tests/test_staleness_manager.py
@@ -766,6 +766,27 @@ def test_parametrized_version_progression(version):
     assert capacity == min(1000, expected_staleness_capacity)
 
 
+@pytest.mark.parametrize("recovered_version", [5, 10, 50])
+def test_on_version_recovered(recovered_version):
+    """Test that on_version_recovered adjusts accepted so capacity stays bounded."""
+    version_provider = MockVersionProvider(0)
+    manager = StalenessManager(
+        version_provider=version_provider,
+        max_concurrent_rollouts=1000,
+        consumer_batch_size=16,
+        max_staleness=2,
+    )
+
+    # Simulate recovery: version jumps to recovered_version
+    version_provider.set_version(recovered_version)
+    manager.on_version_recovered(recovered_version)
+
+    # After recovery, capacity should be (max_staleness + 1) * consumer_batch_size
+    # regardless of the recovered version value.
+    capacity = manager.get_capacity()
+    assert capacity == (2 + 1) * 16
+
+
 if __name__ == "__main__":
     # Run tests with pytest
     pytest.main([__file__, "-v"])

--- a/tests/test_staleness_manager.py
+++ b/tests/test_staleness_manager.py
@@ -766,7 +766,7 @@ def test_parametrized_version_progression(version):
     assert capacity == min(1000, expected_staleness_capacity)
 
 
-@pytest.mark.parametrize("recovered_version", [5, 10, 50])
+@pytest.mark.parametrize("recovered_version", [0, 5, 10, 50])
 def test_on_version_recovered(recovered_version):
     """Test that on_version_recovered adjusts accepted so capacity stays bounded."""
     version_provider = MockVersionProvider(0)
@@ -785,6 +785,31 @@ def test_on_version_recovered(recovered_version):
     # regardless of the recovered version value.
     capacity = manager.get_capacity()
     assert capacity == (2 + 1) * 16
+
+
+@pytest.mark.parametrize("running", [1, 5, 16])
+def test_on_version_recovered_with_running_rollouts(running):
+    """Test that on_version_recovered sets accepted correctly even when running > 0."""
+    recovered_version = 10
+    version_provider = MockVersionProvider(0)
+    manager = StalenessManager(
+        version_provider=version_provider,
+        max_concurrent_rollouts=1000,
+        consumer_batch_size=16,
+        max_staleness=2,
+    )
+
+    # Simulate in-flight rollouts at recovery time
+    for _ in range(running):
+        manager.on_rollout_enqueued()
+        manager.on_rollout_submitted()
+
+    version_provider.set_version(recovered_version)
+    manager.on_version_recovered(recovered_version)
+
+    # Capacity formula: (max_staleness + 1) * consumer_bs - running
+    capacity = manager.get_capacity()
+    assert capacity == (2 + 1) * 16 - running
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fix staleness capacity inflation after checkpoint recovery in async RL training.

When recovering from a checkpoint, `StalenessManager`'s `accepted` counter started at 0 while the model version was restored to a high value. This caused the capacity formula to yield `(max_staleness + recovered_version + 1) * batch_size` instead of the intended `(max_staleness + 1) * batch_size`, allowing a burst of rollout submissions and unbounded staleness growth

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix

## Changes

- **`areal/infra/staleness_manager.py`**: Add `on_version_recovered(version)` method that adjusts the `accepted` counter to `version * consumer_batch_size`, restoring correct capacity bounds.
- **`areal/trainer/rl_trainer.py`**: Call `on_version_recovered()` after `recover_handler.load()` completes. Accesses the staleness manager directly via the known concrete type (`RolloutController._staleness_manager` in single-controller mode, `workflow_executor._staleness_manager` in SPMD mode).
- **`tests/test_staleness_manager.py`**: Add parametrized test `test_on_version_recovered` validating capacity stays bounded regardless of recovered version.

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

**Root cause**: In the staleness capacity formula `(max_staleness + current_version + 1) * consumer_bs - sample_cnt`, after recovery the version jumps (e.g., 0 → 268) but `sample_cnt` (accepted + running) remains 0. This yields capacity = `(2 + 268 + 1) * 4 = 1084` on a single SPMD rank, instead of the intended `(2 + 1) * 4 = 12`, flooding the rollout queue with requests that become stale before consumption.

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!