### PR TITLE
feat(mcore): add Bailing-MoE V2.5 megatron-bridge adapter

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -16,7 +16,10 @@ from contextlib import contextmanager
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-import mbridge
+try:
+    import mbridge
+except ImportError:
+    mbridge = None
 import torch
 import torch.distributed as dist
 from megatron.bridge import AutoBridge as MegatronBridgeAutoBridge
@@ -35,7 +38,15 @@ from torch import nn
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import PretrainedConfig
 
-import areal.models.mcore.bailing_moe_bridge  # noqa: F401  # register bridge
+# mbridge-based bridge modules are optional; their @register_model decorators
+# only fire when mbridge is installed. Wrap each import so the engine still
+# loads in megatron-bridge-only deployments.
+try:
+    import areal.models.mcore.bailing_moe_bridge  # noqa: F401  # register bridge
+except ImportError:
+    pass
+# megatron-bridge adapters do not depend on mbridge and register on import.
+import areal.models.mcore.bailing_moe_megatron_bridge  # noqa: F401  # register bridge
 from areal.api import (
     FinetuneSpec,
     InferenceEngine,
@@ -548,6 +559,12 @@ class MegatronEngine(TrainEngine):
 
     def _build_hf_mcore_bridge(self):
         if self.bridge_cls == "mbridge":
+            if mbridge is None:
+                raise ImportError(
+                    "bridge_type='mbridge' requested but the 'mbridge' package "
+                    "is not installed. Install it or switch to "
+                    "bridge_type='megatron-bridge'."
+                )
             self.bridge = mbridge.AutoBridge.from_pretrained(
                 self.config.path, trust_remote_code=True
             )

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -9,6 +9,7 @@ import json
 import math
 import os
 import re
+import shutil
 import struct
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
@@ -100,6 +101,7 @@ from areal.infra.dist_rollout import DistRolloutCoordinator
 from areal.infra.platforms import current_platform
 from areal.models.mcore.hf_load import load_weights_from_hf_with_mbridge_fast
 from areal.models.mcore.hf_save import (
+    _patch_saved_config,
     save_critic_value_head,
     save_weights_to_hf_with_mbridge_fast,
 )
@@ -2057,6 +2059,20 @@ class MegatronEngine(TrainEngine):
                     source_path=base_model_path,
                     strict=not self._mtp_head_dropped,
                 )
+                # Patch config.json and copy auxiliary files from source.
+                # PretrainedConfig.to_dict() reads model_type from the class
+                # attribute, which trust_remote_code configs may lack — without
+                # the patch the saved checkpoint cannot be loaded by inference
+                # engines (e.g. sglang).
+                if base_model_path and dist.get_rank() == 0:
+                    _patch_saved_config(base_model_path, path)
+                    src_gen_cfg = os.path.join(
+                        base_model_path, "generation_config.json"
+                    )
+                    if os.path.isfile(src_gen_cfg):
+                        shutil.copy2(
+                            src_gen_cfg, os.path.join(path, "generation_config.json")
+                        )
         else:
             if self.mcore_config.use_mbridge_save:
                 # when loading model using AreaL's fast hf load, the safetensor_io is never set

