### PR TITLE
docs(roadmap): add 2026 Q2 and H2 milestones

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,6 +7,125 @@ direction of the project.
 **Latest Release:** Check [releases](https://github.com/areal-project/AReaL/releases)
 for the most recent version.
 
+## 2026 H2 Roadmap (due December 31, 2026)
+
+[GitHub Issue #1381](https://github.com/areal-project/AReaL/issues/1381).
+
+This roadmap tracks major planned enhancements for the second half of 2026. Items are
+organized into two categories:
+
+- **On-going:** Features currently under active development by the core AReaL team
+- **Planned but not in progress:** Features that are good to have but currently lacking
+  bandwidth
+
+We use `[CC]` to mark items suitable for community contributions. If you're interested
+in contributing, please reach out to discuss implementation details.
+
+### Backends
+
+**On-going**
+
+- [ ] Support training the latest large MoE models with the Megatron backend (including
+  Kimi 2.5 / GLM 5 / DeepSeek V3 / Qwen 3.6, etc.)
+  ([#1372](https://github.com/areal-project/AReaL/pull/1372),
+  [#1373](https://github.com/areal-project/AReaL/pull/1373))
+- [ ] More distribution strategies for colocated deployment
+
+**Planned but not in progress**
+
+- [ ] Omini model RL support with FSDP backend
+- [ ] Proxy server support via RayScheduler (HTTP launcher actor) `[CC]`
+- [ ] Weight delta update with `awex`
+- [ ] Memory service for self-evolving agent
+
+### Usability
+
+**On-going**
+
+- [ ] Effective AReaL CLI support
+  ([#1374](https://github.com/areal-project/AReaL/issues/1374))
+- [ ] Profiling toolkit (distributed trace)
+- [ ] Online RL training example based on AReaL 2.0 architecture
+
+**Planned but not in progress**
+
+- [ ] More RL post-training paradigms: IcePop Plus algorithm (verified in Ling MoE
+  training) and stepwise reward rubrics
+- [ ] GUI Agent VLM training example
+- [ ] OS-bench VLM training example `[CC]`
+- [ ] Diffusion image/video generation model RL post-training `[CC]`
+- [ ] Comprehensive LoRA support over the existing policy model training
+- [ ] AReaL autopilot (automatic performance-optimized RL deployment suggestions and
+  systematic bottleneck analysis)
+
+### Documentation
+
+**Planned but not in progress**
+
+- [ ] Explain benchmarking results from nightly CI and how to extract issues
+
+## 2026 Q2 Roadmap (due July 31, 2026)
+
+[GitHub Issue #1302](https://github.com/areal-project/AReaL/issues/1302).
+
+This roadmap tracks major planned enhancements through July 31, 2026. Items are
+organized into two categories:
+
+- **On-going:** Features currently under active development by the core AReaL team
+- **Planned but not in progress:** Features that are good to have but currently lacking
+  bandwidth
+
+We use `[CC]` to mark items suitable for community contributions. If you're interested
+in contributing, please reach out to discuss implementation details.
+
+### Backends
+
+**On-going**
+
+- [ ] Full training example with AReaL 2.0 architecture
+- [ ] Deprecate support for SPMD mode (launcher, sglang/vllm server, etc.)
+- [ ] Initial support of colocation weight transfer with `awex`
+
+**Planned but not in progress**
+
+- [ ] Migrate primary Megatron integration lib from `mbridge` to `megatron-bridge`
+  ([#1260](https://github.com/areal-project/AReaL/issues/1260)) `[CC]`
+- [ ] Full support for colocation/separation weight transfer with `awex` as the backend
+  (`areal/experimental/weight_update/`) `[CC]`
+- [ ] Migrate legacy NCCL broadcast weight transfer approach from `areal/engine` into
+  `areal/experimental/weight_update/` `[CC]`
+- [ ] Omini model RL support with FSDP backend
+  ([#879](https://github.com/areal-project/AReaL/issues/879)) `[CC]`
+- [ ] Support training the latest large MoE models with the Megatron backend, including
+  dpsk-v3/v4, Kimi-2.5, GLM-4/5 `[CC]`
+- [ ] Native Kubernetes (K8S) scheduler `[CC]`
+
+### Usability
+
+**On-going**
+
+- [ ] Nightly CI workflow for performance benchmarking
+  ([#1284](https://github.com/areal-project/AReaL/issues/1284))
+- [ ] Refactor unit tests for faster execution
+
+**Planned but not in progress**
+
+- [ ] OS-bench VLM training example `[CC]`
+- [ ] Multi-agent training example (single LLM, different prompts, e.g., planner agent
+  with sub-agents) `[CC]`
+- [ ] Migrate legacy multi-turn agent examples to new API (`agenerate` → `ArealOpenAI`
+  or URL-based `AgentWorkflow`) `[CC]`
+- [ ] Publish PyPI packages and CLI for running experiments
+- [ ] Support distributed training and debugging in Jupyter notebooks
+- [ ] Implement controller construction with model-centric API similar to `transformers`
+
+### Documentation
+
+**Planned but not in progress**
+
+- [ ] Explain benchmarking results from nightly CI and how to extract issues
+- [ ] Document AReaL 2.0 architecture
+
 ## 2026 Q1 Roadmap (due April 30, 2026)
 
 [GitHub Issue #907](https://github.com/areal-project/AReaL/issues/907).
@@ -207,7 +326,7 @@ agentic AI systems** that is:
 
 ______________________________________________________________________
 
-**Last Updated:** 2026-02-06
+**Last Updated:** 2026-06-05
 
 **Questions about the roadmap?** Open a discussion in
 [GitHub Discussions](https://github.com/areal-project/AReaL/discussions) or ask in our

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,7 +147,7 @@ organized into two categories:
 **Planned but not in progress**
 
 - [ ] Support for agentic training with large VLM MoE models (Archon backend)
-- [ ] Omni model RL support with FSDP/Archon backend
+- [ ] Omini model RL support with FSDP/Archon backend
 - [ ] Decoupling agent service from the inference service
 - [ ] Online RL training with the proxy server
 - [ ] LoRA support for the Archon backend


### PR DESCRIPTION
## Description

Add the 2026 Q2 (#1302) and 2026 H2 (#1381) milestone trackers to ROADMAP.md so
the file reflects the latest planning. Existing Q1 and historical sections are
preserved; "Last Updated" bumped to 2026-06-05.

## Related Issue

Refs #1302, #1381

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

- Inserted in chronological order: H2 first, then Q2, then existing Q1.
- Rewrote bare URLs from #1381 source as inline issue/PR links (#1372, #1373,
  #1374, #1260, #879, #1284).