### PR TITLE
fix(io_struct): support multi-EOS models in stop-token handling

### DIFF
--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -122,7 +122,12 @@ class ModelResponse:
     def output_tokens_without_stop(self) -> list[int]:
         if self.tokenizer is None:
             raise ValueError("tokenizer is None, cannot get output_tokens_without_stop")
-        if self.stop_reason in ["length", "abort"] or not self.output_tokens:
+        # "tool_calls" outputs terminate on the tool-call structure rather than a
+        # stop token, so (like "length"/"abort") they are returned unstripped.
+        if (
+            self.stop_reason in ["length", "abort", "tool_calls"]
+            or not self.output_tokens
+        ):
             return self.output_tokens
         stop_tokens = self._stop_token_set()
         if not stop_tokens:

--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -82,6 +82,12 @@ class ModelResponse:
     # MoE routing (only populated when return_routed_experts=True)
     routed_experts: np.ndarray | None = None
 
+    # Full stop-token id list for the source model. Needed for multi-EOS
+    # models (e.g. Gemma 4 has several EOS ids) where tokenizer.eos_token_id
+    # exposes only a single int. When None, falls back to the tokenizer's
+    # eos/pad ids. See areal.utils.hf_utils.resolve_stop_token_ids.
+    stop_token_ids: list[int] | None = None
+
     @property
     def input_len(self) -> int:
         return len(self.input_tokens)
@@ -90,44 +96,59 @@ class ModelResponse:
     def output_len(self) -> int:
         return len(self.output_tokens)
 
+    def _stop_token_set(self) -> set[int]:
+        """Full stop-token set used to recognise trailing stops in output.
+
+        Union of the explicit ``stop_token_ids`` (multi-EOS models) and the
+        tokenizer's eos/pad ids.
+        """
+        s: set[int] = set()
+        if self.stop_token_ids:
+            s.update(self.stop_token_ids)
+        if self.tokenizer is not None:
+            if self.tokenizer.eos_token_id is not None:
+                s.add(self.tokenizer.eos_token_id)
+            if self.tokenizer.pad_token_id is not None:
+                s.add(self.tokenizer.pad_token_id)
+        return s
+
     @property
     def end_with_stop(self) -> bool:
-        if self.tokenizer is None:
-            raise ValueError("tokenizer is None, cannot check end_with_stop")
-        eos_id = self.tokenizer.eos_token_id
-        pad_id = self.tokenizer.pad_token_id
-        if len(self.output_tokens) == 0:
+        if not self.output_tokens:
             return False
-        last_token = self.output_tokens[-1]
-        return (eos_id is not None and last_token == eos_id) or (
-            pad_id is not None and last_token == pad_id
-        )
+        return self.output_tokens[-1] in self._stop_token_set()
 
     @property
     def output_tokens_without_stop(self) -> list[int]:
         if self.tokenizer is None:
             raise ValueError("tokenizer is None, cannot get output_tokens_without_stop")