--- a/areal/models/mcore/bailing_moe_megatron_bridge.py
+++ b/areal/models/mcore/bailing_moe_megatron_bridge.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Megatron-Bridge registration for BailingMoeV2.5.
+
+Registers BailingMoeV2.5 (and its Linear/Hybrid variants) with NVIDIA's
+open-source megatron-bridge, enabling ``bridge_type: megatron-bridge`` in
+AReaL for these models.
+
+BailingMoeV2.5 uses heterogeneous attention layers:
+- Lightning Attention (linear attention with learned decay) for most layers
+- MLA (Multi-Latent Attention) for the last layer of every ``layer_group_size``
+  group
+
+The mbridge backend remains the default; this module is only imported (and
+its decorators only run) when the user opts in via ``mcore.bridge_type:
+megatron-bridge``.
+
+Implementation mirrors ``glm5_megatron_bridge.py``:
+- One ``BailingMoeV25Bridge`` class with three ``@register_bridge`` decorators
+  for the three HF architectures (V2_5 / Linear / Hybrid)
+- ``provider_bridge()`` sets MLA + MoE fields and injects the heterogeneous
+  layer spec from ``bailing_moe.make_mcore_layer_specs_bailing_moe``
+- ``mapping_registry()`` enumerates attention mappings per-layer
+  (Lightning vs MLA) because ``AutoMapping`` wildcards cannot express
+  per-layer mapping selection
+- ``LightningQKVMapping`` is an ``AutoMapping`` subclass that permutes the
+  fused QKV weight between HF ``[Q|K|V]`` and mcore ``[q0,k0,v0,...]``
+  layouts. If the megatron-bridge release in use does not support
+  overriding ``hf_to_megatron`` / ``megatron_to_hf``, fall back to a hook
+  via ``maybe_modify_converted_hf_weight`` (see TODO in that method).
+"""
+
+import os
+from collections.abc import Mapping
+from functools import partial
+
+import torch
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.model_bridge import (
+    MegatronModelBridge,
+    WeightConversionTask,
+)
+from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.mla_provider import MLAModelProvider
+from megatron.core.models.gpt.gpt_model import GPTModel
+
+from areal.models.mcore.bailing_moe import (
+    is_lightning_layer,
+    make_mcore_layer_specs_bailing_moe,
+)
+from areal.utils import logging
+
+logger = logging.getLogger("BailingMoeMegatronBridge")
+
+
+# ---------------------------------------------------------------------------
+# Lightning Attention fused-QKV permutation
+# ---------------------------------------------------------------------------
+
+
+def _permute_qkv_hf_to_mcore(
+    weight: torch.Tensor, num_heads: int, head_dim: int
+) -> torch.Tensor:
+    """Permute HF fused QKV ([3,H,D,...]) to mcore layout ([H,3,D,...])."""
+    if weight.ndim == 1:
+        w = weight.view(3, num_heads, head_dim)
+        w = w.permute(1, 0, 2).contiguous()
+        return w.view(-1)
+    hidden = weight.shape[1]
+    w = weight.view(3, num_heads, head_dim, hidden)
+    w = w.permute(1, 0, 2, 3).contiguous()
+    return w.view(num_heads * 3 * head_dim, hidden)
+
+
+def _permute_qkv_mcore_to_hf(
+    weight: torch.Tensor, num_heads: int, head_dim: int
+) -> torch.Tensor:
+    """Permute mcore fused QKV ([H,3,D,...]) back to HF layout ([3,H,D,...])."""
+    if weight.ndim == 1:
+        w = weight.view(num_heads, 3, head_dim)
+        w = w.permute(1, 0, 2).contiguous()
+        return w.view(-1)
+    hidden = weight.shape[1]
+    w = weight.view(num_heads, 3, head_dim, hidden)
+    w = w.permute(1, 0, 2, 3).contiguous()
+    return w.view(3 * num_heads * head_dim, hidden)
+
+
+class LightningQKVMapping(AutoMapping):
+    """Fused-QKV mapping for BailingMoe Lightning Attention layers.
+
+    HF layout : ``[3*H*D, hidden]`` ordered as ``[Q_all | K_all | V_all]``
+    mcore layout: ``[H*3*D, hidden]`` ordered as ``[q0,k0,v0 | q1,k1,v1 | ...]``
+
+    Both ``weight`` and ``bias`` need the same permutation. ``layer_norm``
+    sub-parameters of the fused QKV are NOT routed here (the registry
+    excludes them by giving them their own ``AutoMapping`` entries).
+    """
+
+    def __init__(
+        self,
+        megatron_param: str,
+        hf_param: str,
+        *,
+        num_heads: int,
+        head_dim: int,
+    ):
+        super().__init__(megatron_param=megatron_param, hf_param=hf_param)
+        self._num_heads = num_heads
+        self._head_dim = head_dim
+
+    def hf_to_megatron(self, hf_weights, *args, **kwargs):
+        """Apply [3,H,D] -> [H,3,D] permutation when converting HF -> mcore."""
+        weight = hf_weights[0] if isinstance(hf_weights, (list, tuple)) else hf_weights
+        return _permute_qkv_hf_to_mcore(weight, self._num_heads, self._head_dim)
+
+    def megatron_to_hf(self, megatron_weight, *args, **kwargs):
+        """Apply [H,3,D] -> [3,H,D] permutation when converting mcore -> HF."""
+        result = super().megatron_to_hf(megatron_weight, *args, **kwargs)
+        if not result:
+            return result
+        return {
+            k: _permute_qkv_mcore_to_hf(v, self._num_heads, self._head_dim)
+            for k, v in result.items()
+        }
+
+
+# ---------------------------------------------------------------------------
+# Per-layer mapping helpers
+# ---------------------------------------------------------------------------
+
+_GLOBAL_MAPPINGS = [
+    ("embedding.word_embeddings.weight", "model.word_embeddings.weight"),
+    ("decoder.final_layernorm.weight", "model.norm.weight"),
+    ("output_layer.weight", "lm_head.weight"),
+]
+
+
+def _dense_mlp_mappings(layer_idx: int) -> list:
+    """Mappings for a dense (non-MoE) MLP layer."""
+    return [
+        AutoMapping(
+            megatron_param=(
+                f"decoder.layers.{layer_idx}.mlp.linear_fc1.layer_norm_weight"
+            ),
+            hf_param=f"model.layers.{layer_idx}.post_attention_layernorm.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"decoder.layers.{layer_idx}.mlp.linear_fc2.weight",
+            hf_param=f"model.layers.{layer_idx}.mlp.down_proj.weight",
+        ),
+        GatedMLPMapping(
+            megatron_param=f"decoder.layers.{layer_idx}.mlp.linear_fc1.weight",
+            gate=f"model.layers.{layer_idx}.mlp.gate_proj.weight",
+            up=f"model.layers.{layer_idx}.mlp.up_proj.weight",
+        ),
+    ]
+
+
+def _moe_mlp_mappings(layer_idx: int) -> list:
+    """Mappings for a MoE MLP layer (router + shared experts + expert MLP)."""
+    return [
+        AutoMapping(
+            megatron_param=f"decoder.layers.{layer_idx}.pre_mlp_layernorm.weight",
+            hf_param=f"model.layers.{layer_idx}.post_attention_layernorm.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"decoder.layers.{layer_idx}.mlp.router.weight",
+            hf_param=f"model.layers.{layer_idx}.mlp.gate.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"decoder.layers.{layer_idx}.mlp.router.expert_bias",
+            hf_param=f"model.layers.{layer_idx}.mlp.gate.expert_bias",
+        ),
+        AutoMapping(
+            megatron_param=(
+                f"decoder.layers.{layer_idx}.mlp.shared_experts.linear_fc2.weight"
+            ),
+            hf_param=(f"model.layers.{layer_idx}.mlp.shared_experts.down_proj.weight"),
+        ),
+        GatedMLPMapping(
+            megatron_param=(
+                f"decoder.layers.{layer_idx}.mlp.shared_experts.linear_fc1.weight"
+            ),
+            gate=(f"model.layers.{layer_idx}.mlp.shared_experts.gate_proj.weight"),
+            up=f"model.layers.{layer_idx}.mlp.shared_experts.up_proj.weight",
+        ),
+        AutoMapping(
+            megatron_param=(
+                f"decoder.layers.{layer_idx}.mlp.experts.linear_fc2.weight*"
+            ),
+            hf_param=f"model.layers.{layer_idx}.mlp.experts.*.down_proj.weight",
+        ),
+        GatedMLPMapping(
+            megatron_param=(
+                f"decoder.layers.{layer_idx}.mlp.experts.linear_fc1.weight*"
+            ),
+            gate=f"model.layers.{layer_idx}.mlp.experts.*.gate_proj.weight",
+            up=f"model.layers.{layer_idx}.mlp.experts.*.up_proj.weight",
+        ),
+    ]
+
+
+def _lightning_attention_mappings(
+    layer_idx: int, num_heads: int, head_dim: int
+) -> list:
+    """Mappings for a Lightning Attention layer.
+
+    Uses ``LightningQKVMapping`` for the fused QKV weight/bias so the
+    [Q|K|V] -> [q0,k0,v0,...] permutation is applied during conversion.
+    """
+    prefix_mcore = f"decoder.layers.{layer_idx}.self_attention"
+    prefix_hf = f"model.layers.{layer_idx}.attention"
+    return [
+        AutoMapping(
+            megatron_param=f"decoder.layers.{layer_idx}.input_layernorm.weight",
+            hf_param=f"model.layers.{layer_idx}.input_layernorm.weight",
+        ),
+        LightningQKVMapping(
+            megatron_param=f"{prefix_mcore}.linear_qkv.weight",
+            hf_param=f"{prefix_hf}.query_key_value.weight",
+            num_heads=num_heads,
+            head_dim=head_dim,
+        ),
+        AutoMapping(
+            megatron_param=f"{prefix_mcore}.linear_proj.weight",
+            hf_param=f"{prefix_hf}.dense.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"{prefix_mcore}.linear_gate.weight",
+            hf_param=f"{prefix_hf}.g_proj.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"{prefix_mcore}.gate_norm.weight",
+            hf_param=f"{prefix_hf}.g_norm.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"{prefix_mcore}.q_layernorm.weight",
+            hf_param=f"{prefix_hf}.query_layernorm.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"{prefix_mcore}.k_layernorm.weight",
+            hf_param=f"{prefix_hf}.key_layernorm.weight",
+        ),
+    ]
+
+
+def _mla_attention_mappings(layer_idx: int, q_lora_rank: int | None) -> list:
+    """Mappings for an MLA Attention layer.
+
+    Two sub-shapes depending on whether Q uses a LoRA decomposition:
+    - ``q_lora_rank=None``  : direct ``q_proj``
+    - ``q_lora_rank != None``: low-rank ``q_a_proj`` + ``q_a_layernorm`` +
+      ``q_b_proj``
+    """
+    prefix_mcore = f"decoder.layers.{layer_idx}.self_attention"
+    prefix_hf = f"model.layers.{layer_idx}.attention"
+    common = [
+        AutoMapping(
+            megatron_param=f"decoder.layers.{layer_idx}.input_layernorm.weight",
+            hf_param=f"model.layers.{layer_idx}.input_layernorm.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"{prefix_mcore}.linear_kv_down_proj.weight",
+            hf_param=f"{prefix_hf}.kv_a_proj_with_mqa.weight",
+        ),
+        AutoMapping(
+            megatron_param=(f"{prefix_mcore}.linear_kv_up_proj.layer_norm_weight"),
+            hf_param=f"{prefix_hf}.kv_a_layernorm.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"{prefix_mcore}.linear_kv_up_proj.weight",
+            hf_param=f"{prefix_hf}.kv_b_proj.weight",
+        ),
+        AutoMapping(
+            megatron_param=f"{prefix_mcore}.linear_proj.weight",
+            hf_param=f"{prefix_hf}.dense.weight",
+        ),
+    ]
+    if q_lora_rank is None:
+        q_specific = [
+            AutoMapping(
+                megatron_param=f"{prefix_mcore}.linear_q_proj.weight",
+                hf_param=f"{prefix_hf}.q_proj.weight",
+            ),
+        ]
+    else:
+        q_specific = [
+            AutoMapping(
+                megatron_param=f"{prefix_mcore}.linear_q_down_proj.weight",
+                hf_param=f"{prefix_hf}.q_a_proj.weight",
+            ),
+            AutoMapping(
+                megatron_param=(f"{prefix_mcore}.linear_q_up_proj.layer_norm_weight"),
+                hf_param=f"{prefix_hf}.q_a_layernorm.weight",
+            ),
+            AutoMapping(
+                megatron_param=f"{prefix_mcore}.linear_q_up_proj.weight",
+                hf_param=f"{prefix_hf}.q_b_proj.weight",
+            ),
+        ]
+    return common + q_specific
+
+
+# ---------------------------------------------------------------------------
+# Bridge
+# ---------------------------------------------------------------------------
+
+
+@MegatronModelBridge.register_bridge(
+    source="BailingMoeV2_5ForCausalLM",
+    target=GPTModel,
+    provider=MLAModelProvider,
+    model_type="bailing_moe_v2",
+)
+@MegatronModelBridge.register_bridge(
+    source="BailingMoeLinearForCausalLM",
+    target=GPTModel,
+    provider=MLAModelProvider,
+    model_type="bailing_moe_linear",
+)
+@MegatronModelBridge.register_bridge(
+    source="BailingHybridForCausalLM",
+    target=GPTModel,
+    provider=MLAModelProvider,
+    model_type="bailing_hybrid",
+)
+class BailingMoeV25Bridge(MegatronModelBridge):
+    """Megatron Bridge for BailingMoeV2.5 (Lightning + MLA heterogeneous)."""
+
+    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> MLAModelProvider:
+        provider = super().provider_bridge(hf_pretrained)
+        hf_config = hf_pretrained.config
+
+        # Inject AReaL's heterogeneous layer spec. The provider's default
+        # get_gpt_decoder_block_spec is uniform and does not know about
+        # Lightning Attention. The signature
+        # ``(tf_config, vp_stage=None) -> TransformerBlockSubmodules``
+        # matches what megatron-bridge calls.
+        provider.transformer_layer_spec = partial(
+            make_mcore_layer_specs_bailing_moe,
+            hf_config=hf_config,
+            use_te=True,
+        )
+
+        # ---------------- MTP ----------------
+        mtp_num_layers = getattr(hf_config, "num_nextn_predict_layers", None)
+        if os.environ.get("AREAL_DISABLE_MTP", "0") == "1" and mtp_num_layers:
+            logger.warning(
+                f"AREAL_DISABLE_MTP=1: overriding mtp_num_layers from {mtp_num_layers} to 0"
+            )
+            mtp_num_layers = 0
+        provider.mtp_num_layers = mtp_num_layers or 0
+
+        # ---------------- Architecture basics ----------------
+        provider.normalization = "RMSNorm"
+        provider.gated_linear_unit = True
+        provider.position_embedding_type = "rope"
+        provider.add_bias_linear = False
+        provider.share_embeddings_and_output_weights = False
+        provider.qk_layernorm = True
+        provider.multi_latent_attention = True
+
+        # ---------------- MLA dimensions ----------------
+        provider.q_lora_rank = getattr(hf_config, "q_lora_rank", None)
+        provider.kv_lora_rank = getattr(hf_config, "kv_lora_rank", 512)
+        provider.qk_head_dim = getattr(hf_config, "qk_nope_head_dim", 128)
+        provider.qk_pos_emb_head_dim = getattr(hf_config, "qk_rope_head_dim", 64)
+        provider.v_head_dim = getattr(hf_config, "v_head_dim", 128)
+
+        # ---------------- MoE ----------------
+        num_layers = hf_config.num_hidden_layers
+        first_k_dense = getattr(hf_config, "first_k_dense_replace", 0)
+        provider.moe_layer_freq = [
+            0 if i < first_k_dense else 1 for i in range(num_layers)
+        ]
+
+        shared_expert_intermediate = getattr(
+            hf_config, "moe_shared_expert_intermediate_size", None
+        )
+        if shared_expert_intermediate is None:
+            num_shared = getattr(hf_config, "num_shared_experts", 0)
+            inter = getattr(
+                hf_config, "moe_intermediate_size", hf_config.intermediate_size
+            )
+            shared_expert_intermediate = num_shared * inter if num_shared > 0 else None
+        provider.moe_shared_expert_intermediate_size = shared_expert_intermediate
+
+        provider.num_moe_experts = getattr(hf_config, "num_experts", None)
+        provider.moe_ffn_hidden_size = getattr(hf_config, "moe_intermediate_size", None)
+        provider.moe_router_topk = getattr(hf_config, "num_experts_per_tok", 8)
+        provider.moe_router_score_function = getattr(
+            hf_config, "scoring_func", "sigmoid"
+        )
+        provider.moe_router_num_groups = getattr(hf_config, "n_group", 8)
+        provider.moe_router_group_topk = getattr(hf_config, "topk_group", 4)
+        provider.moe_router_topk_scaling_factor = getattr(
+            hf_config, "routed_scaling_factor", None
+        )
+        provider.moe_router_enable_expert_bias = True
+        provider.moe_router_load_balancing_type = "none"
+        provider.moe_router_bias_update_rate = 0.0
+        provider.moe_router_dtype = "fp32"
+        provider.moe_grouped_gemm = True
+        provider.moe_token_dispatcher_type = "alltoall"
+        provider.moe_z_loss_coeff = 3.5e-6
+        provider.moe_shared_expert_overlap = False
+        provider.moe_permute_fusion = True
+
+        # ---------------- RoPE ----------------
+        # Field values mirror hf_to_mcore_config_bailing_moe to avoid drift
+        # against newer mcore defaults (mscale=1.0/mscale_all_dim=0.0 vs
+        # original 0.707/0.707).
+        rope_scaling = getattr(hf_config, "rope_scaling", None) or {}
+        provider.rope_type = "rope"
+        provider.rotary_base = getattr(hf_config, "rope_theta", 10000.0)
+        provider.rotary_percent = 1.0
+        provider.rotary_scaling_factor = rope_scaling.get("factor", 1.0)
+        provider.apply_rope_fusion = False
+        provider.mscale = 0.707
+        provider.mscale_all_dim = 0.707
+        provider.original_max_position_embeddings = (
+            rope_scaling.get("original_max_position_embeddings")
+            or getattr(hf_config, "original_max_position_embeddings", None)
+            or getattr(hf_config, "max_position_embeddings", 4096)
+        )
+
+        # ---------------- Fusions / misc ----------------
+        provider.bias_activation_fusion = True
+        provider.bias_dropout_fusion = True
+        provider.cross_entropy_loss_fusion = False
+        provider.masked_softmax_fusion = True
+        provider.persist_layer_norm = True
+        provider.gradient_accumulation_fusion = True
+        provider.attention_softmax_in_fp32 = True
+        provider.disable_bf16_reduced_precision_matmul = True
+        provider.hidden_dropout = 0.0
+        provider.make_vocab_size_divisible_by = 128
+        provider.seq_length = getattr(hf_config, "max_position_embeddings", 4096)
+
+        # ---------------- Layer norm epsilon ----------------
+        provider.layernorm_epsilon = getattr(
+            hf_config, "rms_norm_eps", provider.layernorm_epsilon
+        )
+
+        return provider
+
+    def mapping_registry(self) -> MegatronMappingRegistry:
+        hf_config = self.hf_config
+        num_layers = hf_config.num_hidden_layers
+        layer_group_size = getattr(hf_config, "layer_group_size", 1)
+        first_k_dense = getattr(hf_config, "first_k_dense_replace", 0)
+        q_lora_rank = getattr(hf_config, "q_lora_rank", None)
+        num_heads = hf_config.num_attention_heads
+        head_dim = getattr(hf_config, "head_dim", hf_config.hidden_size // num_heads)
+
+        mappings: list = []
+
+        # 1. Global tensors (note: BailingMoe uses ``word_embeddings`` not
+        # ``embed_tokens``; share is False)
+        for mcore_name, hf_name in _GLOBAL_MAPPINGS:
+            mappings.append(AutoMapping(megatron_param=mcore_name, hf_param=hf_name))
+
+        # 2. MLP — same structure within dense / MoE halves, but enumerated
+        # per-layer to keep mappings flat and avoid wildcard ambiguity with
+        # attention parameters that share the layer-prefix.
+        for layer_idx in range(num_layers):
+            if layer_idx < first_k_dense:
+                mappings.extend(_dense_mlp_mappings(layer_idx))
+            else:
+                mappings.extend(_moe_mlp_mappings(layer_idx))
+
+        # 3. Attention — per-layer Lightning vs MLA dispatch
+        n_lightning = 0
+        n_mla = 0
+        for layer_idx in range(num_layers):
+            if is_lightning_layer(layer_idx, layer_group_size):
+                mappings.extend(
+                    _lightning_attention_mappings(layer_idx, num_heads, head_dim)
+                )
+                n_lightning += 1
+            else:
+                mappings.extend(_mla_attention_mappings(layer_idx, q_lora_rank))
+                n_mla += 1
+
+        logger.info(
+            f"Built BailingMoe megatron-bridge mapping registry: "
+            f"{num_layers} layers ({n_lightning} Lightning + {n_mla} MLA), "
+            f"layer_group_size={layer_group_size}, first_k_dense={first_k_dense}, "
+            f"q_lora_rank={q_lora_rank}, total mappings={len(mappings)}"
+        )
+
+        return MegatronMappingRegistry(*mappings)
+
+    def maybe_modify_converted_hf_weight(
+        self,
+        task: WeightConversionTask,
+        converted_weights_dict: dict[str, torch.Tensor],
+        hf_state_dict: Mapping[str, torch.Tensor],
+    ) -> dict[str, torch.Tensor]:
+        """Fallback QKV permute hook.
+
+        ``LightningQKVMapping`` already permutes the fused QKV via its
+        overridden ``hf_to_megatron`` / ``megatron_to_hf`` methods. If a
+        particular megatron-bridge release does not honour those overrides
+        (early versions of the conversion subsystem ignored subclasses),
+        the permutation will not run and the weights will be wrong. Detect
+        that case here and fix the output in place.
+
+        This method is a no-op when ``LightningQKVMapping`` worked
+        correctly: the converted weight is already in mcore layout
+        ``[H,3,D,hidden]``, and trying to re-detect by shape alone would
+        be unsafe — so we don't. The hook is wired up for diagnostic
+        completeness; if you observe NaN/garbage on the very first
+        forward of a Lightning layer after loading HF weights, replace
+        this stub with an explicit re-permute keyed on the global param
+        name (see commented sketch below).
+
+            # if (
+            #     global_name.startswith("decoder.layers.")
+            #     and ".self_attention.linear_qkv." in global_name
+            #     and "layer_norm" not in global_name
+            # ):
+            #     parts = global_name.split(".")
+            #     layer_idx = int(parts[2])
+            #     if is_lightning_layer(layer_idx, layer_group_size):
+            #         ...  # re-apply permute on converted_weights_dict[global_name]
+        """
+        return converted_weights_dict

--- a/areal/models/mcore/bailing_moe_megatron_bridge.py
+++ b/areal/models/mcore/bailing_moe_megatron_bridge.py
@@ -15,7 +15,7 @@ The mbridge backend remains the default; this module is only imported (and
 its decorators only run) when the user opts in via ``mcore.bridge_type:
 megatron-bridge``.
 
-Implementation mirrors ``glm5_megatron_bridge.py``:
+Implementation outline:
 - One ``BailingMoeV25Bridge`` class with three ``@register_bridge`` decorators
   for the three HF architectures (V2_5 / Linear / Hybrid)
 - ``provider_bridge()`` sets MLA + MoE fields and injects the heterogeneous
@@ -25,21 +25,16 @@ Implementation mirrors ``glm5_megatron_bridge.py``:
   per-layer mapping selection
 - ``LightningQKVMapping`` is an ``AutoMapping`` subclass that permutes the
   fused QKV weight between HF ``[Q|K|V]`` and mcore ``[q0,k0,v0,...]``
-  layouts. If the megatron-bridge release in use does not support
-  overriding ``hf_to_megatron`` / ``megatron_to_hf``, fall back to a hook
-  via ``maybe_modify_converted_hf_weight`` (see TODO in that method).
+  layouts before TP sharding (HF -> mcore) and after TP gathering
+  (mcore -> HF).
 """
 
 import os
