### PR TITLE
fix: Prevent workers from applying dp-scaled staleness to fix rollout hanging issues caused by zero local capacity

### DIFF
--- a/areal/infra/controller/rollout_controller.py
+++ b/areal/infra/controller/rollout_controller.py
@@ -267,6 +267,13 @@ class RolloutController:
         logger.info("Engine created on all workers!")
 
         logger.info("Calling engine initialization...")
+
+        # Workers are controller-managed: the controller handles staleness
+        # globally, so workers must NOT apply their own dp-scaled staleness
+        # constraints. Pass train_data_parallel_size=1 to prevent workers
+        # from dividing capacity by dist.get_world_size().
+        kwargs.setdefault("train_data_parallel_size", 1)
+        
         if server_infos is not None:
             # Connecting to existing local servers for evaluation
             self.server_infos = server_infos

--- a/areal/infra/controller/rollout_controller.py
+++ b/areal/infra/controller/rollout_controller.py
@@ -273,7 +273,7 @@ class RolloutController:
         # constraints. Pass train_data_parallel_size=1 to prevent workers
         # from dividing capacity by dist.get_world_size().
         kwargs.setdefault("train_data_parallel_size", 1)
-        
+
         if server_infos is not None:
             # Connecting to existing local servers for evaluation
             self.server_infos = server_infos


### PR DESCRIPTION
Set default train_data_parallel_size to 1 for workers.

## Description

<!-- Provide a clear and concise description of what this PR does -->

When `RolloutController` dispatches tasks to Workers, each Worker's `WorkflowExecutor.initialize()` creates a local `StalenessManager` with capacity parameters scaled down by `train_data_parallel_size` (dp_world_size):

```python
max_concurrent_rollouts = max(1, self.max_concurrent_rollouts // dp_world_size)
consumer_batch_size = max(1, self.consumer_batch_size // dp_world_size)
```

This double-scaling (Controller manages global capacity, Worker re-scales locally) causes Worker-level capacity to drop to 0, permanently blocking rollout tasks.

### Worked Example

Config:
- `rollout.max_head_offpolicyness=0`
- `rollout.max_concurrent_rollouts=2`
- `rollout.backend=sglang:d2`
- `train_dataset.batch_size=2`

Capacity formula:

```
capacity = min(
  max_concurrent - running,
  (max_staleness + version + 1) * consumer_bs - accepted
)
```

Timeline (model version=0, sampling first batch):

| Step | Event | Worker State | Result |
|------|-------|-------------|--------|
| 1 | task 0 → rank 0 | accepted=1, capacity=0 | Accepted |
| 2 | task 1 → rank 1 | accepted=0, rejected=1, capacity=1 | Rejected |
| — | Global: accepted=1, rejected=1, capacity=1. Batch incomplete, Controller retries. | | |
| 3 | task 2 → rank 0 | queued=1, accepted=1, capacity=0 | Deadlocked |

Rank 0's capacity is locked at 0. The queued task cannot execute. Model version never advances (needs full batch). Permanent hang.

### Fix

Set `train_data_parallel_size=1` as the default for Controller-managed Workers via `kwargs.setdefault("train_data_parallel_size", 1)` in `RolloutController._async_initialize()`. This makes Workers' local `StalenessManager` pass-through, deferring all capacity/staleness decisions to the Controller — which already manages these globally.

`setdefault` ensures explicitly-passed values are still respected.

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->


## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
