### PR TITLE
refactor(workflow): extract grouped rollout wrapper

### DIFF
--- a/areal/api/workflow_api.py
+++ b/areal/api/workflow_api.py
@@ -16,7 +16,10 @@ class RolloutWorkflow(ABC):
     async def arun_episode(
         self, engine: InferenceEngine, data: dict[str, Any]
     ) -> dict[str, Any] | None | dict[str, InteractionWithTokenLogpReward]:
-        """Run a single episode of the workflow.
+        """Run one rollout task with the workflow.
+
+        Most workflows return one trajectory. Wrapper workflows may return multiple
+        trajectories batched along the first dimension.
 
         Note
         ----

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -12,9 +12,8 @@ import uuid
 from collections.abc import Callable
 from concurrent.futures import Future
 from datetime import datetime
-from logging import Logger
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import Any, Protocol
 
 import aiohttp
 import numpy as np
@@ -48,7 +47,6 @@ from areal.infra.utils.http import arequest_with_retry, get_default_connector
 from areal.infra.utils.launcher import wait_llm_server_addrs
 from areal.infra.utils.proc import kill_process_tree
 from areal.utils import logging, name_resolve, names
-from areal.utils.data import concat_padded_tensors
 from areal.utils.dynamic_import import import_from_string
 from areal.utils.network import (
     find_free_ports,
@@ -57,70 +55,13 @@ from areal.utils.network import (
     split_hostport,
 )
 from areal.utils.perf_tracer import trace_perf
+from areal.workflow.wrappers import GroupedRolloutWorkflow
 
 from .workflow_executor import WorkflowExecutor
-
-if TYPE_CHECKING:
-    from areal.experimental.openai import InteractionWithTokenLogpReward
 
 RID_CACHE_SIZE = 128
 
 logger = logging.getLogger("RemoteInfEngine")
-
-
-class GroupedRolloutWorkflow(RolloutWorkflow):
-    def __init__(
-        self,
-        workflow: RolloutWorkflow,
-        group_size: int,
-        logger: Logger,
-    ):
-        if group_size < 1:
-            raise ValueError(f"group_size must be >= 1, got {group_size}")
-        self.workflow = workflow
-        self.group_size = group_size
-        self.logger = logger
-
-    async def arun_episode(
-        self, engine: InferenceEngine, data: dict[str, Any]
-    ) -> dict[str, Any] | None:
-        from areal.experimental.openai import InteractionWithTokenLogpReward
-
-        results = await asyncio.gather(
-            *[self.workflow.arun_episode(engine, data) for _ in range(self.group_size)]
-        )
-
-        valid_results = [r for r in results if r is not None]
-
-        # All results None -> return None
-        if not valid_results:
-            return None
-
-        # Some results None -> warn and continue with valid ones
-        if len(valid_results) < len(results):
-            self.logger.warning(
-                f"GroupedRolloutWorkflow: {len(results) - len(valid_results)}/{len(results)} "
-                "trajectories returned None, using remaining results"
-            )
-
-        # Check if results are InteractionWithTokenLogpReward dicts
-        first = valid_results[0]
-        if (
-            isinstance(first, dict)
-            and first
-            and all(
-                isinstance(v, InteractionWithTokenLogpReward) for v in first.values()
-            )
-        ):
-            # Merge dicts - each result is {completion_id: InteractionWithTokenLogpReward}
-            merged: dict[str, InteractionWithTokenLogpReward] = {}
-            for result in valid_results:
-                merged.update(result)
-            return merged if merged else None
-
-        # Otherwise, tensor dicts - concatenate
-        concatenated = concat_padded_tensors(valid_results)
-        return concatenated if concatenated else None
 
 
 class RemoteInfBackendProtocol(Protocol):

--- a/areal/workflow/wrappers.py
+++ b/areal/workflow/wrappers.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workflow wrappers that adapt rollout execution behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from logging import Logger
+from typing import Any
+
+from areal.api import InferenceEngine, RolloutWorkflow
+from areal.utils.data import concat_padded_tensors
+
+
+class GroupedRolloutWorkflow(RolloutWorkflow):
+    """Run a wrapped workflow multiple times for one input and merge results."""
+
+    def __init__(
+        self,
+        workflow: RolloutWorkflow,
+        group_size: int,
+        logger: Logger,
+    ):
+        if group_size < 1:
+            raise ValueError(f"group_size must be >= 1, got {group_size}")
+        self.workflow = workflow
+        self.group_size = group_size
+        self.logger = logger
+
+    async def arun_episode(
+        self, engine: InferenceEngine, data: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        from areal.experimental.openai import InteractionWithTokenLogpReward
+
+        results = await asyncio.gather(
+            *[self.workflow.arun_episode(engine, data) for _ in range(self.group_size)]
+        )
+
+        valid_results = [r for r in results if r is not None]
+
+        # All results None -> return None
+        if not valid_results:
+            return None
+
+        # Some results None -> warn and continue with valid ones
+        if len(valid_results) < len(results):
+            self.logger.warning(
+                f"GroupedRolloutWorkflow: {len(results) - len(valid_results)}/{len(results)} "
+                "trajectories returned None, using remaining results"
+            )
+
+        # Check if results are InteractionWithTokenLogpReward dicts
+        first = valid_results[0]
+        if (
+            isinstance(first, dict)
+            and first
+            and all(
+                isinstance(v, InteractionWithTokenLogpReward) for v in first.values()
+            )
+        ):
+            # Merge dicts - each result is {completion_id: InteractionWithTokenLogpReward}
+            merged: dict[str, InteractionWithTokenLogpReward] = {}
+            for result in valid_results:
+                merged.update(result)
+            return merged if merged else None
+
+        # Otherwise, tensor dicts - concatenate
+        concatenated = concat_padded_tensors(valid_results)
+        return concatenated if concatenated else None

--- a/docs/en/reference/rollout_workflow.md
+++ b/docs/en/reference/rollout_workflow.md
@@ -33,7 +33,7 @@ class RolloutWorkflow(ABC):
     async def arun_episode(
         self, engine: InferenceEngine, data: dict[str, Any]
     ) -> dict[str, Any] | None | dict[str, InteractionWithTokenLogpReward]:
-        """Run a single episode of the workflow."""
+        """Run one rollout task with the workflow."""
         ...
 ```
 
@@ -195,7 +195,7 @@ has shape `[4, seq_len]` (4 samples concatenated).
 
 ### Implementation
 
-From `areal/infra/remote_inf_engine.py`:
+From `areal/workflow/wrappers.py`:
 
 ```python
 class GroupedRolloutWorkflow(RolloutWorkflow):

--- a/docs/zh/reference/rollout_workflow.md
+++ b/docs/zh/reference/rollout_workflow.md
@@ -29,7 +29,7 @@ class RolloutWorkflow(ABC):
     async def arun_episode(
         self, engine: InferenceEngine, data: dict[str, Any]
     ) -> dict[str, Any] | None | dict[str, InteractionWithTokenLogpReward]:
-        """运行单个工作流 episode。"""
+        """使用该工作流运行一个 rollout 任务。"""
         ...
 ```
 
@@ -185,7 +185,7 @@ rollout:
 
 ### 实现
 
-来自 `areal/infra/remote_inf_engine.py`：
+来自 `areal/workflow/wrappers.py`：
 
 ```python
 class GroupedRolloutWorkflow(RolloutWorkflow):


### PR DESCRIPTION
## Description

Move `GroupedRolloutWorkflow` out of `areal/infra/remote_inf_engine.py` and into a
dedicated workflow wrapper module. The class is a workflow-level adapter for
`group_size > 1`, not remote inference backend logic.

This is a behavior-preserving refactor. `RemoteInfEngine._resolve_workflow` still
applies grouped rollout automatically when needed, while the wrapper implementation
now lives under `areal/workflow/wrappers.py`.

The `RolloutWorkflow.arun_episode` docstring is also tightened. The previous
"single episode" wording can be misleading for wrapper workflows: grouped rollout
still corresponds to one rollout task, but may run the wrapped workflow multiple
times and return multiple trajectories batched together.

**Key changes:**

- `areal/workflow/wrappers.py`: add `GroupedRolloutWorkflow` with the existing
  grouping behavior and short wrapper-level documentation.
- `areal/infra/remote_inf_engine.py`: import the wrapper instead of defining it
  inline.
- `areal/api/workflow_api.py`: clarify that `arun_episode` runs one rollout task
  and wrapper workflows may return batched trajectories.
- `docs/{en,zh}/reference/rollout_workflow.md`: update the implementation path
  and interface snippet to match the new location and API wording.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change


## Additional Context

**Checks run:**

```bash
env -u ALL_PROXY -u all_proxy UV_CACHE_DIR=/tmp/areal-uv-cache PRE_COMMIT_HOME=/tmp/areal-precommit-cache uv run pre-commit run --all-files
PYTHONPYCACHEPREFIX=/tmp/areal-pycache python3 -m py_compile areal/api/workflow_api.py areal/workflow/wrappers.py areal/infra/remote_inf_engine.py
UV_CACHE_DIR=/tmp/areal-uv-cache ./docs/build_all.sh
```

`./docs/build_all.sh` succeeded with existing documentation warnings unrelated to
this PR.