-from collections.abc import Mapping
 from functools import partial
 
 import torch
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
-from megatron.bridge.models.conversion.model_bridge import (
-    MegatronModelBridge,
-    WeightConversionTask,
-)
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.mla_provider import MLAModelProvider
@@ -111,9 +106,17 @@ class LightningQKVMapping(AutoMapping):
         self._head_dim = head_dim
 
     def hf_to_megatron(self, hf_weights, *args, **kwargs):
-        """Apply [3,H,D] -> [H,3,D] permutation when converting HF -> mcore."""
+        """Apply [3,H,D] -> [H,3,D] permutation when converting HF -> mcore.
+
+        The permutation runs on the full tensor before ``super()`` shards it
+        to TP ranks (the permutation does not commute with TP splitting).
+        ``hf_weights`` is None on non-source TP ranks, which only participate
+        in the scatter.
+        """
         weight = hf_weights[0] if isinstance(hf_weights, (list, tuple)) else hf_weights
-        return _permute_qkv_hf_to_mcore(weight, self._num_heads, self._head_dim)
+        if weight is not None:
+            weight = _permute_qkv_hf_to_mcore(weight, self._num_heads, self._head_dim)
+        return super().hf_to_megatron(weight, *args, **kwargs)
 
     def megatron_to_hf(self, megatron_weight, *args, **kwargs):
         """Apply [H,3,D] -> [3,H,D] permutation when converting mcore -> HF."""
