### PR TITLE
refactor(infra): backport rl infra cleanup 

### DIFF
--- a/areal/api/reward_api.py
+++ b/areal/api/reward_api.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import atexit
 import os
 import threading
-import traceback
-import weakref
 from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
@@ -61,15 +60,18 @@ def reward_fn(
 
 
 class AsyncRewardWrapper:
-    """
-    Wraps a synchronous reward function to make it async with timeout handling.
-    Automatically manages ProcessPoolExecutor lifecycle based on instance count.
+    """Wraps a synchronous reward function for async execution with timeout and retries.
+
+    Executors are shared by ``max_workers`` key and cleaned up via ``atexit``.
     Includes automatic recovery from broken process pools.
+
+    The reward function and its arguments must be picklable since they
+    are dispatched to worker processes via ``ProcessPoolExecutor``.
     """
 
-    _executors = {}
-    _instance_counts = {}
+    _executors: dict[int, ProcessPoolExecutor] = {}
     _lock = threading.Lock()
+    _atexit_registered = False
 
     def __init__(
         self,
@@ -83,8 +85,6 @@ class AsyncRewardWrapper:
         if max_workers is None:
             cpu_count = os.cpu_count() or 1
             device_count = _get_device_count_safely()
-            # Heuristic for max_workers: distribute CPU cores across devices,
-            # then halve to be conservative, ensuring at least one worker.
             max_workers = max((cpu_count // device_count) // 2, 1)
         self.max_workers = max_workers
         self.max_retries = max_retries
@@ -95,115 +95,89 @@ class AsyncRewardWrapper:
                 self._executors[self._executor_key] = ProcessPoolExecutor(
                     max_workers=max_workers
                 )
-                self._instance_counts[self._executor_key] = 0
-            self._instance_counts[self._executor_key] += 1
-
-        weakref.finalize(self, AsyncRewardWrapper._cleanup_executor, max_workers)
-
-    @classmethod
-    def _cleanup_executor(cls, executor_key):
-        """Called when an AsyncRewardWrapper instance is garbage collected"""
-        with cls._lock:
-            if executor_key in cls._instance_counts:
-                cls._instance_counts[executor_key] -= 1
-                if cls._instance_counts[executor_key] <= 0:
-                    if executor_key in cls._executors:
-                        executor = cls._executors.pop(executor_key)
-                        executor.shutdown(wait=False, cancel_futures=True)
-                        logger.debug(
-                            f"ProcessPoolExecutor with {executor_key} workers shut down"
-                        )
-                    cls._instance_counts.pop(executor_key, None)
+            if not AsyncRewardWrapper._atexit_registered:
+                atexit.register(AsyncRewardWrapper._atexit_shutdown_all)
+                AsyncRewardWrapper._atexit_registered = True
 
     @classmethod
-    def _recreate_executor(cls, executor_key, max_workers):
-        """Recreate a broken ProcessPoolExecutor"""
+    def _atexit_shutdown_all(cls):
+        """Shut down all executors before ``_python_exit`` to prevent
+        worker processes deadlocking in ``_finalize_join``.
+        Must use ``wait=True`` so the result queue is fully drained.
+        """
         with cls._lock:
-            if executor_key in cls._executors:
-                # Clean up the broken executor
-                old_executor = cls._executors[executor_key]
+            for executor in cls._executors.values():
                 try:
-                    old_executor.shutdown(wait=False)
+                    executor.shutdown(wait=True, cancel_futures=True)
                 except Exception as e:
-                    logger.warning(f"Error shutting down broken executor: {e}")
+                    logger.warning(f"Error shutting down executor at exit: {e}")
+            cls._executors.clear()
 
-                # Create a new executor
-                cls._executors[executor_key] = ProcessPoolExecutor(
-                    max_workers=max_workers
-                )
-                logger.info(f"Recreated ProcessPoolExecutor with {max_workers} workers")
-                return cls._executors[executor_key]
-        return None
+    @classmethod
+    def _recreate_executor(
+        cls,
+        executor_key: int,
+        max_workers: int,
+        broken: ProcessPoolExecutor,
+    ) -> ProcessPoolExecutor | None:
+        with cls._lock:
+            current = cls._executors.get(executor_key)
+            if current is not broken:
+                return current
+            try:
+                broken.shutdown(wait=False)
+            except Exception as e:
+                logger.warning(f"Error shutting down broken executor: {e}")
+            try:
+                new_executor = ProcessPoolExecutor(max_workers=max_workers)
+            except Exception:
+                logger.exception("Failed to create replacement ProcessPoolExecutor")
+                cls._executors.pop(executor_key, None)
+                return None
+            cls._executors[executor_key] = new_executor
+            logger.info(f"Recreated ProcessPoolExecutor with {max_workers} workers")
+            return new_executor
 
     async def __call__(self, *args, **kwargs) -> float:
-        last_exception = None
-
         for attempt in range(self.max_retries + 1):
-            with self._lock:
-                executor = self._executors.get(self._executor_key)
-
+            executor = self._executors.get(self._executor_key)
             if executor is None:
                 raise RuntimeError("ProcessPoolExecutor has been shut down")
 
-            loop = asyncio.get_event_loop()
+            is_last = attempt == self.max_retries
             try:
-                future = loop.run_in_executor(
+                future = asyncio.get_running_loop().run_in_executor(
                     executor,
                     partial(self.reward_fn, *args, **kwargs),
                 )
-                reward = await asyncio.wait_for(
-                    future,
-                    timeout=self.timeout_seconds,
-                )
-                return reward
+                return await asyncio.wait_for(future, timeout=self.timeout_seconds)
             except TimeoutError:
-                last_exception = TimeoutError(
-                    f"Reward computation timed out after {self.timeout_seconds}s"
-                )
                 logger.warning(
                     f"Computing reward timeout after {self.timeout_seconds}s "
                     f"(attempt {attempt + 1}/{self.max_retries + 1}). "
-                    f"{'Retrying...' if attempt < self.max_retries else 'Returning 0.'}"
+                    f"{'Returning 0.' if is_last else 'Retrying...'}"
                 )
-                if attempt < self.max_retries:
-                    continue
-                return 0
-            except BrokenProcessPool as e:
-                last_exception = e
+                if is_last:
+                    return 0
+            except BrokenProcessPool:
                 logger.warning(
                     f"ProcessPoolExecutor broken (attempt {attempt + 1}/{self.max_retries + 1}). "
                     "Attempting to recreate..."
                 )
-                if attempt < self.max_retries:
-                    # Try to recreate the executor
-                    new_executor = self._recreate_executor(
-                        self._executor_key, self.max_workers
+                if is_last:
+                    raise
+                if (
+                    self._recreate_executor(
+                        self._executor_key, self.max_workers, executor
                     )
-                    if new_executor is None:
-                        logger.error("Failed to recreate ProcessPoolExecutor")
-                        break
-                    # Continue to next attempt
-                    continue
-                else:
-                    logger.error("Max retries exceeded for BrokenProcessPool.")
-                    traceback.print_exc()
-                    raise e
-            except Exception as e:
-                last_exception = e
-                logger.error(f"Unexpected error in reward computation: {e}")
-                if attempt < self.max_retries:
-                    logger.info(
-                        f"Retrying... (attempt {attempt + 1}/{self.max_retries + 1})"
-                    )
-                    continue
-                else:
-                    logger.error("Max retries exceeded for unexpected error.")
-                    traceback.print_exc()
-                    raise e
+                    is None
+                ):
+                    raise
+            except Exception:
+                logger.exception(
+                    f"Reward computation error (attempt {attempt + 1}/{self.max_retries + 1})"
+                )
+                if is_last:
+                    raise
 
-        # If we get here, all retries failed
-        if last_exception:
-            traceback.print_exc()
-            raise last_exception
-        else:
-            raise RuntimeError("Reward computation failed after all retries.")
+        return 0

--- a/areal/experimental/inference_service/data_proxy/app.py
+++ b/areal/experimental/inference_service/data_proxy/app.py
@@ -438,6 +438,11 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         if version is None or not isinstance(version, int):
             raise HTTPException(status_code=400, detail="'version' (int) is required")
         app.state.version = version
+
+        # Propagate version to InfBridge so it stamps correct versions on generated tokens
+        if app.state.inf_bridge is not None:
+            app.state.inf_bridge.set_version(version)
+
         return SetVersionResponse(status="ok", version=version)
 
     @app.get("/get_version", response_model=GetVersionResponse)

--- a/areal/experimental/inference_service/inf_bridge.py
+++ b/areal/experimental/inference_service/inf_bridge.py
@@ -191,6 +191,7 @@ class InfBridge:
 
         accumulated_tokens: list[int] = []
         accumulated_logprobs: list[float] = []
+        accumulated_versions: list[int] = []
         stop_reason: _StopReason | None = None
         final_routed_experts: np.ndarray | None = None
 
@@ -220,6 +221,7 @@ class InfBridge:
 
             accumulated_tokens.extend(result.output_tokens)
             accumulated_logprobs.extend(result.output_logprobs)
+            accumulated_versions.extend([self._version] * len(result.output_tokens))
             stop_reason = cast(_StopReason, result.stop_reason)
 
             if result.routed_experts is not None:
@@ -254,7 +256,7 @@ class InfBridge:
             input_tokens=list(req.input_ids),
             output_tokens=accumulated_tokens,
             output_logprobs=accumulated_logprobs,
-            output_versions=[self._version] * len(accumulated_tokens),
+            output_versions=accumulated_versions,
             stop_reason=stop_reason,
             tokenizer=req.tokenizer,
             latency=latency,

--- a/areal/experimental/weight_update/awex/fsdp_adapter.py
+++ b/areal/experimental/weight_update/awex/fsdp_adapter.py
@@ -59,12 +59,18 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             "dp_replicated": False,
         }
 
+    @property
+    def _tie_word_embeddings(self) -> bool:
+        return getattr(self._engine.model_config, "tie_word_embeddings", False)
+
     def get_weight_metadata(self) -> list[ParameterMeta]:
         rank_info = self._build_rank_info()
         metadata: list[ParameterMeta] = []
 
         for raw_name, param in self._engine.model.named_parameters():
             name = self._to_hf_name(raw_name)
+            if self._tie_word_embeddings and name == "lm_head.weight":
+                continue
             tensor = param.data
             if isinstance(tensor, DTensor):
                 shard_meta = self._extract_dtensor_shard_meta(name, tensor, rank_info)
@@ -99,6 +105,8 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
 
         for raw_name, param in self._engine.model.named_parameters():
             name = self._to_hf_name(raw_name)
+            if self._tie_word_embeddings and name == "lm_head.weight":
+                continue
             if required is not None and name not in required:
                 continue
 

--- a/areal/infra/controller/rollout_controller.py
+++ b/areal/infra/controller/rollout_controller.py
@@ -474,6 +474,7 @@ class RolloutController:
                     host="0.0.0.0",
                     port=self._proxy_gateway_port,
                     log_level="warning",
+                    access_log=False,
                 )
                 server = uvicorn.Server(config)
                 self._proxy_gateway_server = server

--- a/areal/infra/workflow_context.py
+++ b/areal/infra/workflow_context.py
@@ -11,7 +11,11 @@ import aiohttp
 import httpx
 
 from areal.infra.utils.concurrent import register_loop_cleanup
-from areal.infra.utils.http import DEFAULT_REQUEST_TIMEOUT, get_default_connector
+from areal.infra.utils.http import (
+    DEFAULT_REQUEST_TIMEOUT,
+    create_httpx_client,
+    get_default_connector,
+)
 from areal.utils import logging
 
 logger = logging.getLogger("WorkflowContext")
@@ -126,7 +130,11 @@ class HttpClientManager:
         await self._check_event_loop_change()
 
         if self._aiohttp_session is None:
-            timeout = aiohttp.ClientTimeout(total=DEFAULT_REQUEST_TIMEOUT)
+            timeout = aiohttp.ClientTimeout(
+                total=DEFAULT_REQUEST_TIMEOUT,
+                sock_connect=DEFAULT_REQUEST_TIMEOUT,
+                connect=DEFAULT_REQUEST_TIMEOUT,
+            )
             self._aiohttp_session = aiohttp.ClientSession(
                 timeout=timeout,
                 read_bufsize=1024 * 1024 * 10,
@@ -165,9 +173,7 @@ class HttpClientManager:
         await self._check_event_loop_change()
 
         if self._httpx_client is None:
-            self._httpx_client = httpx.AsyncClient(
-                timeout=httpx.Timeout(DEFAULT_REQUEST_TIMEOUT)
-            )
+            self._httpx_client = create_httpx_client(timeout=DEFAULT_REQUEST_TIMEOUT)
             # Track which event loop this client belongs to
             self._event_loop = asyncio.get_running_loop()
 

--- a/areal/workflow/openai/math_agent.py
+++ b/areal/workflow/openai/math_agent.py
@@ -29,6 +29,7 @@ class MathAgent:
         self.kwargs = kwargs.copy()
         self.kwargs.pop("max_tokens", None)
         self.kwargs.pop("max_turns", None)
+        self._reward_fn = AsyncRewardWrapper(math_reward_fn)
 
     async def run(self, data: dict, **extra_kwargs):
         http_client = extra_kwargs.get("http_client", None)
@@ -41,8 +42,7 @@ class MathAgent:
             messages=data["messages"], model="default", **self.kwargs
         )
 
-        reward_fn = AsyncRewardWrapper(math_reward_fn)
-        return await reward_fn(
+        return await self._reward_fn(
             completions=comp.choices[0].message.content, answer=data["answer"]
         )
 
@@ -52,6 +52,7 @@ class MultiTurnMathAgent:
         self.max_turns = max_turns
         self.kwargs = kwargs.copy()
         self.kwargs.pop("max_tokens", None)
+        self._reward_fn = AsyncRewardWrapper(math_reward_fn)
 
     async def run(self, data: dict, **extra_kwargs):
         http_client = extra_kwargs.get("http_client", None)
@@ -70,8 +71,9 @@ class MultiTurnMathAgent:
             )
             message = response.choices[0].message
             messages.append(message.model_dump(exclude_none=True))
-            reward_fn = AsyncRewardWrapper(math_reward_fn)
-            reward = await reward_fn(completions=message.content, answer=data["answer"])
+            reward = await self._reward_fn(
+                completions=message.content, answer=data["answer"]
+            )
             rewards[response.id] = reward
             if reward == 1:
                 break
@@ -131,6 +133,7 @@ class MathToolAgent:
         self.kwargs = kwargs.copy()
         self.kwargs.pop("max_tokens", None)
         self.kwargs.pop("max_turns", None)
+        self._reward_fn = AsyncRewardWrapper(math_reward_fn)
 
     async def run(self, data: dict, **extra_kwargs):
         http_client = extra_kwargs.get("http_client", None)
@@ -142,7 +145,7 @@ class MathToolAgent:
         content = data["messages"][-1]["content"]
         run_config = RunConfig(
             model_provider=OpenAIProvider(openai_client=client),
-            model="default",  # no need to pass
+            model="default",
             tracing_disabled=True,
             model_settings=ModelSettings(**self.kwargs),
         )
@@ -163,6 +166,6 @@ class MathToolAgent:
             agent, input=content, session=session, run_config=run_config
         )
 
-        reward_fn = AsyncRewardWrapper(math_reward_fn)
-        reward = await reward_fn(completions=result.final_output, answer=data["answer"])
-        return reward
+        return await self._reward_fn(
+            completions=result.final_output, answer=data["answer"]
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ dependencies = [
     "uvicorn",
     "uvloop>=0.21.0",
     "flask",
-    "tenacity",
+    "tenacity>=8.2.0",
 
     # Build and packaging tools
     "build>=1.2.1",

--- a/pyproject.vllm.toml
+++ b/pyproject.vllm.toml
@@ -145,7 +145,7 @@ dependencies = [
     "uvicorn",
     "uvloop>=0.21.0",
     "flask",
-    "tenacity",
+    "tenacity>=8.2.0",
 
     # Build and packaging tools
     "build>=1.2.1",

--- a/tests/test_async_reward_wrapper.py
+++ b/tests/test_async_reward_wrapper.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import time
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
+
+import pytest
+
+from areal.api.reward_api import AsyncRewardWrapper
+
+
+# Module-level: ProcessPoolExecutor requires picklable callables
+def _add_reward(a: float, b: float) -> float:
+    return a + b
+
+
+def _slow_reward(seconds: float) -> float:
+    time.sleep(seconds)
+    return 1.0
+
+
+def _crash_worker() -> float:
+    os._exit(1)
+
+
+def _raise_value_error() -> float:
+    raise ValueError("intentional error from reward fn")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_executor_state():
+    """Shut down and clear all shared executors before and after each test."""
+    AsyncRewardWrapper._atexit_shutdown_all()
+    yield
+    AsyncRewardWrapper._atexit_shutdown_all()
+
+
+class TestAsyncRewardWrapperBasic:
+    @pytest.mark.asyncio
+    async def test_returns_correct_result(self):
+        wrapper = AsyncRewardWrapper(_add_reward, max_workers=1, max_retries=0)
+        result = await wrapper(3.0, 4.0)
+        assert result == 7.0
+
+    @pytest.mark.asyncio
+    async def test_multiple_calls_return_correct_results(self):
+        wrapper = AsyncRewardWrapper(_add_reward, max_workers=2, max_retries=0)
+        results = [await wrapper(float(i), 1.0) for i in range(5)]
+        assert results == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    def test_shared_executor_for_same_max_workers(self):
+        w1 = AsyncRewardWrapper(_add_reward, max_workers=2)
+        w2 = AsyncRewardWrapper(_add_reward, max_workers=2)
+        assert w1._executor_key == w2._executor_key
+        assert AsyncRewardWrapper._executors.get(2) is not None
+        assert len(AsyncRewardWrapper._executors) == 1
+
+    def test_different_executor_for_different_max_workers(self):
+        AsyncRewardWrapper(_add_reward, max_workers=1)
+        AsyncRewardWrapper(_add_reward, max_workers=2)
+        assert len(AsyncRewardWrapper._executors) == 2
+
+
+class TestAsyncRewardWrapperTimeout:
+    @pytest.mark.asyncio
+    async def test_timeout_returns_zero_after_retries(self):
+        wrapper = AsyncRewardWrapper(
+            _slow_reward, timeout_seconds=0.1, max_workers=1, max_retries=1
+        )
+        result = await wrapper(10.0)
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_no_retries_returns_zero(self):
+        wrapper = AsyncRewardWrapper(
+            _slow_reward, timeout_seconds=0.1, max_workers=1, max_retries=0
+        )
+        result = await wrapper(10.0)
+        assert result == 0
+
+
+class TestAsyncRewardWrapperBrokenPool:
+    @pytest.mark.asyncio
+    async def test_crash_raises_broken_process_pool(self):
+        wrapper = AsyncRewardWrapper(
+            _crash_worker, max_workers=1, max_retries=0, timeout_seconds=5
+        )
+        with pytest.raises(BrokenProcessPool):
+            await wrapper()
+
+    @pytest.mark.asyncio
+    async def test_recreation_replaces_executor(self):
+        wrapper = AsyncRewardWrapper(
+            _crash_worker, max_workers=1, max_retries=1, timeout_seconds=5
+        )
+        executor_before = AsyncRewardWrapper._executors.get(1)
+        assert executor_before is not None
+
+        with pytest.raises(BrokenProcessPool):
+            await wrapper()
+
+        executor_after = AsyncRewardWrapper._executors.get(1)
+        assert executor_after is not executor_before
+
+
+class TestAsyncRewardWrapperExceptionHandling:
+    @pytest.mark.asyncio
+    async def test_reward_fn_exception_propagates(self):
+        wrapper = AsyncRewardWrapper(_raise_value_error, max_workers=1, max_retries=0)
+        with pytest.raises(ValueError, match="intentional error"):
+            await wrapper()
+
+    @pytest.mark.asyncio
+    async def test_reward_fn_exception_retries_then_raises(self):
+        wrapper = AsyncRewardWrapper(_raise_value_error, max_workers=1, max_retries=2)
+        with pytest.raises(ValueError, match="intentional error"):
+            await wrapper()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_then_call_raises_runtime_error(self):
+        wrapper = AsyncRewardWrapper(_add_reward, max_workers=1, max_retries=0)
+        AsyncRewardWrapper._atexit_shutdown_all()
+        with pytest.raises(RuntimeError, match="has been shut down"):
+            await wrapper(1.0, 2.0)
+
+
+class TestAsyncRewardWrapperAtexitCleanup:
+    def test_atexit_clears_all_executors(self):
+        AsyncRewardWrapper(_add_reward, max_workers=1)
+        AsyncRewardWrapper(_add_reward, max_workers=2)
+        assert len(AsyncRewardWrapper._executors) == 2
+
+        AsyncRewardWrapper._atexit_shutdown_all()
+        assert len(AsyncRewardWrapper._executors) == 0
+
+    def test_atexit_is_idempotent(self):
+        AsyncRewardWrapper(_add_reward, max_workers=1)
+        AsyncRewardWrapper._atexit_shutdown_all()
+        AsyncRewardWrapper._atexit_shutdown_all()
+        assert len(AsyncRewardWrapper._executors) == 0
+
+
+class TestRecreateExecutorRaceSafety:
+    def test_recreate_skips_when_already_replaced(self):
+        AsyncRewardWrapper(_add_reward, max_workers=1)
+        original = AsyncRewardWrapper._executors[1]
+
+        # Simulate a concurrent thread having already replaced the executor
+        replacement = ProcessPoolExecutor(max_workers=1)
+        AsyncRewardWrapper._executors[1] = replacement
+
+        result = AsyncRewardWrapper._recreate_executor(1, 1, original)
+        assert result is replacement
+
+        replacement.shutdown(wait=False)
+
+    def test_recreate_replaces_when_identity_matches(self):
+        AsyncRewardWrapper(_add_reward, max_workers=1)
+        original = AsyncRewardWrapper._executors[1]
+
+        result = AsyncRewardWrapper._recreate_executor(1, 1, original)
+        assert result is not None
+        assert result is not original
+        assert AsyncRewardWrapper._executors[1] is result

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ requires-dist = [
     { name = "swanboard", specifier = "==0.1.9b1" },
     { name = "swanlab", extras = ["dashboard"], specifier = "==0.6.12" },
     { name = "tabulate" },
-    { name = "tenacity" },
+    { name = "tenacity", specifier = ">=8.2.0" },
     { name = "tensorboardx" },
     { name = "tilelang", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'cuda-train'", specifier = ">=0.1.9" },
     { name = "timeout-decorator" },

--- a/uv.vllm.lock
+++ b/uv.vllm.lock
@@ -591,7 +591,7 @@ requires-dist = [
     { name = "swanboard", specifier = "==0.1.9b1" },
     { name = "swanlab", extras = ["dashboard"], specifier = "==0.6.12" },
     { name = "tabulate" },
-    { name = "tenacity" },
+    { name = "tenacity", specifier = ">=8.2.0" },
     { name = "tensorboardx" },
     { name = "tilelang", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'cuda-train'", specifier = ">=0.1.9" },
     { name = "timeout-decorator" },


### PR DESCRIPTION
- AsyncRewardWrapper: atexit-shared executors, CAS recreate, simpler retry; cache one wrapper per math agent; add tests.
- HTTP: unify httpx client via create_httpx_client; bound aiohttp sock_connect/connect timeouts.
- InfBridge: stamp per-chunk versions; data proxy /set_version propagates to the bridge.
- AWEX: skip lm_head.weight when word embeddings are tied.
- Rollout proxy: disable uvicorn access_log.
- Pin tenacity>=8.2.0, drop duplicate entry in both pyprojects/locks.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the [Contributing Guide](../CONTRIBUTING.md) or ask in
[GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
