### PR TITLE
Support Megatron FP8 weight transfer in AWEX mode

### DIFF
--- a/areal/engine/megatron_utils/fp8/tensor_helper.py
+++ b/areal/engine/megatron_utils/fp8/tensor_helper.py
@@ -434,7 +434,7 @@ def convert_fp8_helper_to_pytorch_fp8(
     converted = []
     for name, tensor in named_tensors:
         if isinstance(tensor, FP8BlockwiseTensorHelper):
-            weight, scale_inv = tensor.to_pytorch_fp8()
+            weight, scale_inv = tensor.to_pytorch_fp8(scale_inv_dtype=torch.float32)
             converted.append((name, weight))
             converted.append((f"{name}_scale_inv", scale_inv))
         else:

--- a/areal/v2/weight_update/awex/megatron_adapter.py
+++ b/areal/v2/weight_update/awex/megatron_adapter.py
@@ -293,8 +293,8 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             gathered = all_gather_param(
                 mcore_name,
                 param,
-                fp8_direct_convert=False,
-                quantization_config=None,
+                fp8_direct_convert=self._engine.fp8_direct_convert,
+                quantization_config=self._engine.quantization_config,
                 duplicated_param_names=self._engine._duplicated_param_names,
             )
             if not isinstance(gathered, torch.Tensor):
@@ -305,6 +305,9 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
                 model_name,
                 mcore_name,
                 gathered,
+                fp8_direct_convert=self._engine.fp8_direct_convert,
+                quantization_config=self._engine.quantization_config,
+                hf_config=self._engine.hf_config,
             ):
                 if tie_word_embeddings and hf_name == "lm_head.weight":
                     continue
@@ -527,11 +530,20 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
 
     def _offload_model_weights(self) -> None:
         """Move model parameters to CPU, keeping references for reload."""
+        from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
+
         if self._engine.model is None:
             return
 
         for name, param in self._engine.model.named_parameters():
-            if param.is_cuda:
+            if isinstance(param, QuantizedTensor):
+                tensors, _ = param.prepare_for_saving()
+                self._offloaded_weights[name] = [
+                    t.detach().to("cpu", non_blocking=True) if t is not None else None
+                    for t in tensors
+                ]
+                param.clear()
+            elif param.is_cuda:
                 self._offloaded_weights[name] = param.data.detach().to(
                     "cpu", non_blocking=True
                 )
@@ -551,8 +563,17 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
 
         device = self._engine.device
         for name, param in self._engine.model.named_parameters():
-            if name in self._offloaded_weights:
-                param.data = self._offloaded_weights[name].to(device, non_blocking=True)
+            if name not in self._offloaded_weights:
+                continue
+            saved = self._offloaded_weights[name]
+            if isinstance(saved, list):
+                tensors_gpu = [
+                    t.to(device, non_blocking=True) if t is not None else None
+                    for t in saved
+                ]
+                param.restore_from_saved(tensors_gpu)
+            else:
+                param.data = saved.to(device, non_blocking=True)
 
         self._offloaded_weights.clear()
         logger.info("Reloaded model weights to GPU")

--- a/areal/v2/weight_update/awex/sglang_adapter.py
+++ b/areal/v2/weight_update/awex/sglang_adapter.py
@@ -346,7 +346,14 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
 
     def randomize_parameters(self) -> None:
         for _, param in self._get_model().named_parameters():