-        if self.stop_reason not in ["length", "abort"] and self.output_tokens:
-            if not self.end_with_stop:
-                raise ValueError(
-                    f"output_tokens does not end with eos or pad token, it ends with {self.output_tokens[-1]}, but stop_reason is {self.stop_reason}"
-                )
-            pad_or_eos_len = 0
-            eos_id = self.tokenizer.eos_token_id
-            pad_id = self.tokenizer.pad_token_id
-            stop_tokens = {eos_id, pad_id}
-            stop_tokens.discard(None)
-            for tok in reversed(self.output_tokens):
-                if tok in stop_tokens:
-                    pad_or_eos_len += 1
-                else:
-                    break
-            if pad_or_eos_len == len(self.output_tokens):
-                raise ValueError(
-                    "All output_tokens are EOS or PAD tokens; cannot strip stop tokens without removing entire output."
-                )
-            return self.output_tokens[:-pad_or_eos_len]
-        return self.output_tokens
+        if self.stop_reason in ["length", "abort"] or not self.output_tokens:
+            return self.output_tokens
+        stop_tokens = self._stop_token_set()
+        if not stop_tokens:
+            raise ValueError(
+                "Empty stop-token set: tokenizer has no eos/pad and no "
+                "stop_token_ids set on ModelResponse."
+            )
+        pad_or_eos_len = 0
+        for tok in reversed(self.output_tokens):
+            if tok in stop_tokens:
+                pad_or_eos_len += 1
+            else:
+                break
+        if pad_or_eos_len == 0:
+            raise ValueError(
+                f"output_tokens ends with {self.output_tokens[-1]} which is "
+                f"not in the stop set {sorted(stop_tokens)} but stop_reason="
+                f"{self.stop_reason!r}. Engine may be misreporting "
+                f"stop_reason, or stop_token_ids on ModelResponse is incomplete."
+            )
+        if pad_or_eos_len == len(self.output_tokens):
+            raise ValueError(
+                "All output_tokens are stop tokens; cannot strip without "
+                "removing entire output."
+            )
+        return self.output_tokens[:-pad_or_eos_len]
 
 
 @dataclass

--- a/areal/experimental/inference_service/inf_bridge.py
+++ b/areal/experimental/inference_service/inf_bridge.py
@@ -19,6 +19,7 @@ import numpy as np
 from areal.api.io_struct import HttpRequest
 from areal.experimental.inference_service.backend import InfBridgeBackend
 from areal.utils import logging
+from areal.utils.hf_utils import resolve_stop_token_ids
 
 if TYPE_CHECKING:
     from areal.api.io_struct import ModelRequest, ModelResponse
@@ -261,4 +262,5 @@ class InfBridge:
             tokenizer=req.tokenizer,
             latency=latency,
             routed_experts=final_routed_experts,
+            stop_token_ids=resolve_stop_token_ids(req.tokenizer),
         )

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -50,6 +50,7 @@ from areal.infra.utils.proc import kill_process_tree
 from areal.utils import logging, name_resolve, names
 from areal.utils.data import concat_padded_tensors
 from areal.utils.dynamic_import import import_from_string
+from areal.utils.hf_utils import resolve_stop_token_ids
 from areal.utils.network import (
     find_free_ports,
     format_hostport,
@@ -942,6 +943,7 @@ class RemoteInfEngine(InferenceEngine):
             tokenizer=req.tokenizer,
             processor=req.processor,
             routed_experts=accumulated_routed_experts,
+            stop_token_ids=resolve_stop_token_ids(req.tokenizer),
         )
         return response
 

