### PR TITLE
feat(cli): add experimental cli scaffold for service-style subcommands

### DIFF
--- a/areal/experimental/cli/__init__.py
+++ b/areal/experimental/cli/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/areal/experimental/cli/__main__.py
+++ b/areal/experimental/cli/__main__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from areal.experimental.cli.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/areal/experimental/cli/cli.py
+++ b/areal/experimental/cli/cli.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import click
+
+from areal.version import __version__
+
+
+@click.group(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help="AReaL operator CLI.",
+)
+@click.version_option(__version__, prog_name="areal")
+def cli() -> None:
+    pass
+
+
+# Subcommand groups (inf / train / agent / ...) attach themselves to ``cli``
+# from their own modules — see e.g. ``areal.experimental.cli.inference``,
+# ``areal.experimental.cli.training``, ``areal.experimental.cli.agent``.

--- a/areal/experimental/cli/client.py
+++ b/areal/experimental/cli/client.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTTP client base for subcommand CLIs.
+
+Provides:
+
+- ``ServiceHTTPError`` / ``ServiceUnreachable`` exceptions to distinguish
+  "server replied with 4xx/5xx" from "couldn't reach the server".
+- A low-level ``request_json`` helper that builds the request, handles
+  optional Bearer auth, decodes JSON, and translates ``urllib`` errors
+  into the two exception types above.
+- ``BaseHTTPClient`` — minimal base for per-component clients
+  (gateway / router / data-proxy / etc.). Subclasses add their own RPC
+  methods that call ``self._get`` / ``self._post`` / ``self._request``.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+class ServiceHTTPError(Exception):
+    """Non-2xx response from the service. Body is captured so callers
+    can inspect application-level error payloads."""
+
+    def __init__(self, status: int, body: str) -> None:
+        super().__init__(f"HTTP {status}: {body}")
+        self.status = status
+        self.body = body
+
+
+class ServiceUnreachable(Exception):
+    """Network-level error reaching the service: connection refused,
+    DNS failure, timeout, etc."""
+
+
+def request_json(
+    url: str,
+    *,
+    method: str = "GET",
+    payload: dict | None = None,
+    bearer: str | None = None,
+    timeout: float = 5.0,
+) -> dict[str, Any]:
+    """Issue an HTTP request returning parsed JSON.
+
+    A ``payload`` dict triggers JSON encoding + ``Content-Type``.
+    ``bearer`` adds ``Authorization: Bearer <token>``. 2xx → returns the
+    parsed body (empty dict if body is empty). 4xx/5xx → ``ServiceHTTPError``.
+    Network errors → ``ServiceUnreachable``.
+    """
+
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode()
+        headers["Content-Type"] = "application/json"
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode()
+            return json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        raise ServiceHTTPError(exc.code, exc.read().decode(errors="replace")) from exc
+    except (urllib.error.URLError, ConnectionError, TimeoutError, OSError) as exc:
+        raise ServiceUnreachable(str(exc)) from exc
+
+
+class BaseHTTPClient:
+    """Minimal HTTP client base. Subclasses add business RPC methods.
+
+    Holds ``base_url`` and an optional ``api_key`` used as Bearer auth on
+    every helper call. ``health()`` is provided as it's universal across
+    all daemon types.
+    """
+
+    def __init__(self, base_url: str, api_key: str | None = None) -> None:
+        self.base = base_url.rstrip("/")
+        self.api_key = api_key
+
+    def health(self, *, timeout: float = 2.0) -> dict[str, Any]:
+        return self._get("/health", timeout=timeout, auth=False)
+
+    # ------------------------------------------------------------------
+    # Helpers for subclass RPC methods
+
+    def _get(self, path: str, *, timeout: float = 5.0, auth: bool = True) -> dict:
+        return request_json(
+            f"{self.base}{path}",
+            timeout=timeout,
+            bearer=self.api_key if auth else None,
+        )
+
+    def _post(
+        self,
+        path: str,
+        payload: dict | None = None,
+        *,
+        timeout: float = 10.0,
+        auth: bool = True,
+    ) -> dict:
+        return request_json(
+            f"{self.base}{path}",
+            method="POST",
+            payload=payload,
+            timeout=timeout,
+            bearer=self.api_key if auth else None,
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict | None = None,
+        *,
+        timeout: float = 10.0,
+        auth: bool = True,
+    ) -> dict:
+        return request_json(
+            f"{self.base}{path}",
+            method=method,
+            payload=payload,
+            timeout=timeout,
+            bearer=self.api_key if auth else None,
+        )

--- a/areal/experimental/cli/commands/__init__.py
+++ b/areal/experimental/cli/commands/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/areal/experimental/cli/commands/logs.py
+++ b/areal/experimental/cli/commands/logs.py
@@ -21,7 +21,6 @@ from pathlib import Path
 import click
 
 from areal.experimental.cli.lifecycle import ServiceLifecycle
-from areal.experimental.cli.state import logs_dir
 
 
 class LogsCommand:
@@ -79,7 +78,7 @@ class LogsCommand:
         component name alias / translation layer (e.g. accepting
         ``qwen/0/worker`` as shorthand for ``qwen-worker-0``)."""
 
-        return logs_dir(self.lifecycle.namespace, service) / f"{component}.log"
+        return self.lifecycle.store.logs_dir(service) / f"{component}.log"
 
     def _exec_tail(self, target: Path, *, lines: int, follow: bool) -> None:
         cmd = ["tail", f"-n{lines}"]

--- a/areal/experimental/cli/commands/logs.py
+++ b/areal/experimental/cli/commands/logs.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""``<group> logs`` verb factory.
+
+Every service-style CLI has a ``logs`` command that does the same
+thing: resolve the service, find the log directory, tail one component
+file. This class packages that pattern. Subcommand CLIs do::
+
+    from areal.experimental.cli.commands.logs import LogsCommand
+    from areal.experimental.cli.inference.lifecycle import inf_lifecycle
+
+    logs_cmd = LogsCommand(lifecycle=inf_lifecycle).build()
+    inf.add_command(logs_cmd)
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import click
+
+from areal.experimental.cli.lifecycle import ServiceLifecycle
+from areal.experimental.cli.state import logs_dir
+
+
+class LogsCommand:
+    default_component: str = "gateway"
+    default_lines: int = 200
+
+    def __init__(self, *, lifecycle: ServiceLifecycle) -> None:
+        self.lifecycle = lifecycle
+
+    def build(self) -> click.Command:
+        @click.command(name="logs", help="Tail a service log file.")
+        @click.option("--service", default=None)
+        @click.option(
+            "--component",
+            default=self.default_component,
+            show_default=True,
+            help="Component log to tail (gateway / router / worker-N / etc.).",
+        )
+        @click.option("-f", "--follow", is_flag=True, help="Stream appended lines.")
+        @click.option(
+            "-n",
+            "--lines",
+            type=int,
+            default=self.default_lines,
+            show_default=True,
+            help="Number of trailing lines to show before optional follow.",
+        )
+        def logs_cmd(
+            service: str | None, component: str, follow: bool, lines: int
+        ) -> None:
+            self.execute(service, component, follow, lines)
+
+        return logs_cmd
+
+    def execute(
+        self,
+        service: str | None,
+        component: str,
+        follow: bool,
+        lines: int,
+    ) -> None:
+        name = self.lifecycle.resolve_service_name(service)
+        target = self.log_target(name, component)
+        if not target.exists():
+            available = sorted(p.stem for p in target.parent.glob("*.log"))
+            if not available:
+                raise click.ClickException(f"no logs found under {target.parent}")
+            raise click.ClickException(
+                f"no log named {component!r}; available: {', '.join(available)}"
+            )
+        self._exec_tail(target, lines=lines, follow=follow)
+
+    def log_target(self, service: str, component: str) -> Path:
+        """Resolve the log file path. Subclasses may override to add a
+        component name alias / translation layer (e.g. accepting
+        ``qwen/0/worker`` as shorthand for ``qwen-worker-0``)."""
+
+        return logs_dir(self.lifecycle.namespace, service) / f"{component}.log"
+
+    def _exec_tail(self, target: Path, *, lines: int, follow: bool) -> None:
+        cmd = ["tail", f"-n{lines}"]
+        if follow:
+            cmd.append("-F")
+        cmd.append(str(target))
+        os.execvp(cmd[0], cmd)

--- a/areal/experimental/cli/config.py
+++ b/areal/experimental/cli/config.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from areal.experimental.cli.state import config_path
+from areal.experimental.cli.state import NamespacedStateStore
 
 # (section, key) → (verb_name_or_tuple, click_option_name)
 BindingMap = dict[tuple[str, str], tuple[str | tuple[str, ...], str]]
@@ -40,9 +40,10 @@ class ConfigLoader:
             self.bindings = bindings
         if not self.namespace:
             raise ValueError("ConfigLoader requires a namespace")
+        self.store = NamespacedStateStore(self.namespace)
 
     def default_config_path(self) -> Path:
-        return config_path(self.namespace)
+        return self.store.config_path()
 
     def load_click_default_map(self, extra: Path | None = None) -> dict:
         """Return a ``click`` ``default_map`` built by merging the

