### PR TITLE
fix(network): find_free_ports ignores out-of-range exclude_ports

### DIFF
--- a/areal/utils/network.py
+++ b/areal/utils/network.py
@@ -139,8 +139,10 @@ def find_free_ports(
     free_ports = []
     attempted_ports = set()
 
-    # Calculate available port range
-    available_range = max_port - min_port + 1 - len(exclude_ports)
+    # Calculate available port range. Only excluded ports that fall within
+    # [min_port, max_port] reduce availability; out-of-range entries do not.
+    in_range_excluded = sum(min_port <= p <= max_port for p in exclude_ports)
+    available_range = max_port - min_port + 1 - in_range_excluded
 
     if count > available_range:
         raise ValueError(

--- a/tests/test_network_ipv6_utils.py
+++ b/tests/test_network_ipv6_utils.py
@@ -86,3 +86,13 @@ def test_get_loopback_ip_returns_bindable_address():
     network = _load_network_module()
     ip = network.get_loopback_ip()
     assert ip in {"127.0.0.1", "::1"}
+
+
+def test_find_free_ports_ignores_out_of_range_excludes():
+    # Excluded ports outside [min_port, max_port] must not deflate the
+    # availability check; all in-range ports here are free.
+    network = _load_network_module()
+    ports = network.find_free_ports(
+        count=6, port_range=(10000, 10005), exclude_ports={50000}
+    )
+    assert len(ports) == 6


### PR DESCRIPTION
## Description

`find_free_ports` rejects valid requests when `exclude_ports` contains ports outside the search range:

```python
available_range = max_port - min_port + 1 - len(exclude_ports)
```

This subtracts the **full** `exclude_ports` count without intersecting it with `[min_port, max_port]`. An excluded port outside the range deflates `available_range` and raises a spurious `ValueError` ("Cannot find N ports … Only M available") even though every in-range port is free.

The fix only subtracts excluded ports that actually fall within the range.

## Related Issue

No filed issue — found by reading `find_free_ports`.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] Relevant tests pass; new tests added for new functionality
- [x] Branch is up to date with `main`
- [x] This PR was created by a coding agent

## Additional Context

`tests/test_network_ipv6_utils.py::test_find_free_ports_ignores_out_of_range_excludes`: `find_free_ports(count=6, port_range=(10000, 10005), exclude_ports={50000})` returns 6 ports. Fails on `main` (`ValueError: ... Only 5 ports available`), passes after. `ruff` clean.
