### PR TITLE
feat(megatron): implement async_save with AsyncCallsQueue

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -872,7 +872,18 @@ class MegatronEngineConfig:
     exp_avg_sq_dtype: str = "float32"
 
     # Checkpointing Configuration
-    async_save: bool = False
+    async_save: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "If True, Megatron checkpoint saves run in background processes and "
+                "save_checkpoint() returns immediately after weights are durably "
+                "staged off the GPU. Pending saves are drained before the next "
+                "load_checkpoint() and during engine.destroy(). Reduces per-save "
+                "sync wait on large MoE checkpoints."
+            ),
+        },
+    )
     use_checkpoint_opt_param_scheduler: bool = True
 
     # Deterministic Option

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -602,6 +602,10 @@ class MegatronEngine(TrainEngine):
     def destroy(self):
         self._initialized = False
         self.process_group_initialized = False
+        # Drain any pending async checkpoint saves before tearing down process
+        # groups; the background save workers issue collectives during finalize.
+        if getattr(self, "checkpointer", None) is not None:
+            self.checkpointer.close()
         if hasattr(self, "optimizer"):
             del self.optimizer
         if hasattr(self, "model"):

--- a/areal/engine/megatron_utils/checkpointer.py
+++ b/areal/engine/megatron_utils/checkpointer.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import random
 
@@ -26,13 +28,17 @@ from megatron.core.dist_checkpointing.serialization import (
     get_default_load_sharded_strategy,
     get_default_save_sharded_strategy,
 )
+from megatron.core.dist_checkpointing.strategies.async_utils import (
+    AsyncCallsQueue,
+    AsyncRequest,
+)
 from megatron.core.dist_checkpointing.strategies.fully_parallel import (
     FullyParallelLoadStrategyWrapper,
     FullyParallelSaveStrategyWrapper,
 )
 
 from areal.infra.platforms import current_platform
-from areal.utils import logging
+from areal.utils import logging, stats_tracker
 
 logger = logging.getLogger("MegatronCheckpointer")
 
@@ -50,7 +56,9 @@ def get_device_name() -> str:
     return device
 
 
-def save_dist_checkpointing(sharded_state_dict, ckpt_path, async_save=False):
+def save_dist_checkpointing(
+    sharded_state_dict, ckpt_path, async_save=False
+) -> AsyncRequest | None:
     validate_sharding_integrity = True
     # Get checkpointing strategies
     save_strategy = get_default_save_sharded_strategy("torch_dist")
@@ -58,14 +66,21 @@ def save_dist_checkpointing(sharded_state_dict, ckpt_path, async_save=False):
         save_strategy, mpu.get_data_parallel_group(with_context_parallel=True)
     )
 
