### PR TITLE
fix(CI): fix vlm_grpo CI OOM bug

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -306,6 +306,7 @@ def test_vlm_grpo(tmp_path_factory, rollout_backend, actor_backend):
         "gconfig.n_samples=2",
         "gconfig.max_new_tokens=256",
         "actor.mb_spec.max_tokens_per_mb=1024",
+        "+actor.optimizer_dtype=bfloat16",
         "train_dataset.batch_size=2",
         "valid_dataset.batch_size=2",
         f"train_dataset.path={dataset_path}",

--- a/tests/test_packed_vs_padded_consistency.py
+++ b/tests/test_packed_vs_padded_consistency.py
@@ -69,6 +69,7 @@ def test_llm_consistency(model_path, mock_padded_llm_data):
         backend="fsdp:d1",
         path=model_path,
         dtype="bfloat16",
+        optimizer_dtype="bfloat16",
         attn_impl="flash_attention_2",
         gradient_checkpointing=False,
         disable_dropout=True,

--- a/tests/test_train_engine.py
+++ b/tests/test_train_engine.py
@@ -325,6 +325,7 @@ def test_create_llm_actor_or_critic_forwards_attn_impl(
         trial_name="trial0",
         path="test-model",
         attn_impl="kernels-community/flash-attn",
+        optimizer_dtype="bfloat16",
         fsdp=FSDPEngineConfig(memory_efficient_load=memory_efficient_load),
     )
     engine = fsdp_module.FSDPEngine(config)


### PR DESCRIPTION
Default fp32 master weights (PR #1369) push Qwen2.5-VL-3B beyond A100-40G capacity at the first AdamW step. Pin the test to bf16 storage with adam_bf16 (Kahan summation) so it runs on 40G runners.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses. PRs should be related to a well-templated issue. -->

Fixes #(issue)

## Type of Change

<!-- Select ONE that best describes this PR -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

<!-- Mark with 'x' what you've done -->

- [ ] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [ ] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

<!-- Describe what breaks and how users should migrate -->

## Additional Context

<!-- Add any other context, screenshots, logs, or explanations here -->

______________________________________________________________________

**Need help?** Check the
[Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
or ask in [GitHub Discussions](https://github.com/areal-project/AReaL/discussions)!
