### PR TITLE
fix(utils): mask 2d sequence advantages

### DIFF
--- a/areal/utils/functional/functional.py
+++ b/areal/utils/functional/functional.py
@@ -140,9 +140,11 @@ def _compute_sequence_level_ratio_and_advantages(
         # Average token advantages per sequence
         # This ensures gradient magnitude is independent of sequence length
         seq_lengths = loss_mask.sum(dim=-1, keepdim=True).clamp(min=1)
-        advantages = (advantages.sum(dim=-1, keepdim=True) / seq_lengths).expand_as(
-            log_ratio
-        )
+        masked_advantages = torch.where(loss_mask, advantages, 0.0)
+        advantages = (
+            masked_advantages.sum(dim=-1, keepdim=True) / seq_lengths
+        ).expand_as(log_ratio)
+        advantages = torch.where(loss_mask, advantages, 0.0)
 
     return ratio, advantages
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -258,6 +258,43 @@ class TestPPOActorLossFnSequenceLevel:
             stat["importance_weight"][0, 0], stat["importance_weight"][0, 3], atol=1e-5
         )
 
+    def test_sequence_level_2d_advantage_average_ignores_masked_values(self):
+        """Masked padding advantages must not change valid-token sequence loss."""
+        loss_mask = torch.tensor([[True, True, False, False]])
+        logprobs = torch.zeros(1, 4)
+        proximal_logprobs = torch.zeros(1, 4)
+        old_logprobs = torch.zeros(1, 4)
+        clean_advantages = torch.tensor([[1.0, 1.0, 0.0, 0.0]])
+        contaminated_advantages = torch.tensor([[1.0, 1.0, 10.0, 10.0]])
+
+        clean_loss, clean_stat = ppo_actor_loss_fn(
+            logprobs=logprobs,
+            proximal_logprobs=proximal_logprobs,
+            old_logprobs=old_logprobs,
+            advantages=clean_advantages,
+            eps_clip=0.2,
+            loss_mask=loss_mask,
+            importance_sampling_level="sequence",
+        )
+        contaminated_loss, contaminated_stat = ppo_actor_loss_fn(
+            logprobs=logprobs,
+            proximal_logprobs=proximal_logprobs,
+            old_logprobs=old_logprobs,
+            advantages=contaminated_advantages,
+            eps_clip=0.2,
+            loss_mask=loss_mask,
+            importance_sampling_level="sequence",
+        )
+
+        assert torch.allclose(contaminated_loss, clean_loss)
+        assert torch.allclose(
+            contaminated_stat["loss"][loss_mask], clean_stat["loss"][loss_mask]
+        )
+        assert torch.allclose(
+            contaminated_stat["loss"][~loss_mask],
+            torch.zeros_like(contaminated_stat["loss"][~loss_mask]),
+        )
+
     def test_sequence_level_with_mask_1d(self):
         """Test sequence-level with partial masking for 1D tensors (packed sequences)."""
         # Two sequences: [4 tokens, 4 tokens]


### PR DESCRIPTION
## Summary

AReaL's 2D padded sequence-level PPO/GSPO loss can include `loss_mask=False` padding positions when it averages token advantages into one sequence advantage. As a result, changing only masked padding values can silently change valid-token loss, gradients, and one-step updates.

This patch applies `loss_mask` before the 2D per-sequence advantage reduction, then zeros masked positions after broadcasting the sequence advantage back to token shape.


## Concrete Minimal Example

Boundary:

```python
from areal.utils.functional import ppo_actor_loss_fn

loss_mask = torch.tensor([[True, True, False, False]])
logprobs = torch.zeros(1, 4)
proximal_logprobs = torch.zeros(1, 4)
old_logprobs = torch.zeros(1, 4)

clean_advantages = torch.tensor([[1.0, 1.0, 0.0, 0.0]])
contaminated_advantages = torch.tensor([[1.0, 1.0, 10.0, 10.0]])

ppo_actor_loss_fn(
    logprobs=logprobs,
    proximal_logprobs=proximal_logprobs,
    old_logprobs=old_logprobs,
    advantages=contaminated_advantages,
    eps_clip=0.2,
    loss_mask=loss_mask,
    importance_sampling_level="sequence",
)
```

Only positions where `loss_mask` is `False` change.

Wrong value on current `main`:

```json
{
  "clean_2d": {
    "loss": -1.0,
    "valid_logging_loss": [-1.0, -1.0],
    "grad_norm": 1.0,
    "update_delta_norm": 0.10000000149011612
  },
  "contaminated_2d": {
    "loss": -11.0,
    "valid_logging_loss": [-11.0, -11.0],
    "grad_norm": 11.0,
    "update_delta_norm": 1.100000023841858
  }
}
```

Fixed value on this branch:

```json
{
  "clean_2d": {
    "loss": -1.0,
    "valid_logging_loss": [-1.0, -1.0],
    "grad_norm": 1.0,
    "update_delta_norm": 0.10000000149011612
  },
  "contaminated_2d": {
    "loss": -1.0,
    "valid_logging_loss": [-1.0, -1.0],
    "grad_norm": 1.0,
    "update_delta_norm": 0.10000000149011612
  }
}
```

## Root Cause

The packed 1D branch already does:

```python
masked_advantages = torch.where(loss_mask, advantages, 0.0)
```

before reducing by sequence. The 2D padded branch used:

```python
advantages.sum(dim=-1, keepdim=True) / loss_mask.sum(dim=-1, keepdim=True).clamp(min=1)
```