-    # Save model sharded state dicts
-    async_save_request = dist_checkpointing.save(
-        sharded_state_dict,
-        ckpt_path,
+    # Save model sharded state dicts. When async_save=True the actual IO is
+    # deferred; the returned AsyncRequest must be scheduled by the caller via
+    # AsyncCallsQueue.schedule_async_request(). Recent megatron-core versions
+    # require an explicit async_strategy when async_sharded_save=True; "mcore"
+    # selects the AsyncCallsQueue-backed implementation we use below.
+    save_kwargs = dict(
+        sharded_state_dict=sharded_state_dict,
+        checkpoint_dir=ckpt_path,
         sharded_strategy=save_strategy,
         async_sharded_save=async_save,
         validate_access_integrity=validate_sharding_integrity,
     )
+    if async_save:
+        save_kwargs["async_strategy"] = "mcore"
+    async_save_request = dist_checkpointing.save(**save_kwargs)
 
     return async_save_request
 
@@ -160,8 +175,11 @@ class MegatronCheckpointManager:
         self.rank = torch.distributed.get_rank()
         self.use_dist_checkpointing = use_dist_checkpointing
         self.async_save = async_save
-        if async_save:
-            raise NotImplementedError("Async save not implenmented yet!")
+        # AsyncCallsQueue manages outstanding background save processes.
+        # Created only when async_save is enabled; sync path keeps zero overhead.
+        self._async_queue: AsyncCallsQueue | None = (
+            AsyncCallsQueue() if async_save else None
+        )
 
     def get_rng_state(
         self, use_dist_ckpt: bool = True, data_parallel_random_init: bool = False
@@ -322,6 +340,11 @@ class MegatronCheckpointManager:
         with_optimizer: bool = True,
         with_rng: bool = True,
     ):
+        # If a prior save to the same directory is still flushing in the
+        # background, block until it finishes so we don't load a half-written
+        # checkpoint.
+        self.wait_async_saves()
+
         if local_path is not None:
             assert os.path.exists(local_path), (
                 f"Checkpoint path {local_path} does not exist."
@@ -403,21 +426,107 @@ class MegatronCheckpointManager:
     ):
         dist_checkpoint_path = local_path
 
-        if self.use_dist_checkpointing:
-            # Generate state dict for saving
-            state_dict = self.generate_state_dict(with_model, with_optimizer, with_rng)
-            # Start Async save if enabled
-            async_save_request = save_dist_checkpointing(
-                sharded_state_dict=state_dict,
-                ckpt_path=dist_checkpoint_path,
-                async_save=self.async_save,
+        if not self.use_dist_checkpointing:
+            raise NotImplementedError("Please use dist checkpointing!")
+
+        # Reap any previously scheduled async saves that have already finished.
+        # Non-blocking: this only finalizes completed background processes and
+        # writes their metadata.json. Pending saves remain queued.
+        self._reap_finished_async_saves()
+
+        # Generate state dict for saving
+        state_dict = self.generate_state_dict(with_model, with_optimizer, with_rng)
+        # Start Async save if enabled
+        async_save_request = save_dist_checkpointing(
+            sharded_state_dict=state_dict,
+            ckpt_path=dist_checkpoint_path,
+            async_save=self.async_save,
+        )
+
+        if self.async_save:
+            # Invariant relies on save_dist_checkpointing using "torch_dist" +
+            # FullyParallelSaveStrategyWrapper, both of which support async in
+            # current megatron-core. A different strategy could legitimately
+            # return None here; revisit if the save strategy changes.
+            assert async_save_request is not None, (
+                "Megatron returned no AsyncRequest despite async_sharded_save=True."
+            )
+            assert self._async_queue is not None
+            call_idx = self._async_queue.schedule_async_request(async_save_request)
+            # By the time schedule_async_request returns, AsyncCallsQueue has
+            # already done torch.cuda.synchronize() and forked the background
+            # save process — so weights are durably staged off the GPU. The
+            # wall-clock the trainer sees (timeperf/save) covers up to this
+            # point. Disk IO continues in the background; success is observable
+            # as ckpt/async_save_queue_depth dropping back to 0 (and a failing
+            # finalize raises from wait_async_saves -> engine.destroy()).
+            stats_tracker.scalar(
+                **{
+                    "ckpt/async_save_queue_depth": float(
+                        self._async_queue.get_num_unfinalized_calls()
+                    ),
+                }
+            )
+            log_with_rank(
+                f"Scheduled async checkpoint save #{call_idx} to {local_path} "
+                f"(queue_depth={self._async_queue.get_num_unfinalized_calls()})",
+                rank=self.rank,
+                log_only_rank_0=True,
+            )
+        else:
+            assert async_save_request is None, (
+                "Async save request should be None when not using async save."
+            )
+            torch.distributed.barrier()
+
+    def _reap_finished_async_saves(self) -> None:
+        """Non-blocking finalize of any background save processes that have finished.
+
+        Must be called collectively on all ranks: maybe_finalize_async_calls
+        runs an all_reduce internally to agree on which calls have completed.
+        Safe to call when async_save is disabled (becomes a no-op).
+        """
+        if self._async_queue is None:
+            return
+        finalized = self._async_queue.maybe_finalize_async_calls(blocking=False)
+        for call_idx in finalized:
+            log_with_rank(
+                f"Finalized async checkpoint save #{call_idx}",
+                rank=self.rank,
+                log_only_rank_0=True,
             )
 
-            # Synchronize all async save requests
-            if not self.async_save:
-                assert async_save_request is None, (
-                    "Async save request should be None when not using async save."
-                )
-                torch.distributed.barrier()
-        else:
-            raise NotImplementedError("Please use dist checkpointing!")
+    def wait_async_saves(self) -> None:
+        """Block until every previously scheduled async save has finalized.
+
+        Must be called collectively on all ranks. Call before:
+        - loading a checkpoint (so prior saves to the same dir are durable),
+        - tearing down process groups,
+        - exiting the training process.
+        """
+        if self._async_queue is None:
+            return
+        # Do NOT early-return when get_num_unfinalized_calls()==0: that count is
+        # rank-local, but a previous non-blocking reap can leave ranks skewed
+        # (process-exit timing differs). maybe_finalize_async_calls(blocking=True)
+        # is a collective; if one rank skips it while another waits inside it,
+        # the cluster deadlocks. The call is cheap when truly empty.
+        pending = self._async_queue.get_num_unfinalized_calls()
+        if pending > 0:
+            log_with_rank(
+                f"Waiting for {pending} pending async checkpoint save(s) to finalize",
+                rank=self.rank,
+                log_only_rank_0=True,
+            )
+        finalized = self._async_queue.maybe_finalize_async_calls(blocking=True)
+        for call_idx in finalized:
+            log_with_rank(
+                f"Finalized async checkpoint save #{call_idx}",
+                rank=self.rank,
+                log_only_rank_0=True,
+            )
+
+    def close(self) -> None:
+        """Drain all pending async saves. Idempotent; safe to call multiple times."""
+        self.wait_async_saves()
+        self._async_queue = None

--- a/tests/test_megatron_async_save.py
+++ b/tests/test_megatron_async_save.py
@@ -1,0 +1,248 @@
+"""Unit tests for the Megatron checkpoint manager's async-save state machine.
+
+These tests do NOT exercise real Megatron dist_checkpointing or distributed
+process groups. They patch the queue and `save_dist_checkpointing` to verify
+that the manager correctly:
+
+- skips queue creation when async_save is False
+- routes the AsyncRequest to AsyncCallsQueue.schedule_async_request when True
+- finalizes completed saves non-blockingly on each new save call
+- blocks on load_checkpoint / close
+- treats close as idempotent
+- emits the async-only metric (queue_depth on schedule)
+- emits no async metrics on the sync path
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _import_checkpointer():
+    """Import the checkpointer module without triggering the full areal package."""
+    if "areal.engine.megatron_utils.checkpointer" in sys.modules:
+        return sys.modules["areal.engine.megatron_utils.checkpointer"]
+
+    # Stub out heavy/optional dependencies so the module loads on a CPU box
+    # without Megatron or a Stager-capable torch build.
+    for path in (
+        "megatron",
+        "megatron.core",
+        "megatron.core.dist_checkpointing",
+        "megatron.core.dist_checkpointing.mapping",
+        "megatron.core.dist_checkpointing.serialization",
+        "megatron.core.dist_checkpointing.strategies",
+        "megatron.core.dist_checkpointing.strategies.async_utils",
+        "megatron.core.dist_checkpointing.strategies.fully_parallel",
+        "areal",
+        "areal.engine",
+        "areal.engine.megatron_utils",
+        "areal.infra",
+        "areal.infra.platforms",
+        "areal.utils",
+        "areal.utils.logging",
+    ):
+        sys.modules.setdefault(path, types.ModuleType(path))
+
+    sys.modules["megatron.core"].dist_checkpointing = sys.modules[
+        "megatron.core.dist_checkpointing"
+    ]
+    sys.modules["megatron.core"].mpu = MagicMock()
+    sys.modules["megatron.core"].tensor_parallel = MagicMock()
+    sys.modules["megatron.core.dist_checkpointing.mapping"].ShardedObject = MagicMock()
+    sys.modules[
+        "megatron.core.dist_checkpointing.serialization"
+    ].get_default_load_sharded_strategy = MagicMock()
+    sys.modules[
+        "megatron.core.dist_checkpointing.serialization"
+    ].get_default_save_sharded_strategy = MagicMock()
+    async_utils = sys.modules["megatron.core.dist_checkpointing.strategies.async_utils"]
+    async_utils.AsyncCallsQueue = MagicMock
+    async_utils.AsyncRequest = MagicMock
+    fp_mod = sys.modules["megatron.core.dist_checkpointing.strategies.fully_parallel"]
+    fp_mod.FullyParallelLoadStrategyWrapper = MagicMock
+    fp_mod.FullyParallelSaveStrategyWrapper = MagicMock
+    sys.modules["areal.infra.platforms"].current_platform = MagicMock(
+        device_type="cuda", is_available=lambda: False
+    )
+    sys.modules["areal.utils.logging"].getLogger = lambda *_a, **_k: MagicMock()
+
+    # stats_tracker.scalar is called by the manager to report latency.
+    stats_mod = types.ModuleType("areal.utils.stats_tracker")
+    stats_mod.scalar = MagicMock()
+    sys.modules["areal.utils.stats_tracker"] = stats_mod
+
+    # The checkpointer imports `from areal.utils import logging, stats_tracker`.
+    # Make sure the parent `areal.utils` package exposes both as attributes.
+    sys.modules["areal.utils"].logging = sys.modules["areal.utils.logging"]
+    sys.modules["areal.utils"].stats_tracker = stats_mod
+
+    # Load the real checkpointer module from disk under the stubbed parents.
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "areal.engine.megatron_utils.checkpointer",
+        repo_root / "areal" / "engine" / "megatron_utils" / "checkpointer.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["areal.engine.megatron_utils.checkpointer"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def patched_checkpointer():
+    mod = _import_checkpointer()
+
+    queue = MagicMock()
+    queue.get_num_unfinalized_calls.return_value = 0
+    queue.maybe_finalize_async_calls.return_value = []
+    queue.schedule_async_request.return_value = 0
+
+    with (
+        patch("torch.distributed.get_rank", return_value=0),
+        patch.object(mod, "AsyncCallsQueue", return_value=queue),
+    ):
+        manager = mod.MegatronCheckpointManager(
+            model=MagicMock(),
+            optimizer=MagicMock(),
+            lr_scheduler=None,
+            async_save=True,
+        )
+        yield mod, manager, queue
+
+
+def test_async_disabled_creates_no_queue():
+    mod = _import_checkpointer()
+    with patch("torch.distributed.get_rank", return_value=0):
+        m = mod.MegatronCheckpointManager(
+            model=MagicMock(),
+            optimizer=MagicMock(),
+            lr_scheduler=None,
+            async_save=False,
+        )
+    assert m._async_queue is None
+    m._reap_finished_async_saves()
+    m.wait_async_saves()
+    m.close()
+
+
+def test_save_schedules_async_request(patched_checkpointer, tmp_path):
+    mod, manager, queue = patched_checkpointer
+    fake_request = object()
+
+    with (
+        patch.object(manager, "generate_state_dict", return_value={"model": {}}),
+        patch.object(
+            mod, "save_dist_checkpointing", return_value=fake_request
+        ) as save_fn,
+        patch("torch.cuda.empty_cache"),
+        patch("torch.distributed.barrier"),
+    ):
+        manager.save_checkpoint(str(tmp_path / "step0"))
+
+    save_fn.assert_called_once()
+    assert save_fn.call_args.kwargs["async_save"] is True
+    queue.schedule_async_request.assert_called_once_with(fake_request)
+
+
+def test_save_reaps_before_scheduling_next(patched_checkpointer, tmp_path):
+    mod, manager, queue = patched_checkpointer
+
+    with (
+        patch.object(manager, "generate_state_dict", return_value={"model": {}}),
+        patch.object(mod, "save_dist_checkpointing", side_effect=["r1", "r2"]),
+        patch("torch.cuda.empty_cache"),
+        patch("torch.distributed.barrier"),
+    ):
+        manager.save_checkpoint(str(tmp_path / "step0"))
+        manager.save_checkpoint(str(tmp_path / "step1"))
+
+    calls = queue.maybe_finalize_async_calls.call_args_list
+    assert len(calls) == 2
+    assert all(call.kwargs.get("blocking", False) is False for call in calls)
+    assert queue.schedule_async_request.call_count == 2
+
+
+def test_load_blocks_on_pending_saves(patched_checkpointer, tmp_path):
+    mod, manager, queue = patched_checkpointer
+    queue.get_num_unfinalized_calls.return_value = 1
+
+    with (
+        patch("os.path.exists", return_value=True),
+        patch.object(manager, "generate_state_dict", return_value={}),
+        patch.object(mod, "load_dist_checkpointing", return_value={}),
+    ):
+        with pytest.raises((AssertionError, KeyError)):
+            manager.load_checkpoint(str(tmp_path / "step0"))
+
+    queue.maybe_finalize_async_calls.assert_called_with(blocking=True)
+
+
+def test_close_is_idempotent(patched_checkpointer):
+    _, manager, queue = patched_checkpointer
+    queue.get_num_unfinalized_calls.return_value = 0
+
+    manager.close()
+    manager.close()
+
+    assert manager._async_queue is None
+
+
+def test_async_save_reports_queue_depth_only(patched_checkpointer, tmp_path):
+    """async_save emits ckpt/async_save_queue_depth on schedule and no other metric.
+
+    Successful finalize is observable as queue_depth returning to 0; a failing
+    background save raises from wait_async_saves, so an explicit count metric
+    would be redundant.
+    """
+    mod, manager, queue = patched_checkpointer
+    stats_scalar = sys.modules["areal.utils.stats_tracker"].scalar
+    stats_scalar.reset_mock()
+
+    queue.schedule_async_request.return_value = 42
+    queue.get_num_unfinalized_calls.return_value = 1
+
+    with (
+        patch.object(manager, "generate_state_dict", return_value={"model": {}}),
+        patch.object(mod, "save_dist_checkpointing", side_effect=["r1", "r2"]),
+        patch("torch.cuda.empty_cache"),
+        patch("torch.distributed.barrier"),
+    ):
+        manager.save_checkpoint(str(tmp_path / "step0"))
+
+        # On the next save, reap returns [42] -> still no extra metrics.
+        queue.maybe_finalize_async_calls.return_value = [42]
+        queue.schedule_async_request.return_value = 43
+        manager.save_checkpoint(str(tmp_path / "step1"))
+
+    all_keys = set()
+    for c in stats_scalar.call_args_list:
+        all_keys.update(c.kwargs.keys())
+    assert all_keys == {"ckpt/async_save_queue_depth"}
+
+
+def test_sync_save_emits_no_async_metrics(patched_checkpointer, tmp_path):
+    """Sync save path stays metric-free; trainer-side `timeperf/save` is sufficient."""
+    mod, manager, _ = patched_checkpointer
+    manager.async_save = False
+    manager._async_queue = None
+    stats_scalar = sys.modules["areal.utils.stats_tracker"].scalar
+    stats_scalar.reset_mock()
+
+    with (
+        patch.object(manager, "generate_state_dict", return_value={"model": {}}),
+        patch.object(mod, "save_dist_checkpointing", return_value=None),
+        patch("torch.cuda.empty_cache"),
+        patch("torch.distributed.barrier"),
+    ):
+        manager.save_checkpoint(str(tmp_path / "step0"))
+
+    stats_scalar.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #1355.

`MegatronEngineConfig.async_save` was exposed but `MegatronCheckpointManager` rejected the path with `NotImplementedError("Async save not implenmented yet!")`. This PR wires it up using megatron-core's `AsyncCallsQueue` / `AsyncRequest`.

When `async_save=true`, `save_checkpoint()` schedules an `AsyncRequest` and returns as soon as weights are durably staged off the GPU, freeing the training loop from blocking on disk IO. Pending saves are drained automatically before `load_checkpoint()` and during `MegatronEngine.destroy()`.

## Hardening

A few non-obvious correctness points addressed up front:

- **`wait_async_saves` does NOT early-return on a rank-local empty-queue check.** An earlier non-blocking reap can leave ranks skewed on which call has finalized (process-exit timing differs), and `maybe_finalize_async_calls(blocking=True)` is a collective. Skipping it on a subset of ranks deadlocks the cluster. The blocking call is cheap when the queue is truly empty.
- **`_reap_finished_async_saves` documents the collective requirement** so future callers don't introduce a non-collective call site.
- **`save_dist_checkpointing` passes `async_strategy=\"mcore\"` when async** — newer megatron-core versions require an explicit strategy when `async_sharded_save=True`.

## Metrics

One scalar on the async path (sync path stays metric-free, trainer-side `timeperf/save` already covers it):

- `ckpt/async_save_queue_depth` — emitted on schedule. Spikes if disk IO is slower than save frequency (saves piling up in the background). Returning to 0 is the natural \"all saves succeeded\" signal.

A per-save disk-latency metric was prototyped (`ckpt/async_save_disk_seconds`) but dropped after review (see [discussion](https://github.com/areal-project/AReaL/pull/1356#discussion_r3279817904)): it actually measured schedule-time → trainer-observed-reap-time, which is dominated by the inter-save interval rather than real disk IO, so the reported value was systematically inflated and misleading. Process exit status from a failing `wait_async_saves()` (which propagates from `engine.destroy()`) remains the authoritative \"all saves succeeded\" signal, so an explicit per-save count was redundant.

Memory-ready latency is intentionally NOT duplicated under `ckpt/*` — trainer code already records that under `timeperf/save` via `stats_tracker.record_timing(\"save\")`, which in async mode naturally measures schedule-return time (D2H + fork).

## Files changed

- `areal/api/cli_args.py` — add help metadata to `MegatronEngineConfig.async_save`.
- `areal/engine/megatron_engine.py` — drain pending saves in `destroy()` before tearing down process groups.
- `areal/engine/megatron_utils/checkpointer.py` — main implementation: `AsyncCallsQueue`, `save_checkpoint` schedule + non-blocking reap, `wait_async_saves` / `close` blocking drain, `async_strategy=\"mcore\"`, `queue_depth` metric.
- `tests/test_megatron_async_save.py` — new file, 7 unit tests covering: queue not created when disabled, schedule path, non-blocking reap between saves, blocking wait on load, idempotent close, `queue_depth`-only emission on the async path, sync path emits no async metrics. Stubs `megatron.core` / `areal.infra` so they run on a CPU-only box without a real distributed env.

## Test plan

- [x] `python -m pytest tests/test_megatron_async_save.py -v` — 7/7 pass on CPU-only env
- [x] `python -m ruff format --check` and `python -m ruff check` — pass on all 4 changed files
- [x] `pre-commit run` — passes (ruff, SPDX header, large-file/private-key, etc.); `generate-cli-docs` skipped due to a local torch / `DefaultStager` import issue unrelated to this PR
- [ ] End-to-end Megatron run with `mcore.async_save=true` on a multi-GPU cluster — verify queue depth stays bounded across many save steps and that `load_checkpoint` correctly blocks on a still-flushing prior save (cannot run locally; relies on cluster CI)
- [ ] Verify `MegatronEngine.destroy()` ordering on shutdown — no NCCL collectives outliving process group teardown (cannot reproduce locally without distributed env)

## Hardware limitations of local test

Local tests stub out `megatron.core`, distributed process groups, and `current_platform` so the state machine of the manager is exercised without requiring real Megatron, NCCL, or a GPU. Full end-to-end validation requires a multi-GPU cluster; my internal copy of this implementation has been running on production infrastructure for several weeks.