### PR TITLE
fix(openai): render tool-call arguments as a mapping for HF chat templates

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -131,16 +131,7 @@ def _ensure_message_dict_list(
 def _messages_for_hf_chat_template(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Return a tokenizer-only copy of OpenAI messages.
-
-    OpenAI chat completions represent function-call arguments as a JSON string.
-    Some HuggingFace chat templates, including Qwen3 Coder's, render prior tool
-    calls by iterating over ``tool_call.function.arguments`` as a mapping; given
-    a string they raise ``AttributeError`` (or iterate it character-by-character)
-    and the rendered prompt diverges from the tokens the policy sampled. Keep the
-    public/cache representation OpenAI-compatible (wire strings), but decode the
-    arguments to a mapping for tokenizer rendering only.
-    """
+    """Return tokenizer-only messages with tool-call arguments as mappings."""
 
     rendered = deepcopy(messages)
     for message in rendered:
@@ -161,13 +152,8 @@ def _messages_for_hf_chat_template(
             try:
                 decoded = json.loads(arguments)
             except json.JSONDecodeError:
-                # A non-JSON argument string is not valid OpenAI function-call
-                # output; wrapping it under a single key is more useful than a
-                # template crash when replaying a trajectory.
                 decoded = {"arguments": arguments}
             if not isinstance(decoded, Mapping):
-                # Valid JSON that is not an object (e.g. a list) still has to
-                # satisfy the template's ``.items()`` contract.
                 decoded = {"arguments": decoded}
             if isinstance(function, dict):
                 function["arguments"] = dict(decoded)

--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -128,6 +128,54 @@ def _ensure_message_dict_list(
     return normalized
 
 
+def _messages_for_hf_chat_template(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return a tokenizer-only copy of OpenAI messages.
+
+    OpenAI chat completions represent function-call arguments as a JSON string.
+    Some HuggingFace chat templates, including Qwen3 Coder's, render prior tool
+    calls by iterating over ``tool_call.function.arguments`` as a mapping; given
+    a string they raise ``AttributeError`` (or iterate it character-by-character)
+    and the rendered prompt diverges from the tokens the policy sampled. Keep the
+    public/cache representation OpenAI-compatible (wire strings), but decode the
+    arguments to a mapping for tokenizer rendering only.
+    """
+
+    rendered = deepcopy(messages)
+    for message in rendered:
+        if message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, Mapping):
+                continue
+            function = tool_call.get("function")
+            if not isinstance(function, Mapping):
+                continue
+            arguments = function.get("arguments")
+            if not isinstance(arguments, str):
+                continue
+            try:
+                decoded = json.loads(arguments)
+            except json.JSONDecodeError:
+                # A non-JSON argument string is not valid OpenAI function-call
+                # output; wrapping it under a single key is more useful than a
+                # template crash when replaying a trajectory.
+                decoded = {"arguments": arguments}
+            if not isinstance(decoded, Mapping):
+                # Valid JSON that is not an object (e.g. a list) still has to
+                # satisfy the template's ``.items()`` contract.
+                decoded = {"arguments": decoded}
+            if isinstance(function, dict):
+                function["arguments"] = dict(decoded)
+            else:
+                tool_call["function"] = {**dict(function), "arguments": dict(decoded)}
+    return rendered
+
+
 def _find_kth(lst: list, target, k: int) -> int:
     def target_indices():
         for i, char in enumerate(lst):
@@ -388,7 +436,7 @@ def concat_prompt_token_ids_with_parent(
 
     all_tokens = apply_chat_template(
         tokenizer,
-        all_message_list,
+        _messages_for_hf_chat_template(all_message_list),
         tools=tools,
         add_generation_prompt=True,
         tokenize=True,
@@ -609,7 +657,9 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
         )
         has_images = len(image_data) > 0
 
-        tokenizer_messages = messages_for_tokenizer if has_images else messages_list
+        tokenizer_messages = _messages_for_hf_chat_template(
+            messages_for_tokenizer if has_images else messages_list
+        )
         if self.chat_template_type == "hf":
             prompt_token_ids = apply_chat_template(
                 self.tokenizer,
@@ -1017,7 +1067,9 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
         )
         has_images = len(image_data) > 0
 
-        tokenizer_messages = messages_for_tokenizer if has_images else messages_list
+        tokenizer_messages = _messages_for_hf_chat_template(
+            messages_for_tokenizer if has_images else messages_list
+        )
         if self.chat_template_type == "hf":
             prompt_token_ids = apply_chat_template(
                 self.tokenizer,

--- a/tests/experimental/openai/test_hf_chat_template_messages.py
+++ b/tests/experimental/openai/test_hf_chat_template_messages.py
@@ -83,7 +83,6 @@ def test_messages_for_hf_chat_template_decodes_tool_call_arguments_copy():
         "query": "AReaL",
         "limit": 2,
     }
-    # The wire/cache representation must stay a JSON string (unchanged).
     assert messages == original
 
 

--- a/tests/experimental/openai/test_hf_chat_template_messages.py
+++ b/tests/experimental/openai/test_hf_chat_template_messages.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+import areal.experimental.openai.client as client_module
+from areal.api import ModelRequest, ModelResponse
+from areal.experimental.openai import ArealOpenAI
+from areal.experimental.openai.client import (
+    _messages_for_hf_chat_template,
+    concat_prompt_token_ids_with_parent,
+)
+from areal.experimental.openai.types import InteractionWithTokenLogpReward
+
+
+class RecordingTokenizer:
+    eos_token_id = 0
+    pad_token_id = 0
+
+    def __init__(self):
+        self.template_messages: list[list[dict[str, Any]]] = []
+
+    def apply_chat_template(
+        self, messages: list[dict[str, Any]], **kwargs: Any
+    ) -> dict[str, list[int]]:
+        self.template_messages.append(deepcopy(messages))
+        return {"input_ids": [10, 11, 12]}
+
+    def decode(self, token_ids: list[int]) -> str:
+        return ""
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return [ord(char) for char in text]
+
+
+class FakeEngine:
+    def __init__(self):
+        self.requests: list[ModelRequest] = []
+
+    async def agenerate(self, req: ModelRequest) -> ModelResponse:
+        self.requests.append(req)
+        return ModelResponse(
+            input_tokens=req.input_ids,
+            output_tokens=[42, 0],
+            output_logprobs=[0.0, 0.0],
+            output_versions=[0, 0],
+            stop_reason="stop",
+            tokenizer=req.tokenizer,
+        )
+
+
+def _assistant_tool_message(arguments: str) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_123",
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "arguments": arguments,
+                },
+            }
+        ],
+    }
+
+
+def test_messages_for_hf_chat_template_decodes_tool_call_arguments_copy():
+    messages = [
+        {"role": "user", "content": "look this up"},
+        _assistant_tool_message(json.dumps({"query": "AReaL", "limit": 2})),
+        {"role": "tool", "tool_call_id": "call_123", "content": "done"},
+    ]
+    original = deepcopy(messages)
+
+    rendered = _messages_for_hf_chat_template(messages)
+
+    assert rendered[1]["tool_calls"][0]["function"]["arguments"] == {
+        "query": "AReaL",
+        "limit": 2,
+    }
+    # The wire/cache representation must stay a JSON string (unchanged).
+    assert messages == original
+
+
+@pytest.mark.parametrize(
+    ("raw_arguments", "rendered_arguments"),
+    [
+        ("not-json", {"arguments": "not-json"}),
+        (json.dumps(["a", "b"]), {"arguments": ["a", "b"]}),
+    ],
+)
+def test_messages_for_hf_chat_template_keeps_arguments_mapping_shaped(
+    raw_arguments: str, rendered_arguments: dict[str, Any]
+):
+    rendered = _messages_for_hf_chat_template([_assistant_tool_message(raw_arguments)])
+
+    assert rendered[0]["tool_calls"][0]["function"]["arguments"] == rendered_arguments
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_templates_decoded_copy_but_caches_openai_messages():
+    tokenizer = RecordingTokenizer()
+    engine = FakeEngine()
+    client = ArealOpenAI(
+        engine=engine,
+        tokenizer=tokenizer,
+        api_key="test",
+        base_url="http://localhost",
+    )
+    messages = [
+        {"role": "user", "content": "look this up"},
+        _assistant_tool_message(json.dumps({"query": "AReaL"})),
+        {"role": "tool", "tool_call_id": "call_123", "content": "done"},
+        {"role": "user", "content": "summarize it"},
+    ]
+    original = deepcopy(messages)
+
+    completion = await client.chat.completions.create(
+        messages=messages,
+        max_completion_tokens=1,
+    )
+
+    rendered_arguments = tokenizer.template_messages[0][1]["tool_calls"][0]["function"][
+        "arguments"
+    ]
+    cached_arguments = client.get_interaction(completion.id).messages[1]["tool_calls"][
+        0
+    ]["function"]["arguments"]
+
+    assert rendered_arguments == {"query": "AReaL"}
+    assert cached_arguments == json.dumps({"query": "AReaL"})
+    assert messages == original
+
+
+def test_concat_prompt_templates_decoded_copy(monkeypatch: pytest.MonkeyPatch):
+    tokenizer = RecordingTokenizer()
+    parent = InteractionWithTokenLogpReward(
+        messages=[{"role": "user", "content": "look this up"}],
+        model_response=ModelResponse(
+            input_tokens=[10],
+            output_tokens=[11, tokenizer.eos_token_id],
+            output_logprobs=[0.0, 0.0],
+            output_versions=[0, 0],
+            stop_reason="stop",
+            tokenizer=tokenizer,
+        ),
+        output_message_list=[_assistant_tool_message(json.dumps({"query": "AReaL"}))],
+        chat_template_type="concat",
+    )
+    captured_messages: list[dict[str, Any]] | None = None
+
+    def fake_apply_chat_template(
+        tokenizer: RecordingTokenizer,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> list[int]:
+        nonlocal captured_messages
+        captured_messages = deepcopy(messages)
+        return [99, tokenizer.eos_token_id, 100]
+
+    monkeypatch.setattr(client_module, "apply_chat_template", fake_apply_chat_template)
+
+    concat_prompt_token_ids_with_parent(
+        message_list=[{"role": "tool", "tool_call_id": "call_123", "content": "done"}],
+        parent=parent,
+        tokenizer=tokenizer,
+    )
+
+    assert captured_messages is not None
+    assert captured_messages[1]["tool_calls"][0]["function"]["arguments"] == {
+        "query": "AReaL"
+    }
+    assert parent.output_message_list[0]["tool_calls"][0]["function"][
+        "arguments"
+    ] == json.dumps({"query": "AReaL"})


### PR DESCRIPTION
## Description

## Problem

OpenAI chat completions encode `tool_calls[].function.arguments` as a **JSON string** (the wire format). HuggingFace chat templates — including Qwen3 Coder's — render prior assistant tool calls by iterating `tool_call.arguments.items()`, which expects a **mapping**. Given a string they raise `AttributeError` (or, on tolerant templates, iterate the string character-by-character and emit a garbled tool block).

In `areal/experimental/openai/client.py` the messages flow to `apply_chat_template` at three render boundaries — `concat_prompt_token_ids_with_parent`, `AsyncCompletionsWithReward`, and `AsyncResponsesWithReward`. In a token-capturing multi-turn / tool-calling rollout, the prompt rendered for a replayed trajectory then **diverges from the tokens the policy actually sampled** — a rollout/train token desync that trains the policy on tokens it never produced.

## Before vs After

```python
# assistant turn whose tool call carries arguments as the wire JSON string
{"role": "assistant",
 "tool_calls": [{"type": "function",
                 "function": {"name": "lookup", "arguments": '{"q": "AReaL"}'}}]}
```

**Before** — the string reaches the Qwen template's `arguments.items()` → `AttributeError` (or a garbled per-character tool block). Rendered prompt ≠ sampled tokens.

**After** — decoded to a mapping for **tokenizer rendering only**:

```python
"function": {"name": "lookup", "arguments": {"q": "AReaL"}}   # dict
```

`.items()` now yields `[("q", "AReaL")]`. The OpenAI-facing response and the cached interaction messages still carry the JSON string (verified by test).

## Why this fix

- **Wire/render separation.** The bug is that one representation served two contracts. A new pure helper `_messages_for_hf_chat_template` deep-copies and decodes **only for the tokenizer**; the response path and the cache are byte-identical, so the outbound OpenAI contract is preserved.
- **Total `-> mapping` contract.** Only `str` arguments are decoded; dicts and absent arguments pass through. JSON that isn't an object (a list) and non-JSON strings are wrapped under a single `arguments` key, so `.items()` can never crash even on a hostile replayed trajectory — no payload is silently dropped.
- **Applied at the choke points.** Threaded through exactly the three boundaries that feed assistant tool-calls to `apply_chat_template`, so future render paths inherit the decode.

## Tests

`tests/experimental/openai/test_hf_chat_template_messages.py` — helper unit tests (decode object args; preserve the original wire string via copy; wrap non-dict JSON and non-JSON under `arguments`) and integration tests asserting the **rendered** tokenizer messages carry the decoded mapping while the **cached** messages keep the JSON string. The two integration tests are mutation-verified to fail if the helper is not applied at the render boundary. CPU-only; `pre-commit`-clean.


## Related Issue

Closes #1420.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (N/A — no config/doc surface)
- [x] Branch is up to date with `main`
- [x] Self-reviewed
- [x] This PR was created by a coding agent
- [ ] This PR is a breaking change

