### PR TITLE
fix(vllm): forward frequency_penalty and stop in generation requests

### DIFF
--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -58,11 +58,14 @@ class VLLMBackend:
             "stop_token_ids": stop_token_ids,
             "ignore_eos": gconfig.ignore_eos,
             "skip_special_tokens": gconfig.skip_special_tokens,
+            "frequency_penalty": gconfig.frequency_penalty,
             "return_tokens_as_token_ids": True,
             "logprobs": 0,
             "use_beam_search": gconfig.use_beam_search,
             "stream": False,
         }
+        if gconfig.stop:
+            payload["stop"] = gconfig.stop
 
         if with_lora:
             lora_name = gconfig.lora_name

--- a/tests/test_vllm_generation_request.py
+++ b/tests/test_vllm_generation_request.py
@@ -1,0 +1,20 @@
+from areal.api.cli_args import GenerationHyperparameters
+from areal.api.io_struct import ModelRequest
+from areal.engine.vllm_remote import VLLMBackend
+
+
+def test_vllm_forwards_frequency_penalty_and_stop():
+    """The vLLM backend must forward frequency_penalty and stop like the SGLang
+    backend does; both are GenerationHyperparameters and are accepted by vLLM's
+    OpenAI-compatible /v1/completions endpoint."""
+    gconfig = GenerationHyperparameters(
+        max_new_tokens=8, frequency_penalty=0.5, stop=["STOP"]
+    )
+    req = ModelRequest(input_ids=[11, 12], gconfig=gconfig)
+
+    payload = (
+        VLLMBackend().build_generation_request(req, with_lora=False, version=0).payload
+    )
+
+    assert payload["frequency_penalty"] == 0.5
+    assert payload["stop"] == ["STOP"]


### PR DESCRIPTION
## Description

`VLLMBackend.build_generation_request` omitted `gconfig.frequency_penalty` and `gconfig.stop`, while the sibling `SGLangBackend.build_generation_request` forwards both. Both are documented `GenerationHyperparameters` and neither is in `_OPENAI_UNSUPPORTED_ARGS`, and vLLM's OpenAI-compatible `/v1/completions` and `/v1/chat/completions` endpoints (which this backend targets) accept them.

As a result, a user who set `frequency_penalty` (anti-repetition) or `stop` strings had them honored on SGLang but **silently ignored on vLLM**, changing the sampling distribution and rollout behavior between the two backends.

This adds `frequency_penalty` to the payload and `stop` when set, mirroring the SGLang backend.

## Related Issue

No filed issue — found by comparing the two backends' request builders.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] Relevant tests pass; new tests added for new functionality
- [x] Branch is up to date with `main`
- [x] This PR was created by a coding agent

## Additional Context

Test: `tests/test_vllm_generation_request.py` asserts the vLLM payload carries `frequency_penalty` and `stop`. It fails on `main` (`KeyError: 'frequency_penalty'`) and passes after the fix. `ruff format` / `ruff check` clean.

Note: #1389 (R3 for vLLM backend) also edits the payload in `build_generation_request`; if it lands first this is a trivial one-line rebase — happy to do so.
