### PR TITLE
feat(ppo): add reuse_train_logp proximal logp method

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1613,7 +1613,9 @@ class PPOActorConfig(TrainEngineConfig):
             "Only effective when use_decoupled_loss=True. Options: "
             "'recompute' (default): Standard decoupled PPO, recompute proximal policy via forward pass. "
             "'loglinear': Use log-linear interpolation to approximate proximal policy (skip forward pass). "
-            "'metrics': Like 'recompute', but also compute approximation metrics for evaluation.",
+            "'metrics': Like 'recompute', but also compute approximation metrics for evaluation. "
+            "'reuse_train_logp': Reuse training forward-pass logprobs as the proximal "
+            "logp (skip the extra forward; requires ppo_n_minibatches=1).",
             "choices": PROX_LOGP_METHODS_ALL,
         },
     )
@@ -1648,6 +1650,18 @@ class PPOActorConfig(TrainEngineConfig):
 
     def __post_init__(self):
         """Validate PPO actor configuration."""
+        from areal.utils.constants import ProxLogpMethod
+
+        if (
+            ProxLogpMethod(self.prox_logp_method) == ProxLogpMethod.REUSE_TRAIN_LOGP
+            and self.ppo_n_minibatches > 1
+        ):
+            raise ValueError(
+                "prox_logp_method='reuse_train_logp' requires ppo_n_minibatches=1. "
+                f"Got ppo_n_minibatches={self.ppo_n_minibatches}. "
+                "With multiple minibatches, weights change between steps, "
+                "so training forward logprobs differ from the original policy."
+            )
         # Warn if rejection_sampling is configured but use_decoupled_loss is False
         if not self.use_decoupled_loss and self.rejection_sampling is not None:
             logger.warning(

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -436,6 +436,9 @@ def grpo_loss_fn(
 
     entropy = entropy.detach()
 
+    if ProxLogpMethod(prox_logp_method) == ProxLogpMethod.REUSE_TRAIN_LOGP:
+        prox_logp_gt = logprobs.detach()
+
     # Resolve proximal log-probabilities based on method
     prox_logp = _resolve_proximal_logp(
         prox_logp_gt=prox_logp_gt,

--- a/areal/utils/constants.py
+++ b/areal/utils/constants.py
@@ -40,15 +40,19 @@ class ProxLogpMethod(str, Enum):
         RECOMPUTE: Standard decoupled PPO - recompute via forward pass.
         LOGLINEAR: Use log-linear approximation (skip forward pass).
         METRICS: Recompute + compute approximation metrics for evaluation.
+        REUSE_TRAIN_LOGP: Reuse training forward-pass logprobs as the proximal
+            logp. Requires ppo_n_minibatches == 1 so the training forward sees
+            the unchanged policy.
     """
 
     RECOMPUTE = "recompute"
     LOGLINEAR = "loglinear"
     METRICS = "metrics"
+    REUSE_TRAIN_LOGP = "reuse_train_logp"
 
     def skips_forward_pass(self) -> bool:
         """Return True if this method skips the forward pass (optimization enabled)."""
-        return self == ProxLogpMethod.LOGLINEAR
+        return self in (ProxLogpMethod.LOGLINEAR, ProxLogpMethod.REUSE_TRAIN_LOGP)
 
 
 class ProxApproxMethod(str, Enum):
@@ -74,6 +78,7 @@ class ProxApproxMethod(str, Enum):
 PROX_LOGP_METHOD_RECOMPUTE = ProxLogpMethod.RECOMPUTE.value
 PROX_LOGP_METHOD_LOGLINEAR = ProxLogpMethod.LOGLINEAR.value
 PROX_LOGP_METHOD_METRICS = ProxLogpMethod.METRICS.value
+PROX_LOGP_METHOD_REUSE_TRAIN_LOGP = ProxLogpMethod.REUSE_TRAIN_LOGP.value
 
 # List of all valid prox_logp_method values for configuration
 PROX_LOGP_METHODS_ALL = [m.value for m in ProxLogpMethod]

--- a/tests/test_reuse_train_logp.py
+++ b/tests/test_reuse_train_logp.py
@@ -1,0 +1,58 @@
+"""Tests for the ``reuse_train_logp`` proximal-logp method.
+
+``reuse_train_logp`` reuses the training forward-pass logprobs as the proximal
+logp, skipping the extra decoupled-PPO forward. It requires
+``ppo_n_minibatches == 1`` so the training forward still reflects the policy
+that produced the rollout (with multiple minibatches the weights change between
+steps, so the reused logprobs would no longer be the proximal policy).
+"""
+
+import pytest
+
+from areal.api.cli_args import PPOActorConfig
+from areal.utils.constants import (
+    PROX_LOGP_METHOD_REUSE_TRAIN_LOGP,
+    PROX_LOGP_METHODS_ALL,
+    ProxLogpMethod,
+)
+
+
+def test_enum_includes_reuse_train_logp():
+    assert ProxLogpMethod.REUSE_TRAIN_LOGP.value == "reuse_train_logp"
+    assert ProxLogpMethod("reuse_train_logp") is ProxLogpMethod.REUSE_TRAIN_LOGP
+    assert "reuse_train_logp" in PROX_LOGP_METHODS_ALL
+    assert PROX_LOGP_METHOD_REUSE_TRAIN_LOGP == "reuse_train_logp"
+
+
+def test_reuse_train_logp_skips_forward_pass():
+    # It must skip the extra proximal forward, like loglinear does.
+    assert ProxLogpMethod.REUSE_TRAIN_LOGP.skips_forward_pass()
+
+
+def test_reuse_train_logp_allows_single_minibatch():
+    config = PPOActorConfig(
+        backend="fsdp:d1",
+        prox_logp_method="reuse_train_logp",
+        ppo_n_minibatches=1,
+    )
+    assert config.prox_logp_method == "reuse_train_logp"
+    assert config.ppo_n_minibatches == 1
+
+
+def test_reuse_train_logp_rejects_multiple_minibatches():
+    with pytest.raises(ValueError, match="ppo_n_minibatches=1"):
+        PPOActorConfig(
+            backend="fsdp:d1",
+            prox_logp_method="reuse_train_logp",
+            ppo_n_minibatches=2,
+        )
+
+
+def test_other_methods_unaffected_by_minibatch_count():
+    # The constraint only applies to reuse_train_logp.
+    config = PPOActorConfig(
+        backend="fsdp:d1",
+        prox_logp_method="recompute",
+        ppo_n_minibatches=4,
+    )
+    assert config.ppo_n_minibatches == 4


### PR DESCRIPTION
## Summary

Adds a `reuse_train_logp` option to `prox_logp_method` for decoupled PPO. It reuses the training forward-pass logprobs (detached) as the proximal logp, skipping the extra proximal forward pass and its memory/compute cost.

## Details

- `areal/utils/constants.py`: new `ProxLogpMethod.REUSE_TRAIN_LOGP`; `skips_forward_pass()` returns `True` for it (like `loglinear`).
- `areal/trainer/ppo/actor.py`: in `grpo_loss_fn`, when the method is `reuse_train_logp`, set `prox_logp_gt = logprobs.detach()` before resolving the proximal logp.
- `areal/api/cli_args.py`: add it to the `prox_logp_method` choices and validate in `PPOActorConfig.__post_init__`.

## Constraint

Only valid with `ppo_n_minibatches=1`: with a single minibatch the training forward still reflects the policy that generated the rollout, so its logprobs equal the proximal policy. With multiple minibatches the weights change between steps, so the config validation rejects that combination with a clear error.

## Tests

`tests/test_reuse_train_logp.py`:
- enum / constant wiring (`REUSE_TRAIN_LOGP`, `PROX_LOGP_METHODS_ALL`)
- `skips_forward_pass()` is `True`
- `ppo_n_minibatches=1` is accepted
- `ppo_n_minibatches=2` raises `ValueError`
- other methods are unaffected by the minibatch count

All pass.