This divided by the valid-token count but still included padded or otherwise masked advantage values in the numerator.

## Fix

The 2D branch now selects valid advantages before the sequence reduction and zeros the broadcast result on masked positions:

```python
masked_advantages = torch.where(loss_mask, advantages, 0.0)
advantages = (
    masked_advantages.sum(dim=-1, keepdim=True) / seq_lengths
).expand_as(log_ratio)
advantages = torch.where(loss_mask, advantages, 0.0)
```

## Validation Recipe

```json
{
  "bug_id": "AREAL-GSPO-2D-MASKED-ADV-LEAK",
  "validation_mode": "actual_areal_ppo_actor_loss_boundary_hook",
  "hooked_boundary": "areal.utils.functional.ppo_actor_loss_fn with importance_sampling_level='sequence'",
  "constructed_scenario": {
    "format": "2D padded batch",
    "loss_mask": [[true, true, false, false]],
    "clean_advantages": [[1.0, 1.0, 0.0, 0.0]],
    "contaminated_masked_advantages": [[1.0, 1.0, 10.0, 10.0]]
  },
  "expected_invariant": "Changing advantage values where loss_mask is false must not change loss, valid-token logging loss, gradient, or one-step update.",
  "replaced_component": null
}
```

Runner script:

```python
import importlib
import json
import os
import sys
from pathlib import Path

import torch


target_repo = Path(os.environ["TARGET_REPO"]).resolve()
sys.path.insert(0, str(target_repo))
functional_module = importlib.import_module("areal.utils.functional.functional")
ppo_actor_loss_fn = functional_module.ppo_actor_loss_fn


def run_case(advantages):
    loss_mask = torch.tensor([[True, True, False, False]])
    theta = torch.nn.Parameter(torch.tensor(0.0))
    optimizer = torch.optim.SGD([theta], lr=0.1)
    optimizer.zero_grad()
    logprobs = theta.expand_as(advantages)
    zeros = torch.zeros_like(advantages)
    loss, stat = ppo_actor_loss_fn(
        logprobs=logprobs,
        proximal_logprobs=zeros,
        old_logprobs=zeros,
        advantages=advantages,
        eps_clip=0.2,
        loss_mask=loss_mask,
        rejection_sampling=None,
        importance_sampling_level="sequence",
        cu_seqlens=None,
    )
    loss.backward()
    before = float(theta.detach().item())
    grad = float(theta.grad.detach().item())
    optimizer.step()
    after = float(theta.detach().item())
    return {
        "loss": float(loss.detach().item()),
        "valid_logging_loss": stat["loss"][loss_mask].detach().cpu().tolist(),
        "grad_norm": abs(grad),
        "update_delta_norm": abs(after - before),
    }


clean_advantages = torch.tensor([[1.0, 1.0, 0.0, 0.0]])
contaminated_advantages = torch.tensor([[1.0, 1.0, 10.0, 10.0]])
print(
    json.dumps(
        {
            "clean_2d": run_case(clean_advantages),
            "contaminated_2d": run_case(contaminated_advantages),
        },
        indent=2,
        sort_keys=True,
    )
)
```

The hook imports `areal.utils.functional.functional` from the checkout under test and uses real PyTorch autograd plus `torch.optim.SGD`. It does not replace the target loss function.

## Checks

Passed:

```bash
git diff --check
python3 -m ruff check areal/utils/functional/functional.py tests/test_functional.py
python3 -m ruff format --check areal/utils/functional/functional.py tests/test_functional.py
python3 -m pre_commit install --install-hooks
python3 -m pre_commit run --files areal/utils/functional/functional.py tests/test_functional.py
```

## Relevant Output

Unfixed target output:

```json
{
  "clean_2d": {"loss": -1.0, "grad_norm": 1.0, "update_delta_norm": 0.10000000149011612},
  "contaminated_2d": {"loss": -11.0, "grad_norm": 11.0, "update_delta_norm": 1.100000023841858}
}
```

Fixed-path hook output:

```json
{
  "status": "fixed",
  "repair_commit": "9631a1d651cfd2870f18edc7213e4f932ce83869",
  "observed_fixed_behavior": {
    "clean_2d": {"loss": -1.0, "grad_norm": 1.0},
    "contaminated_2d": {"loss": -1.0, "grad_norm": 1.0}
  }
}
```

Local pytest note:

```text
python3 -m pytest -q tests/test_functional.py::TestPPOActorLossFnSequenceLevel::test_sequence_level_2d_advantage_average_ignores_masked_values
```

is blocked in this local environment by a top-level AReaL import error:

```text
ImportError: cannot import name 'DefaultStager' from 'torch.distributed.checkpoint.staging'
```

The targeted boundary hook avoids top-level `import areal` per the AReaL workflow and imports the concrete real module from the checkout under test.

## Related Work / Dedup

- `inclusionAI/AReaL` redirects to `areal-project/AReaL`.
- GitHub issue/PR search found related feature PRs, including `areal-project/AReaL#501` and `areal-project/AReaL#1088`, but no PR or issue describing this 2D padded masked-advantage bug. Current refreshed `main` still had the unmasked `advantages.sum(dim=-1, keepdim=True)` path.
- Historical RL-Sentinel findings include same-family masked-signal bugs in other projects, but no exact AReaL `areal/utils/functional/functional.py` duplicate with this 2D padded advantage trigger.

## AI Assistance

This draft and patch were prepared with AI assistance in an RL-Sentinel testing loop.