--- a/areal/utils/hf_utils.py
+++ b/areal/utils/hf_utils.py
@@ -48,6 +48,53 @@ def apply_chat_template(
 
 
 @lru_cache(maxsize=8)
+def get_eos_token_ids(model_name_or_path: str) -> tuple[int, ...]:
+    """Union of EOS ids from model config and generation_config.
+
+    Multi-EOS models (e.g. Gemma 4 [1, 106, 50]) need this because
+    tokenizer.eos_token_id only exposes a single int.
+    """
+    eos: set[int] = set()
+
+    def _absorb(value: Any) -> None:
+        if isinstance(value, int):
+            eos.add(value)
+        elif isinstance(value, (list, tuple)):
+            eos.update(x for x in value if isinstance(x, int))
+
+    try:
+        _absorb(
+            transformers.GenerationConfig.from_pretrained(
+                model_name_or_path
+            ).eos_token_id
+        )
+    except (FileNotFoundError, OSError):
+        pass
+    try:
+        cfg = transformers.AutoConfig.from_pretrained(
+            model_name_or_path, trust_remote_code=True
+        )
+        _absorb(getattr(cfg, "eos_token_id", None))
+        _absorb(getattr(getattr(cfg, "text_config", None), "eos_token_id", None))
+    except (FileNotFoundError, OSError):
+        pass
+    return tuple(sorted(eos))
+
+
+def resolve_stop_token_ids(
+    tokenizer: transformers.PreTrainedTokenizerBase | None,
+) -> list[int] | None:
+    """Full EOS list for a tokenizer's source model, or None if unresolvable."""
+    if tokenizer is None:
+        return None
+    path = getattr(tokenizer, "name_or_path", None)
+    if not path:
+        return None
+    ids = get_eos_token_ids(path)
+    return list(ids) if ids else None
+
+
+@lru_cache(maxsize=8)
 def load_hf_tokenizer(
     model_name_or_path: str,
     fast_tokenizer=True,

--- a/areal/utils/hf_utils.py
+++ b/areal/utils/hf_utils.py
@@ -62,22 +62,32 @@ def get_eos_token_ids(model_name_or_path: str) -> tuple[int, ...]:
         elif isinstance(value, (list, tuple)):
             eos.update(x for x in value if isinstance(x, int))
 
+    # Best effort: any failure falls back to the tokenizer's eos/pad ids.
+    # Catch-all (not just OSError) so malformed repo ids, gated/offline hub
+    # repos, or trust_remote_code errors degrade gracefully instead of
+    # crashing the generation path. The resolved set is lru_cached per path.
     try:
         _absorb(
             transformers.GenerationConfig.from_pretrained(
                 model_name_or_path
             ).eos_token_id
         )
-    except (FileNotFoundError, OSError):
-        pass
+    except Exception as e:
+        logger.debug(
+            f"Could not read eos_token_id from generation_config of "
+            f"{model_name_or_path!r}; falling back to tokenizer eos/pad. ({e!r})"
+        )
     try:
         cfg = transformers.AutoConfig.from_pretrained(
             model_name_or_path, trust_remote_code=True
         )
         _absorb(getattr(cfg, "eos_token_id", None))
         _absorb(getattr(getattr(cfg, "text_config", None), "eos_token_id", None))
-    except (FileNotFoundError, OSError):
-        pass
+    except Exception as e:
+        logger.debug(
+            f"Could not read eos_token_id from model config of "
+            f"{model_name_or_path!r}; falling back to tokenizer eos/pad. ({e!r})"
+        )
     return tuple(sorted(eos))
 
 

--- a/tests/test_hf_utils.py
+++ b/tests/test_hf_utils.py
@@ -1,0 +1,127 @@
+"""Tests for areal.utils.hf_utils.
+
+Currently covers the multi-EOS resolution helpers:
+get_eos_token_ids (union of EOS ids across generation_config + model
+config, including the text_config VLM path and graceful degradation when the
+config loaders fail) and resolve_stop_token_ids (tokenizer -> EOS list | None).
+
+The two transformers loaders are monkeypatched, so these tests touch no network
+and no real model files.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import transformers
+
+from areal.utils.hf_utils import get_eos_token_ids, resolve_stop_token_ids
+
+
+@pytest.fixture(autouse=True)
+def _clear_eos_cache():
+    """get_eos_token_ids is lru_cached; clear it so tests do not leak results."""
+    get_eos_token_ids.cache_clear()
+    yield
+    get_eos_token_ids.cache_clear()
+
+
+def _patch_configs(monkeypatch, *, gen_eos="__raise__", cfg=None):
+    """Stub GenerationConfig/AutoConfig.from_pretrained for get_eos_token_ids.
+
+    gen_eos: eos_token_id returned by the fake GenerationConfig, or the sentinel
+        "__raise__" to make GenerationConfig.from_pretrained raise (config absent).
+    cfg: object returned by the fake AutoConfig (use SimpleNamespace), or None to
+        make AutoConfig.from_pretrained raise.
+    """
+
+    def fake_gen(_path, *args, **kwargs):
+        if gen_eos == "__raise__":
+            raise OSError("no generation_config.json")
+        return SimpleNamespace(eos_token_id=gen_eos)
+
+    def fake_auto(_path, *args, **kwargs):
+        if cfg is None:
+            raise OSError("no config.json")
+        return cfg
+
+    monkeypatch.setattr(
+        transformers.GenerationConfig, "from_pretrained", staticmethod(fake_gen)
+    )
+    monkeypatch.setattr(
+        transformers.AutoConfig, "from_pretrained", staticmethod(fake_auto)
+    )
+
+
+# --- get_eos_token_ids ------------------------------------------------------
+
+
+def test_get_eos_token_ids_returns_single_int_from_generation_config(monkeypatch):
+    """A scalar int eos_token_id in generation_config yields a 1-tuple."""
+    _patch_configs(monkeypatch, gen_eos=2)
+    assert get_eos_token_ids("model-a") == (2,)
+
+
+def test_get_eos_token_ids_returns_sorted_unique_from_list(monkeypatch):
+    """A list eos_token_id is deduplicated and sorted."""
+    _patch_configs(monkeypatch, gen_eos=[50, 1, 106, 1])
+    assert get_eos_token_ids("model-b") == (1, 50, 106)
+
+
+def test_get_eos_token_ids_unions_generation_config_and_model_config(monkeypatch):
+    """EOS ids from both generation_config and model config are unioned."""
+    _patch_configs(monkeypatch, gen_eos=[1, 106], cfg=SimpleNamespace(eos_token_id=50))
+    assert get_eos_token_ids("model-c") == (1, 50, 106)
+
+
+def test_get_eos_token_ids_reads_text_config_for_vlm(monkeypatch):
+    """Nested text_config.eos_token_id (VLM configs) is included."""
+    cfg = SimpleNamespace(
+        eos_token_id=None, text_config=SimpleNamespace(eos_token_id=[7, 8])
+    )
+    _patch_configs(monkeypatch, gen_eos="__raise__", cfg=cfg)
+    assert get_eos_token_ids("model-vlm") == (7, 8)
+
+
+def test_get_eos_token_ids_ignores_non_int_values(monkeypatch):
+    """Non-int entries (e.g. None in a list) are skipped, not coerced."""
+    _patch_configs(
+        monkeypatch, gen_eos=[1, None, "x"], cfg=SimpleNamespace(eos_token_id=None)
+    )
+    assert get_eos_token_ids("model-d") == (1,)
+
+
+def test_get_eos_token_ids_returns_empty_when_both_loaders_raise(monkeypatch):
+    """Both config sources failing degrades to () instead of propagating.
+
+    Guards the catch-all behaviour: malformed/gated/offline configs must not
+    crash the generation path that builds a ModelResponse.
+    """
+    _patch_configs(monkeypatch, gen_eos="__raise__", cfg=None)
+    assert get_eos_token_ids("missing-model") == ()
+
+
+# --- resolve_stop_token_ids -------------------------------------------------
+
+
+def test_resolve_stop_token_ids_none_tokenizer_returns_none():
+    """A None tokenizer resolves to None."""
+    assert resolve_stop_token_ids(None) is None
+
+
+def test_resolve_stop_token_ids_empty_name_or_path_returns_none():
+    """A tokenizer without a usable name_or_path resolves to None."""
+    assert resolve_stop_token_ids(SimpleNamespace(name_or_path="")) is None
+
+
+def test_resolve_stop_token_ids_returns_list_when_ids_found(monkeypatch):
+    """A resolvable path returns the EOS ids as a list."""
+    _patch_configs(monkeypatch, gen_eos=[1, 106])
+    tokenizer = SimpleNamespace(name_or_path="model-e")
+    assert resolve_stop_token_ids(tokenizer) == [1, 106]
+
+
+def test_resolve_stop_token_ids_returns_none_when_no_ids(monkeypatch):
+    """A resolvable path that yields no EOS ids resolves to None, not []."""
+    _patch_configs(monkeypatch, gen_eos="__raise__", cfg=None)
+    tokenizer = SimpleNamespace(name_or_path="missing-model")
+    assert resolve_stop_token_ids(tokenizer) is None

--- a/tests/test_model_response_stop_tokens.py
+++ b/tests/test_model_response_stop_tokens.py
@@ -81,6 +81,17 @@ def test_without_stop_passthrough_for_length_and_abort():
         assert resp.output_tokens_without_stop == [7, 8, 9]
 
 
+def test_without_stop_passthrough_for_tool_calls():
+    """tool_calls outputs end on the tool-call structure, not a stop token.
+
+    Like length/abort, they are returned unstripped rather than raising when the
+    final token is not in the stop set. A ModelResponse with stop_reason="tool_calls"
+    is reachable directly from the inference engines' finish_reason passthrough.
+    """
+    resp = _resp([7, 8, 9], stop_token_ids=[106], stop_reason="tool_calls")
+    assert resp.output_tokens_without_stop == [7, 8, 9]
+
+
 def test_without_stop_raises_when_no_trailing_stop_but_stop_reason():
     """stop_reason=stop but output doesn't end in a stop id → diagnostic error."""
     resp = _resp([7, 8, 9], stop_token_ids=[106])

--- a/tests/test_model_response_stop_tokens.py
+++ b/tests/test_model_response_stop_tokens.py
@@ -1,0 +1,105 @@
+"""Tests for multi-EOS stop-token handling on ModelResponse.
+
+Covers the stop-token set (explicit stop_token_ids ∪ tokenizer eos/pad),
+end_with_stop, and output_tokens_without_stop — including the multi-EOS case
+(several valid EOS ids) that a single tokenizer.eos_token_id cannot express.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+from areal.api.io_struct import ModelResponse
+
+
+@dataclass
+class _FakeTokenizer:
+    """Minimal tokenizer stub: ModelResponse only reads eos/pad token ids.
+
+    A stub (not a real tokenizer) is deliberate — a real single-EOS tokenizer
+    can't exercise the multi-EOS path under test.
+    """
+
+    eos_token_id: int | None = 1
+    pad_token_id: int | None = 0
+
+
+def _resp(output_tokens, *, stop_token_ids=None, stop_reason="stop", tokenizer=None):
+    return ModelResponse(
+        input_tokens=[9, 9],
+        output_tokens=output_tokens,
+        stop_reason=stop_reason,
+        tokenizer=tokenizer if tokenizer is not None else _FakeTokenizer(),
+        stop_token_ids=stop_token_ids,
+    )
+
+
+def test_end_with_stop_unions_explicit_ids_and_tokenizer_eos_pad():
+    """end_with_stop recognises explicit stop_token_ids AND tokenizer eos/pad.
+
+    Asserts through the public property: each of the explicit ids (106, 50) and
+    the tokenizer's eos (1) / pad (0) is treated as a trailing stop.
+    """
+    for last in (106, 50, 1, 0):
+        assert _resp([5, last], stop_token_ids=[106, 50]).end_with_stop is True
+    assert _resp([5, 7], stop_token_ids=[106, 50]).end_with_stop is False
+
+
+def test_end_with_stop_true_for_multi_eos_id():
+    """A multi-EOS id (in stop_token_ids, not tokenizer.eos) counts as a stop."""
+    # 106 is a valid EOS for the model but tokenizer.eos_token_id is only 1.
+    resp = _resp([7, 8, 106], stop_token_ids=[106, 50])
+    assert resp.end_with_stop is True
+
+
+def test_end_with_stop_false_when_last_token_not_a_stop():
+    resp = _resp([7, 8, 9], stop_token_ids=[106])
+    assert resp.end_with_stop is False
+
+
+def test_end_with_stop_false_on_empty_output():
+    resp = _resp([], stop_token_ids=[106])
+    assert resp.end_with_stop is False
+
+
+def test_without_stop_strips_trailing_multi_eos():
+    """output_tokens_without_stop strips a trailing multi-EOS id."""
+    resp = _resp([7, 8, 106], stop_token_ids=[106, 50])
+    assert resp.output_tokens_without_stop == [7, 8]
+
+
+def test_without_stop_falls_back_to_tokenizer_eos_when_no_explicit_ids():
+    """With stop_token_ids=None, behaviour falls back to tokenizer eos/pad."""
+    resp = _resp([7, 8, 1], stop_token_ids=None)  # 1 == tokenizer.eos
+    assert resp.output_tokens_without_stop == [7, 8]
+
+
+def test_without_stop_passthrough_for_length_and_abort():
+    """No stripping / no error when generation stopped by length or abort."""
+    for reason in ("length", "abort"):
+        resp = _resp([7, 8, 9], stop_token_ids=[106], stop_reason=reason)
+        assert resp.output_tokens_without_stop == [7, 8, 9]
+
+
+def test_without_stop_raises_when_no_trailing_stop_but_stop_reason():
+    """stop_reason=stop but output doesn't end in a stop id → diagnostic error."""
+    resp = _resp([7, 8, 9], stop_token_ids=[106])
+    with pytest.raises(ValueError, match="not in the stop set"):
+        _ = resp.output_tokens_without_stop
+
+
+def test_without_stop_raises_when_all_tokens_are_stops():
+    resp = _resp([106, 106], stop_token_ids=[106])
+    with pytest.raises(ValueError, match="All output_tokens are stop tokens"):
+        _ = resp.output_tokens_without_stop
+
+
+def test_without_stop_raises_on_empty_stop_set():
+    """No tokenizer eos/pad and no explicit ids → cannot identify stops."""
+    resp = _resp(
+        [7, 8],
+        stop_token_ids=None,
+        tokenizer=_FakeTokenizer(eos_token_id=None, pad_token_id=None),
+    )
+    with pytest.raises(ValueError, match="Empty stop-token set"):
+        _ = resp.output_tokens_without_stop


### PR DESCRIPTION
## Description

`ModelResponse` recognised only a single `tokenizer.eos_token_id` / `pad_token_id` when detecting and stripping trailing stop tokens. Multi-EOS models — e.g. Gemma 4 [see Additional Context](#additional-context), has several valid EOS ids — break this: when generation legitimately ends on one of the *other* EOS ids, `tokenizer.eos_token_id` doesn't match it, so `end_with_stop` returns `False` and `output_tokens_without_stop` raises ("does not end with eos or pad token"), or a real stop token is left in the training sequence.

This PR generalises stop-token handling from a single eos/pad to a **stop-token set**:

- `ModelResponse.stop_token_ids: list[int] | None` — the full EOS id list for the source  model (multi-EOS), defaulting to `None`.
- `ModelResponse._stop_token_set()` — unions `stop_token_ids` with the tokenizer's  eos/pad ids; `end_with_stop` and `output_tokens_without_stop` now route through it.
- `hf_utils.get_eos_token_ids()` / `resolve_stop_token_ids()` — resolve the full EOS set  from the model config + generation config (covers `text_config` for VLMs).
- The two `ModelResponse` construction sites (`remote_inf_engine`, `inf_bridge`) populate  `stop_token_ids=resolve_stop_token_ids(req.tokenizer)`.

Model-agnostic and backward-compatible: `stop_token_ids=None` reproduces the previous eos/pad behaviour.  output_tokens_without_stop` also gains clearer diagnostics (distinguishes "doesn't end in a stop / engine misreported stop_reason" from "all tokens are stops").

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

N/A (can create one, just ping me)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Me and @BiggieW are working on supporting Gemma 4 within AReaL.

This is the first branch and a canary/test for a series of PRs we intend to submit , any feedback or issues on how to go about this is highly welcome. We will start a separate discussion on this, once we have the Gemma 4 training loop/engine integration worked out (there are upstream transformer bugs and inefficiencies we are finding suitable workarounds for)

## Self-review

A /review-pr pass surfaced 5 findings:
- 1 fixed (HIGH — get_eos_token_ids now catches broadly with DEBUG-logged fallback, instead of only FileNotFoundError/OSError, so malformed/gated/remote-code configs degrade gracefully on the generation path rather than crashing)
- 3 deemed irrelevant or no-op (a tokenizer=None raise→False change with no production caller; a harmless PreTrainedTokenizerBase vs Fast annotation widening; and a latency note dismissed as not worth the complexity given lru_cache amortization).
- 1 deferred (pre-existing: gconfig.stop_token_ids and the response-side stop set are independent, and new_with_stop_and_pad_token_ids only emits a single EOS id — converging them + multi-EOS generation-side stopping is a larger refactor, tracked for a follow-up in this series).

## How to test

Quick focused tests:
```bash
uv run pytest tests/test_model_response_stop_tokens.py -q   # 10 passed
```

<details>
<summary>Full CI test suite (sglang variant) — 2432 passed, 4 failed (pre-existing, unrelated), 145 skipped, 387 deselected</summary>

Ran the full CI marker-filtered suite inside the upstream runtime image
`ghcr.io/areal-project/areal-runtime:test-sglang`:

```
pytest -m "(not slow or ci) and not vllm" --durations=20 \
  tests/test_*.py tests/experimental/ tests/infra/
```

Result:
```
4 failed, 2432 passed, 145 skipped, 387 deselected, 17 warnings in 2759.93s (0:45:59)
```

The 4 failures are **pre-existing and unrelated to this change** — FlashAttention /
train-engine dtype issues, in modules this PR does not touch:
```
FAILED tests/test_packed_vs_padded_consistency.py::test_llm_consistency[Qwen3-0.6B]
       RuntimeError: FlashAttention only support fp16 and bf16 data type
FAILED tests/test_packed_vs_padded_consistency.py::test_llm_consistency[Qwen2.5-1.5B]
       RuntimeError: FlashAttention only support fp16 and bf16 data type
FAILED tests/test_train_engine.py::test_create_llm_actor_or_critic_forwards_attn_impl[False-from_pretrained]
       assert torch.float32 == torch.bfloat16
FAILED tests/test_train_engine.py::test_create_llm_actor_or_critic_forwards_attn_impl[True-from_config]
       assert torch.float32 == torch.bfloat16
```
This PR changes only `io_struct` stop-token handling, two `ModelResponse` construction
sites, and adds two `hf_utils` functions — none of the FlashAttention / train-engine /
dtype paths the failures exercise.

</details>

<details>
<summary>Skipped (145) and deselected (387) breakdown</summary>

**Deselected (387):** the marker filter `-m "(not slow or ci) and not vllm"` — i.e. `slow`
tests (not also `ci`-marked) and `vllm`-backend tests, excluded by design on the sglang run.

**Skipped (145)** — all environmental (no module / no creds / GPU count / CI-machine
quirks / pending migrations):
```
[88] tests/test_local_scheduler.py            LocalScheduler unexpected behavior on GCP CI machines (run manually)
[16] tests/test_inference_engines.py:209      vLLM is not installed
 [8] tests/test_ray_scheduler.py              Ray env not explicitly initialized
 [3] tests/test_data_redistribution.py:31     CI machine crashes with all_gather_object
 [3] tests/test_inference_engines.py:154      vLLM is not installed
 [3] tests/test_local_scheduler.py:977        LocalScheduler unexpected behavior on GCP CI machines
 [5] tests/infra/sandbox/test_runner.py       DAYTONA_API_KEY required (x5)
 [9] tests/experimental/inference_service/*   pending /export_trajectories traj schema migration (x9 across 8 files)
 [1] tests/test_inference_engines.py:277      vLLM is not installed
 [1] tests/test_inference_engines.py:354      vLLM is not installed
 [1] tests/test_slurm_scheduler.py:25         srun executable not found (integration)
 [2] tests/test_megatron_async_save.py        fixture not isolated across files (tracked follow-up)
 [2] tests/test_network_ipv6_utils.py         not an IPv6-only / dual-stack host
 [1] tests/test_serialization.py:180          ray test skipped unless mark commented out
 [1] tests/test_train_engine.py:416           requires 4 GPUs / 4 processes
 [1] tests/experimental/archon/fp8/test_checkpoint_e2e.py:68  FP8 model not found locally
```
None relate to this change.

</details>

Pre-commit (lint/format) passes on the changed files.
