### PR TITLE
feat: support v2 weight update disk mode for lora RL

### DIFF
--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -323,18 +323,30 @@ class PPOTrainer:
         # Proxy worker initialization (lazy, for AgentWorkflow support)
         self._proxy_started = False
 
-        # Prepare weight update meta and connect to inference engine
+        # Prepare weight update meta and connect to inference engine.
+        # v2 controllers pick transport from use_lora: LoRA must go through
+        # disk (P2P transports cannot carry PEFT-wrapped tensors); non-LoRA
+        # uses awex. v1 keeps the legacy weight_update_mode dispatch.
         if self.config.actor._version == "v2":
-            awex_kwargs: dict[str, Any] = {}
             if config.actor.use_lora:
-                awex_kwargs.update(
-                    {
-                        "use_lora": config.actor.use_lora,
-                        "lora_name": config.gconfig.lora_name,
-                        "base_model_name": config.actor.path,
-                    }
-                )
-            self.weight_update_meta = WeightUpdateMeta.from_awex(**awex_kwargs)
+                disk_kwargs: dict[str, Any] = {
+                    "experiment_name": config.experiment_name,
+                    "trial_name": config.trial_name,
+                    "file_root": config.cluster.fileroot,
+                    "name": "default",
+                    "clear_checkpoint_after_load": True,
+                    "use_lora": config.actor.use_lora,
+                    "lora_name": config.gconfig.lora_name,
+                    "base_model_name": config.actor.path,
+                    # Keep enough recent adapter versions for off-policy
+                    # rollouts (max_head_offpolicyness) plus a safety margin;
+                    # older versions are unloaded to bound sglang VRAM and
+                    # avoid the adapter-accumulation hang.
+                    "lora_keep_versions": config.rollout.max_head_offpolicyness + 2,
+                }
+                self.weight_update_meta = WeightUpdateMeta.from_disk(**disk_kwargs)
+            else:
+                self.weight_update_meta = WeightUpdateMeta.from_awex()
         elif self.config.actor.weight_update_mode == "disk":
             disk_kwargs = {
                 "experiment_name": config.experiment_name,
@@ -358,7 +370,7 @@ class PPOTrainer:
                 )
             self.weight_update_meta = WeightUpdateMeta.from_disk(**disk_kwargs)
         elif self.config.actor.weight_update_mode == "xccl":
-            # NCCL/XCCL weight update
+            # NCCL/XCCL weight update (v1 only)
             xccl_kwargs: dict[str, Any] = {
                 "gen_allocation": self.rollout_alloc,
             }

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -17,7 +17,7 @@ import aiohttp
 from areal.infra.utils.concurrent import get_executor, run_async_task
 from areal.infra.utils.http import create_httpx_client
 from areal.utils import logging
-from areal.utils.network import format_hostport
+from areal.utils.network import format_hostport, gethostip
 
 if TYPE_CHECKING:
     from areal.api import ParallelStrategy, TrainEngine
@@ -955,13 +955,18 @@ class GatewayTrainController:
 
         self.rollout = rollout
 
-        if meta.type != "awex":
+        if meta.type not in ("awex", "disk"):
             raise ValueError(
-                f"GatewayTrainController only supports 'awex' weight updates, got '{meta.type}'"
+                f"GatewayTrainController supports 'awex' or 'disk' weight "
+                f"updates, got '{meta.type}'"
             )
 
         ctrl = WeightUpdateController(
             WeightUpdateControllerConfig(
+                # Bind gateway to this node's outbound IP so cross-host
+                # train/inf workers can reach the kv_store_url the gateway
+                # publishes. Default "127.0.0.1" only works single-machine.
+                host=gethostip(),
                 admin_api_key=self.config.admin_api_key,
                 log_level=self.config.log_level,
             )
@@ -969,29 +974,39 @@ class GatewayTrainController:
         ctrl.initialize()
 
         inference_urls: list[str] = rollout.inference_worker_urls
-
-        # NCCL rendezvous master must live on the rank-0 process's node.
-        # awex assigns rank 0 to inference[0], so allocate on the inference
-        # rank-0 guard rather than a train guard.
-        inf_guard_addrs = rollout.inference_guard_addrs
-        resp = requests.post(
-            f"{inf_guard_addrs[0]}/alloc_ports",
-            json={"count": 1},
-            timeout=30,
-        )
-        resp.raise_for_status()
-        port_data = resp.json()
-        nccl_master_addr = port_data["host"]
-        nccl_master_port = port_data["ports"][0]
-
         pair_name = f"{self._role}-rollout"
-        ctrl.connect(
-            pair_name=pair_name,
-            train_worker_urls=self._worker_addrs,
-            inference_worker_urls=inference_urls,
-            nccl_master_addr=nccl_master_addr,
-            nccl_master_port=nccl_master_port,
-        )
+
+        if meta.type == "awex":
+            # NCCL rendezvous master must live on the rank-0 process's node.
+            # awex assigns rank 0 to inference[0], so allocate on the inference
+            # rank-0 guard rather than a train guard.
+            inf_guard_addrs = rollout.inference_guard_addrs
+            resp = requests.post(
+                f"{inf_guard_addrs[0]}/alloc_ports",
+                json={"count": 1},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            port_data = resp.json()
+            ctrl.connect(
+                pair_name=pair_name,
+                train_worker_urls=self._worker_addrs,
+                inference_worker_urls=inference_urls,
+                mode="awex",
+                nccl_master_addr=port_data["host"],
+                nccl_master_port=port_data["ports"][0],
+            )
+        else:  # disk
+            ctrl.connect(
+                pair_name=pair_name,
+                train_worker_urls=self._worker_addrs,
+                inference_worker_urls=inference_urls,
+                mode="disk",
+                save_path=meta.path or "",
+                use_lora=meta.use_lora,
+                lora_name=meta.lora_name,
+                lora_keep_versions=meta.lora_keep_versions,
+            )
         self._weight_update_ctrl = ctrl
         logger.info(
             "WeightUpdateController connected (pair=%s, train=%d, inf=%d)",

--- a/areal/v2/weight_update/controller/controller.py
+++ b/areal/v2/weight_update/controller/controller.py
@@ -112,6 +112,7 @@ class WeightUpdateController:
         save_path: str = "",
         use_lora: bool = False,
         lora_name: str = "",
+        lora_keep_versions: int = 0,
         colocate: bool = False,
         nccl_master_addr: str = "",
         nccl_master_port: int = 0,
@@ -125,6 +126,7 @@ class WeightUpdateController:
             "save_path": save_path,
             "use_lora": use_lora,
             "lora_name": lora_name,
+            "lora_keep_versions": lora_keep_versions,
             "colocate": colocate,
             "nccl_master_addr": nccl_master_addr,
             "nccl_master_port": nccl_master_port,
@@ -136,7 +138,11 @@ class WeightUpdateController:
         )
         resp.raise_for_status()
         logger.info(
-            "Connected pair '%s' (mode=%s, colocate=%s)", pair_name, mode, colocate
+            "Connected pair '%s' (mode=%s, colocate=%s, use_lora=%s)",
+            pair_name,
+            mode,
+            colocate,
+            use_lora,
         )
 
     def update_weights(self, version: int) -> WeightUpdateResult:

--- a/areal/v2/weight_update/gateway/app.py
+++ b/areal/v2/weight_update/gateway/app.py
@@ -38,6 +38,7 @@ class ConnectRequest(BaseModel):
     save_path: str = ""
     use_lora: bool = False
     lora_name: str = ""
+    lora_keep_versions: int = 0
     colocate: bool = False
 
 
@@ -229,12 +230,34 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                 save_path=body.save_path,
                 use_lora=body.use_lora,
                 lora_name=body.lora_name,
+                lora_keep_versions=body.lora_keep_versions,
             )
             registry.register(pair_info)
             logger.info(
-                "Connected disk pair '%s' (save_path=%s)", pair_name, body.save_path
+                "Connected disk pair '%s' (save_path=%s, use_lora=%s, "
+                "lora_keep_versions=%d)",
+                pair_name,
+                body.save_path,
+                body.use_lora,
+                body.lora_keep_versions,
             )
             return ConnectResponse(pair_name=pair_name)
+
+        # awex mode -- LoRA is unsupported because the NCCL P2P transfer plan
+        # assumes train/infer parameter names match the HF layout, but PEFT
+        # exposes ``base_model.model.*.{base_layer,lora_A,lora_B}.weight`` on
+        # the train side. Fail fast with an actionable error rather than
+        # bubbling up a cryptic TransferPlanBuilder key-mismatch at init.
+        if body.use_lora:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": (
+                        "awex weight update does not support LoRA; set "
+                        "actor.weight_update_mode=disk in your config."
+                    )
+                },
+            )
 
         session = request.app.state.http_session
         init_timeout_s = config.init_timeout_s
@@ -633,6 +656,35 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
                     for url in pair_info.inference_worker_urls
                 ]
             )
+            # Unload the version that fell outside the retention window so
+            # sglang does not accumulate one adapter per train step (leaks
+            # VRAM and eventually hangs). Best-effort: the stale adapter may
+            # already have been evicted or never loaded on this worker.
+            keep = pair_info.lora_keep_versions
+            if keep > 0 and version - keep >= 0:
+                stale_name = get_versioned_lora_name(
+                    pair_info.lora_name, version - keep
+                )
+
+                async def _unload(url: str) -> None:
+                    try:
+                        await _post_json(
+                            session,
+                            f"{url}/unload_lora_adapter",
+                            timeout_s,
+                            json_data={"lora_name": stale_name},
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "unload_lora_adapter(%s) on %s failed (best-effort): %s",
+                            stale_name,
+                            url,
+                            e,
+                        )
+
+                await asyncio.gather(
+                    *[_unload(url) for url in pair_info.inference_worker_urls]
+                )
         else:
             await asyncio.gather(
                 *[

--- a/areal/v2/weight_update/gateway/config.py
+++ b/areal/v2/weight_update/gateway/config.py
@@ -59,6 +59,10 @@ class PairInfo:
     save_path: str = ""
     use_lora: bool = False
     lora_name: str = ""
+    # Number of recent LoRA adapter versions to keep loaded on each inference
+    # worker. Older versions are unloaded after a successful load_lora_adapter
+    # to bound VRAM and avoid the adapter-accumulation hang. 0 disables cleanup.
+    lora_keep_versions: int = 0
 
     # Colocated mode (training and inference share GPUs)
     colocate: bool = False


### PR DESCRIPTION
## Description

Enable LoRA RL training under `actor._version=v2` / `rollout._version=v2`.Today, the v2 controller short-circuits all weight updates onto the awex NCCL P2P path
LoRA can only travel over disk + `load_lora_adapter`. This PR wires the existing v2 gateway disk branch end-to-end:

- `rl_trainer.py`: when `_version=v2`, route LoRA to `WeightUpdateMeta.from_disk` and non-LoRA to `from_awex`. v1 still dispatches via `weight_update_mode` unchanged.
- `GatewayTrainController.connect_engine`: accept `meta.type in {awex, disk}`; forward `mode/save_path/use_lora/lora_name/lora_keep_versions` to the gateway; skip the NCCL master port allocation on the disk path.
- `WeightUpdateController.connect`: pass `lora_keep_versions` through to the gateway payload.
- Gateway `PairInfo` / `ConnectRequest`: add `lora_keep_versions`.
- Gateway disk transfer: after each `/load_lora_adapter`, dispatch a best-effort parallel `/unload_lora_adapter` for the version that falls outside the retention window. Prevents adapter accumulation (which leaks SGLang VRAM and eventually hangs).
- Gateway awex branch: reject `use_lora=True` with HTTP 400 pointing at `weight_update_mode=disk`, replacing the cryptic `TransferPlanBuilder` mismatch

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have run formatting tools (pre-commit or manual)
- [ ] I have run relevant unit tests and they pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed
- [x] My branch is up to date with main
- [ ] This PR introduces breaking changes (if yes, fill out details below)
- [ ] If this PR changes documentation, I have built and previewed it locally with `jb build docs`
- [ ] No critical issues raised by AI reviewers (`/gemini review`)

**Breaking Change Details (if applicable):**

N/A


Files changed:
- `areal/trainer/rl_trainer.py`: route v2 LoRA to disk, non-LoRA to awex.
- `areal/v2/training_service/controller/controller.py`: per-mode `ctrl.connect`; `host=gethostip()`.
- `areal/v2/weight_update/controller/controller.py`: forward `lora_keep_versions`.
- `areal/v2/weight_update/gateway/config.py`: add `lora_keep_versions` to `PairInfo`.
- `areal/v2/weight_update/gateway/app.py`: `ConnectRequest` field; awex+LoRA fail-fast; best-effort `unload_lora_adapter` after `load_lora_adapter`.