-            param.data.normal_()
+            if param.data.dtype == torch.float8_e4m3fn:
+                param.data.copy_(
+                    torch.randn_like(param.data, dtype=torch.bfloat16).to(
+                        param.data.dtype
+                    )
+                )
+            else:
+                param.data.normal_()
 
     def init_weight_update_group(
         self,

--- a/examples/math/gsm8k_grpo_megatron_fp8_v2.yaml
+++ b/examples/math/gsm8k_grpo_megatron_fp8_v2.yaml
@@ -1,0 +1,194 @@
+experiment_name: gsm8k-grpo-megatron
+trial_name: trial0
+
+seed: 1
+enable_offload: false
+total_train_epochs: 10
+tokenizer_path: ${actor.path}
+
+cluster:
+  n_nodes: 1
+  n_gpus_per_node: 8
+  fileroot: /tmp/areal/experiments
+  name_resolve:
+    type: nfs
+    nfs_record_root: /tmp/areal/name_resolve
+
+
+scheduler:
+  type: null
+
+rollout:
+  _version: v2
+  backend: "sglang:d4p1t1"
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 256
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 2
+  enable_rollout_tracing: false
+  scheduling_spec: ${actor.scheduling_spec}
+  fileroot: ${cluster.fileroot}
+  tokenizer_path: ${tokenizer_path}
+  dump_to_file: true
+  agent:
+    mode: inline
+    export_style: individual
+    turn_discount: 1.0
+
+gconfig:
+  n_samples: 4
+  min_new_tokens: 0
+  max_new_tokens: 1024
+  max_tokens: 2048
+  greedy: false
+  temperature: 1.0
+
+actor:
+  _version: v2
+  backend: "megatron:d4p1t1"
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen3-1.7B-FP8
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: false
+  dtype: bfloat16
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer:
+    type: adam
+    lr: 3e-6
+    weight_decay: 0.003
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+  eps_clip: 0.4
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  rejection_sampling:
+    metric: ratio
+    upper: 5.0
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_spec:
+    - task_type: worker
+      port_count: 2
+      gpu: 1
+      mem: 32
+      cmd: python3 -m areal.infra.rpc.rpc_server
+      env_vars: {}
+  megatron:
+    fp8_config:
+      mode: hybrid
+      recipe: blockwise
+      param: true
+    ddp:
+      fp8_param_gather: true
+
+ref:
+  backend: ${actor.backend}
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  init_from_scratch: false
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+# SGLang
+sglang:
+  model_path: ${actor.path}
+  random_seed: ${seed}
+  skip_tokenizer_init: true
+  dtype: ${actor.dtype}
+  max_running_requests: null
+  context_length: 32768
+  mem_fraction_static: 0.8
+
+vllm:
+  model: ${actor.path}
+  seed: ${seed}
+  skip_tokenizer_init: false
+  dtype: ${actor.dtype}
+  max_model_len: 32768
+  gpu_memory_utilization: 0.9
+
+# datasets
+train_dataset:
+  batch_size: 256
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+  max_length: 1024
+
+valid_dataset:
+  batch_size: 256
+  pin_memory: true
+  num_workers: 4
+  path: openai/gsm8k
+  type: rl
+
+# Utilities
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: disabled
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: 3600
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: disabled
+
+perf_tracer:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  enabled: false
+  session_tracer:
+    enabled: false

--- a/tests/v2/weight_update/test_fp8.py
+++ b/tests/v2/weight_update/test_fp8.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import httpx
+import pytest
+import torch
+
+from areal.infra.platforms import current_platform
+from areal.utils.network import find_free_ports
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA not available"
+)
+
+_VALIDATE_PARAM_NAMES = [
+    "model.layers.0.self_attn.q_proj.weight",
+    "model.layers.0.self_attn.q_proj.weight_scale_inv",
+    "model.layers.0.self_attn.k_proj.weight",
+    "model.layers.0.self_attn.k_proj.weight_scale_inv",
+    "model.layers.0.self_attn.v_proj.weight",
+    "model.layers.0.self_attn.v_proj.weight_scale_inv",
+    "model.layers.0.mlp.gate_proj.weight",
+    "model.layers.0.mlp.gate_proj.weight_scale_inv",
+    "model.layers.0.mlp.up_proj.weight",
+    "model.layers.0.mlp.up_proj.weight_scale_inv",
+    "model.layers.27.self_attn.q_proj.weight",
+    "model.layers.27.self_attn.q_proj.weight_scale_inv",
+    "model.norm.weight",
+]
+
+
+def _get_test_model_path() -> str:
+    local = "/storage/openpsi/models/Qwen__Qwen3-0.6B-FP8/"
+    if os.path.isdir(local):
+        return local
+    return "Qwen/Qwen3-0.6B-FP8"
+
+
+def _make_local_scheduler(tmp_path, name: str, gpu_devices: list[int]):
+    from areal.infra.scheduler.local import LocalScheduler
+
+    fileroot = tmp_path / f"{name}_fileroot"
+    fileroot.mkdir(exist_ok=True)
+    nr_root = tmp_path / f"{name}_name_resolve"
+    nr_root.mkdir(exist_ok=True)
+
+    return LocalScheduler(
+        gpu_devices=gpu_devices,
+        log_dir=str(tmp_path / f"{name}_logs"),
+        experiment_name=f"test-fp8-{name}",
+        trial_name="t0",
+        fileroot=str(fileroot),
+        nfs_record_root=str(nr_root),
+    )
+
+
+def _validate_weight_update_correctness(
+    train_worker_urls: list[str],
+    inf_worker_urls: list[str],
+    param_dir,
+) -> None:
+    print(
+        "\n[weight-validation] Fetching parameters from 1 training "
+        "worker and 1 inference worker …"
+    )
+
+    train_worker_url = train_worker_urls[0]
+    inf_worker_url = inf_worker_urls[0]
+
+    train_path = str(param_dir / "train_params.pt")
+    resp = httpx.post(
+        f"{train_worker_url}/awex/debug/get_parameters",
+        json={"save_path": train_path, "names": _VALIDATE_PARAM_NAMES},
+        timeout=120.0,
+    )
+    assert resp.status_code == 200, (
+        f"get_parameters failed on training worker: {resp.text}"
+    )
+
+    inf_path = str(param_dir / "infer_params.pt")
+    resp = httpx.post(
+        f"{inf_worker_url}/awex/debug/get_parameters",
+        json={"save_path": inf_path, "names": _VALIDATE_PARAM_NAMES},
+        timeout=120.0,
+    )
+    assert resp.status_code == 200, (
+        f"get_parameters failed on inference worker: {resp.text}"
+    )
+
+    train_params = torch.load(train_path, map_location="cpu", weights_only=True)
+    infer_params = torch.load(inf_path, map_location="cpu", weights_only=True)
+
+    print(f"[weight-validation] Comparing {len(_VALIDATE_PARAM_NAMES)} parameters …")
+    for name in _VALIDATE_PARAM_NAMES:
+        assert name in train_params, f"Training missing: {name}"
+        assert name in infer_params, f"Inference missing: {name}"
+
+        train_tensor = train_params[name]
+        infer_tensor = infer_params[name]
+
+        if train_tensor.dtype == torch.float8_e4m3fn:
+            assert infer_tensor.dtype == torch.float8_e4m3fn, (
+                f"Param '{name}' was dequantized from float8_e4m3fn"
+                f" to {infer_tensor.dtype} during transfer"
+            )
+
+        torch.testing.assert_close(
+            train_tensor,
+            infer_tensor,
+            rtol=0,
+            atol=0,
+            msg=f"Parameter mismatch after weight update: {name}",
+        )
+        print(
+            f"[weight-validation]   {name}: OK "
+            f"(shape={list(train_tensor.shape)}, dtype={train_tensor.dtype})"
+        )
+
+    print(
+        f"[weight-validation] All {len(_VALIDATE_PARAM_NAMES)} parameters "
+        f"match between Megatron FP8 training and inference ✓"
+    )
+
+
+def _run_megatron_fp8_awex_e2e(
+    *,
+    n_gpus: int,
+    pair_name: str,
+    tag: str,
+    tmp_path_factory,
+    colocate: bool,
+    model_path: str | None = None,
+):
+    from areal.api import FinetuneSpec
+    from areal.api.cli_args import (
+        FP8EngineConfig,
+        InferenceEngineConfig,
+        MegatronEngineConfig,
+        OptimizerConfig,
+        SchedulingSpec,
+        TrainEngineConfig,
+    )
+    from areal.v2.inference_service.controller.controller import (
+        RolloutControllerV2,
+    )
+    from areal.v2.training_service.controller.controller import (
+        GatewayTrainController,
+    )
+    from areal.v2.weight_update.controller import (
+        WeightUpdateController,
+        WeightUpdateControllerConfig,
+    )
+
+    if colocate:
+        dp = n_gpus
+    else:
+        dp = n_gpus // 2
+
+    tmp = tmp_path_factory.mktemp(tag)
+    model_path = model_path or _get_test_model_path()
+    scheduler = _make_local_scheduler(tmp, tag, gpu_devices=list(range(n_gpus)))
+
+    inf_config = InferenceEngineConfig(
+        tokenizer_path=model_path,
+        backend=f"sglang:d{dp}",
+        scheduling_spec=(
+            SchedulingSpec(
+                gpu=1,
+                cmd="python -m areal.v2.inference_service.guard",
+            ),
+        ),
+        consumer_batch_size=8,
+        max_head_offpolicyness=1024,
+        setup_timeout=300.0,
+        admin_api_key="test-admin",
+    )
+    inf_ctrl = RolloutControllerV2(config=inf_config, scheduler=scheduler)
+
+    train_config = TrainEngineConfig(
+        backend=f"megatron:d{dp}",
+        experiment_name=f"test-fp8-awex-{tag}",
+        trial_name="t0",
+        path=model_path,
+        optimizer=OptimizerConfig(),
+        _version="v2",
+        setup_timeout=300.0,
+        megatron=MegatronEngineConfig(
+            fp8_config=FP8EngineConfig(
+                mode="e4m3",
+                recipe="blockwise",
+                param=True,
+                direct_convert=True,
+            ),
+        ),
+        scheduling_spec=(
+            SchedulingSpec(
+                gpu=1,
+                cmd="python -m areal.v2.training_service.guard",
+                env_vars=dict(NCCL_CUMEM_ENABLE="0", NCCL_NVLS_ENABLE="0"),
+            ),
+        ),
+    )
+    train_ctrl = GatewayTrainController(
+        train_engine="areal.engine.megatron_engine.MegatronLMEngine",
+        config=train_config,
+        scheduler=scheduler,
+    )
+
+    wu_ctrl: WeightUpdateController | None = None
+    try:
+        # -- 1. SGLang inference ---------------------------------------------
+        inf_ctrl.initialize(
+            role="rollout",
+            server_args={"model_path": model_path, "mem_fraction_static": 0.7},
+            wait=True,
+        )
+        inf_worker_urls = list(inf_ctrl._inf_addrs)
+
+        # Randomize inference weights so the transfer is NOT a no-op.
+        for url in inf_worker_urls:
+            resp = httpx.post(f"{url}/awex/debug/randomize_parameters", timeout=120.0)
+            assert resp.status_code == 200, f"randomize_parameters failed: {resp.text}"
+
+        # -- 2. Megatron training --------------------------------------------
+        train_ctrl.initialize(
+            role="actor",
+            ft_spec=FinetuneSpec(
+                total_train_epochs=1, dataset_size=100, train_batch_size=2
+            ),
+            wait=True,
+        )
+        train_worker_urls = list(train_ctrl._worker_addrs)
+
+        # -- 3. Weight update gateway ----------------------------------------
+        wu_ctrl = WeightUpdateController(
+            config=WeightUpdateControllerConfig(host="127.0.0.1", request_timeout=300.0)
+        )
+        wu_ctrl.initialize()
+        assert wu_ctrl.health_check(), "Weight update gateway health check failed"
+
+        # -- 4. Connect with colocate=True/False -----------------------------
+        wu_ctrl.connect(
+            pair_name=pair_name,
+            train_worker_urls=train_worker_urls,
+            inference_worker_urls=inf_worker_urls,
+            colocate=colocate,
+            nccl_master_addr="127.0.0.1",
+            nccl_master_port=find_free_ports(1)[0],
+        )
+
+        # -- 5. Colocated weight update -------------------------------------
+        result = wu_ctrl.update_weights(version=1)
+        assert result.status == "ok"
+        assert result.version == 1
+        wu_ctrl.disconnect()
+
+        # -- 6. Verify inference server still works post-update -------------
+        gen_resp = httpx.post(
+            f"{inf_worker_urls[0]}/generate",
+            json={
+                "text": "Hello",
+                "sampling_params": {"max_new_tokens": 5, "temperature": 0},
+            },
+            timeout=30.0,
+        )
+        assert gen_resp.status_code == 200, (
+            f"Generation failed after weight update: {gen_resp.text}"
+        )
+
+        # -- 7. Validate training ↔ inference parameter equality ------------
+        _validate_weight_update_correctness(
+            train_worker_urls=train_worker_urls,
+            inf_worker_urls=inf_worker_urls,
+            param_dir=tmp,
+        )
+    finally:
+        if wu_ctrl is not None:
+            wu_ctrl.destroy()
+        train_ctrl.destroy()
+        inf_ctrl.destroy()
+        scheduler.delete_workers(None)
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.parametrize("n_gpus", [2, 4, 8], ids=["2gpu", "4gpu", "8gpu"])
+def test_awex_megatron_fp8_xccl_dp_e2e_weight_update(n_gpus, tmp_path_factory):
+    """Full round trip: MegatronEngine (pure DP) + SGLang for FP8 model on
+    separated GPUs.
+
+    Weight transfer uses NCCL P2P across devices.
+
+    Only pure DP (TP=1, PP=1, EP=1) is supported.
+    """
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+    _run_megatron_fp8_awex_e2e(
+        n_gpus=n_gpus,
+        pair_name=f"test_fp8_xccl_dp{n_gpus}",
+        tag=f"xccl_dp{n_gpus}",
+        tmp_path_factory=tmp_path_factory,
+        colocate=False,
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+@pytest.mark.sglang
+@pytest.mark.parametrize("n_gpus", [2, 4, 8], ids=["2gpu", "4gpu", "8gpu"])
+def test_awex_megatron_fp8_colocate_dp_e2e_weight_update(n_gpus, tmp_path_factory):
+    """Full round trip: colocated MegatronEngine (pure DP) + SGLang for FP8 model
+    on same GPUs.
+
+    Unlike separated tests that split GPUs between training and inference,
+    colocated mode shares all GPUs.  Weight transfer uses CUDA IPC
+    (zero-copy on same device) instead of NCCL P2P across devices.
+
+    Only pure DP (TP=1, PP=1, EP=1) is supported.
+    """
+
+    if current_platform.device_count() < n_gpus:
+        pytest.skip(f"This test requires {n_gpus} GPUs")
+    _run_megatron_fp8_awex_e2e(
+        n_gpus=n_gpus,
+        pair_name=f"test_fp8_colocate_dp{n_gpus}",
+        tag=f"colocate_dp{n_gpus}",
+        tmp_path_factory=tmp_path_factory,
+        colocate=True,
+    )


### PR DESCRIPTION
## Description

Enable FP8 direct transfer in AWEX mode (both xccl and colocated paths). Training-side megatron_adapter now detects FP8 models via `quantization_config` and passes `fp8_direct_convert=True`, 
avoiding implicit dequantization to BF16. `scale_inv` output uses float32 to match SGLang/transformers FP8Linear convention. FP8 weight offload/reload preserves original data and scale without re-quantization.            
                              
## Related Issue
                                                            
Fixes #1359.
                                                            
## Type of Change
                                                            
- [x] Bug fix (non-breaking change that fixes an issue)     
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change                                       
- [ ] Documentation update                                  
- [ ] Code refactoring                                      
- [ ] Performance improvement
- [x] Test coverage improvement                             
                              
## Checklist
                                                            
- [x] I have read the Contributing Guide
- [x] I have run formatting tools                           
- [x] I have run relevant unit tests and they pass
- [x] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes
