### PR TITLE
fix(reward): guard clevr_count_70k_reward_fn against scoring failures

### DIFF
--- a/areal/reward/clevr_count_70k.py
+++ b/areal/reward/clevr_count_70k.py
@@ -18,15 +18,17 @@ def extract_answer(pred_str, data_name, use_last_number=True):
 def clevr_count_70k_reward_fn(
     prompt, completions, prompt_ids, completion_ids, answer, **kwargs
 ) -> float:
-    sol = extract_answer(completions, data_name="")  # str number
-    ans = answer
+    try:
+        sol = extract_answer(str(completions), data_name="")  # str number
+        ans = str(answer)
 
-    if sol is None:
-        return 0.0
-    if ans is None:
-        return 0.0
+        if not sol or not ans:
+            return 0.0
 
-    is_correct = sol.strip() == ans.strip()
-    if is_correct:
-        logger.info(f"completions: {completions}, answer: {answer}")
-    return float(is_correct)
+        is_correct = sol.strip() == ans.strip()
+        if is_correct:
+            logger.info(f"completions: {completions}, answer: {answer}")
+        return float(is_correct)
+    except Exception:
+        logger.warning("Exception in clevr_count_70k_reward_fn", exc_info=True)
+        return 0.0

--- a/examples/vlm/clevr_count_70k_grpo.py
+++ b/examples/vlm/clevr_count_70k_grpo.py
@@ -4,7 +4,10 @@ import sys
 from areal import PPOTrainer
 from areal.api.cli_args import GRPOConfig, load_expr_config
 from areal.dataset import get_custom_dataset
+from areal.utils import logging
 from areal.utils.hf_utils import load_hf_processor_and_tokenizer
+
+logger = logging.getLogger("clevr_count_70k_grpo")
 
 
 def extract_answer(pred_str, data_name, use_last_number=True):
@@ -18,15 +21,17 @@ def extract_answer(pred_str, data_name, use_last_number=True):
 def clevr_count_70k_reward_fn(
     prompt, completions, prompt_ids, completion_ids, answer, **kwargs
 ):
-    sol = extract_answer(completions, data_name="")  # str number
-    ans = answer
+    try:
+        sol = extract_answer(str(completions), data_name="")  # str number
+        ans = str(answer)
 
-    if sol is None:
-        return 0
-    if ans is None:
-        return 0
+        if not sol or not ans:
+            return 0.0
 
-    return float(sol.strip() == ans.strip())
+        return float(sol.strip() == ans.strip())
+    except Exception:
+        logger.warning("Exception in clevr_count_70k_reward_fn", exc_info=True)
+        return 0.0
 
 
 def main(args):

--- a/tests/test_clevr_reward.py
+++ b/tests/test_clevr_reward.py
@@ -1,0 +1,15 @@
+from areal.reward import clevr_count_70k_reward_fn
+
+
+def test_clevr_non_string_answer_scored_correctly():
+    """A non-string answer (e.g. an int) must be coerced and scored, not crash.
+    The sibling reward fns str()-coerce both inputs; clevr did not, so a matching
+    completion scored as a dropped trajectory instead of 1.0."""
+    reward = clevr_count_70k_reward_fn(
+        prompt="",
+        completions="[3]",
+        prompt_ids=[],
+        completion_ids=[],
+        answer=3,
+    )
+    assert reward == 1.0


### PR DESCRIPTION
## Description

`clevr_count_70k_reward_fn` did not `str()`-coerce its inputs or guard against errors, unlike the sibling reward functions `gsm8k_reward_fn` and `geometry3k_reward_fn`.

A non-string `answer` (e.g. an `int`) made `ans.strip()` raise `AttributeError`, which `WorkflowExecutor` catches and uses to **reject the whole trajectory** (`on_rollout_rejected`) instead of scoring the sample — and a *correct* completion (e.g. `"[3]"` for answer `3`) was lost rather than scored `1.0`.

This coerces `completions` and `answer` to `str` and wraps the body in `try/except`, matching the sibling reward functions, so non-string answers are scored correctly.

## Related Issue

No filed issue — found by comparing the reward functions in `areal/reward/`.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] Relevant tests pass; new tests added for new functionality
- [x] Branch is up to date with `main`
- [x] This PR was created by a coding agent

## Additional Context

Test: `tests/test_clevr_reward.py` scores completion `"[3]"` with an `int` answer `3`; it fails on `main` (`AttributeError`) and returns `1.0` after the fix. `ruff format` / `ruff check` clean.