--- a/areal/experimental/cli/config.py
+++ b/areal/experimental/cli/config.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""TOML config loader for subcommand CLIs.
+
+Each CLI's config file lives at ``$AREAL_HOME/<namespace>/config.toml``.
+Sections + keys map to ``(verb, click_option_name)`` via a per-CLI
+``bindings`` dict that subclasses provide; this base handles all the
+flatten + merge + dispatch plumbing.
+
+Precedence: explicit CLI flag > extra config passed via ``--config`` >
+``$AREAL_HOME/<namespace>/config.toml`` > the click option's hard-coded
+default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from areal.experimental.cli.state import config_path
+
+# (section, key) → (verb_name_or_tuple, click_option_name)
+BindingMap = dict[tuple[str, str], tuple[str | tuple[str, ...], str]]
+
+
+class ConfigLoader:
+    """Subclass and set ``namespace`` + ``bindings`` (or pass them in)."""
+
+    namespace: str = ""
+    bindings: BindingMap = {}
+
+    def __init__(
+        self,
+        *,
+        namespace: str | None = None,
+        bindings: BindingMap | None = None,
+    ) -> None:
+        if namespace is not None:
+            self.namespace = namespace
+        if bindings is not None:
+            self.bindings = bindings
+        if not self.namespace:
+            raise ValueError("ConfigLoader requires a namespace")
+
+    def default_config_path(self) -> Path:
+        return config_path(self.namespace)
+
+    def load_click_default_map(self, extra: Path | None = None) -> dict:
+        """Return a ``click`` ``default_map`` built by merging the
+        namespace's default config.toml with an optional extra file.
+
+        ``extra`` (typically the ``--config FILE`` flag) wins on
+        conflicts; bindings absent from the map are silently ignored.
+        """
+
+        merged: dict[tuple[str, str], object] = {}
+        for path in (self.default_config_path(), extra):
+            if path is None:
+                continue
+            merged.update(self._flatten(self._read_toml(path)))
+
+        default_map: dict[str, dict] = {}
+        for (section, key), value in merged.items():
+            binding = self.bindings.get((section, key))
+            if binding is None:
+                continue
+            verbs, opt = binding
+            if isinstance(verbs, str):
+                verbs = (verbs,)
+            for verb in verbs:
+                default_map.setdefault(verb, {})[opt] = value
+        return default_map
+
+    # ------------------------------------------------------------------
+    # Helpers — subclasses generally don't need to override these
+
+    def _read_toml(self, path: Path) -> dict:
+        try:
+            import tomllib
+        except ImportError:
+            return {}
+        if not path.exists():
+            return {}
+        try:
+            with open(path, "rb") as f:
+                return tomllib.load(f)
+        except Exception:
+            return {}
+
+    def _flatten(self, toml: dict, parent: str = "") -> dict[tuple[str, str], object]:
+        """Flatten nested TOML tables to ``(section, key) -> value``.
+
+        Nested keys are dotted on the section side:
+        ``[register.internal] backend = "..."`` →
+        ``("register.internal", "backend") -> "..."``.
+        """
+
+        out: dict[tuple[str, str], object] = {}
+        for k, v in toml.items():
+            if isinstance(v, dict):
+                sub_parent = f"{parent}.{k}" if parent else k
+                for (sec, key), val in self._flatten(v, sub_parent).items():
+                    out[(sec, key)] = val
+            else:
+                out[(parent, k)] = v
+        return out

--- a/areal/experimental/cli/lifecycle.py
+++ b/areal/experimental/cli/lifecycle.py
@@ -19,14 +19,7 @@ from pathlib import Path
 import click
 
 from areal.experimental.cli.process import kill_pids
-from areal.experimental.cli.state import (
-    DEFAULT_SERVICE,
-    clear_current_service,
-    list_service_names,
-    recover_pids_from_raw_state,
-    resolve_service_name,
-    service_state_path,
-)
+from areal.experimental.cli.state import DEFAULT_SERVICE, NamespacedStateStore
 
 
 class ServiceLifecycle:
@@ -52,6 +45,7 @@ class ServiceLifecycle:
             raise ValueError("ServiceLifecycle requires a namespace")
         if not self.stop_command:
             raise ValueError("ServiceLifecycle requires a stop_command")
+        self.store = NamespacedStateStore(self.namespace)
 
     # ------------------------------------------------------------------
     # Hooks subclasses may override
@@ -64,15 +58,13 @@ class ServiceLifecycle:
         return state.gateway_alive()
 
     def state_path(self, service: str) -> Path:
-        return service_state_path(self.namespace, service)
+        return self.store.service_state_path(service)
 
     def resolve_service_name(self, explicit: str | None) -> str:
-        return resolve_service_name(
-            self.namespace, explicit, fallback=self.default_service
-        )
+        return self.store.resolve_service_name(explicit, fallback=self.default_service)
 
     def list_services(self) -> list[str]:
-        return list_service_names(self.namespace)
+        return self.store.list_service_names()
 
     def load_state(self, service: str):
         return self.state_class.load(service)
@@ -140,13 +132,13 @@ class ServiceLifecycle:
             pids = self._collect_pids(state)
         except Exception:
             try:
-                pids = recover_pids_from_raw_state(self.namespace, service)
+                pids = self.store.recover_pids_from_raw_state(service)
             except Exception:
                 pids = []
         if pids:
             kill_pids(pids, grace_s=grace_s)
         path.unlink(missing_ok=True)
-        clear_current_service(self.namespace, service)
+        self.store.clear_current_service(service)
 
     def _collect_pids(self, state) -> list[int]:
         """Default implementation pulls ``.pid`` off every component

--- a/areal/experimental/cli/lifecycle.py
+++ b/areal/experimental/cli/lifecycle.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Service lifecycle helpers shared across subcommand CLIs.
+
+A ``ServiceLifecycle`` bundles a CLI's namespace + state class + stop
+command name, then exposes the three "is this service running"
+predicates (``running_state`` / ``load_running_state`` /
+``refuse_if_running``) plus ``force_replace_slot`` for ``run --force``.
+
+Subcommand CLIs subclass to inject their state class and may override
+``gateway_alive`` if they don't want the default
+``state.gateway_alive()`` delegation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from areal.experimental.cli.process import kill_pids
+from areal.experimental.cli.state import (
+    DEFAULT_SERVICE,
+    clear_current_service,
+    list_service_names,
+    recover_pids_from_raw_state,
+    resolve_service_name,
+    service_state_path,
+)
+
+
+class ServiceLifecycle:
+    namespace: str = ""
+    state_class: type = type(None)
+    stop_command: str = ""
+    default_service: str = DEFAULT_SERVICE
+
+    def __init__(
+        self,
+        *,
+        namespace: str | None = None,
+        state_class: type | None = None,
+        stop_command: str | None = None,
+    ) -> None:
+        if namespace is not None:
+            self.namespace = namespace
+        if state_class is not None:
+            self.state_class = state_class
+        if stop_command is not None:
+            self.stop_command = stop_command
+        if not self.namespace:
+            raise ValueError("ServiceLifecycle requires a namespace")
+        if not self.stop_command:
+            raise ValueError("ServiceLifecycle requires a stop_command")
+
+    # ------------------------------------------------------------------
+    # Hooks subclasses may override
+
+    def gateway_alive(self, state) -> bool:
+        """Default delegates to ``state.gateway_alive()`` (the
+        ServiceStateBase contract). Subclasses may override if their
+        state object can't or shouldn't implement that method itself."""
+
+        return state.gateway_alive()
+
+    def state_path(self, service: str) -> Path:
+        return service_state_path(self.namespace, service)
+
+    def resolve_service_name(self, explicit: str | None) -> str:
+        return resolve_service_name(
+            self.namespace, explicit, fallback=self.default_service
+        )
+
+    def list_services(self) -> list[str]:
+        return list_service_names(self.namespace)
+
+    def load_state(self, service: str):
+        return self.state_class.load(service)
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def running_state(self, service: str | None = None):
+        """Return the loaded state iff it exists, parses, and reports
+        the gateway alive. Returns None otherwise — never raises."""
+
+        name = self.resolve_service_name(service)
+        if not self.state_path(name).exists():
+            return None
+        try:
+            state = self.load_state(name)
+        except Exception:
+            return None
+        if not self.gateway_alive(state):
+            return None
+        return state
+
+    def load_running_state(self, service: str | None = None):
+        """Like ``running_state`` but raises ``ClickException`` on
+        every failure — for command bodies that need a state to proceed."""
+
+        name = self.resolve_service_name(service)
+        if not self.state_path(name).exists():
+            raise click.ClickException(f"service {name!r} is not running")
+        try:
+            state = self.load_state(name)
+        except Exception as exc:
+            raise click.ClickException(f"failed to load state: {exc}") from exc
+        if not self.gateway_alive(state):
+            raise click.ClickException(f"service {name!r} gateway is not alive")
+        return state
+
+    def refuse_if_running(self, service: str | None = None) -> None:
+        """Used by ``run`` to refuse double-start. No-op if no running
+        service exists; raises ``ClickException`` if one does."""
+
+        state = self.running_state(service)
+        if state is None:
+            return
+        raise click.ClickException(
+            f"service {state.service!r} already running. "
+            f"Run `{self.stop_command} --service {state.service}` first."
+        )
+
+    def force_replace_slot(self, service: str, *, grace_s: float = 5.0) -> None:
+        """``run --force`` path: tear down any existing children for
+        ``service`` (loading the state for an orderly kill, falling back
+        to the raw-JSON PID walk if the state file is corrupted), then
+        unlink the state file so the next spawn starts clean.
+
+        Caller is still responsible for the subsequent fresh spawn.
+        """
+
+        path = self.state_path(service)
+        if not path.exists():
+            return
+        pids: list[int] = []
+        try:
+            state = self.load_state(service)
+            pids = self._collect_pids(state)
+        except Exception:
+            try:
+                pids = recover_pids_from_raw_state(self.namespace, service)
+            except Exception:
+                pids = []
+        if pids:
+            kill_pids(pids, grace_s=grace_s)
+        path.unlink(missing_ok=True)
+        clear_current_service(self.namespace, service)
+
+    def _collect_pids(self, state) -> list[int]:
+        """Default implementation pulls ``.pid`` off every component
+        ``state.components()`` yields. Subclasses with extra state files
+        (e.g. inf's ``models/<svc>.json``) may override to extend the
+        list."""
+
+        return [pid for _, h in state.components() if (pid := h.pid) > 0]

--- a/areal/experimental/cli/main.py
+++ b/areal/experimental/cli/main.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from areal.experimental.cli.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/areal/experimental/cli/process.py
+++ b/areal/experimental/cli/process.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+
+def pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def spawn_process(
+    cmd: list[str], log_file: Path, env: dict[str, str] | None = None
+) -> int:
+    """Spawn a detached subprocess that survives parent exit.
+
+    ``start_new_session=True`` puts the child in its own session so the
+    parent receiving SIGHUP (terminal close) does not propagate to the
+    child. stdout / stderr are appended to ``log_file``. Extra env vars
+    in ``env`` are merged on top of the parent environment.
+    """
+
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    log_handle = open(log_file, "ab", buffering=0)
+    final_env = os.environ.copy()
+    final_env.setdefault("PYTHONUNBUFFERED", "1")
+    if env:
+        final_env.update(env)
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        env=final_env,
+    )
+    return proc.pid
+
+
+def signal_pid(pid: int, sig: int) -> bool:
+    """Best-effort signal delivery, first to the process group then the bare pid."""
+
+    if pid <= 0:
+        return False
+    try:
+        os.killpg(os.getpgid(pid), sig)
+        return True
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OSError):
+        pass
+    try:
+        os.kill(pid, sig)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+def kill_pids(pids: list[int], grace_s: float) -> None:
+    """SIGTERM all pids, wait up to ``grace_s`` for them to exit, then SIGKILL stragglers."""
+
+    pids = [p for p in pids if p > 0]
+    if not pids:
+        return
+    for pid in pids:
+        if pid_alive(pid):
+            signal_pid(pid, signal.SIGTERM)
+    deadline = time.time() + grace_s
+    while time.time() < deadline:
+        if not any(pid_alive(pid) for pid in pids):
+            return
+        time.sleep(0.2)
+    for pid in pids:
+        if pid_alive(pid):
+            signal_pid(pid, signal.SIGKILL)

--- a/areal/experimental/cli/process.py
+++ b/areal/experimental/cli/process.py
@@ -1,13 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
+"""Local-only process primitives for service-style CLIs.
+
+These helpers operate on local PIDs and process trees. Remote backends
+(K8s / Slurm) should not consume them directly — route teardown through
+``areal.experimental.cli.scheduler.terminate`` instead, which dispatches
+per backend.
+
+For port allocation use ``areal.utils.network.find_free_ports``; it
+draws from a non-ephemeral range and supports excluding already-handed-
+out ports, avoiding the TOCTOU collisions a naive ``bind(0)`` walks
+into.
+"""
+
 from __future__ import annotations
 
 import os
-import signal
-import socket
 import subprocess
-import time
 from pathlib import Path
+
+from areal.infra.utils.proc import kill_process_tree
 
 
 def pid_alive(pid: int) -> bool:
@@ -32,12 +44,6 @@ def pid_alive(pid: int) -> bool:
     except PermissionError:
         return True
     return True
-
-
-def pick_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
 
 
 def spawn_process(
@@ -71,39 +77,17 @@ def spawn_process(
     return proc.pid
 
 
-def signal_pid(pid: int, sig: int) -> bool:
-    """Best-effort signal delivery, first to the process group then the bare pid."""
-
-    if pid <= 0:
-        return False
-    try:
-        os.killpg(os.getpgid(pid), sig)
-        return True
-    except ProcessLookupError:
-        return False
-    except (PermissionError, OSError):
-        pass
-    try:
-        os.kill(pid, sig)
-        return True
-    except ProcessLookupError:
-        return False
-
-
 def kill_pids(pids: list[int], grace_s: float) -> None:
-    """SIGTERM all pids, wait up to ``grace_s`` for them to exit, then SIGKILL stragglers."""
+    """SIGTERM → wait ``grace_s`` → SIGKILL across local pids and their
+    descendant process trees.
 
-    pids = [p for p in pids if p > 0]
-    if not pids:
-        return
+    Delegates per-pid to ``areal.infra.utils.proc.kill_process_tree``,
+    which walks ``psutil.Process(pid).children(recursive=True)`` so
+    grandchildren that escaped the original process group are still
+    caught. Local-only — for remote backends use
+    ``areal.experimental.cli.scheduler.terminate``.
+    """
+
     for pid in pids:
-        if pid_alive(pid):
-            signal_pid(pid, signal.SIGTERM)
-    deadline = time.time() + grace_s
-    while time.time() < deadline:
-        if not any(pid_alive(pid) for pid in pids):
-            return
-        time.sleep(0.2)
-    for pid in pids:
-        if pid_alive(pid):
-            signal_pid(pid, signal.SIGKILL)
+        if pid > 0:
+            kill_process_tree(pid, timeout=int(grace_s), graceful=True)

--- a/areal/experimental/cli/process.py
+++ b/areal/experimental/cli/process.py
@@ -13,6 +13,18 @@ from pathlib import Path
 def pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
+    # If ``pid`` is one of our own children we may catch it mid-zombie:
+    # ``os.kill(pid, 0)`` still succeeds for zombies, so an unreaped child
+    # would look alive forever and kill_pids would burn its full grace
+    # window before sending a redundant SIGKILL. Reap it first via WNOHANG
+    # so a zombie is reported dead immediately.
+    try:
+        reaped, _ = os.waitpid(pid, os.WNOHANG)
+        if reaped == pid:
+            return False
+    except (ChildProcessError, OSError):
+        # Not our child, or already reaped — fall through to the kill probe.
+        pass
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -40,19 +52,22 @@ def spawn_process(
     """
 
     log_file.parent.mkdir(parents=True, exist_ok=True)
-    log_handle = open(log_file, "ab", buffering=0)
     final_env = os.environ.copy()
     final_env.setdefault("PYTHONUNBUFFERED", "1")
     if env:
         final_env.update(env)
-    proc = subprocess.Popen(
-        cmd,
-        stdin=subprocess.DEVNULL,
-        stdout=log_handle,
-        stderr=subprocess.STDOUT,
-        start_new_session=True,
-        env=final_env,
-    )
+    # Popen dup()s the fd for the child, so closing our copy here does not
+    # affect the child's stdout/stderr — and it stops us from leaking a fd
+    # in the parent every time spawn_process is called.
+    with open(log_file, "ab", buffering=0) as log_handle:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            env=final_env,
+        )
     return proc.pid
 
 

