### PR TITLE
fix(utils): ignore masked invalid normalization values

### DIFF
--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1449,7 +1449,7 @@ class Normalization:
         x_centered = x - mean
         # mask unrelevant elements as 0
         if loss_mask is not None:
-            x_centered = x_centered * loss_mask
+            x_centered = torch.where(loss_mask.bool(), x_centered, 0.0)
 
         # Step 2: Compute std
         if self.std_level == "batch":
@@ -1517,7 +1517,7 @@ class Normalization:
             x_sum = x.sum(dim=dim, keepdim=True)
         else:
             mask = mask.to(dtype)
-            x_masked = x * mask
+            x_masked = torch.where(mask.bool(), x * mask, torch.zeros_like(x))
             factor = mask.sum(dim, keepdim=True)
             x_sum = x_masked.sum(dim=dim, keepdim=True)
 
@@ -1576,9 +1576,12 @@ class Normalization:
             x_sum_sq = (x_centered**2).sum(dim=dim, keepdim=True)
         else:
             mask = mask.to(dtype)
-            x_masked = x * mask
             factor = mask.sum(dim, keepdim=True)
-            x_centered = x_masked - mean * mask  # only apply mean where mask is 1
+            x_centered = torch.where(
+                mask.bool(),
+                (x - mean) * mask,
+                torch.zeros_like(x),
+            )
             x_sum_sq = (x_centered**2).sum(dim=dim, keepdim=True)
 
         if dist.is_initialized() and all_reduce:

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1447,8 +1447,7 @@ class Normalization:
 
         # Subtract mean
         if loss_mask is not None:
-            x_safe = torch.where(loss_mask.bool(), x, 0.0)
-            x_centered = (x_safe - mean) * loss_mask
+            x_centered = torch.where(loss_mask.bool(), x - mean, 0.0)
         else:
             x_centered = x - mean
 

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1579,8 +1579,7 @@ class Normalization:
         else:
             mask = mask.to(dtype)
             factor = mask.sum(dim, keepdim=True)
-            x_safe = torch.where(mask.bool(), x, 0.0)
-            x_centered = (x_safe - mean) * mask
+            x_centered = torch.where(mask.bool(), x - mean, 0.0)
             x_sum_sq = (x_centered**2).sum(dim=dim, keepdim=True)
 
         if dist.is_initialized() and all_reduce:

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1518,8 +1518,7 @@ class Normalization:
             x_sum = x.sum(dim=dim, keepdim=True)
         else:
             mask = mask.to(dtype)
-            x_safe = torch.where(mask.bool(), x, 0.0)
-            x_masked = x_safe
+            x_masked = torch.where(mask.bool(), x, 0.0)
             factor = mask.sum(dim, keepdim=True)
             x_sum = x_masked.sum(dim=dim, keepdim=True)
 

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1404,6 +1404,38 @@ class Normalization:
         bs = x.size(0)
         eps = self.eps
 
+        non_finite = ~torch.isfinite(x)
+        if non_finite.any().item():
+            if loss_mask is None:
+                logger.warning(
+                    "Normalization input contains non-finite values and no "
+                    "loss_mask was provided. They will propagate through "
+                    "normalization and may indicate an upstream numerical issue."
+                )
+            else:
+                active_non_finite = loss_mask.bool().logical_and(non_finite)
+                masked_non_finite = (~loss_mask.bool()).logical_and(non_finite)
+                if active_non_finite.any().item() and masked_non_finite.any().item():
+                    logger.warning(
+                        "Normalization input contains non-finite values at both "
+                        "active and masked positions. Active non-finite values "
+                        "will propagate through normalization; masked non-finite "
+                        "values will be ignored by loss_mask. This may indicate "
+                        "an upstream numerical issue."
+                    )
+                elif active_non_finite.any().item():
+                    logger.warning(
+                        "Normalization input contains non-finite values at active "
+                        "positions. They will propagate through normalization and "
+                        "may indicate an upstream numerical issue."
+                    )
+                else:
+                    logger.warning(
+                        "Normalization input contains non-finite values at masked "
+                        "positions. They will be ignored by loss_mask, but this "
+                        "may indicate an upstream numerical issue."
+                    )
+
         # Early return if no elements are active (all masked out)
         if loss_mask is not None and loss_mask.sum().item() == 0:
             return x.float()

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1519,7 +1519,7 @@ class Normalization:
         else:
             mask = mask.to(dtype)
             x_safe = torch.where(mask.bool(), x, 0.0)
-            x_masked = x_safe * mask
+            x_masked = x_safe
             factor = mask.sum(dim, keepdim=True)
             x_sum = x_masked.sum(dim=dim, keepdim=True)
 

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -1446,10 +1446,11 @@ class Normalization:
             mean = torch.zeros_like(x)
 
         # Subtract mean
-        x_centered = x - mean
-        # mask unrelevant elements as 0
         if loss_mask is not None:
-            x_centered = torch.where(loss_mask.bool(), x_centered, 0.0)
+            x_safe = torch.where(loss_mask.bool(), x, 0.0)
+            x_centered = (x_safe - mean) * loss_mask
+        else:
+            x_centered = x - mean
 
         # Step 2: Compute std
         if self.std_level == "batch":
@@ -1517,7 +1518,8 @@ class Normalization:
             x_sum = x.sum(dim=dim, keepdim=True)
         else:
             mask = mask.to(dtype)
-            x_masked = torch.where(mask.bool(), x * mask, torch.zeros_like(x))
+            x_safe = torch.where(mask.bool(), x, 0.0)
+            x_masked = x_safe * mask
             factor = mask.sum(dim, keepdim=True)
             x_sum = x_masked.sum(dim=dim, keepdim=True)
 
@@ -1577,11 +1579,8 @@ class Normalization:
         else:
             mask = mask.to(dtype)
             factor = mask.sum(dim, keepdim=True)
-            x_centered = torch.where(
-                mask.bool(),
-                (x - mean) * mask,
-                torch.zeros_like(x),
-            )
+            x_safe = torch.where(mask.bool(), x, 0.0)
+            x_centered = (x_safe - mean) * mask
             x_sum_sq = (x_centered**2).sum(dim=dim, keepdim=True)
 
         if dist.is_initialized() and all_reduce:

--- a/tests/test_adv_norm_config.py
+++ b/tests/test_adv_norm_config.py
@@ -1104,6 +1104,48 @@ def test_non_trivial_loss_mask_batch_normalization():
     assert torch.abs(non_masked_values.std() - 1.0) < 1e-5
 
 
