### PR TITLE
fix(test): add missing colocate field to wu_controller connect tests

### DIFF
--- a/tests/experimental/weight_update/test_wu_controller.py
+++ b/tests/experimental/weight_update/test_wu_controller.py
@@ -81,6 +81,7 @@ class TestConnect:
                 "save_path": "",
                 "use_lora": False,
                 "lora_name": "",
+                "colocate": False,
             },
             timeout=10.0,
         )
@@ -110,6 +111,7 @@ class TestConnect:
                 "save_path": "/shared/weights",
                 "use_lora": True,
                 "lora_name": "my-lora",
+                "colocate": False,
             },
             timeout=10.0,
         )


### PR DESCRIPTION
Tests in `test_wu_controller.py::TestConnect` assert the exact JSON payload sent to `/connect`. #1310 added a `colocate` field to the controller's payload but did not update these tests, breaking CI on main.