--- a/areal/experimental/cli/scheduler.py
+++ b/areal/experimental/cli/scheduler.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unified termination dispatch for service-style CLIs.
+
+Provides a stateless top-level ``terminate`` that takes a TaskHandle's
+``ref`` dict plus the backend tag, and routes to the matching kill
+path. Currently only the local backend is implemented; future backends
+extend this module with their own branches.
+"""
+
+from __future__ import annotations
+
+from areal.experimental.cli.process import kill_pids
+
+
+def terminate(
+    ref: dict,
+    *,
+    backend: str = "local",
+    grace_s: float = 10.0,
+) -> None:
+    """Terminate the task identified by ``ref`` using the given backend.
+
+    For ``backend="local"`` ``ref`` must contain a ``"pid"`` key — the
+    local PID and its descendant process tree are SIGTERM'd, given
+    ``grace_s`` seconds to exit, then SIGKILL'd.
+    """
+
+    if backend == "local":
+        pid = int(ref.get("pid", 0) or 0)
+        if pid > 0:
+            kill_pids([pid], grace_s=grace_s)
+        return
+
+    raise ValueError(f"unknown scheduler backend: {backend!r}")

--- a/areal/experimental/cli/state.py
+++ b/areal/experimental/cli/state.py
@@ -2,15 +2,20 @@
 
 """On-disk state primitives shared across service-style CLIs.
 
-Two layers live here:
+Three layers live here:
 
