### PR TITLE
fix(awex): allow disabling batch_send_recv use_group via AWEX_WU_USE_GROUP

### DIFF
--- a/areal/experimental/weight_update/awex/__init__.py
+++ b/areal/experimental/weight_update/awex/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Any
 
 import aiohttp  # pyright: ignore[reportMissingImports]
@@ -11,6 +12,16 @@ from areal.infra.utils.concurrent import run_async_task
 from areal.utils import logging
 
 logger = logging.getLogger("AwexHTTP")
+
+
+def awex_wu_use_group() -> bool:
+    """Resolve whether ``batch_send_recv`` should use ``use_group=True``.
+
+    Why: on some hardware/driver combinations, ``torch.distributed.batch_isend_irecv``
+    can hang during weight update. ``AWEX_WU_USE_GROUP=0`` lets the caller fall back
+    to per-op send/recv to bypass the hang. Defaults to ``1`` (True).
+    """
+    return bool(int(os.getenv("AWEX_WU_USE_GROUP", "1")))
 
 
 async def _fetch_kv_metadata(

--- a/areal/experimental/weight_update/awex/fsdp_adapter.py
+++ b/areal/experimental/weight_update/awex/fsdp_adapter.py
@@ -19,7 +19,10 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Shard
 
 from areal.engine.core.model import is_qwen_vl_model
-from areal.experimental.weight_update.awex import fetch_kv_metadata
+from areal.experimental.weight_update.awex import (
+    awex_wu_use_group,
+    fetch_kv_metadata,
+)
 from areal.experimental.weight_update.nccl_group import (
     init_weights_update_group,
     setup_batch_isend_irecv,
@@ -174,7 +177,12 @@ class AwexFSDPAdapter(AwexTrainingAdapter):
             self._weights_update_group,
             copy_rank=self._transfer_rank,
         )
-        batch_send_recv(send_ops=send_ops, recv_ops=[], blocking=True)
+        batch_send_recv(
+            send_ops=send_ops,
+            recv_ops=[],
+            blocking=True,
+            use_group=awex_wu_use_group(),
+        )
         torch.distributed.barrier(group=self._weights_update_group)
 
     def batch_isend_irecv(self, **kwargs) -> None:

--- a/areal/experimental/weight_update/awex/megatron_adapter.py
+++ b/areal/experimental/weight_update/awex/megatron_adapter.py
@@ -24,7 +24,10 @@ from awex.util.tensor_util import (
     group_tensors_by_shape_and_dtype,
 )
 
-from areal.experimental.weight_update.awex import fetch_kv_metadata
+from areal.experimental.weight_update.awex import (
+    awex_wu_use_group,
+    fetch_kv_metadata,
+)
 from areal.experimental.weight_update.nccl_group import (
     init_weights_update_group,
     setup_batch_isend_irecv,
@@ -198,7 +201,12 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             self._weights_update_group,
             copy_rank=self._transfer_rank,
         )
-        batch_send_recv(send_ops=send_ops, recv_ops=[], blocking=True)
+        batch_send_recv(
+            send_ops=send_ops,
+            recv_ops=[],
+            blocking=True,
+            use_group=awex_wu_use_group(),
+        )
         dist.barrier(group=self._weights_update_group)
 
     def batch_isend_irecv(self, **kwargs) -> None:

--- a/areal/experimental/weight_update/awex/sglang_adapter.py
+++ b/areal/experimental/weight_update/awex/sglang_adapter.py
@@ -30,7 +30,10 @@ from awex.util.tensor_util import (
     reconstruct_tensors_from_groups,
 )
 
-from areal.experimental.weight_update.awex import fetch_kv_metadata
+from areal.experimental.weight_update.awex import (
+    awex_wu_use_group,
+    fetch_kv_metadata,
+)
 from areal.experimental.weight_update.inference_adapter import (
     AwexInferenceAdapter,
 )
@@ -409,7 +412,12 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             self._transfer_plan,
             self._weights_update_group,
         )
-        batch_send_recv(send_ops=[], recv_ops=recv_ops, blocking=True)
+        batch_send_recv(
+            send_ops=[],
+            recv_ops=recv_ops,
+            blocking=True,
+            use_group=awex_wu_use_group(),
+        )
 
         for original, contiguous in non_contiguous_pairs:
             original.copy_(contiguous)


### PR DESCRIPTION
Weight update when creating a large number of ops using a single group,torch.distributed.batch_isend_irecv hangs. Add AWEX_WU_USE_GROUP env var so callers can fall back to per-op send/recv.

Usage: defaults to 1 (use_group=True). Set AWEX_WU_USE_GROUP=0 to bypass the group path. Applied at the three adapter call sites: fsdp/megatron/sglang execute_weight_update().

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
