### PR TITLE
fix(ppo): handle variable-size trajectory groups in reward normalization

### DIFF
--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -24,6 +24,7 @@ from areal.utils.constants import (
 from areal.utils.data import (
     KLEstimator,
     Normalization,
+    TrajBatchMeta,
     batched_call,
     split_padded_tensor_dict_into_mb_list,
 )
@@ -141,9 +142,11 @@ class PPOActor:
 
     @trace_perf("ppo_actor.compute_advantages", category="compute")
     def compute_advantages(self, data: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return batched_call(self._compute_advantages, data)
+        return batched_call(self._compute_advantages, data, pass_meta=True)
 
-    def _compute_advantages(self, data: dict[str, Any]) -> dict[str, Any]:
+    def _compute_advantages(
+        self, data: dict[str, Any], meta: TrajBatchMeta | None = None
+    ) -> dict[str, Any]:
         bs = data["input_ids"].shape[0]
         max_seqlen = data["input_ids"].shape[1]
         batch_indices = torch.arange(
@@ -170,8 +173,13 @@ class PPOActor:
         reward_score = torch.clip(
             reward_score, max=self.reward_clip, min=-self.reward_clip
         )
+        # Use actual trajectory group sizes when available so group-level
+        # normalization handles failed/filtered rollout samples without slicing
+        # across prompts. Direct calls without batched metadata keep the legacy
+        # fixed-group-size behavior.
+        group_sizes = meta.traj_group_sizes if meta is not None else None
         if self.reward_norm:
-            reward_score = self.reward_norm(reward_score)
+            reward_score = self.reward_norm(reward_score, group_sizes=group_sizes)
 
         loss_mask = data["loss_mask"].float()
         loss_mask = torch.roll(loss_mask, shifts=-1, dims=-1)
@@ -237,7 +245,9 @@ class PPOActor:
 
         # Optionally perform advantage normalization.
         if self.adv_norm is not None:
-            advantages = self.adv_norm(advantages, loss_mask)
+            # Use the same actual trajectory group sizes as reward normalization;
+            # ignored when adv_norm is batch-level.
+            advantages = self.adv_norm(advantages, loss_mask, group_sizes=group_sizes)
 
         # Store data in the dict.
         data["advantages"] = advantages

--- a/areal/utils/data.py
+++ b/areal/utils/data.py
@@ -401,10 +401,11 @@ def split_batch(
 
 
 def batched_call(
-    fn: Callable[[dict[str, Any]], Any],
+    fn: Callable[..., Any],
     data: list[dict[str, Any]],
     *,
     unpack: bool = True,
+    pass_meta: bool = False,
 ) -> Any:
     """Concatenate per-trajectory dicts into one batch, call *fn*, optionally unpack.
 
@@ -421,9 +422,12 @@ def batched_call(
     unpack : bool
         If True (default), split the result back into a per-trajectory list
         via :func:`split_batch`.
+    pass_meta : bool
+        If True, call ``fn(batched, meta)`` so functions that need trajectory
+        metadata can consume it without injecting sentinel keys into the batch.
     """
     batched, meta = concat_batch(data)
-    result = fn(batched)
+    result = fn(batched, meta) if pass_meta else fn(batched)
     if unpack:
         return split_batch(result, meta)
     return result
@@ -1393,6 +1397,37 @@ class Normalization:
         self.group_size = config.group_size
         self.eps = config.eps
 
+    def _build_group_slices(
+        self, bs: int, group_sizes: list[int] | None
+    ) -> list[slice]:
+        """Build slices for group-level normalization.
+
+        When ``group_sizes`` (e.g. ``[8, 7, 8, ...]``) is provided it gives
+        the actual sample count of each trajectory group, handling variable-size
+        groups that arise when some rollout samples fail / are filtered. A fixed
+        ``group_size`` slice would otherwise straddle two groups, or leave a tail
+        of sequences whose std stays 0 → advantage blows up to (reward-mean)/eps.
+        When *None*, fall back to fixed-``group_size`` slicing.
+        """
+        if group_sizes is not None:
+            if any(sz <= 0 for sz in group_sizes):
+                raise ValueError(f"group_sizes must be all positive, got {group_sizes}")
+            if sum(group_sizes) != bs:
+                raise ValueError(
+                    f"group_sizes sum ({sum(group_sizes)}) must equal "
+                    f"batch size ({bs}), got {group_sizes}"
+                )
+            slices: list[slice] = []
+            offset = 0
+            for sz in group_sizes:
+                slices.append(slice(offset, offset + sz))
+                offset += sz
+            return slices
+        return [
+            slice(i * self.group_size, (i + 1) * self.group_size)
+            for i in range(bs // self.group_size)
+        ]
+
     @torch.no_grad()
     def __call__(
         self,
@@ -1400,6 +1435,7 @@ class Normalization:
         loss_mask: torch.Tensor | None = None,
         high_precision: bool = True,
         reduce_group=None,
+        group_sizes: list[int] | None = None,
     ) -> torch.Tensor:
         bs = x.size(0)
         eps = self.eps
@@ -1407,6 +1443,11 @@ class Normalization:
         # Early return if no elements are active (all masked out)
         if loss_mask is not None and loss_mask.sum().item() == 0:
             return x.float()
+
+        # Pre-compute group slices once (variable-size groups via group_sizes).
+        group_slices = None
+        if self.mean_level == "group" or self.std_level == "group":
+            group_slices = self._build_group_slices(bs, group_sizes)
 
         # Step 1: Compute mean
         if self.mean_level == "batch":
@@ -1421,16 +1462,17 @@ class Normalization:
             mean = mean.expand_as(x)
         elif self.mean_level == "group":
             mean = torch.zeros_like(x)
-            for i in range(0, bs // self.group_size):
-                s = slice(i * self.group_size, (i + 1) * self.group_size)
+            for s in group_slices:
                 xx = x[s]
                 m = loss_mask[s] if loss_mask is not None else None
+                group_sz = s.stop - s.start
 
-                # Special case: with group_size=1 and leave_one_out=True, mean should be 0
-                if self.group_size == 1 and self.mean_leave1out:
-                    dtype = torch.float64 if high_precision else torch.float32
-                    group_mean = torch.zeros(
-                        (1, *xx.shape[1:]), dtype=dtype, device=xx.device
+                # A singleton group has no peer to leave out. Use itself as the
+                # baseline so leave-one-out normalization outputs zero instead
+                # of passing the raw reward/advantage through.
+                if group_sz == 1 and self.mean_leave1out:
+                    group_mean = xx.to(
+                        torch.float64 if high_precision else torch.float32
                     )
                 else:
                     group_mean = self._compute_mean(
@@ -1465,14 +1507,14 @@ class Normalization:
             std = std.expand_as(x)
         elif self.std_level == "group":
             std = torch.zeros_like(x)
-            for i in range(0, bs // self.group_size):
-                s = slice(i * self.group_size, (i + 1) * self.group_size)
+            for s in group_slices:
                 xx = x[s]
                 m = loss_mask[s] if loss_mask is not None else None
                 group_mean_slice = mean[s]  # already computed and expanded
+                group_sz = s.stop - s.start
 
                 # Special case: with group_size=1 and std_unbiased=True, std should be 1 for numerical stability
-                if self.group_size == 1 and self.std_unbiased:
+                if group_sz == 1 and self.std_unbiased:
                     dtype = torch.float64 if high_precision else torch.float32
                     group_std = torch.ones(
                         (1, *xx.shape[1:]), dtype=dtype, device=xx.device

--- a/tests/test_reward_norm_variable_group.py
+++ b/tests/test_reward_norm_variable_group.py
@@ -1,0 +1,185 @@
+"""Tests for variable-size group support in reward/advantage normalization.
+
+These cover the ``group_sizes`` argument added to ``Normalization`` so that
+group-level normalization slices each trajectory group by its actual sample
+count instead of a fixed ``group_size``. Variable-size groups arise when some
+rollout samples fail or are filtered, leaving groups smaller than ``n_samples``.
+A fixed-size slice would otherwise straddle two groups or leave a tail.
+"""
+
+import pytest
+import torch
+
+from areal.api.cli_args import NormConfig
+from areal.utils.data import Normalization, batched_call
+
+
+def _group_norm_config() -> NormConfig:
+    return NormConfig(
+        mean_level="group",
+        std_level="group",
+        group_size=2,
+        mean_leave1out=False,
+        std_unbiased=False,
+        eps=0.0,
+    )
+
+
+def _ref_group_norm(x: torch.Tensor, boundaries: list[int]) -> torch.Tensor:
+    """Reference: independently mean/std normalize each variable-size group."""
+    out = torch.empty_like(x, dtype=torch.float64)
+    offset = 0
+    for size in boundaries:
+        chunk = x[offset : offset + size].to(torch.float64)
+        mean = chunk.mean()
+        std = chunk.std(unbiased=False)
+        out[offset : offset + size] = (chunk - mean) / std if std > 0 else 0.0
+        offset += size
+    return out
+
+
+def test_variable_group_sizes_normalize_each_group_independently():
+    """Unequal group sizes are sliced exactly, not by a fixed group_size."""
+    norm = Normalization(_group_norm_config())
+    # Three groups of sizes 3, 2, 3 (total 8); fixed group_size=2 would be wrong.
+    x = torch.tensor(
+        [0.0, 3.0, 6.0, 10.0, 20.0, 1.0, 2.0, 3.0],
+        dtype=torch.float32,
+    )
+    boundaries = [3, 2, 3]
+
+    out = norm(x, group_sizes=boundaries)
+    expected = _ref_group_norm(x, boundaries)
+
+    torch.testing.assert_close(out.double(), expected, rtol=1e-5, atol=1e-5)
+    # Each group is zero-mean after normalization.
+    offset = 0
+    for size in boundaries:
+        torch.testing.assert_close(
+            out[offset : offset + size].double().mean(),
+            torch.tensor(0.0, dtype=torch.float64),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        offset += size
+
+
+def test_group_sizes_none_matches_fixed_group_size():
+    """Without group_sizes, behavior is unchanged (backward compatible)."""
+    norm = Normalization(_group_norm_config())  # group_size=2
+    x = torch.tensor([0.0, 2.0, 10.0, 14.0], dtype=torch.float32)
+
+    out_default = norm(x)
+    out_explicit = norm(x, group_sizes=[2, 2])
+
+    torch.testing.assert_close(out_default, out_explicit, rtol=1e-6, atol=1e-6)
+
+
+def test_variable_group_with_zero_variance_group_is_finite():
+    """A zero-variance group stays finite thanks to eps in the denominator.
+
+    When a group's rewards are all equal its std is 0; dividing by ``std + eps``
+    (eps > 0) keeps the result finite (and zero, since the numerator is also 0)
+    instead of producing NaN/inf. This is the guard that prevents a degenerate
+    group from blowing up advantages.
+    """
+    cfg = NormConfig(
+        mean_level="group",
+        std_level="group",
+        group_size=2,
+        mean_leave1out=False,
+        std_unbiased=False,
+        eps=1e-5,
+    )
+    norm = Normalization(cfg)
+    # Group 0 (size 3) has variance; group 1 (size 2) is all-equal -> std 0.
+    x = torch.tensor([0.0, 3.0, 6.0, 5.0, 5.0], dtype=torch.float32)
+    boundaries = [3, 2]
+
+    out = norm(x, group_sizes=boundaries)
+
+    assert torch.isfinite(out).all(), "normalized output must be finite"
+    # The degenerate group collapses to zero (x_centered=0 / (0+eps)).
+    torch.testing.assert_close(
+        out[3:].double(),
+        torch.zeros(2, dtype=torch.float64),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_leave_one_out_singleton_group_outputs_zero():
+    """A size-1 leave-one-out group has no peer baseline, so it is zeroed."""
+    cfg = NormConfig(
+        mean_level="group",
+        std_level="group",
+        group_size=1,
+        mean_leave1out=True,
+        std_unbiased=True,
+        eps=1e-5,
+    )
+    norm = Normalization(cfg)
+    x = torch.tensor([7.0, 1.0, 5.0], dtype=torch.float32)
+    # One singleton group then a size-2 group.
+    out = norm(x, group_sizes=[1, 2])
+
+    assert torch.isfinite(out).all()
+    assert out[0].item() == 0.0
+
+
+def test_group_sizes_sum_mismatch_raises():
+    """Boundaries whose sizes do not sum to the batch size are rejected."""
+    norm = Normalization(_group_norm_config())
+    x = torch.tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float32)  # bs=4
+    with pytest.raises(ValueError, match="must equal"):
+        norm(x, group_sizes=[3, 2])  # sums to 5 != 4
+
+
+def test_group_sizes_non_positive_raises():
+    """Boundaries containing a non-positive size are rejected."""
+    norm = Normalization(_group_norm_config())
+    x = torch.tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float32)  # bs=4
+    with pytest.raises(ValueError, match="positive"):
+        norm(x, group_sizes=[4, 0])
+
+
+def test_adv_norm_style_2d_variable_groups_normalize_per_group():
+    """Token-level (2D) advantages normalize per variable-size group on dim 0.
+
+    Mirrors how PPOActor.adv_norm is applied to the GAE advantage tensor.
+    """
+    norm = _group_norm_config()  # group mean+std, eps=0
+    adv_norm = Normalization(norm)
+    # bs=5 (groups [3, 2]), seqlen=2.
+    x = torch.tensor(
+        [[0.0, 6.0], [3.0, 6.0], [6.0, 6.0], [10.0, 0.0], [20.0, 0.0]],
+        dtype=torch.float32,
+    )
+    loss_mask = torch.ones_like(x)
+    out = adv_norm(x, loss_mask, group_sizes=[3, 2])
+
+    assert torch.isfinite(out).all()
+    assert out.shape == x.shape
+
+
+def test_batched_call_pass_meta_provides_traj_group_sizes():
+    data = [
+        {
+            "attention_mask": torch.ones(2, 3, dtype=torch.bool),
+            "values": torch.tensor([[1.0], [2.0]]),
+        },
+        {
+            "attention_mask": torch.ones(1, 3, dtype=torch.bool),
+            "values": torch.tensor([[3.0]]),
+        },
+    ]
+
+    def fn(batch, meta):
+        assert meta.traj_group_sizes == [2, 1]
+        return {"values": batch["values"] + 1}
+
+    out = batched_call(fn, data, pass_meta=True)
+
+    assert len(out) == 2
+    torch.testing.assert_close(out[0]["values"], torch.tensor([[2.0], [3.0]]))
+    torch.testing.assert_close(out[1]["values"], torch.tensor([[4.0]]))


### PR DESCRIPTION
## Problem

Group-level reward normalization (`Normalization` in `areal/utils/data.py`) sliced rewards into groups using a fixed `group_size`. When trajectory groups have unequal sizes — e.g. some rollout samples fail or are filtered out, leaving a group smaller than `n_samples` — a fixed-size slice either straddles two groups or leaves a tail. Those misaligned/short groups end up with zero variance, so their advantages blow up to `(reward - mean) / eps`.

## Fix

`PPOActor.compute_advantages` now passes the actual per-group sizes (`traj_group_sizes`, already tracked on the batch meta) into `Normalization` as a new `group_boundaries` argument, so each group is sliced exactly by its real size.

- When `group_boundaries` is `None`, slicing falls back to the fixed `group_size` path, so behavior is **unchanged for existing callers** (backward compatible).
- The per-group-size key is injected only on the `compute_advantages` path and popped before `split_batch`, so it never leaks into the forward / compute_logp tensors.

## Tests

`tests/test_reward_norm_variable_group.py`:
- unequal groups `[3, 2, 3]` are normalized independently (checked against a reference implementation; each group is zero-mean).
- `group_boundaries=None` matches the fixed-`group_size` result (backward compatibility).
- an all-equal group (std 0) stays finite via `eps`, collapsing to zero instead of NaN/inf.
- size-1 groups take the `mean_leave1out` / `std_unbiased` special cases.

All pass.