-1. **Utility functions** — ``areal_home``, ``atomic_write_json``, and the
-   namespace-aware path helpers (``services_dir``, ``logs_dir``, etc.).
-   Every subcommand CLI reads its on-disk state from
-   ``$AREAL_HOME/<namespace>/...``; passing the namespace explicitly lets
-   the same helpers serve every CLI from one place.
+1. **Global helpers** — ``areal_home`` (the user's CLI root) and
+   ``atomic_write_json`` (a generic write primitive). Both are
+   stateless; no namespace involvement.
 
-2. **Contract types** — ``SupportsComponentProbe`` (Protocol) and
+2. **NamespacedStateStore** — every subcommand CLI binds a namespace
+   (``inf``, ``agent``, ``train``, …) and lives under
+   ``$AREAL_HOME/<namespace>/``. The store class collects the path
+   resolution / pointer file / orphan-recovery operations so callers
+   construct one instance per namespace and use methods on it rather
+   than threading the namespace string through every call site.
+
+3. **Contract types** — ``SupportsComponentProbe`` (Protocol) and
    ``ServiceStateBase`` (ABC). Subcommand CLIs implement their own
    ServiceState dataclass that satisfies the protocol / base class, and
    in return get to plug into scaffold's ``ServiceLifecycle`` /
@@ -31,7 +36,7 @@ DEFAULT_SERVICE = "default"
 
 
 # ---------------------------------------------------------------------------
-# Utility functions
+# Global helpers
 # ---------------------------------------------------------------------------
 
 
@@ -80,143 +85,143 @@ def atomic_write_json(path: Path, data: Any, *, indent: int = 2) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Namespace-aware path helpers
+# Namespace-bound state store
 # ---------------------------------------------------------------------------
 
 
-def namespace_root(namespace: str) -> Path:
-    d = areal_home() / namespace
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+class NamespacedStateStore:
+    """All ``$AREAL_HOME/<namespace>/...`` path resolution + pointer
+    file management for one subcommand CLI.
 
-
-def services_dir(namespace: str) -> Path:
-    d = namespace_root(namespace) / "services"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
-
-
-def logs_root(namespace: str) -> Path:
-    d = namespace_root(namespace) / "logs"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
-
-
-def logs_dir(namespace: str, service: str) -> Path:
-    d = logs_root(namespace) / service
-    d.mkdir(parents=True, exist_ok=True)
-    return d
-
-
-def service_state_path(namespace: str, service: str) -> Path:
-    return services_dir(namespace) / f"{service}.json"
-
-
-def service_lock_path(namespace: str, service: str) -> Path:
-    return services_dir(namespace) / f"{service}.lock"
-
-
-def current_service_path(namespace: str) -> Path:
-    return namespace_root(namespace) / "current-service"
-
-
-def config_path(namespace: str) -> Path:
-    return namespace_root(namespace) / "config.toml"
-
-
-def list_service_names(namespace: str) -> list[str]:
-    return sorted(p.stem for p in services_dir(namespace).glob("*.json"))
-
-
-def set_current_service(namespace: str, service: str) -> None:
-    current_service_path(namespace).write_text(service + "\n")
-
-
-def clear_current_service(namespace: str, service: str) -> None:
-    path = current_service_path(namespace)
-    if path.exists() and path.read_text().strip() == service:
-        path.unlink()
-
-
-def resolve_service_name(
-    namespace: str,
-    explicit: str | None = None,
-    *,
-    fallback: str = DEFAULT_SERVICE,
-) -> str:
-    """Resolve the active service name for a CLI call.
-
-    Order: ``--service`` flag > current-service pointer file > the single
-    running service (if exactly one) > ``fallback``.
+    Construct one per CLI (e.g. ``store = NamespacedStateStore("inf")``)
+    and use the methods on it. Paths are re-resolved on every call so
+    tests that override the home directory via ``AREAL_HOME`` work
+    without rebuilding the store.
     """
 
-    if explicit:
-        return explicit
-    pointer = current_service_path(namespace)
-    if pointer.exists():
-        value = pointer.read_text().strip()
-        if value:
-            return value
-    running = list_service_names(namespace)
-    if len(running) == 1:
-        return running[0]
-    return fallback
+    def __init__(self, namespace: str) -> None:
+        if not namespace:
+            raise ValueError("NamespacedStateStore requires a non-empty namespace")
+        self.namespace = namespace
 
+    # --- directory roots -------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# Best-effort orphan PID recovery
-# ---------------------------------------------------------------------------
+    def root(self) -> Path:
+        d = areal_home() / self.namespace
+        d.mkdir(parents=True, exist_ok=True)
+        return d
 
+    def services_dir(self) -> Path:
+        d = self.root() / "services"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
 
-def recover_pids_from_raw_state(namespace: str, service: str) -> list[int]:
-    """Walk the on-disk state files for ``service`` and pull any
-    ``pid`` / ``pids`` numbers.
+    def logs_root(self) -> Path:
+        d = self.root() / "logs"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
 
-    Used by ``run --force`` to clean up children when the dataclass
-    parse fails (state file from an older / corrupted schema).
-    """
+    def logs_dir(self, service: str) -> Path:
+        d = self.logs_root() / service
+        d.mkdir(parents=True, exist_ok=True)
+        return d
 
-    pids: list[int] = []
-    pid_keys = {"pid", "pids"}
+    # --- file paths ------------------------------------------------------
 
-    def add(value) -> None:
-        if isinstance(value, int) and value > 0:
-            pids.append(value)
-        elif isinstance(value, list):
-            for item in value:
-                add(item)
+    def service_state_path(self, service: str) -> Path:
+        return self.services_dir() / f"{service}.json"
 
-    def walk(value) -> None:
-        if isinstance(value, dict):
-            for key, item in value.items():
-                if key in pid_keys:
+    def service_lock_path(self, service: str) -> Path:
+        return self.services_dir() / f"{service}.lock"
+
+    def current_service_path(self) -> Path:
+        return self.root() / "current-service"
+
+    def config_path(self) -> Path:
+        return self.root() / "config.toml"
+
+    # --- pointer file ----------------------------------------------------
+
+    def list_service_names(self) -> list[str]:
+        return sorted(p.stem for p in self.services_dir().glob("*.json"))
+
+    def set_current_service(self, service: str) -> None:
+        self.current_service_path().write_text(service + "\n")
+
+    def clear_current_service(self, service: str) -> None:
+        path = self.current_service_path()
+        if path.exists() and path.read_text().strip() == service:
+            path.unlink()
+
+    def resolve_service_name(
+        self,
+        explicit: str | None = None,
+        *,
+        fallback: str = DEFAULT_SERVICE,
+    ) -> str:
+        """Resolve the active service name for a CLI call.
+
+        Order: ``--service`` flag > current-service pointer file > the
+        single running service (if exactly one) > ``fallback``.
+        """
+
+        if explicit:
+            return explicit
+        pointer = self.current_service_path()
+        if pointer.exists():
+            value = pointer.read_text().strip()
+            if value:
+                return value
+        running = self.list_service_names()
+        if len(running) == 1:
+            return running[0]
+        return fallback
+
+    # --- best-effort orphan PID recovery ---------------------------------
+
+    def recover_pids_from_raw_state(self, service: str) -> list[int]:
+        """Walk the service-state file for ``service`` and pull any
+        ``pid`` / ``pids`` numbers.
+
+        Used by ``run --force`` to clean up children when the dataclass
+        parse fails (state file from an older / corrupted schema).
+        Subclasses with extra state files (e.g. inf's
+        ``models/<svc>.json``) override to walk the additional files.
+        """
+
+        pids: list[int] = []
+        pid_keys = {"pid", "pids"}
+
+        def add(value) -> None:
+            if isinstance(value, int) and value > 0:
+                pids.append(value)
+            elif isinstance(value, list):
+                for item in value:
                     add(item)
-                else:
+
+        def walk(value) -> None:
+            if isinstance(value, dict):
+                for key, item in value.items():
+                    if key in pid_keys:
+                        add(item)
+                    else:
+                        walk(item)
+            elif isinstance(value, list):
+                for item in value:
                     walk(item)
-        elif isinstance(value, list):
-            for item in value:
-                walk(item)
 
-    candidate_files = [
-        service_state_path(namespace, service),
-        # Subcommand CLIs may also keep secondary state files (e.g. inf's
-        # models/<svc>.json). Walking namespace_root/* once would catch
-        # them, but we keep this targeted to the service-state file to
-        # avoid surprising file enumeration.
-    ]
-    for path in candidate_files:
-        if not path.exists():
-            continue
-        with open(path) as f:
-            walk(json.load(f))
+        path = self.service_state_path(service)
+        if path.exists():
+            with open(path) as f:
+                walk(json.load(f))
 
-    seen: set[int] = set()
-    unique: list[int] = []
-    for pid in pids:
-        if pid not in seen:
-            seen.add(pid)
-            unique.append(pid)
-    return unique
+        seen: set[int] = set()
+        unique: list[int] = []
+        for pid in pids:
+            if pid not in seen:
+                seen.add(pid)
+                unique.append(pid)
+        return unique
 
 
 # ---------------------------------------------------------------------------

--- a/areal/experimental/cli/state.py
+++ b/areal/experimental/cli/state.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def areal_home() -> Path:
+    """Return the AReaL CLI home directory.
+
+    Resolves ``$AREAL_HOME`` if set, otherwise ``~/.areal``. The directory
+    is created on first access so callers can mkdir-then-write subdirs
+    without an explicit setup step.
+    """
+
+    env = os.environ.get("AREAL_HOME")
+    root = Path(env).expanduser() if env else Path.home() / ".areal"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def atomic_write_json(path: Path, data: Any, *, indent: int = 2) -> None:
+    """Atomically write ``data`` as JSON to ``path``.
+
+    Writes to ``path + .tmp`` first then renames into place, so partial
+    writes never leave a half-formed file on disk.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp, "w") as f:
+        f.write(json.dumps(data, indent=indent) + "\n")
+    os.replace(tmp, path)

--- a/areal/experimental/cli/state.py
+++ b/areal/experimental/cli/state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -25,12 +26,28 @@ def areal_home() -> Path:
 def atomic_write_json(path: Path, data: Any, *, indent: int = 2) -> None:
     """Atomically write ``data`` as JSON to ``path``.
 
-    Writes to ``path + .tmp`` first then renames into place, so partial
-    writes never leave a half-formed file on disk.
+    Writes to a unique tempfile in ``path``'s directory, fsync()s it to
+    disk, then renames into place. ``NamedTemporaryFile(delete=False)``
+    gives us a fresh name per call so concurrent writers do not stomp on
+    each other's tempfiles, and the tempfile is unlinked on serialization
+    or rename failure so half-written state never lingers on disk.
     """
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with open(tmp, "w") as f:
-        f.write(json.dumps(data, indent=indent) + "\n")
-    os.replace(tmp, path)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=path.parent, delete=False, suffix=".tmp"
+    ) as f:
+        tmp_path = Path(f.name)
+        try:
+            json.dump(data, f, indent=indent)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+    try:
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/areal/experimental/cli/state.py
+++ b/areal/experimental/cli/state.py
@@ -1,20 +1,46 @@
 # SPDX-License-Identifier: Apache-2.0
 