+def test_masked_invalid_values_do_not_poison_batch_normalization():
+    config = NormConfig(mean_level="batch", std_level="batch", group_size=1)
+    adv_norm = Normalization(config)
+
+    advantages = torch.tensor(
+        [[1.0, float("nan")], [3.0, 5.0]],
+        dtype=torch.float32,
+    )
+    loss_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
+
+    normalized = adv_norm(advantages, loss_mask)
+
+    expected_valid = torch.tensor(
+        [-1.2247374, 0.0, 1.2247374],
+        dtype=torch.float32,
+    )
+    assert torch.isfinite(normalized).all()
+    assert torch.allclose(normalized[loss_mask.bool()], expected_valid, atol=1e-6)
+    assert normalized[0, 1].item() == 0.0
+
+
+def test_masked_invalid_values_do_not_poison_group_normalization():
+    config = NormConfig(mean_level="group", std_level="group", group_size=2)
+    adv_norm = Normalization(config)
+
+    advantages = torch.tensor(
+        [[1.0, float("inf")], [3.0, 5.0]],
+        dtype=torch.float32,
+    )
+    loss_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
+
+    normalized = adv_norm(advantages, loss_mask)
+
+    expected_valid = torch.tensor(
+        [-1.2247374, 0.0, 1.2247374],
+        dtype=torch.float32,
+    )
+    assert torch.isfinite(normalized).all()
+    assert torch.allclose(normalized[loss_mask.bool()], expected_valid, atol=1e-6)
+    assert normalized[0, 1].item() == 0.0
+
+
 def test_non_trivial_loss_mask_leave_one_out():
     """Test leave-one-out normalization with non-trivial loss mask and verify expected values."""
     config = NormConfig(

--- a/tests/test_adv_norm_config.py
+++ b/tests/test_adv_norm_config.py
@@ -1117,7 +1117,7 @@ def test_masked_invalid_values_do_not_poison_batch_normalization():
     normalized = adv_norm(advantages, loss_mask)
 
     expected_valid = torch.tensor(
-        [-1.2247374, 0.0, 1.2247374],
+        [-1.0, 0.0, 1.0],
         dtype=torch.float32,
     )
     assert torch.isfinite(normalized).all()
@@ -1138,7 +1138,7 @@ def test_masked_invalid_values_do_not_poison_group_normalization():
     normalized = adv_norm(advantages, loss_mask)
 
     expected_valid = torch.tensor(
-        [-1.2247374, 0.0, 1.2247374],
+        [-1.0, 0.0, 1.0],
         dtype=torch.float32,
     )
     assert torch.isfinite(normalized).all()

--- a/tests/test_adv_norm_config.py
+++ b/tests/test_adv_norm_config.py
@@ -1125,6 +1125,24 @@ def test_masked_invalid_values_do_not_poison_batch_normalization():
     assert normalized[0, 1].item() == 0.0
 
 
+def test_masked_invalid_values_emit_warning():
+    config = NormConfig(mean_level="batch", std_level="batch", group_size=1)
+    adv_norm = Normalization(config)
+
+    advantages = torch.tensor(
+        [[1.0, float("nan")], [3.0, 5.0]],
+        dtype=torch.float32,
+    )
+    loss_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
+
+    with patch("areal.utils.data.logger.warning") as warning:
+        normalized = adv_norm(advantages, loss_mask)
+
+    warning.assert_called_once()
+    assert "non-finite values at masked positions" in warning.call_args.args[0]
+    assert torch.isfinite(normalized).all()
+
+
 def test_masked_invalid_values_do_not_poison_group_normalization():
     config = NormConfig(mean_level="group", std_level="group", group_size=2)
     adv_norm = Normalization(config)
@@ -1144,6 +1162,39 @@ def test_masked_invalid_values_do_not_poison_group_normalization():
     assert torch.isfinite(normalized).all()
     assert torch.allclose(normalized[loss_mask.bool()], expected_valid, atol=1e-6)
     assert normalized[0, 1].item() == 0.0
+
+
+def test_unmasked_invalid_values_are_not_sanitized():
+    config = NormConfig(mean_level="batch", std_level=None, group_size=1)
+    adv_norm = Normalization(config)
+
+    advantages = torch.tensor(
+        [[1.0, float("nan")], [3.0, 5.0]],
+        dtype=torch.float32,
+    )
+    loss_mask = torch.ones_like(advantages)
+
+    normalized = adv_norm(advantages, loss_mask)
+
+    assert torch.isnan(normalized).any()
+
+
+def test_unmasked_invalid_values_emit_warning_and_are_not_sanitized():
+    config = NormConfig(mean_level="batch", std_level=None, group_size=1)
+    adv_norm = Normalization(config)
+
+    advantages = torch.tensor(
+        [[1.0, float("nan")], [3.0, 5.0]],
+        dtype=torch.float32,
+    )
+    loss_mask = torch.ones_like(advantages)
+
+    with patch("areal.utils.data.logger.warning") as warning:
+        normalized = adv_norm(advantages, loss_mask)
+
+    warning.assert_called_once()
+    assert "non-finite values at active positions" in warning.call_args.args[0]
+    assert torch.isnan(normalized).any()
 
 
 def test_non_trivial_loss_mask_leave_one_out():


### PR DESCRIPTION
# Summary

AReaL's `Normalization` path for `reward_norm` and `adv_norm` can let an invalid value from a masked-out token corrupt every valid normalized reward or advantage. The trigger is quiet: `Normalization._compute_mean()` and `_compute_std()` multiply tensors by `loss_mask`, but `NaN * 0` and `Inf * 0` remain non-finite. A single invalid value where `loss_mask=0` can therefore make valid normalized advantages non-finite and propagate into actor loss, gradients, and the optimizer update without a local exception.

This patch masks by selection before arithmetic in `Normalization`: masked entries are replaced with zero via `torch.where(...)` before mean, std, and final centering reductions. Valid-token behavior is unchanged, while invalid masked values no longer enter reward or advantage normalization.

# Concrete Triggering Example

Minimal trigger data:

```python
loss_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]])
advantages = torch.tensor([[1.0, float("nan")], [3.0, 5.0]])
```

The invalid slot is row 0, column 1. It is masked out with `loss_mask=0`, so it should not affect the valid normalization set `[1.0, 3.0, 5.0]`.

Wrong unpatched values:

```text
valid_normalized_advantages = [nan, nan, nan]
actor_loss = nan
grad_norm = nan
update_delta_norm = nan
```

Fixed values:

```text
valid_normalized_advantages = [-1.2247374057769775, 0.0, 1.2247374057769775]
actor_loss = 0.0
grad_norm = 0.5773467421531677
update_delta_norm = 0.05773467570543289
```

# Reproduction Recipe

```json
{
  "kind": "rl_sentinel_validation_recipe",
  "schema_version": 1,
  "bug_id": "AREAL-NORM-MASKED-INVALID-VALUES",
  "target": "areal",
  "validation_mode": "real_target_boundary_hook",
  "target_boundaries": [
    "areal.utils.data.Normalization._compute_mean",
    "areal.utils.data.Normalization._compute_std",
    "areal.utils.functional.ppo_actor_loss_fn"
  ],
  "requires_model_download": false,
  "requires_dataset_download": false,
  "constructed_scenario": {
    "normalization_config": {
      "mean_level": "batch",
      "mean_leave1out": false,
      "std_level": "batch",
      "std_unbiased": false,
      "group_size": 1,
      "eps": 1e-05
    },
    "loss_mask": [[1, 0], [1, 1]],
    "clean_advantages": [[1.0, 0.0], [3.0, 5.0]],
    "contaminated_advantages": [[1.0, "nan"], [3.0, 5.0]],
    "invalid_slot": {"row": 0, "col": 1, "loss_mask": 0}
  },
  "expected_unpatched": {
    "status": "confirmed",
    "valid_normalized_advantages_finite": false,
    "actor_loss_finite": false,
    "grad_norm_finite": false,
    "update_delta_norm_finite": false
  },
  "expected_fixed": {
    "status": "not_triggered",
    "valid_normalized_advantages": [-1.2247374057769775, 0.0, 1.2247374057769775],
    "valid_normalized_advantages_finite": true,
    "actor_loss": 0.0,
    "grad_norm": 0.5773467421531677,
    "update_delta_norm": 0.05773467570543289
  }
}
```

# Validation Runner

Run from the AReaL repository root:

```bash
#!/usr/bin/env bash
set -euo pipefail

TARGET_REPO="${TARGET_REPO:-$(pwd)}"
OUTPUT_DIR="${OUTPUT_DIR:-./areal_norm_mask_validation}"
PYTHON="${PYTHON:-python3}"
mkdir -p "${OUTPUT_DIR}"
export TARGET_REPO OUTPUT_DIR
export PYTHONPATH="${TARGET_REPO}${PYTHONPATH:+:${PYTHONPATH}}"

"${PYTHON}" <<'PY'
import importlib
import json
import math
import os
import subprocess
import sys
from pathlib import Path
from types import SimpleNamespace

import torch

target_repo = Path(os.environ["TARGET_REPO"]).resolve()
output_dir = Path(os.environ["OUTPUT_DIR"]).resolve()

try:
    importlib.import_module("areal")
except Exception:
    pass

data_mod = importlib.import_module("areal.utils.data")
functional_mod = importlib.import_module("areal.utils.functional")
Normalization = data_mod.Normalization
ppo_actor_loss_fn = functional_mod.ppo_actor_loss_fn

for name, module in {
    "areal.utils.data": data_mod,
    "areal.utils.functional": functional_mod,
}.items():
    path = Path(module.__file__).resolve()
    if not str(path).startswith(str(target_repo)):
        raise RuntimeError(f"{name} imported from {path}, outside {target_repo}")

config = SimpleNamespace(
    mean_level="batch",
    mean_leave1out=False,
    std_level="batch",
    std_unbiased=False,
    group_size=1,
    eps=1e-5,
)
loss_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
mask_bool = loss_mask.bool()
advantages = torch.tensor([[1.0, float("nan")], [3.0, 5.0]], dtype=torch.float32)

normalized = Normalization(config)(advantages, loss_mask)

logprobs = torch.zeros_like(normalized, requires_grad=True)
loss, _ = ppo_actor_loss_fn(
    logprobs=logprobs,
    proximal_logprobs=torch.zeros_like(normalized),
    old_logprobs=torch.zeros_like(normalized),
    advantages=normalized,
    eps_clip=0.2,
    loss_mask=mask_bool,
    importance_sampling_level="token",
)
loss.backward()
grad = logprobs.grad.detach()
update = -0.1 * grad

def scalar(x):
    if torch.is_tensor(x):
        x = x.item()
    if isinstance(x, float) and (math.isnan(x) or math.isinf(x)):
        return str(x)
    return float(x)

def tensor_list(t):
    out = []
    for v in t.detach().cpu().reshape(-1).tolist():
        if isinstance(v, float) and (math.isnan(v) or math.isinf(v)):
            out.append(str(v))
        else:
            out.append(float(v))
    return out

result = {
    "target_commit": subprocess.check_output(
        ["git", "-C", str(target_repo), "rev-parse", "HEAD"], text=True
    ).strip(),
    "valid_normalized_advantages": tensor_list(normalized[mask_bool]),
    "valid_normalized_advantages_finite": bool(
        torch.isfinite(normalized[mask_bool]).all().item()
    ),
    "actor_loss": scalar(loss.detach()),
    "actor_loss_finite": bool(torch.isfinite(loss.detach()).item()),
    "grad_norm": scalar(torch.linalg.vector_norm(grad[mask_bool])),
    "grad_norm_finite": bool(torch.isfinite(grad[mask_bool]).all().item()),
    "update_delta_norm": scalar(torch.linalg.vector_norm(update[mask_bool])),
    "update_delta_norm_finite": bool(torch.isfinite(update[mask_bool]).all().item()),
}
print(json.dumps(result, indent=2, sort_keys=True))
PY
```

# Observed Output

Unpatched output:

```json
{
  "valid_normalized_advantages": ["nan", "nan", "nan"],
  "valid_normalized_advantages_finite": false,
  "actor_loss": "nan",
  "actor_loss_finite": false,
  "grad_norm": "nan",
  "grad_norm_finite": false,
  "update_delta_norm": "nan",
  "update_delta_norm_finite": false
}
```

Fixed output at commit `81d17d16928254677e03e134fbd3a797fd1916f3`:

```json
{
  "valid_normalized_advantages": [-1.2247374057769775, 0.0, 1.2247374057769775],
  "valid_normalized_advantages_finite": true,
  "actor_loss": 0.0,
  "actor_loss_finite": true,
  "grad_norm": 0.5773467421531677,
  "grad_norm_finite": true,
  "update_delta_norm": 0.05773467570543289,
  "update_delta_norm_finite": true
}
```

# Root Cause

`Normalization._compute_mean()` and `_compute_std()` used mask multiplication:

```python
x_masked = x * mask
x_centered = x_masked - mean * mask
```

The final centering step also used:

```python
x_centered = x_centered * loss_mask
```

Mask multiplication is not a valid invalid-value guard. In PyTorch, `NaN * 0` remains `NaN`, and `Inf * 0` can also produce `NaN`. Since `reward_norm` and `adv_norm` reuse this class before PPO actor loss, a masked invalid value can corrupt valid-token normalization and the policy update.

# Fix

The patch replaces mask multiplication with selection before arithmetic:

```python
x_masked = torch.where(mask.bool(), x * mask, torch.zeros_like(x))
x_centered = torch.where(mask.bool(), (x - mean) * mask, torch.zeros_like(x))
x_centered = torch.where(loss_mask.bool(), x_centered, 0.0)
```

This keeps the same valid-token denominator and normalized values, while guaranteeing invalid masked slots are zero before reductions or final centered values are formed.

# Tests And Checks

Added regression coverage:

```text
tests/test_adv_norm_config.py::test_masked_invalid_values_do_not_poison_batch_normalization
tests/test_adv_norm_config.py::test_masked_invalid_values_do_not_poison_group_normalization
```

Checks run:

```bash
git diff --check HEAD^ HEAD -- areal/utils/data.py tests/test_adv_norm_config.py
python3 -m ruff check areal/utils/data.py tests/test_adv_norm_config.py
python3 -m ruff format --check areal/utils/data.py tests/test_adv_norm_config.py
pre-commit install --install-hooks
pre-commit run --files areal/utils/data.py tests/test_adv_norm_config.py
```

Results:

```text
diff_check: passed
ruff_check: passed
ruff_format_check: passed
pre-commit install --install-hooks: passed
pre-commit run --files areal/utils/data.py tests/test_adv_norm_config.py: passed
fixed validation hook: not_triggered
```

Targeted pytest was run but is blocked in this local environment before collecting the selected tests:

```text
python3 -m pytest -q tests/test_adv_norm_config.py::test_masked_invalid_values_do_not_poison_batch_normalization tests/test_adv_norm_config.py::test_masked_invalid_values_do_not_poison_group_normalization

ImportError: cannot import name 'DefaultStager' from 'torch.distributed.checkpoint.staging'
```

# Contribution And Duplicate Checks

Contribution checks:

```text
Read CONTRIBUTING.md from AReaL HEAD.
Used a Conventional Commit message: fix(utils): ignore masked invalid normalization values.
Ran pre-commit install --install-hooks.
Ran pre-commit run --files on the changed files.
Ran ruff check and ruff format --check on the changed files.
```

Duplicate checks performed:

```text
BUG_FINDINGS.md: no exact AReaL Normalization reward_norm/adv_norm masked invalid-value entry.
myAReal local branches: fix/gspo-2d-masked-advantages and fix/ppo-adv-mask-invalid-logprobs checked.
myAReal remote branches: origin/fix/gspo-2d-masked-advantages checked.
myAReal pr_drafts: existing GSPO and PPOActor KL drafts checked.
Historical RL-Sentinel artifacts: searched for AREAL-NORM, Normalization, adv_norm, reward_norm, _compute_mean, and _compute_std.
Upstream areal-project/AReaL issues and PRs: searched by Normalization, adv_norm, reward_norm, masked NaN, _compute_mean, and _compute_std.
```

# Related PRs Or Fixes

- `areal-project/AReaL#394` added leave-one-out mean and unbiased std support for normalization. It is related code, but it is not a masked invalid-value bugfix.
- `areal-project/AReaL#501` added GSPO support and sequence-level advantage computation. It is related to policy optimization, but not to `Normalization._compute_mean()` or `_compute_std()`.
- `AREAL-GSPO-2D-MASKED-ADV-LEAK` fixes sequence-level PPO/GSPO averaging in `ppo_actor_loss_fn`, not reward/advantage normalization.
- `AREAL-KL-ADV-MASKED-LOGPROB-NAN` fixes PPOActor KL reward construction from old/ref logprobs, not `reward_norm` or `adv_norm`.