@@ -338,6 +341,10 @@ class BailingMoeV25Bridge(MegatronModelBridge):
         # Lightning Attention. The signature
         # ``(tf_config, vp_stage=None) -> TransformerBlockSubmodules``
         # matches what megatron-bridge calls.
+        # This assignment serves direct megatron-bridge usage (e.g.
+        # ``AutoBridge.to_megatron_provider()`` outside AReaL); AReaL's own
+        # flow overrides it again in ``registry.make_mcore_model()`` with a
+        # spec built in the current TP/PP/CP/EP context.
         provider.transformer_layer_spec = partial(
             make_mcore_layer_specs_bailing_moe,
             hf_config=hf_config,
@@ -351,6 +358,15 @@ class BailingMoeV25Bridge(MegatronModelBridge):
                 f"AREAL_DISABLE_MTP=1: overriding mtp_num_layers from {mtp_num_layers} to 0"
             )
             mtp_num_layers = 0
+        if mtp_num_layers:
+            # mapping_registry() has no mtp.* entries yet; megatron-bridge only
+            # warns on unmapped params, so MTP layers would stay randomly
+            # initialized instead of loading from the HF checkpoint.
+            logger.warning(
+                f"mtp_num_layers={mtp_num_layers} from HF config, but MTP weight "
+                "mappings are not implemented — MTP layers will NOT be loaded "
+                "from the checkpoint. Set AREAL_DISABLE_MTP=1 to disable MTP."
+            )
         provider.mtp_num_layers = mtp_num_layers or 0
 
         # ---------------- Architecture basics ----------------
@@ -382,9 +398,13 @@ class BailingMoeV25Bridge(MegatronModelBridge):
         if shared_expert_intermediate is None:
             num_shared = getattr(hf_config, "num_shared_experts", 0)
             inter = getattr(
-                hf_config, "moe_intermediate_size", hf_config.intermediate_size
+                hf_config,
+                "moe_intermediate_size",
+                getattr(hf_config, "intermediate_size", None),
             )