+"""On-disk state primitives shared across service-style CLIs.
+
+Two layers live here:
+
+1. **Utility functions** — ``areal_home``, ``atomic_write_json``, and the
+   namespace-aware path helpers (``services_dir``, ``logs_dir``, etc.).
+   Every subcommand CLI reads its on-disk state from
+   ``$AREAL_HOME/<namespace>/...``; passing the namespace explicitly lets
+   the same helpers serve every CLI from one place.
+
+2. **Contract types** — ``SupportsComponentProbe`` (Protocol) and
+   ``ServiceStateBase`` (ABC). Subcommand CLIs implement their own
+   ServiceState dataclass that satisfies the protocol / base class, and
+   in return get to plug into scaffold's ``ServiceLifecycle`` /
+   ``StatusReporter`` / etc. without further glue.
+"""
+
 from __future__ import annotations
 
 import json
 import os
 import tempfile
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
+
+DEFAULT_SERVICE = "default"
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
 
 
 def areal_home() -> Path:
     """Return the AReaL CLI home directory.
 
-    Resolves ``$AREAL_HOME`` if set, otherwise ``~/.areal``. The directory
-    is created on first access so callers can mkdir-then-write subdirs
-    without an explicit setup step.
+    Resolves ``$AREAL_HOME`` if set, otherwise ``~/.areal``. Created on
+    first access so callers can mkdir-then-write subdirs without an
+    explicit setup step.
     """
 
     env = os.environ.get("AREAL_HOME")
@@ -39,7 +65,7 @@ def atomic_write_json(path: Path, data: Any, *, indent: int = 2) -> None:
     ) as f:
         tmp_path = Path(f.name)
         try:
-            json.dump(data, f, indent=indent)
+            json.dump(data, f, indent=indent, default=str)
             f.write("\n")
             f.flush()
             os.fsync(f.fileno())
@@ -51,3 +77,199 @@ def atomic_write_json(path: Path, data: Any, *, indent: int = 2) -> None:
     except Exception:
         tmp_path.unlink(missing_ok=True)
         raise
+
+
+# ---------------------------------------------------------------------------
+# Namespace-aware path helpers
+# ---------------------------------------------------------------------------
+
+
+def namespace_root(namespace: str) -> Path:
+    d = areal_home() / namespace
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def services_dir(namespace: str) -> Path:
+    d = namespace_root(namespace) / "services"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def logs_root(namespace: str) -> Path:
+    d = namespace_root(namespace) / "logs"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def logs_dir(namespace: str, service: str) -> Path:
+    d = logs_root(namespace) / service
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def service_state_path(namespace: str, service: str) -> Path:
+    return services_dir(namespace) / f"{service}.json"
+
+
+def service_lock_path(namespace: str, service: str) -> Path:
+    return services_dir(namespace) / f"{service}.lock"
+
+
+def current_service_path(namespace: str) -> Path:
+    return namespace_root(namespace) / "current-service"
+
+
+def config_path(namespace: str) -> Path:
+    return namespace_root(namespace) / "config.toml"
+
+
+def list_service_names(namespace: str) -> list[str]:
+    return sorted(p.stem for p in services_dir(namespace).glob("*.json"))
+
+
+def set_current_service(namespace: str, service: str) -> None:
+    current_service_path(namespace).write_text(service + "\n")
+
+
+def clear_current_service(namespace: str, service: str) -> None:
+    path = current_service_path(namespace)
+    if path.exists() and path.read_text().strip() == service:
+        path.unlink()
+
+
+def resolve_service_name(
+    namespace: str,
+    explicit: str | None = None,
+    *,
+    fallback: str = DEFAULT_SERVICE,
+) -> str:
+    """Resolve the active service name for a CLI call.
+
+    Order: ``--service`` flag > current-service pointer file > the single
+    running service (if exactly one) > ``fallback``.
+    """
+
+    if explicit:
+        return explicit
+    pointer = current_service_path(namespace)
+    if pointer.exists():
+        value = pointer.read_text().strip()
+        if value:
+            return value
+    running = list_service_names(namespace)
+    if len(running) == 1:
+        return running[0]
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# Best-effort orphan PID recovery
+# ---------------------------------------------------------------------------
+
+
+def recover_pids_from_raw_state(namespace: str, service: str) -> list[int]:
+    """Walk the on-disk state files for ``service`` and pull any
+    ``pid`` / ``pids`` numbers.
+
+    Used by ``run --force`` to clean up children when the dataclass
+    parse fails (state file from an older / corrupted schema).
+    """
+
+    pids: list[int] = []
+    pid_keys = {"pid", "pids"}
+
+    def add(value) -> None:
+        if isinstance(value, int) and value > 0:
+            pids.append(value)
+        elif isinstance(value, list):
+            for item in value:
+                add(item)
+
+    def walk(value) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if key in pid_keys:
+                    add(item)
+                else:
+                    walk(item)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+
+    candidate_files = [
+        service_state_path(namespace, service),
+        # Subcommand CLIs may also keep secondary state files (e.g. inf's
+        # models/<svc>.json). Walking namespace_root/* once would catch
+        # them, but we keep this targeted to the service-state file to
+        # avoid surprising file enumeration.
+    ]
+    for path in candidate_files:
+        if not path.exists():
+            continue
+        with open(path) as f:
+            walk(json.load(f))
+
+    seen: set[int] = set()
+    unique: list[int] = []
+    for pid in pids:
+        if pid not in seen:
+            seen.add(pid)
+            unique.append(pid)
+    return unique
+
+
+# ---------------------------------------------------------------------------
+# Contract types
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SupportsComponentProbe(Protocol):
+    """Minimum surface a subcommand's component handle must expose so
+    scaffold helpers can probe it and identify it.
+
+    Each subcommand CLI's handle type — inf's ``TaskHandle``, agent's
+    ``ProcessState``, etc. — already provides ``addr`` (HTTP base for
+    ``/health`` probes) and ``pid`` (for local liveness / kill paths).
+    No inheritance needed: structural duck typing.
+    """
+
+    @property
+    def addr(self) -> str: ...
+
+    @property
+    def pid(self) -> int: ...
+
+
+class ServiceStateBase(ABC):
+    """Abstract base every subcommand CLI's ServiceState should satisfy.
+
+    The base nails down the universal fields and the two methods
+    (``gateway_alive`` / ``components``) that scaffold's lifecycle and
+    status reporters rely on. Subclasses are free to add backend-specific
+    fields (engine handles, model registries, agent pair configs, etc.).
+    """
+
+    service: str
+    admin_api_key: str
+    launch_mode: str
+    started_at: float
+
+    @abstractmethod
+    def gateway_alive(self) -> bool:
+        """Return True iff the service's central entry point is reachable.
+
+        ``ServiceLifecycle`` uses this to decide "running" — every CLI
+        must define what alive means for its own architecture (local PID
+        alive / k8s pod ready / slurm job state).
+        """
+
+    @abstractmethod
+    def components(self) -> Iterable[tuple[str, SupportsComponentProbe]]:
+        """Yield ``(label, handle)`` for every component of this service.
+
+        Used by ``StatusReporter`` to enumerate rows; the order is the
+        order rows appear in the table. Labels are display-only strings
+        (e.g. ``"gateway"``, ``"worker[qwen/0]"``).
+        """

