### PR TITLE
fix[v2]: localize RTensor trajectories before reading on controller

### DIFF
--- a/areal/experimental/inference_service/controller/workflow.py
+++ b/areal/experimental/inference_service/controller/workflow.py
@@ -11,6 +11,7 @@ import openai
 
 from areal.api.workflow_api import RolloutWorkflow
 from areal.infra import workflow_context
+from areal.infra.rpc.rtensor import RTensor
 from areal.infra.rpc.serialization import deserialize_value
 from areal.infra.utils.http import async_http_retry
 from areal.utils import logging, stats_tracker
@@ -245,8 +246,12 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         if not traj:
             return None
 
-        if "rewards" in traj and len(traj["rewards"]) > 0:
-            last_reward = float(traj["rewards"][-1])
+        rewards_tensor = traj.get("rewards")
+        if isinstance(rewards_tensor, RTensor):
+            rewards_tensor = rewards_tensor.to_local()
+
+        if rewards_tensor is not None and len(rewards_tensor) > 0:
+            last_reward = float(rewards_tensor[-1])
         elif (
             "interactions" in traj
             and traj["interactions"]

--- a/areal/infra/workflow_executor.py
+++ b/areal/infra/workflow_executor.py
@@ -22,6 +22,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 
 from areal.api.cli_args import InferenceEngineConfig
 from areal.api import RolloutWorkflow
+from areal.infra.rpc.rtensor import RTensor
 from .async_task_runner import (
     AsyncTaskRunner,
     TaskQueueFullError,
@@ -839,6 +840,8 @@ class WorkflowExecutor:
     ) -> tuple[bool, str]:
         if traj is None:
             return False, "trajectory is None"
+
+        traj = RTensor.localize(traj)
 
         dump_dir = self._get_dump_dir(is_eval)
         if dump_dir is None:


### PR DESCRIPTION
## Description

v2 inference service's data_proxy remotizes the exported trajectory dict (`areal/experimental/inference_service/data_proxy/app.py:745`), so the controller side receives a dict-of-RTensor. Existing consumers read tensor values directly and crash with `AttributeError` / `TypeError` (`RTensor` exposes neither `.flatten`/`.shape` nor `__len__`/`__getitem__`).

This PR localizes the trajectory at the exact consumption points:
- `WorkflowExecutor._dump_trajectory`: materialize the whole traj on entry so the subsequent reads of `versions` / `input_ids` / `attention_mask` / `loss_mask` / `rewards` work.
- `InferenceServiceWorkflow._run_online`: `to_local()` `traj["rewards"]` before `len()` / `[-1]` in the tensor branch; the `interactions` branch is plain Python data and is left untouched.

Lazy fetch for the engine training path is preserved: only the local copy used by dump / reward-extraction is materialized, the outer trajectory dict still carries RTensors through to the training worker.

## Related Issue

No tracking issue. Bug surfaced during a v2 run that enabled `dump_to_file=true`; the online-mode reward extraction was a second latent hit on the same root cause.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with \`jb build docs\`
- [ ] No critical issues raised by AI reviewers (\`/gemini review\`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

- Root cause introduced by #1354 (\`feat: controller v2 refactor\`), which lifted \`RTensor.remotize\` to the outermost trajectory dict; downstream consumers were never adapted.
- v1 path (\`RolloutController\` + \`OpenAIProxyWorkflow\`) is unaffected —\`data_proxy\` is v2-only.
- The existing \`test_openclaw_online_rl\` does **not** catch this:
  \`examples/openclaw/config.yaml\` does not set \`_version: v2\`, so the default \`RolloutConfig._version="v1"\` keeps the test on the legacy path. A follow-up PR will either flip openclaw to v2 in CI or add focused UTs (using the \`rpc_server\` fixture from \`tests/test_rtensor.py\`) to lock in regression coverage.