-            shared_expert_intermediate = num_shared * inter if num_shared > 0 else None
+            shared_expert_intermediate = (
+                num_shared * inter if num_shared > 0 and inter is not None else None
+            )
         provider.moe_shared_expert_intermediate_size = shared_expert_intermediate
 
         provider.num_moe_experts = getattr(hf_config, "num_experts", None)
@@ -414,7 +434,9 @@ class BailingMoeV25Bridge(MegatronModelBridge):
         # original 0.707/0.707).
         rope_scaling = getattr(hf_config, "rope_scaling", None) or {}
         provider.rope_type = "rope"
-        provider.rotary_base = getattr(hf_config, "rope_theta", 10000.0)
+        provider.rotary_base = (getattr(hf_config, "rope_parameters", None) or {}).get(
+            "rope_theta", getattr(hf_config, "rope_theta", 10000.0)
+        )
         provider.rotary_percent = 1.0
         provider.rotary_scaling_factor = rope_scaling.get("factor", 1.0)
         provider.apply_rope_fusion = False
@@ -492,39 +514,3 @@ class BailingMoeV25Bridge(MegatronModelBridge):
         )
 
         return MegatronMappingRegistry(*mappings)
-
-    def maybe_modify_converted_hf_weight(
-        self,
-        task: WeightConversionTask,
-        converted_weights_dict: dict[str, torch.Tensor],
-        hf_state_dict: Mapping[str, torch.Tensor],
-    ) -> dict[str, torch.Tensor]:
-        """Fallback QKV permute hook.
-
-        ``LightningQKVMapping`` already permutes the fused QKV via its
-        overridden ``hf_to_megatron`` / ``megatron_to_hf`` methods. If a
-        particular megatron-bridge release does not honour those overrides
-        (early versions of the conversion subsystem ignored subclasses),
-        the permutation will not run and the weights will be wrong. Detect
-        that case here and fix the output in place.
-
-        This method is a no-op when ``LightningQKVMapping`` worked
-        correctly: the converted weight is already in mcore layout
-        ``[H,3,D,hidden]``, and trying to re-detect by shape alone would
-        be unsafe — so we don't. The hook is wired up for diagnostic
-        completeness; if you observe NaN/garbage on the very first
-        forward of a Lightning layer after loading HF weights, replace
-        this stub with an explicit re-permute keyed on the global param
-        name (see commented sketch below).
-
-            # if (
-            #     global_name.startswith("decoder.layers.")
-            #     and ".self_attention.linear_qkv." in global_name
-            #     and "layer_norm" not in global_name
-            # ):
-            #     parts = global_name.split(".")
-            #     layer_idx = int(parts[2])
-            #     if is_lightning_layer(layer_idx, layer_group_size):
-            #         ...  # re-apply permute on converted_weights_dict[global_name]
-        """
-        return converted_weights_dict

--- a/areal/models/mcore/hf_load.py
+++ b/areal/models/mcore/hf_load.py
@@ -9,7 +9,6 @@ from glob import glob
 
 import torch
 import torch.distributed as dist
-from mbridge.core.bridge import Bridge
 from megatron.core import parallel_state as mpu
 from megatron.core.fp8_utils import is_float8tensor
 from safetensors import safe_open