--- a/areal/experimental/cli/status.py
+++ b/areal/experimental/cli/status.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Status drill-down table with parallel /health probing.
+
+A ``StatusReporter`` is constructed with the components to inspect plus
+a list of ``ColumnSpec`` describing the columns to render. It probes
+every component's ``/health`` endpoint concurrently and produces either
+a text table or a JSON payload.
+
+Both the column set and the per-column value extractors are caller-
+supplied — subcommand CLIs decide what to show. Scaffold provides only
+the orchestration (parallel probe + table rendering).
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+
+import click
+
+from areal.experimental.cli.state import SupportsComponentProbe
+
+
+@dataclass
+class ColumnSpec:
+    """One column in the status table.
+
+    ``value`` receives the row's ``(label, handle, alive)`` tuple and
+    returns the rendered string. Returning ``"-"`` for "not applicable"
+    is the conventional placeholder.
+    """
+
+    header: str
+    value: Callable[[str, SupportsComponentProbe, bool], str]
+
+
+class StatusReporter:
+    def __init__(
+        self,
+        components: list[tuple[str, SupportsComponentProbe]],
+        columns: list[ColumnSpec],
+        *,
+        probe_timeout: float = 3.0,
+        max_workers: int = 8,
+    ) -> None:
+        self.components = list(components)
+        self.columns = list(columns)
+        self.probe_timeout = probe_timeout
+        self.max_workers = max_workers
+
+    def probe_all(self) -> list[bool]:
+        """Probe every component's ``/health`` endpoint concurrently.
+
+        Returns a list of bools aligned with ``self.components``. A
+        non-5xx response within ``probe_timeout`` counts as alive; any
+        network error or 5xx counts as not alive.
+        """
+
+        if not self.components:
+            return []
+        addrs = [handle.addr or "" for _, handle in self.components]
+
+        def probe(addr: str) -> bool:
+            if not addr:
+                return False
+            try:
+                with urllib.request.urlopen(
+                    f"{addr.rstrip('/')}/health", timeout=self.probe_timeout
+                ) as resp:
+                    return resp.status < 500
+            except (
+                urllib.error.URLError,
+                ConnectionError,
+                TimeoutError,
+                OSError,
+            ):
+                return False
+
+        with ThreadPoolExecutor(
+            max_workers=max(1, min(self.max_workers, len(addrs)))
+        ) as pool:
+            return list(pool.map(probe, addrs))
+
+    def render_rows(self, alive_flags: list[bool] | None = None) -> list[list[str]]:
+        """Build per-row string lists using each column's value extractor."""
+
+        if alive_flags is None:
+            alive_flags = self.probe_all()
+        rows: list[list[str]] = []
+        for (label, handle), alive in zip(self.components, alive_flags, strict=True):
+            rows.append([col.value(label, handle, alive) for col in self.columns])
+        return rows
+
+    def print_table(
+        self,
+        rows: list[list[str]] | None = None,
+        *,
+        header_line: str | None = None,
+    ) -> None:
+        """Print a left-aligned table with column widths derived from
+        the longest cell in each column. Optional ``header_line`` is
+        echoed before the table (e.g. ``"service: foo  backend: local"``).
+        """
+
+        if rows is None:
+            rows = self.render_rows()
+        if header_line:
+            click.echo(header_line)
+            click.echo()
+        headers = [c.header for c in self.columns]
+        widths = [
+            max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(headers)
+        ]
+        fmt = "  ".join(f"{{:<{w}}}" for w in widths)
+        click.echo(fmt.format(*headers))
+        for row in rows:
+            click.echo(fmt.format(*row))
+
+    def json_snapshot(self, alive_flags: list[bool] | None = None) -> list[dict]:
+        """Return the table content as a list of dicts (one per row)
+        keyed by column header — convenient for ``--json`` output."""
+
+        if alive_flags is None:
+            alive_flags = self.probe_all()
+        snapshot = []
+        for (label, handle), alive in zip(self.components, alive_flags, strict=True):
+            snapshot.append(
+                {col.header: col.value(label, handle, alive) for col in self.columns}
+            )
+        return snapshot

--- a/areal/experimental/cli/utils.py
+++ b/areal/experimental/cli/utils.py
@@ -30,7 +30,6 @@ import click
 from areal.experimental.cli.process import pid_alive
 from areal.utils.logging import LOGGER_COLORS_EXACT, getLogger
 
-
 # ---------------------------------------------------------------------------
 # File locking
 # ---------------------------------------------------------------------------