@@ -451,7 +450,7 @@ def _weight_to_mcore_tp(
 
 
 def _load_weight_with_bridge_worker(
-    bridge: Bridge,
+    bridge,
     state_dict: dict[str, torch.Tensor],
     local_names: list[str],
     filenames: list[str],
@@ -639,7 +638,7 @@ def make_filename_bins(
 
 
 def load_weights_from_hf_with_mbridge_fast(
-    bridge: Bridge,
+    bridge,
     models: list[torch.nn.Module],
     weights_path: str,
     max_workers: int | None = None,

--- a/areal/models/mcore/hf_save.py
+++ b/areal/models/mcore/hf_save.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 import torch.distributed as dist
-from mbridge.core import Bridge
-from mbridge.core.util import unwrap_model
 from megatron.core import parallel_state as mpu
 from megatron.core.fp8_utils import is_float8tensor
 from safetensors.torch import save_file
@@ -26,6 +24,14 @@ from areal.engine.megatron_utils.fp8 import (
 from areal.infra.platforms import current_platform
 from areal.models.mcore.registry import unwrap_to_gpt_model
 from areal.utils import logging
+
+
+def _unwrap_model(model):
+    """Unwrap DDP / FSDP wrappers down to the bare module."""
+    while hasattr(model, "module"):
+        model = model.module
+    return model
+
 
 logger = logging.getLogger("HFSaver")
 
@@ -181,7 +187,7 @@ def _patch_saved_config(base_model_path, saved_path):
         logger.info(f"Patched config.json: {', '.join(patched_fields)}")
 
 
-def _bridge_uses_stacked_experts(bridge: Bridge) -> bool:
+def _bridge_uses_stacked_experts(bridge) -> bool:
     """Detect bridges whose HF format keeps experts grouped under a single
     stacked tensor (e.g., Qwen3-VL-MoE ``mlp.experts.gate_up_proj`` shape
     ``[E, hidden, 2*expert_dim]``) rather than per-expert flat keys.
@@ -251,7 +257,7 @@ class McoreDistributedWeightSpec:
 
 
 def _emit_stacked_moe_expert_sd(
-    bridge: Bridge,
+    bridge,
     expert_specs: list["McoreDistributedWeightSpec"],
     *,
     all_gather_outputs: dict,
@@ -397,7 +403,7 @@ def _emit_stacked_moe_expert_sd(
 
 
 def _emit_per_expert_flat_expert_sd(
-    bridge: Bridge,
+    bridge,
     expert_specs: list["McoreDistributedWeightSpec"],
     *,
     all_gather_outputs: dict,
@@ -441,7 +447,7 @@ def _emit_per_expert_flat_expert_sd(
 
 
 def save_weights_to_hf_with_mbridge_fast(
-    bridge: Bridge,
+    bridge,
     models: list,
     weights_path: str,
     base_model_path: str | None = None,
@@ -450,7 +456,7 @@ def save_weights_to_hf_with_mbridge_fast(
     fp8_direct_convert: bool = False,
 ):
     # 1. Prepare some global metadata required for saving the model.
-    models = [unwrap_model(model) for model in models]
+    models = [_unwrap_model(model) for model in models]
     pp_size = mpu.get_pipeline_model_parallel_world_size()
     pp_rank = mpu.get_pipeline_model_parallel_rank()
     pp_group = mpu.get_pipeline_model_parallel_group()

--- a/areal/models/mcore/registry.py
+++ b/areal/models/mcore/registry.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
-from mbridge.core.bridge import Bridge
 from megatron.core import parallel_state as mpu
 from megatron.core import tensor_parallel
 from megatron.core.distributed import DistributedDataParallel as DDP
@@ -23,6 +22,9 @@ from areal.models.mcore.qwen3 import (
     make_mcore_layer_specs_qwen3_dense,
 )
 from areal.utils import logging
+
+if TYPE_CHECKING:
+    from mbridge.core.bridge import Bridge
 
 logger = logging.getLogger("MCoreRegistry")
 
@@ -111,6 +113,19 @@ def unwrap_to_gpt_model(model: torch.nn.Module) -> GPTModel:
     raise TypeError(f"Model could not be unwrapped to GPTModel. Got {type(_model)}")
 
 
+_BAILING_ARCHITECTURES = {
+    "BailingMoeV2_5ForCausalLM",
+    "BailingMoeLinearForCausalLM",
+    "BailingHybridForCausalLM",
+}
+
+
+def _is_bailing(hf_config: PretrainedConfig) -> bool:
+    """Return True if hf_config belongs to the BailingMoeV2.5 family."""
+    architectures = getattr(hf_config, "architectures", None) or []
+    return bool(architectures) and architectures[0] in _BAILING_ARCHITECTURES
+
+
 # Model registry for different architectures
 def make_hf_and_mcore_config(
     hf_path: str,
@@ -126,7 +141,8 @@ def make_hf_and_mcore_config(
         hf_config = getattr(bridge.hf_pretrained, "config", bridge.hf_pretrained)
         if hasattr(hf_config, "_name_or_path"):
             hf_config._name_or_path = hf_path
-        return hf_config, bridge.transformer_config
+        tf_config = bridge.transformer_config
+        return hf_config, tf_config
     else:
         hf_config: PretrainedConfig = AutoConfig.from_pretrained(
             pretrained_model_name_or_path=hf_path,
@@ -136,11 +152,7 @@ def make_hf_and_mcore_config(
         architecture = hf_config.architectures[0]
         if architecture == "Qwen3ForCausalLM":
             return hf_config, hf_to_mcore_config_qwen3_dense(hf_config, dtype)
-        elif architecture in (
-            "BailingMoeV2_5ForCausalLM",
-            "BailingMoeLinearForCausalLM",
-            "BailingHybridForCausalLM",
-        ):
+        elif architecture in _BAILING_ARCHITECTURES:
             return hf_config, hf_to_mcore_config_bailing_moe(hf_config, dtype)
         else:
             raise ValueError(
@@ -153,11 +165,7 @@ def make_mcore_layer_specs(hf_config: PretrainedConfig, tf_config: TransformerCo
     architecture = hf_config.architectures[0]
     if architecture == "Qwen3ForCausalLM":
         return make_mcore_layer_specs_qwen3_dense(tf_config, use_te=True)
-    elif architecture in (
-        "BailingMoeV2_5ForCausalLM",
-        "BailingMoeLinearForCausalLM",
-        "BailingHybridForCausalLM",
-    ):
+    elif architecture in _BAILING_ARCHITECTURES:
         return make_mcore_layer_specs_bailing_moe(tf_config, hf_config, use_te=True)
     else:
         raise ValueError(
@@ -169,7 +177,7 @@ def make_mcore_model(
     hf_config: PretrainedConfig,
     tf_config: TransformerConfig,
     mcore_config: MegatronEngineConfig | None = None,
-    bridge: Bridge | Any | None = None,
+    bridge: "Bridge | Any | None" = None,
     bridge_type: str = "mbridge",
     is_critic: bool = False,
     use_lora: bool = False,
@@ -199,6 +207,17 @@ def make_mcore_model(
     if bridge is not None and bridge_type == "megatron-bridge":
         provider = bridge.to_megatron_provider(load_weights=False)
         vpp_size = mcore_config.virtual_pipeline_parallel_size or 0
+
+        # Override the bridge's default layer spec when AReaL needs a custom
+        # one that megatron-bridge does not provide. The lambda matches
+        # megatron-bridge's call signature
+        # ``(config, vp_stage=None) -> TransformerBlockSubmodules``.
+        #   * Bailing-MoE V2.5: per-layer heterogeneous Lightning + MLA.
+        if _is_bailing(hf_config):
+            _bailing_specs = make_mcore_layer_specs(hf_config, tf_config)
+            provider.transformer_layer_spec = (
+                lambda config, vp_stage=None, _s=_bailing_specs: _s
+            )
 
         provider.tensor_model_parallel_size = mpu.get_tensor_model_parallel_world_size()
         provider.pipeline_model_parallel_size = (
@@ -240,6 +259,12 @@ def make_mcore_model(
             )
             provider.mtp_num_layers = None
 
+        # Pass through custom pipeline layout when the architecture-specific
+        # config converter sets one (e.g., uneven PP partitioning).
+        pp_layout = getattr(tf_config, "pipeline_model_parallel_layout", None)
+        if pp_layout is not None:
+            provider.pipeline_model_parallel_layout = pp_layout
+
         # LoRA params are injected after model materialization and do not carry
         # Megatron main_grad buffers required by fused grad accumulation kernels.
         if use_lora:
@@ -247,11 +272,13 @@ def make_mcore_model(
 
         # Keep these four flags aligned with mbridge base defaults.
         provider.variable_seq_lengths = True
-        logger.warning(
-            "Ignoring mcore_config.moe_token_dispatcher_type=%s for bridge_type='megatron-bridge'; "
-            "using 'alltoall' and variable_seq_lengths=True.",
-            mcore_config.moe_token_dispatcher_type,
-        )
+        if mcore_config.moe_token_dispatcher_type != "alltoall":
+            logger.info(
+                "Ignoring mcore_config.moe_token_dispatcher_type=%s for "
+                "bridge_type='megatron-bridge'; using 'alltoall' and "
+                "variable_seq_lengths=True.",
+                mcore_config.moe_token_dispatcher_type,
+            )
         provider.moe_token_dispatcher_type = "alltoall"
         provider.batch_p2p_comm = False
         provider.overlap_p2p_comm = (

--- a/areal/models/mcore/registry.py
+++ b/areal/models/mcore/registry.py
@@ -212,7 +212,13 @@ def make_mcore_model(
         # one that megatron-bridge does not provide. The lambda matches
         # megatron-bridge's call signature
         # ``(config, vp_stage=None) -> TransformerBlockSubmodules``.
-        #   * Bailing-MoE V2.5: per-layer heterogeneous Lightning + MLA.
+        #   * Bailing-MoE V2.5: per-layer heterogeneous Lightning + MLA. The
+        #     Bailing bridge already sets transformer_layer_spec in
+        #     provider_bridge() for direct megatron-bridge usage; this
+        #     override is the one AReaL's flow uses and picks up the current
+        #     TP/PP/CP/EP context for layer slicing. Note: the captured spec
+        #     is built for the current PP rank with vp_stage=None, so VPP > 1
+        #     is not supported here.
         if _is_bailing(hf_config):
             _bailing_specs = make_mcore_layer_specs(hf_config, tf_config)
             provider.transformer_layer_spec = (

--- a/areal/models/tree_attn/module_megatron.py
+++ b/areal/models/tree_attn/module_megatron.py
@@ -3,7 +3,6 @@
 from contextlib import contextmanager
 
 import torch
-from mbridge.core import LLMBridge
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.attention import SelfAttention
@@ -190,6 +189,10 @@ def patch_bridge_for_tree_training(enable: bool = True):
     if not enable:
         yield
         return
+
+    # Lazy import: tree training is only used with mbridge; defer the import
+    # so deployments without mbridge can still load this module.
+    from mbridge.core import LLMBridge
 
     # Store original method
     original_layer_spec_getter = LLMBridge._get_transformer_layer_spec

--- a/areal/utils/logging.py
+++ b/areal/utils/logging.py
@@ -137,6 +137,8 @@ LOGGER_PATTERNS = [
     ("MegatronEngine", "light_cyan"),
     ("RemoteInfEngine", "light_cyan"),
     ("MCore", "light_cyan"),
+    # Model bridges - cyan (compute backends)
+    ("BailingMoe", "light_cyan"),
     # HF utilities - white
     ("HF", "white"),
     # Tests - white

--- a/docs/en/_toc.yml
+++ b/docs/en/_toc.yml
@@ -26,6 +26,7 @@ parts:
     - file: best_practices/debugging
     - file: best_practices/handling_oom
     - file: best_practices/perf_profiling
+    - file: best_practices/migrate_to_megatron_bridge
   - caption: Customization
     chapters:
     - file: customization/dataset

--- a/docs/en/best_practices/migrate_to_megatron_bridge.md
+++ b/docs/en/best_practices/migrate_to_megatron_bridge.md
@@ -1,0 +1,172 @@
+# Migrating from mbridge to megatron-bridge
+
+AReaL's `MegatronEngine` supports two backends for HuggingFace ↔ Megatron-Core weight
+conversion and model creation:
+
+- `mbridge` (default): [ISEEKYAN/mbridge](https://github.com/ISEEKYAN/mbridge)
+- `megatron-bridge`:
+  [NVIDIA-NeMo/Megatron-Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge)
+
+You select the backend per-experiment via `actor.megatron.bridge_type`:
+
+```yaml
+actor:
+  megatron:
+    bridge_type: megatron-bridge   # or "mbridge" (default)
+```
+
+This document covers when to switch, what behavior changes, and how to add support for a
+new model architecture under the `megatron-bridge` backend.
+
+## When to use which
+
+| Need                                               | Prefer            |
+| -------------------------------------------------- | ----------------- |
+| Existing setups, disk-based HF weight load/save    | `mbridge`         |
+| Tree-attention training in `MegatronEngine`        | `mbridge`         |
+| PEFT/LoRA support                                  | `megatron-bridge` |
+| Architectures NVIDIA upstream maintains officially | `megatron-bridge` |
+
+`megatron-bridge` is the long-term direction: it has PEFT support, NVIDIA upstream
+maintenance, and broader model coverage. `mbridge` is being deprecated but remains the
+default for backward compatibility — see `docs/en/reference/bridge_backend.md` for the
+policy.
+
+## API differences
+
+The differences mostly do not surface to user code — `MegatronEngine` hides both
+backends behind `_build_hf_mcore_bridge()`. The table below is for contributors adding
+new model adapters.
+
+| Concept               | mbridge                                               | megatron-bridge                                                                                             |
+| --------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Top-level import      | `import mbridge`                                      | `from megatron.bridge import AutoBridge`                                                                    |
+| Adapter base class    | `mbridge.core.LLMBridge`                              | `megatron.bridge.models.conversion.model_bridge.MegatronModelBridge`                                        |
+| Registration          | `@register_model("name")`                             | `@MegatronModelBridge.register_bridge(source=..., target=GPTModel, ...)`                                    |
+| Weight mapping        | Class-level dicts (`_DIRECT_MAPPING`, `_MLP_MAPPING`) | `mapping_registry()` returns `MegatronMappingRegistry(*[AutoMapping/QKVMapping/GatedMLPMapping])`           |
+| HF config             | `bridge.hf_config`                                    | `bridge.hf_pretrained.config`                                                                               |
+| Transformer config    | `bridge.config` (TransformerConfig)                   | `bridge.transformer_config`                                                                                 |
+| Model creation        | `bridge.get_model(wrap_with_ddp=...)`                 | `provider = bridge.to_megatron_provider()` → set parallel sizes → `provider.provide_distributed_model(...)` |
+| Layer spec injection  | Override `bridge._get_transformer_layer_spec()`       | Set `provider.transformer_layer_spec = lambda config: spec`                                                 |
+| Runtime config tweaks | `bridge.set_extra_args(field=value, ...)`             | `provider.field = value` directly                                                                           |
+| Load HF weights       | `bridge.load_weights(model, path)`                    | `bridge.load_hf_weights(model)` / `bridge.import_hf_weights(model)`                                         |
+| Save as HF            | `bridge.save_weights(model, path)`                    | `bridge.save_hf_pretrained(model, path, distributed_save=True)`                                             |
+
+## Supported architectures
+
+Architectures registered in AReaL's `mcore/registry.py` and routed through both
+backends:
+
+| HF architecture               | `mbridge` | `megatron-bridge` | Notes                                 |
+| ----------------------------- | --------- | ----------------- | ------------------------------------- |
+| `Qwen3ForCausalLM`            | ✅        | ✅ (NV upstream)  | Dense.                                |
+| `BailingMoeV2_5ForCausalLM`   | ✅        | ✅                | Heterogeneous Lightning + MLA layers. |
+| `BailingMoeLinearForCausalLM` | ✅        | ✅                | Shares `BailingMoeV25Bridge` adapter. |
+| `BailingHybridForCausalLM`    | ✅        | ✅                | Shares `BailingMoeV25Bridge` adapter. |
+
+Custom adapters live under `areal/models/mcore/`:
+
+- mbridge subclasses: `bailing_moe_bridge.py`
+- megatron-bridge subclasses: `bailing_moe_megatron_bridge.py`
+
+## How registry dispatch works
+
+`areal/models/mcore/registry.py` is the central dispatch point. The relevant functions:
+
+- `make_hf_and_mcore_config(hf_path, dtype, bridge, bridge_type)`:
+
+  - With `bridge_type="mbridge"`, returns `(bridge.hf_config, bridge.config)`.
+  - With `bridge_type="megatron-bridge"`, returns
+    `(bridge.hf_pretrained.config, bridge.transformer_config)`.
+
+- `make_mcore_model(hf_config, tf_config, mcore_config, bridge, bridge_type, ...)`:
+
+  - With `mbridge`, calls `bridge.get_model(...)`.
+  - With `megatron-bridge`, calls `bridge.to_megatron_provider(load_weights=False)` and
+    configures the provider with the current TP/PP/CP/EP context, then
+    `provider.provide_distributed_model(...)`. Before configuring the provider, it
+    overrides `provider.transformer_layer_spec` for models whose layer structure
+    megatron-bridge's default spec doesn't express — currently the **Bailing-MoE V2.5
+    family**, which uses AReaL's heterogeneous Lightning + MLA layer spec.
+
+## Adding a new model under `megatron-bridge`
+
+Sketch of a new adapter (`my_model_megatron_bridge.py`):
+
+```python
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.param_mapping import (
+    AutoMapping, QKVMapping, GatedMLPMapping,
+)
+from megatron.core.models.gpt.gpt_model import GPTModel
+
+
+@MegatronModelBridge.register_bridge(
+    source="MyModelForCausalLM",
+    target=GPTModel,
+    model_type="my_model",
+)
+class MyModelBridge(MegatronModelBridge):
+    def provider_bridge(self, hf_pretrained):
+        provider = self._get_default_provider(hf_pretrained)
+        # Set MLA/MoE/RoPE fields from hf_pretrained.config here.
+        # provider.num_moe_experts = hf_pretrained.config.n_routed_experts
+        # provider.moe_router_topk = hf_pretrained.config.num_experts_per_tok
+        # ...
+        return provider
+
+    def mapping_registry(self, hf_pretrained):
+        return MegatronMappingRegistry(
+            AutoMapping(
+                hf_param="model.embed_tokens.weight",
+                megatron_param="embedding.word_embeddings.weight",
+            ),
+            QKVMapping(...),
+            GatedMLPMapping(...),
+            # ...
+        )
+```
+
+Then register the module-import in `areal/engine/megatron_engine.py` to fire the
+decorator:
+
+```python
+import areal.models.mcore.my_model_megatron_bridge  # noqa: F401  # register bridge
+```
+
+If the model has custom attention modules that megatron-bridge's default
+`get_gpt_decoder_block_spec` cannot express, add a branch in
+`registry.make_mcore_model()` to inject your spec (mirror the `_is_bailing` branch).
+
+## Common pitfalls
+
+- **mbridge package missing.** If `mbridge` is not installed, the import is wrapped in
+  `try/except` so the engine still loads, but attempting to use `bridge_type=mbridge`
+  raises a clear `ImportError`. Switch to `megatron-bridge` or install mbridge.
+- **`moe_token_dispatcher_type` ignored.** Under `megatron-bridge`, AReaL forces
+  `alltoall` and `variable_seq_lengths=True`. A warning is logged when your config
+  requested something else.
+- **Tree training unavailable.** `megatron-bridge` does not yet support tree-attention
+  training. The engine raises `NotImplementedError` at initialization if both are
+  requested. Stay on `mbridge` for tree training.
+- **LoRA only on megatron-bridge.** AReaL's PEFT/LoRA path requires
+  `bridge_type=megatron-bridge`.
+- **Heterogeneous layer specs.** Bailing-MoE V2.5 mixes Lightning and MLA attention
+  per-layer. The `mapping_registry()` cannot use wildcard `*` mappings — enumerate every
+  layer and dispatch on `is_lightning_layer()`.
+
+## Verification checklist
+
+After switching `bridge_type` for an existing experiment, verify:
+
+1. Engine initialization completes (`MegatronEngine.initialize()` returns).
+1. First training step's `loss` matches the previous backend within a small tolerance
+   (recommended: `abs_diff < 5e-3` on the first 5 steps with `disable_dropout=True`,
+   fixed seed).
+1. HF checkpoint round-trip: save with `save_hf_pretrained`, then load with
+   `transformers.AutoModelForCausalLM.from_pretrained(..., trust_remote_code=True)` and
+   run a forward pass.
+1. For MoE models, verify `moe_router_*` fields on the provider match those on
+   `bridge.transformer_config` (under `megatron-bridge`) or `bridge.config` (under
+   `mbridge`).

--- a/docs/en/best_practices/migrate_to_megatron_bridge.md
+++ b/docs/en/best_practices/migrate_to_megatron_bridge.md
@@ -49,7 +49,7 @@ new model adapters.
 | Model creation        | `bridge.get_model(wrap_with_ddp=...)`                 | `provider = bridge.to_megatron_provider()` → set parallel sizes → `provider.provide_distributed_model(...)` |
 | Layer spec injection  | Override `bridge._get_transformer_layer_spec()`       | Set `provider.transformer_layer_spec = lambda config: spec`                                                 |
 | Runtime config tweaks | `bridge.set_extra_args(field=value, ...)`             | `provider.field = value` directly                                                                           |
-| Load HF weights       | `bridge.load_weights(model, path)`                    | `bridge.load_hf_weights(model)` / `bridge.import_hf_weights(model)`                                         |
+| Load HF weights       | `bridge.load_weights(model, path)`                    | `bridge.load_hf_weights(model)`                                                                             |
 | Save as HF            | `bridge.save_weights(model, path)`                    | `bridge.save_hf_pretrained(model, path, distributed_save=True)`                                             |
 
 ## Supported architectures
@@ -109,7 +109,7 @@ from megatron.core.models.gpt.gpt_model import GPTModel
 )
 class MyModelBridge(MegatronModelBridge):
     def provider_bridge(self, hf_pretrained):
-        provider = self._get_default_provider(hf_pretrained)
+        provider = super().provider_bridge(hf_pretrained)
         # Set MLA/MoE/RoPE fields from hf_pretrained.config here.
         # provider.num_moe_experts = hf_pretrained.config.n_routed_experts
         # provider.moe_router_topk = hf_pretrained.config.num_experts_per_tok

--- a/docs/en/best_practices/migrate_to_megatron_bridge.md
+++ b/docs/en/best_practices/migrate_to_megatron_bridge.md
@@ -116,7 +116,7 @@ class MyModelBridge(MegatronModelBridge):
         # ...
         return provider
 
-    def mapping_registry(self, hf_pretrained):
+    def mapping_registry(self):
         return MegatronMappingRegistry(
             AutoMapping(
                 hf_param="model.embed_tokens.weight",

--- a/tests/test_estimate_num_params.py
+++ b/tests/test_estimate_num_params.py
@@ -1,6 +1,5 @@
 import os
 
-import mbridge
 import pytest
 import torch
 import torch.distributed as dist
@@ -13,6 +12,8 @@ from areal.engine.megatron_utils.pipeline_parallel import (
 )
 from areal.models.mcore.registry import make_hf_and_mcore_config
 from areal.utils.network import find_free_ports
+
+mbridge = pytest.importorskip("mbridge")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Switches the Bailing-MoE V2.5 family (`BailingMoeV2_5ForCausalLM`, `BailingMoeLinearForCausalLM`, `BailingHybridForCausalLM`) from `mbridge`-only to dual-bridge by adding a NVIDIA `megatron-bridge` `MegatronModelBridge` adapter alongside the existing `mbridge` one. The `mbridge` default behavior is unchanged; users opt into the new path via `mcore.bridge_type=megatron-bridge`.

The dual-bridge infrastructure (config field `mcore.bridge_type`, `MegatronEngine._build_hf_mcore_bridge()`, registry's megatron-bridge branch, `megatron-bridge==0.4.0` declared in `pyproject.toml`) already exists on `main`.

This is the first of two split PRs (previously combined as #1362, now closed):
- **This PR-A**: Bailing-MoE megatron-bridge adapter + shared cross-cutting infra.
- **PR-B (follow-up)**: GLM-5.1 / DeepSeek-V3 / GLM-4.7-Flash new model support. Depends on PR-A.

## What's added

### New adapter
- `areal/models/mcore/bailing_moe_megatron_bridge.py` — a single `MegatronModelBridge` subclass registered for the three Bailing architectures. Handles per-layer heterogeneous Lightning + MLA attention dispatch via `is_lightning_layer(layer_idx, group_size)`; per-layer enumeration in `mapping_registry()` because `MegatronMappingRegistry`'s wildcard mappings cannot express the heterogeneous case. `LightningQKVMapping` subclass overrides `hf_to_megatron` / `megatron_to_hf` to permute fused QKV between HF `[Q|K|V]` and mcore `[q0,k0,v0,...]` layouts.

### Registry / engine wiring
- `areal/models/mcore/registry.py` — add `_BAILING_ARCHITECTURES` set and `_is_bailing()` helper; inject AReaL's heterogeneous Bailing layer spec into `provider.transformer_layer_spec` for the megatron-bridge path so the bridge's default uniform spec doesn't overwrite it.
- `areal/engine/megatron_engine.py` — import `bailing_moe_megatron_bridge` unconditionally so the `@register_bridge` decorator fires.

### Shared infrastructure
Applies to all current and future bridge adapters (not Bailing-specific), but lands here because PR-A is the first to need it:
- Wrap `mbridge` top-level import and the mbridge-dependent `bailing_moe_bridge` module import in `try/except` so megatron-bridge-only deployments still load the engine. Raise a clear `ImportError` in `_build_hf_mcore_bridge()` when `bridge_type=mbridge` is requested but mbridge is unavailable.
- Drop hard `mbridge.core.Bridge` type annotations in `hf_load.py` / `hf_save.py`; use `TYPE_CHECKING` in `registry.py`.
- Replace `mbridge.core.util.unwrap_model` with a local `_unwrap_model`.
- Lazy-import `LLMBridge` inside `patch_bridge_for_tree_training`.
- Guard `tests/test_estimate_num_params.py` with `pytest.importorskip("mbridge")`.

### Docs
- `docs/en/best_practices/migrate_to_megatron_bridge.md` — migration guide covering API differences, supported architectures, layer-spec injection pattern, and verification checklist.

## Validation

The mbridge ↔ megatron-bridge numerical equivalence (matching starting logp / grad_norm / loss with same seed and config) has been validated on the internal branch this PR is ported from. All `provider.<field>` assignments are preserved as-is from the validated source, including the `provider.rotary_percent = 1.0` MLA RoPE fix.

## Test plan

- [ ] `pre-commit run --all-files` (ruff lint + format, mdformat) — passing locally
- [ ] CI smoke tests (regression for Qwen3 / existing Bailing mbridge path) — to run on PR
- [ ] Manual: Bailing-MoE V2.5 5-step loss alignment between `bridge_type: mbridge` and `bridge_type: megatron-bridge` on same yaml

## Not in scope

- GLM-5.1 / DeepSeek-V3 / GLM-4.7-Flash model support → split into PR-B
- VPP > 1 support for custom layer-spec injection (the lambda currently captures stage-0 specs; validated runs were VPP=1)
- `tests/test_megatron_bridge_smoke.py` (internal smoke tests depend on local model paths)
- Chinese (`docs/zh/`) translation of the migration guide