--- a/areal/experimental/cli/utils.py
+++ b/areal/experimental/cli/utils.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stateless utility helpers shared across subcommand CLIs.
+
+Four groups live here:
+
+- :func:`file_lock` — per-service mutual exclusion via POSIX flock.
+- :func:`wait_http_health` / :func:`wait_client_health` — block until a
+  newly-spawned component reports ready.
+- :func:`json_or_table` — ``--json`` vs table dual-output dispatch.
+- :func:`register_cli_logger` — register a CLI logger name + color in
+  the global color table and return the configured Logger.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Protocol
+
+import click
+
+from areal.experimental.cli.process import pid_alive
+from areal.utils.logging import LOGGER_COLORS_EXACT, getLogger
+
+
+# ---------------------------------------------------------------------------
+# File locking
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def file_lock(path: Path) -> Iterator[None]:
+    """Hold an exclusive flock on ``path`` for the duration of the ``with`` block.
+
+    The lock file is created if missing; concurrent waiters block until
+    the current holder exits the ``with`` block. Used by subcommand CLIs
+    to serialize concurrent ``register`` / ``deregister`` / ``stop``
+    calls against the same service's state file.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a+") as fp:
+        fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+
+
+# ---------------------------------------------------------------------------
+# Health polling
+# ---------------------------------------------------------------------------
+
+
+class _HealthCheckable(Protocol):
+    def health(self, *, timeout: float) -> object: ...
+
+
+def wait_http_health(
+    url: str,
+    *,
+    pid: int,
+    timeout: float,
+    label: str,
+    poll_interval: float = 0.5,
+    request_timeout: float = 2.0,
+) -> None:
+    """Poll ``GET <url>/health`` until it returns < 5xx.
+
+    Raises ``ClickException`` if the deadline elapses, or if the spawned
+    PID dies during startup (cheap early-fail signal for the local
+    case). Pass ``pid=0`` for non-local backends to skip the PID check.
+    """
+
+    deadline = time.time() + timeout
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        if pid > 0 and not pid_alive(pid):
+            raise click.ClickException(f"{label} subprocess died during startup")
+        try:
+            with urllib.request.urlopen(
+                f"{url.rstrip('/')}/health", timeout=request_timeout
+            ) as resp:
+                if resp.status < 500:
+                    return
+        except (urllib.error.URLError, ConnectionError, TimeoutError, OSError) as exc:
+            last_err = exc
+            time.sleep(poll_interval)
+    raise click.ClickException(f"{label} did not become healthy: {last_err}")
+
+
+def wait_client_health(
+    client: _HealthCheckable,
+    *,
+    timeout: float,
+    label: str,
+    poll_interval: float = 0.3,
+    request_timeout: float = 1.5,
+) -> None:
+    """Poll ``client.health(timeout=...)`` until it returns without raising.
+
+    Any exception from ``client.health`` is treated as "not ready yet"
+    and the loop sleeps until the deadline.
+    """
+
+    deadline = time.time() + timeout
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        try:
+            client.health(timeout=request_timeout)
+            return
+        except Exception as exc:
+            last_err = exc
+            time.sleep(poll_interval)
+    raise click.ClickException(
+        f"{label} did not become healthy within {timeout:.0f}s (last error: {last_err})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output dispatch
+# ---------------------------------------------------------------------------
+
+
+def json_or_table(
+    payload: Any,
+    *,
+    as_json: bool,
+    table_renderer: Callable[[Any], None],
+    indent: int = 2,
+) -> None:
+    """Emit ``payload`` as JSON or hand it to a table renderer.
+
+    Most subcommand ``ps`` / ``status`` / ``models`` verbs follow the
+    same pattern: ``--json`` dumps the raw payload, otherwise a table
+    is rendered. Funneling both through this helper keeps the branching
+    out of the command body.
+    """
+
+    if as_json:
+        click.echo(json.dumps(payload, indent=indent, default=str))
+        return
+    table_renderer(payload)
+
+
+# ---------------------------------------------------------------------------
+# Logger registration
+# ---------------------------------------------------------------------------
+
+
+def register_cli_logger(name: str, color: str = "blue") -> logging.Logger:
+    """Register ``name`` with ``color`` in ``areal.utils.logging``'s
+    color table and return the configured Logger.
+
+    Service-style CLIs conventionally use ``"blue"`` (infrastructure /
+    scheduler category). See ``areal/utils/logging.py`` for the palette
+    if a different color fits.
+    """
+
+    LOGGER_COLORS_EXACT[name] = color
+    return getLogger(name)

--- a/areal/experimental/cli/watcher.py
+++ b/areal/experimental/cli/watcher.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Foreground watcher with signal-aware teardown.
+
+Subcommand CLIs use this in their ``run`` (non-detach) path to block
+until the service exits, with a clear distinction between:
+
+  - SIGINT / SIGTERM → user-requested stop → run the teardown callback
+    (kill workers, remove state file) → return 0
+  - SIGHUP → terminal disconnect → exit quietly without teardown;
+    workers spawned with ``start_new_session=True`` survive
+
+Subclasses or constructor kwargs can swap the SIGHUP semantics for
+``"teardown"`` if a particular CLI wants the older "all signals tear
+down" behavior.
+"""
+
+from __future__ import annotations
+
+import signal
+import time
+from collections.abc import Callable
+from typing import Literal
+
+Disposition = Literal["teardown", "detach"]
+
+
+class ForegroundWatcher:
+    """Block the calling thread until the service exits.
+
+    Construct with an ``is_alive`` callback (typically
+    ``lambda: lifecycle.gateway_alive(state)``) and a ``teardown``
+    callback (kills workers + removes state file). Call ``watch()`` —
+    it returns the desired CLI exit code.
+    """
+
+    default_signal_dispositions: dict[int, Disposition] = {
+        signal.SIGTERM: "teardown",
+    }
+    if hasattr(signal, "SIGHUP"):
+        default_signal_dispositions[signal.SIGHUP] = "detach"
+
+    def __init__(
+        self,
+        *,
+        is_alive: Callable[[], bool],
+        teardown: Callable[[], None],
+        idle_poll: float = 1.0,
+        service_name: str = "",
+        signal_dispositions: dict[int, Disposition] | None = None,
+    ) -> None:
+        self.is_alive = is_alive
+        self.teardown = teardown
+        self.idle_poll = idle_poll
+        self.service_name = service_name
+        self.dispositions = (
+            dict(signal_dispositions)
+            if signal_dispositions is not None
+            else dict(self.default_signal_dispositions)
+        )
+
+    def watch(self) -> int:
+        previous = self._install_handlers()
+        try:
+            while self.is_alive():
+                time.sleep(self.idle_poll)
+        except KeyboardInterrupt:
+            # SIGINT (Ctrl+C) plus any SIGTERM-dispatched teardown lands here.
+            self.teardown()
+            return 0
+        except SystemExit as exc:
+            # SIGHUP-dispatched detach path lands here.
+            return exc.code if isinstance(exc.code, int) else 0
+        except BaseException:
+            self.teardown()
+            raise
+        finally:
+            self._restore_handlers(previous)
+        # is_alive() flipped to False on its own — gateway died externally.
+        # We do not call teardown; the children are already gone, but the
+        # caller may want to clean up state (handled outside this class).
+        return 0
+
+    # ------------------------------------------------------------------
+    # Signal plumbing
+
+    def _install_handlers(self) -> dict[int, object]:
+        previous: dict[int, object] = {}
+        for sig, disposition in self.dispositions.items():
+            previous[sig] = signal.getsignal(sig)
+            signal.signal(sig, self._handler_for(disposition))
+        return previous
+
+    def _restore_handlers(self, previous: dict[int, object]) -> None:
+        for sig, handler in previous.items():
+            signal.signal(sig, handler)
+
+    def _handler_for(self, disposition: Disposition):
+        if disposition == "teardown":
+
+            def teardown_handler(signum, frame):  # noqa: ARG001
+                raise KeyboardInterrupt
+
+            return teardown_handler
+
+        def detach_handler(signum, frame):  # noqa: ARG001
+            raise SystemExit(0)
+
+        return detach_handler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,13 @@ cuda = [
 sandbox = [
     "daytona>=0.167.0",
 ]
+cli = [
+    "click>=8.1",
+    "colorlog",
+]
+
+[project.scripts]
+areal = "areal.experimental.cli.main:cli"
 
 [project.urls]
 "Homepage" = "https://github.com/areal-project/AReaL"

--- a/pyproject.vllm.toml
+++ b/pyproject.vllm.toml
@@ -194,6 +194,13 @@ cuda = [
 sandbox = [
     "daytona>=0.167.0",
 ]
+cli = [
+    "click>=8.1",
+    "colorlog",
+]
+
+[project.scripts]
+areal = "areal.experimental.cli.main:cli"
 
 [project.urls]
 "Homepage" = "https://github.com/areal-project/AReaL"

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cli = [
+    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "colorlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 cuda = [
     { name = "flash-linear-attention", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "kernels", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -480,8 +484,10 @@ requires-dist = [
     { name = "blosc" },
     { name = "build", specifier = ">=1.2.1" },
     { name = "claude-agent-sdk" },
+    { name = "click", marker = "extra == 'cli'", specifier = ">=8.1" },
     { name = "colorama" },
     { name = "colorlog" },
+    { name = "colorlog", marker = "extra == 'cli'" },
     { name = "cookiecutter", specifier = ">2.1.1" },
     { name = "datasets", specifier = ">=3.0.0" },
     { name = "daytona", marker = "extra == 'sandbox'", specifier = ">=0.167.0" },
@@ -573,7 +579,7 @@ requires-dist = [
     { name = "word2number" },
     { name = "zstandard" },
 ]
-provides-extras = ["sglang", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox"]
+provides-extras = ["sglang", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox", "cli"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.vllm.lock
+++ b/uv.vllm.lock
@@ -448,6 +448,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cli = [
+    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "colorlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 cuda = [
     { name = "flash-linear-attention", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "kernels", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -526,8 +530,10 @@ requires-dist = [
     { name = "blosc" },
     { name = "build", specifier = ">=1.2.1" },
     { name = "claude-agent-sdk" },
+    { name = "click", marker = "extra == 'cli'", specifier = ">=8.1" },
     { name = "colorama" },
     { name = "colorlog" },
+    { name = "colorlog", marker = "extra == 'cli'" },
     { name = "cookiecutter", specifier = ">2.1.1" },
     { name = "datasets", specifier = ">=3.0.0" },
     { name = "daytona", marker = "extra == 'sandbox'", specifier = ">=0.167.0" },
@@ -619,7 +625,7 @@ requires-dist = [
     { name = "word2number" },
     { name = "zstandard" },
 ]
-provides-extras = ["vllm", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox"]
+provides-extras = ["vllm", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox", "cli"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Description

Sets up the shared scaffolding so that the three in-flight CLI PRs —`feat/inference-service-cli`, `feat/training-service-cli`, and`feat/agent-service-cli` — can land as focused subcommand PRs without duplicating CLI plumbing (the top-level click group, the `areal` script entrypoint, AREAL_HOME state helpers, detached subprocess primitives).

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [x] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with \`jb build docs\`
- [ ] No critical issues raised by AI reviewers (\`/gemini review\`)

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Key pieces shipped here:

- \`areal.experimental.cli.cli\`: empty top-level click group with version + \`--help\`; subcommand modules attach via \`cli.add_command(...)\` from their own packages
- \`areal.experimental.cli.state\`: \`areal_home()\` + \`atomic_write_json()\` for \`\$AREAL_HOME\`-rooted local state files (atomic \`.tmp\` write + \`os.replace\`)
- \`areal.experimental.cli.process\`: \`pid_alive\` / \`pick_free_port\` / \`signal_pid\` / \`kill_pids\`, and \`spawn_process\` with \`start_new_session=True\` so detached worker processes survive parent SIGHUP, plus an ordered SIGTERM → grace → SIGKILL teardown helper
- \`pyproject.toml\` / \`pyproject.vllm.toml\`: \`[project.scripts] areal = areal.experimental.cli.main:cli\` and the \`[cli]\` optional dependency group (\`click\`, \`colorlog\`)

Tested via:

- import / syntax check on all 7 new modules
- \`python -m areal.experimental.cli --help\` renders the click group with \`--version\` wired correctly (no subcommands yet — those land in downstream PRs)