### PR TITLE
feat(swe): add SWE-bench RL training workflow

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -921,6 +921,44 @@ class MegatronEngineConfig:
         default=False,
         metadata={"help": "Fuse token rearrangement ops during token dispatching."},
     )
+    moe_router_fusion: bool = field(
+        default=False,
+        metadata={
+            "help": "Enable fusion for MoE TopK routing and aux-loss computation. "
+            "Requires TransformerEngine >= 2.7.0.",
+        },
+    )
+    moe_router_bias_update_rate: float = field(
+        default=1e-3,
+        metadata={
+            "help": "Update rate for auxiliary-loss-free MoE load balancing "
+            "(DeepSeek V3 style). Controls how fast expert_bias adjusts. "
+            "Default 1e-3 matches DeepSeek V3. Set 0.0 to disable.",
+        },
+    )
+    moe_z_loss_coeff: float | None = field(
+        default=None,
+        metadata={
+            "help": "Scaling coefficient for router z-loss. Complements "
+            "auxiliary-loss-free load balancing for router stability. A starting "
+            "value of 1e-3 is recommended. None disables z-loss.",
+        },
+    )
+
+    # Precision & Loss
+    enable_fp32_lm_head: bool = field(
+        default=False,
+        metadata={
+            "help": "Cast lm_head output to FP32 before loss computation for "
+            "numerical stability."
+        },
+    )
+    cross_entropy_loss_fusion: bool = field(
+        default=False,
+        metadata={
+            "help": "Enable fused cross-entropy loss kernel for better performance."
+        },
+    )
 
     # FP8 Training Configuration
     fp8_config: FP8EngineConfig | None = None
@@ -2105,6 +2143,27 @@ class AgentConfig:
             "choices": ["individual", "concat"],
         },
     )
+    message_preprocessors: list[str] = field(
+        default_factory=list,
+        metadata={
+            "help": (
+                "List of message preprocessor class paths applied in order before "
+                "forwarding requests to the inference engine. Each entry is a dotted "
+                "import path to a callable class."
+            ),
+        },
+    )
+    prefix_matcher: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Dotted import path to a custom prefix matcher function for "
+                "InteractionCache parent-child matching. The function must accept "
+                "two list[dict] arguments (candidate prefix, full messages) and "
+                "return bool. When None, exact element-wise equality is used."
+            ),
+        },
+    )
     subproc_max_workers: int = field(
         default=4,
         metadata={
@@ -2890,6 +2949,17 @@ class BaseExperimentConfig:
     vllm: vLLMConfig = field(default_factory=vLLMConfig)
 
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
+
+    post_exit_hook: str = field(
+        default="",
+        metadata={
+            "help": "Shell command to run after the experiment exits (normal or abnormal). "
+            "Useful for cleaning up external resources (e.g., sandbox instances). "
+            "Runs after all jobs are stopped but before recovery. "
+            "The LOG_DIR environment variable is injected automatically. "
+            "Timeout: 600 seconds. Failures are logged but do not interrupt shutdown."
+        },
+    )
 
     def __post_init__(self):
         """Validate training configuration."""

--- a/areal/dataset/__init__.py
+++ b/areal/dataset/__init__.py
@@ -19,6 +19,7 @@ VALID_DATASETS = [
     "virl39k",
     "hh-rlhf",
     "torl_data",
+    "swe_sft",
 ]
 
 logger = logging.getLogger("Dataset")
@@ -127,6 +128,16 @@ def _get_custom_dataset(
         from .torl_data import get_torl_data_rl_dataset
 
         return get_torl_data_rl_dataset(
+            path=path,
+            split=split,
+            tokenizer=tokenizer,
+            max_length=max_length,
+            **kwargs,
+        )
+    elif "swe" in path.lower() and type == "sft":
+        from .swe_sft import get_swe_sft_dataset
+
+        return get_swe_sft_dataset(
             path=path,
             split=split,
             tokenizer=tokenizer,

--- a/areal/dataset/swe_sft.py
+++ b/areal/dataset/swe_sft.py
@@ -1,0 +1,2557 @@
+"""SWE SFT dataset loader.
+
+Loads SWE-bench trajectory data and converts it into progressive SFT
+training pairs.  Each trajectory is split at assistant-turn boundaries
+so that every pair ends with an assistant segment (assistant message +
+its subsequent tool responses).
+
+Example trajectory::
+
+    [system, user, asst1, tool1a, tool1b, asst2, tool2, asst3]
+
+Produces three pairs::
+
+    Pair 1: [system, user, asst1, tool1a, tool1b]
+    Pair 2: [system, user, asst1, tool1a, tool1b, asst2, tool2]
+    Pair 3: [system, user, asst1, tool1a, tool1b, asst2, tool2, asst3]
+
+In each pair, only the **last** assistant segment is trained (loss=1);
+earlier assistant turns are treated as context (loss=0).
+
+By default, pairs whose current segment contains a tool result with
+``is_error=True`` are discarded.  Set ``filter_errors=False`` to keep them.
+
+The file is organized into the following sections:
+
+1. **Constants & Infrastructure** — shared constants, distributed sync
+2. **Cleaning** — message content transforms (thinking tags, field cleanup)
+3. **Filters** — keep/discard predicates (error, empty, bare-text, truncation)
+4. **Splitting** — trajectory → progressive pairs (segment detection + split)
+5. **Tokenization** — template detection, render→tokenize→loss_mask, dump
+6. **Pipeline** — loading, processing, distributed cache, public API
+7. **CLI** — ``python -m areal.dataset.swe_sft`` entry point
+"""
+
+import json
+import os
+import random
+import re
+import time
+
+from datasets import Dataset
+
+from areal.utils import logging
+
+logger = logging.getLogger("SWESFTDataset")
+
+
+# ============================================================
+# 1. Constants & Infrastructure
+# ============================================================
+
+DATASET_NUM_PROC = 1
+
+# Timeout (seconds) for non-rank-0 workers waiting for rank 0 to finish
+# dataset processing.  Large datasets with tokenization can take minutes;
+# 30 min is a generous upper bound.
+_RANK0_CACHE_TIMEOUT = 36000
+_RANK0_CACHE_POLL_INTERVAL = 5
+
+
+def _wait_for_marker(marker_path: str):
+    """Block until *marker_path* exists on disk, with timeout."""
+    start = time.monotonic()
+    while not os.path.exists(marker_path):
+        elapsed = time.monotonic() - start
+        if elapsed > _RANK0_CACHE_TIMEOUT:
+            raise TimeoutError(
+                f"Waited {_RANK0_CACHE_TIMEOUT}s for rank 0 to finish dataset "
+                f"processing (marker: {marker_path}). Check rank 0 logs."
+            )
+        time.sleep(_RANK0_CACHE_POLL_INTERVAL)
+
+
+def _extract_messages(record, record_idx):
+    """Extract messages and tools from a parsed JSONL record.
+
+    Handles nested (``conversations`` wrapper) and flat formats.
+    Warns if multiple conversations are present.
+
+    Returns:
+        Tuple of ``(messages, record_tools)``.  *messages* may be empty.
+    """
+    convs = record.get("conversations", [])
+    if convs:
+        if len(convs) > 1:
+            logger.warning(
+                "Record %d has %d conversations, using only the last one.",
+                record_idx,
+                len(convs),
+            )
+        conv = convs[-1]
+        return conv.get("messages", []), conv.get("tools")
+    return record.get("messages", []), record.get("tools")
+
+
+def _set_messages(record, messages):
+    """Write *messages* back into *record* (inverse of ``_extract_messages``).
+
+    Used by the ``--save-trajectories`` CLI path to update truncated
+    messages in the original record structure before serialization.
+    """
+    convs = record.get("conversations", [])
+    if convs:
+        convs[-1]["messages"] = messages
+    else:
+        record["messages"] = messages
+
+
+def _iter_jsonl_records(path):
+    """Iterate trajectory JSONL records.
+
+    Yields ``(record_idx, messages, record_tools)`` tuples.  Handles
+    nested (``conversations`` wrapper) vs flat format auto-detection
+    via ``_extract_messages``.  Records with empty messages are skipped.
+
+    Warns about multi-user trajectories which break think-tag rendering
+    in templates with ``ns.last_query_index`` logic (e.g. Bailing).
+    """
+    record_idx = 0
+    n_multi_user = 0
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            record_idx += 1
+            messages, record_tools = _extract_messages(record, record_idx)
+            if not messages:
+                continue
+            n_user = sum(1 for m in messages if m.get("role") == "user")
+            if n_user > 1:
+                n_multi_user += 1
+                if n_multi_user <= 3:
+                    logger.warning(
+                        "Record %d has %d user messages. Templates with "
+                        "ns.last_query_index logic (e.g. Bailing) will NOT "
+                        "render <think> for assistant turns before the last "
+                        "user message. Consider filtering!",
+                        record_idx,
+                        n_user,
+                    )
+            yield record_idx, messages, record_tools
+    if n_multi_user > 0:
+        logger.warning(
+            "Total %d/%d records have multiple user messages. "
+            "These may produce no-think training signal.",
+            n_multi_user,
+            record_idx,
+        )
+
+
+# ============================================================
+# 2. Cleaning — message content transforms
+# ============================================================
+
+# Match reasoning blocks with any common tag variant:
+#   <think>...</think>      (Qwen standard)
+#   <thinking>...</thinking> (Claude)
+# The opening and closing tag names need not match exactly — mixed pairs
+# like ``<think>...</thinking>`` (seen in distillation data) are handled.
+_THINK_OPEN_RE = re.compile(r"<think(?:ing)?>")
+_THINK_CLOSE_RE = re.compile(r"</think(?:ing)?>")
+_THINK_RE = re.compile(r"<think(?:ing)?>(.*?)</think(?:ing)?>", re.DOTALL)
+
+
+def _normalize_thinking_tags(content):
+    """Normalise all thinking tag variants to ``<think>``/``</think>``.
+
+    Distillation data from different models may use ``<thinking>`` (Claude)
+    vs ``<think>`` (Qwen).  Non-standard variants are multi-token for the
+    Qwen tokenizer which breaks think/tool_call boundaries.
+    """
+    if not content:
+        return content
+    content = _THINK_OPEN_RE.sub("<think>", content)
+    content = _THINK_CLOSE_RE.sub("</think>", content)
+    return content
+
+
+def _extract_thinking(content):
+    """Strip thinking blocks from *content*.
+
+    Callers must run ``_normalize_thinking_tags`` first so that all
+    tag variants have been converted to ``<think>``/``</think>``.
+
+    Returns:
+        Cleaned content with thinking blocks removed, or the original
+        content unchanged if no thinking tags are found.
+    """
+    if not content:
+        return content
+    cleaned = _THINK_RE.sub("", content).strip()
+    return cleaned if cleaned != content.strip() else content
+
+
+def _clean_message(msg, strip_thinking=True, ensure_thinking=False):
+    """Remove non-standard fields before tokenization.
+
+    Keeps only the fields expected by tokenizer chat templates:
+    role, content, reasoning_content (for assistant), tool_calls
+    (for assistant), tool_call_id (for tool).
+
+    Handles thinking content in two representations:
+
+    - Inline ``<think>...</think>`` tags in ``content``
+    - Separate ``reasoning_content`` field (DeepSeek, Qwen3 API style)
+
+    If both are present, inline tags take priority and
+    ``reasoning_content`` is dropped with a warning to avoid double
+    thinking blocks in the rendered template.
+
+    Args:
+        msg: Raw message dict.
+        strip_thinking: If True, remove thinking from assistant messages
+            (both inline ``<think>`` tags and ``reasoning_content``).
+            Used for context turns.  If False, preserve thinking as-is
+            (used for the training-target assistant turn).
+        ensure_thinking: If True, inject inline ``<think>\n</think>``
+            on assistant turns that lack a thinking block (either
+            inline or in ``reasoning_content``).  Requires the
+            patched Bailing template (via
+            ``_patch_chat_template_for_training``) which detects
+            ``had_think_tags`` and preserves empty think blocks.
+    """
+    cleaned = {"role": msg["role"]}
+
+    # Handle content — some assistant messages have content=None when
+    # they only contain tool_calls.  Preserve None so chat templates
+    # that distinguish None vs "" render correctly.
+    content = msg.get("content")
+    # Some APIs (DeepSeek, Qwen3 with enable_thinking) return thinking
+    # in a separate ``reasoning_content`` field instead of inline
+    # ``<think>`` tags.  Handle both representations.
+    raw_reasoning = msg.get("reasoning_content") if msg["role"] == "assistant" else None
+    has_thinking = False
+    if content is not None:
+        if msg["role"] == "assistant":
+            content = _normalize_thinking_tags(content)
+            has_inline_thinking = bool(_THINK_RE.search(content))
+            if has_inline_thinking and raw_reasoning and raw_reasoning.strip():
+                # Conflict: both reasoning_content and inline <think> tags.
+                # Keep inline tags (they are already in the content the
+                # tokenizer will see) and drop reasoning_content to avoid
+                # double thinking blocks in the rendered template.
+                if not strip_thinking:
+                    logger.warning(
+                        "Message has both reasoning_content and inline "
+                        "<think> tags.  Keeping inline tags, dropping "
+                        "reasoning_content."
+                    )
+                raw_reasoning = None
+            elif not has_inline_thinking and raw_reasoning and raw_reasoning.strip():
+                # Convert reasoning_content → inline <think> in content.
+                # This ensures a single representation that templates
+                # render identically to the reasoning_content path, while
+                # being more transparent and debuggable.
+                if not strip_thinking:
+                    content = (
+                        f"<think>\n{raw_reasoning.strip(chr(10))}\n</think>"
+                        f"\n\n{content.lstrip(chr(10))}"
+                    )
+                    has_inline_thinking = True
+                raw_reasoning = None
+            has_thinking = has_inline_thinking or bool(
+                raw_reasoning and raw_reasoning.strip()
+            )
+            if strip_thinking:
+                content = _extract_thinking(content)
+        cleaned["content"] = content
+    elif msg["role"] == "assistant" and msg.get("tool_calls"):
+        # Assistant with tool_calls but content=None.
+        if raw_reasoning and raw_reasoning.strip():
+            has_thinking = True
+            if not strip_thinking:
+                # Convert reasoning_content → inline <think> in content.
+                cleaned["content"] = (
+                    f"<think>\n{raw_reasoning.strip(chr(10))}\n</think>"
+                )
+            else:
+                cleaned["content"] = None
+            raw_reasoning = None
+        else:
+            cleaned["content"] = None
+    else:
+        # Non-assistant messages without content: default to empty string.
+        cleaned["content"] = ""
+
+    # Preserve reasoning_content for target turns only when it was NOT
+    # already inlined above (i.e. only when raw_reasoning is still set).
+    if not strip_thinking and raw_reasoning is not None:
+        cleaned["reasoning_content"] = raw_reasoning
+
+    # For the target assistant turn without a thinking block, inject
+    # inline ``<think>\n</think>`` so that the (patched) template detects
+    # think intent via ``had_think_tags`` and renders
+    # ``<think>\n\n</think>\n\n`` — identical token output to the old
+    # ``reasoning_content='\n'`` approach.
+    #
+    # Requires ``_patch_chat_template_for_training`` to have been called
+    # on the tokenizer, otherwise the stock Bailing template will extract
+    # and discard the empty ``<think>`` block.
+    if ensure_thinking and msg["role"] == "assistant" and not has_thinking:
+        cur_content = cleaned.get("content")
+        if cur_content is None or cur_content == "":
+            cleaned["content"] = "<think>\n</think>"
+        else:
+            cleaned["content"] = f"<think>\n</think>\n\n{cur_content.lstrip(chr(10))}"
+
+    # Copy tool_calls for assistant messages
+    if msg["role"] == "assistant" and msg.get("tool_calls"):
+        cleaned_tool_calls = []
+        for tc in msg["tool_calls"]:
+            cleaned_tc = {
+                "type": tc.get("type", "function"),
+                "function": {
+                    "name": tc["function"]["name"],
+                    "arguments": json.dumps(tc["function"]["arguments"])
+                    if isinstance(tc["function"]["arguments"], dict)
+                    else tc["function"]["arguments"],
+                },
+            }
+            if "id" in tc:
+                cleaned_tc["id"] = tc["id"]
+            cleaned_tool_calls.append(cleaned_tc)
+        cleaned["tool_calls"] = cleaned_tool_calls
+
+    # Copy tool_call_id for tool messages
+    if msg["role"] == "tool" and msg.get("tool_call_id"):
+        cleaned["tool_call_id"] = msg["tool_call_id"]
+
+    return cleaned
+
+
+# ============================================================
+# 3. Filters — keep/discard predicates
+# ============================================================
+
+
+def _segment_has_error(messages, start, end):
+    """Check if any tool message in ``messages[start:end]`` has ``is_error=True``."""
+    for m in messages[start:end]:
+        if m.get("role") == "tool" and m.get("is_error") is True:
+            return True
+    return False
+
+
+def _is_empty_tool_call(msg):
+    """True if assistant *msg* has no text content and no reasoning but has tool_calls."""
+    content = msg.get("content") or ""
+    if content.strip() or not msg.get("tool_calls"):
+        return False
+    # If reasoning_content exists, the model did think — not a silent invocation.
+    reasoning = msg.get("reasoning_content")
+    if reasoning and reasoning.strip():
+        return False
+    return True
+
+
+def _is_bare_text_tool_call(msg):
+    """True if assistant *msg* has text without ``<think>`` tags and has tool_calls."""
+    content = msg.get("content") or ""
+    if not content.strip() or not msg.get("tool_calls"):
+        return False
+    # If reasoning_content exists, thinking is in a separate field — not bare text.
+    reasoning = msg.get("reasoning_content")
+    if reasoning and reasoning.strip():
+        return False
+    normalized = _THINK_OPEN_RE.sub("<think>", content)
+    normalized = _THINK_CLOSE_RE.sub("</think>", normalized)
+    match = _THINK_RE.search(normalized)
+    return not (match and match.group(1).strip())
+
+
+def _msg_has_thinking(msg):
+    """True if assistant *msg* has thinking content (inline or reasoning_content)."""
+    if msg.get("role") != "assistant":
+        return False
+    content = msg.get("content") or ""
+    normalized = _THINK_OPEN_RE.sub("<think>", content)
+    normalized = _THINK_CLOSE_RE.sub("</think>", normalized)
+    if _THINK_RE.search(normalized):
+        return True
+    rc = msg.get("reasoning_content") or ""
+    return bool(rc.strip())
+
+
+def _truncate_at_task_notification(messages):
+    """Truncate messages when a ``<task-notification>`` follows a pure-text assistant.
+
+    Claude Code emits ``<task-notification>`` as a user message when a
+    background task (e.g. ``pip install``) completes.  If the model has
+    already produced a text-only summary (no tool_calls), the notification
+    and all subsequent messages are noise — the model just replies
+    "nothing to do".  Truncating here removes that noise.
+
+    Only triggers when the pattern is:
+        assistant (text, no tool_calls) → user (<task-notification>)
+
+    Returns:
+        Truncated message list (or the original list if no truncation needed).
+    """
+    for i, m in enumerate(messages):
+        if m.get("role") != "user":
+            continue
+        if "<task-notification>" not in (m.get("content") or ""):
+            continue
+        # Find preceding assistant
+        prev_asst = None
+        for j in range(i - 1, -1, -1):
+            if messages[j].get("role") == "assistant":
+                prev_asst = messages[j]
+                break
+        if prev_asst is None:
+            continue
+        content = prev_asst.get("content") or ""
+        if content.strip() and not prev_asst.get("tool_calls"):
+            # Truncate: keep everything up to (but not including) this user msg
+            return messages[:i]
+    return messages
+
+
+# ============================================================
+# 3b. Balancing — downsample non-thinking pairs
+# ============================================================
+
+
+def _classify_pair(pair):
+    """Classify a pair by its target assistant turn's content type.
+
+    Returns one of:
+        ``"thinking"`` — target has actual ``<think>`` content or
+            non-empty ``reasoning_content``.
+        ``"no_thinking_tool_call"`` — target has no thinking but has
+            ``tool_calls`` (the dominant category that causes distribution
+            skew).
+        ``"pure_text"`` — target has no thinking and no tool_calls
+            (typically the final summary turn in a trajectory).
+    """
+    target = pair[-1]
+    if target.get("role") != "assistant":
+        return "pure_text"
+
+    content = target.get("content") or ""
+    rc = target.get("reasoning_content") or ""
+    has_thinking = bool(_THINK_RE.search(content)) or bool(rc.strip())
+
+    if has_thinking:
+        return "thinking"
+    if target.get("tool_calls"):
+        return "no_thinking_tool_call"
+    return "pure_text"
+
+
+def _balance_thinking_pairs(pairs, max_no_thinking_ratio, seed=42, tools_list=None):
+    """Downsample non-thinking **tool-call** pairs to control balance.
+
+    Only ``no_thinking_tool_call`` pairs (no thinking but has tool_calls)
+    are subject to downsampling.  ``thinking`` pairs and ``pure_text``
+    pairs (the final summary turn, no thinking and no tool_calls) are
+    always kept — the latter are critical for the model to learn when
+    to stop calling tools and give a final answer.
+
+    Args:
+        pairs: List of progressive SFT pairs.
+        max_no_thinking_ratio: Maximum ratio of non-thinking tool-call
+            pairs to thinking pairs.  For example, ``1.0`` means at most
+            1:1, ``2.0`` means at most 2 non-thinking per 1 thinking pair.
+            ``None`` disables downsampling.
+        seed: Random seed for reproducible downsampling.
+
+    Returns:
+        Balanced list of pairs (order preserved, randomly sampled for
+        the downsampled category).
+    """
+    if max_no_thinking_ratio is None:
+        return pairs, tools_list
+
+    thinking = []
+    no_think_tc = []
+    pure_text = []
+    for i, pair in enumerate(pairs):
+        cat = _classify_pair(pair)
+        if cat == "thinking":
+            thinking.append(i)
+        elif cat == "no_thinking_tool_call":
+            no_think_tc.append(i)
+        else:
+            pure_text.append(i)
+
+    n_think = len(thinking)
+    n_no_think_tc = len(no_think_tc)
+    n_pure_text = len(pure_text)
+
+    if n_think == 0:
+        logger.warning(
+            "No thinking pairs found; skipping balance "
+            "(all %d pairs have empty thinking).",
+            n_no_think_tc + n_pure_text,
+        )
+        return pairs, tools_list
+
+    max_no_think_tc = int(n_think * max_no_thinking_ratio)
+    if n_no_think_tc <= max_no_think_tc:
+        logger.info(
+            "Thinking balance OK: %d thinking + %d no-think-tc + %d pure-text "
+            "(ratio %.1f <= %.1f), no downsampling needed.",
+            n_think,
+            n_no_think_tc,
+            n_pure_text,
+            n_no_think_tc / n_think,
+            max_no_thinking_ratio,
+        )
+        return pairs, tools_list
+
+    rng = random.Random(seed)
+    sampled_tc = set(rng.sample(no_think_tc, max_no_think_tc))
+    keep_indices = sorted(set(thinking) | sampled_tc | set(pure_text))
+    balanced = [pairs[i] for i in keep_indices]
+    balanced_tools = (
+        [tools_list[i] for i in keep_indices] if tools_list is not None else None
+    )
+
+    logger.info(
+        "Balanced thinking pairs: %d thinking + %d no-think-tc "
+        "(downsampled from %d, ratio %.1f → %.1f) + %d pure-text (kept all).",
+        n_think,
+        max_no_think_tc,
+        n_no_think_tc,
+        n_no_think_tc / n_think,
+        max_no_thinking_ratio,
+        n_pure_text,
+    )
+    return balanced, balanced_tools
+
+
+# ============================================================
+# 3c. Thinking augmentation stats
+# ============================================================
+
+
+def _log_thinking_augmentation_stats(
+    n_variants,
+    prob,
+    n_total_trajs,
+    thinking_turns_per_traj,
+    total_asst_turns_per_traj,
+    patterns_per_traj,
+):
+    """Log adaptive-thinking augmentation quality metrics.
+
+    Called after the augmentation loop in loaders to report how well
+    the ``n_thinking_variants`` / ``random_strip_thinking_prob`` settings
+    produce diverse thinking-pattern variants.
+
+    Args:
+        n_variants: ``n_thinking_variants`` setting (K).
+        prob: ``random_strip_thinking_prob`` setting.
+        n_total_trajs: Total number of source trajectories processed.
+        thinking_turns_per_traj: List of N_thinking per source trajectory.
+        total_asst_turns_per_traj: List of N_total_asst per source trajectory.
+        patterns_per_traj: List of ``set[frozenset]`` — the unique strip
+            patterns generated for each source trajectory (including the
+            empty frozenset for the original unstripped variant).
+    """
+    n_eligible = sum(1 for n in thinking_turns_per_traj if n > 0)
+    total_thinking = sum(thinking_turns_per_traj)
+    total_asst = sum(total_asst_turns_per_traj)
+
+    # 1. Thinking Turn Coverage
+    avg_thinking = total_thinking / max(n_total_trajs, 1)
+    thinking_ratio = total_thinking / max(total_asst, 1)
+
+    # 2. Pattern Diversity
+    diversity_ratios = []
+    for n_think, patterns in zip(thinking_turns_per_traj, patterns_per_traj):
+        if n_think == 0:
+            continue
+        theoretical_max = min(n_variants, 2**n_think)
+        actual_unique = len(patterns)
+        diversity_ratios.append(actual_unique / theoretical_max)
+    avg_diversity = sum(diversity_ratios) / max(len(diversity_ratios), 1)
+
+    # 3. Augmentation Efficiency
+    n_non_trivial = 0
+    for patterns in patterns_per_traj:
+        # Count variants that differ from the original (non-empty strip set)
+        n_non_trivial += sum(1 for p in patterns if p)
+    expected_aug = (n_variants - 1) * max(n_eligible, 1)
+    efficiency = n_non_trivial / max(expected_aug, 1)
+
+    # 4. Total sample count
+    n_total_samples = sum(len(p) for p in patterns_per_traj)
+
+    logger.info(
+        f"Thinking augmentation stats (K={n_variants}, p={prob:.2f}):\n"
+        f"  Source trajectories: {n_total_trajs} "
+        f"({n_eligible} with thinking turns)\n"
+        f"  Thinking coverage: {avg_thinking:.1f} thinking turns/traj, "
+        f"{thinking_ratio:.1%} of all assistant turns\n"
+        f"  Pattern diversity: {avg_diversity:.2f} "
+        f"(1.0 = all variants unique)\n"
+        f"  Augmentation efficiency: {efficiency:.2f} "
+        f"({n_non_trivial}/{expected_aug} non-trivial variants)\n"
+        f"  Total samples after augmentation: {n_total_samples}"
+    )
+
+
+# ============================================================
+# 4. Splitting — trajectory → progressive pairs
+# ============================================================
+
+
+def _find_segments(messages):
+    """Find assistant+tools segment boundaries.
+
+    Returns:
+        List of ``(assistant_start_idx, segment_end_idx)`` tuples.
+    """
+    segments = []
+    i = 0
+    while i < len(messages):
+        if messages[i].get("role") == "assistant":
+            j = i + 1
+            while j < len(messages) and messages[j].get("role") == "tool":
+                j += 1
+            segments.append((i, j))
+            i = j
+        else:
+            i += 1
+    return segments
+
+
+def _split_and_filter(
+    messages,
+    filter_errors=True,
+    strip_all_thinking=False,
+    filter_empty_tool_calls=False,
+    filter_bare_text_tool_calls=False,
+    random_strip_thinking_prob=0.0,
+    rng=None,
+):
+    """Split trajectory into progressive pairs and optionally filter.
+
+    By default, thinking (``<think>...</think>``) is stripped from context
+    assistant turns only; the last assistant turn (training target) keeps
+    its content unchanged.  Set *strip_all_thinking* to strip from every
+    assistant turn including the target.
+
+    When *random_strip_thinking_prob* > 0, each target assistant turn that
+    has thinking content is independently stripped with that probability.
+    Stripped turns use the context-cleaned version (thinking fully removed,
+    no empty ``<think></think>`` injected).
+
+    Args:
+        messages: Raw trajectory messages.
+        filter_errors: If True (default), discard pairs whose current segment
+            contains a tool result with ``is_error=True``.  Set to False to
+            keep all pairs regardless of tool errors.
+        strip_all_thinking: If True, strip ``<think>`` blocks from every
+            assistant turn including the training target.
+        filter_empty_tool_calls: If True, discard pairs whose training-target
+            assistant turn has no text content but has tool_calls.
+        filter_bare_text_tool_calls: If True, discard pairs whose
+            training-target assistant turn has text content without
+            ``<think>`` tags and has tool_calls.
+        random_strip_thinking_prob: Probability of stripping thinking
+            from each target assistant turn.  0.0 = no stripping.
+        rng: ``random.Random`` instance for reproducible sampling.
+
+    Returns:
+        Tuple of ``(pairs, n_filtered_errors, n_filtered_empty_tc,
+        n_filtered_bare_tc, n_stripped)``.
+    """
+    segments = _find_segments(messages)
+    if not segments:
+        return [], 0, 0, 0, 0
+
+    pairs = []
+    n_filtered_errors = 0
+    n_filtered_empty_tc = 0
+    n_filtered_bare_tc = 0
+    n_stripped = 0
+
+    # Pre-clean all messages in context mode (thinking stripped).
+    # This avoids re-cleaning the same message for every progressive pair
+    # (O(N+K) instead of O(N*K) where K = number of segments).
+    context_cleaned = [_clean_message(m, strip_thinking=True) for m in messages]
+
+    # For target assistant turns, clean with thinking preserved (unless
+    # strip_all_thinking is set, in which case context_cleaned is reusable).
+    # When stripping is active (augmented variant), use ensure_thinking=False
+    # so empty-thinking turns don't get <think>\n</think> injected.
+    stripping_active = random_strip_thinking_prob > 0.0 and rng is not None
+    target_ensure = not stripping_active
+    target_cleaned = {}
+    if not strip_all_thinking:
+        for asst_start, _ in segments:
+            target_cleaned[asst_start] = _clean_message(
+                messages[asst_start],
+                strip_thinking=False,
+                ensure_thinking=target_ensure,
+            )
+
+    for asst_start, seg_end in segments:
+        # Check if current segment has any tool errors
+        if filter_errors and _segment_has_error(messages, asst_start, seg_end):
+            n_filtered_errors += 1
+            continue
+
+        # Content-type filters operate on the raw assistant message.
+        asst_msg = messages[asst_start]
+        if filter_empty_tool_calls and _is_empty_tool_call(asst_msg):
+            n_filtered_empty_tc += 1
+            continue
+        if filter_bare_text_tool_calls and _is_bare_text_tool_call(asst_msg):
+            n_filtered_bare_tc += 1
+            continue
+
+        # Build pair: include context up to the target assistant turn,
+        # truncating tool responses that follow it.  This ensures the
+        # target assistant is always the *last* message so that chat
+        # templates with ``loop.last``-dependent rendering (e.g. Qwen3
+        # ``<think>`` injection) behave consistently.  The tool responses
+        # would have loss_mask=0 anyway and only add noise.
+        pair = list(context_cleaned[: asst_start + 1])
+        if not strip_all_thinking:
+            # Randomly strip: leave context_cleaned version (thinking
+            # already removed) instead of replacing with target_cleaned.
+            should_strip = (
+                rng is not None
+                and _msg_has_thinking(messages[asst_start])
+                and rng.random() < random_strip_thinking_prob
+            )
+            if not should_strip:
+                pair[asst_start] = target_cleaned[asst_start]
+            else:
+                n_stripped += 1
+        pairs.append(pair)
+
+    return pairs, n_filtered_errors, n_filtered_empty_tc, n_filtered_bare_tc, n_stripped
+
+
+def _prepare_trajectory(
+    messages,
+    filter_errors=True,
+    filter_empty_tool_calls=False,
+    filter_bare_text_tool_calls=False,
+    random_strip_thinking_prob=0.0,
+    rng=None,
+):
+    """Prepare a full trajectory for trajectory-level training.
+
+    Cleans all messages preserving thinking for every assistant turn
+    (``strip_thinking=False``, ``ensure_thinking=True``).  Identifies
+    which assistant segments should be masked (``loss_mask=0``) based
+    on error tool responses, empty tool calls, or bare-text tool calls.
+
+    When *random_strip_thinking_prob* > 0, each assistant turn that has
+    thinking content is independently stripped with that probability.
+    Stripped turns have their ``<think>`` blocks and ``reasoning_content``
+    completely removed (no empty ``<think></think>`` injected).
+
+    Args:
+        messages: Raw trajectory messages.
+        filter_errors: If True (default), mask segments with error tool
+            responses.
+        filter_empty_tool_calls: If True, mask segments whose assistant
+            turn has no text content but has tool_calls.
+        filter_bare_text_tool_calls: If True, mask segments whose
+            assistant turn has text without ``<think>`` tags and has
+            tool_calls.
+        random_strip_thinking_prob: Probability of stripping thinking
+            from each assistant turn that has thinking content.
+            0.0 (default) = no stripping, 1.0 = strip all.
+        rng: ``random.Random`` instance for reproducible sampling.
+
+    Returns:
+        Tuple of ``(cleaned_messages, masked_segment_indices,
+        n_error, n_empty_tc, n_bare_tc, stripped_pattern)`` or ``None``
+        if the trajectory has no assistant turns.  *stripped_pattern* is
+        a ``frozenset`` of message indices whose thinking was stripped
+        (empty if no stripping occurred).
+    """
+    segments = _find_segments(messages)
+    if not segments:
+        return None
+
+    masked_indices = set()
+    n_error = 0
+    n_empty_tc = 0
+    n_bare_tc = 0
+    for idx, (asst_start, seg_end) in enumerate(segments):
+        if filter_errors and _segment_has_error(messages, asst_start, seg_end):
+            masked_indices.add(idx)
+            n_error += 1
+            continue
+        asst_msg = messages[asst_start]
+        if filter_empty_tool_calls and _is_empty_tool_call(asst_msg):
+            masked_indices.add(idx)
+            n_empty_tc += 1
+            continue
+        if filter_bare_text_tool_calls and _is_bare_text_tool_call(asst_msg):
+            masked_indices.add(idx)
+            n_bare_tc += 1
+
+    # Determine which assistant turns to randomly strip thinking from.
+    strip_thinking_indices = set()
+    stripping_active = random_strip_thinking_prob > 0.0 and rng is not None
+    if stripping_active:
+        for asst_start, _seg_end in segments:
+            if _msg_has_thinking(messages[asst_start]):
+                if rng.random() < random_strip_thinking_prob:
+                    strip_thinking_indices.add(asst_start)
+
+    # When stripping is active (augmented variant), use ensure_thinking=False
+    # for ALL turns so that empty-thinking turns don't get <think>\n</think>
+    # injected.  Only real thinking content is preserved.
+    # When stripping is inactive (variant 0 or no augmentation), keep
+    # ensure_thinking=True to match the standard training format.
+    default_ensure = not stripping_active
+
+    cleaned = []
+    for i, m in enumerate(messages):
+        if i in strip_thinking_indices:
+            cleaned.append(
+                _clean_message(m, strip_thinking=True, ensure_thinking=False)
+            )
+        else:
+            cleaned.append(
+                _clean_message(m, strip_thinking=False, ensure_thinking=default_ensure)
+            )
+
+    return (
+        cleaned,
+        sorted(masked_indices),
+        n_error,
+        n_empty_tc,
+        n_bare_tc,
+        frozenset(strip_thinking_indices),
+    )
+
+
+# ============================================================
+# 5. Tokenization — template detection, render, loss mask, dump
+# ============================================================
+
+
+# -- Chat template patch (runtime, no file modification) --------
+
+# Both Bailing and Qwen3 templates have ``ns.last_query_index`` logic
+# that prevents ``<think>`` rendering for assistant turns BEFORE the
+# last user message, AND discards inline empty ``<think>\n</think>``
+# extracted from content.
+#
+# This breaks trajectory-mode training:
+# - Multi-user trajectories: turns before the last user msg lack <think>
+# - Empty ensure_thinking via inline <think> gets stripped
+#
+# The patch below handles both Bailing (`<role>ASSISTANT</role>` style)
+# and Qwen3 (`<|im_start|>assistant` style) templates:
+# 1. Adds ``had_think_tags`` detection so empty ``<think>`` survives.
+# 2. Removes the ``ns.last_query_index`` gate so all assistant turns
+#    render ``<think>`` uniformly when think intent is detected.
+#
+# Applied at runtime via ``tokenizer.chat_template = patched`` — the
+# original template file on disk is never modified.
+
+_BAILING_OLD_BLOCK = (
+    "{%- if loop.index0 > ns.last_query_index %}\n"
+    "            {%- if reasoning_content != '' %}\n"
+    "                {{- '<role>ASSISTANT</role>\\n' + '<think>\\n'"
+    " + reasoning_content.strip('\\n') + '\\n</think>\\n\\n'"
+    " + content.lstrip('\\n') }}\n"
+    "            {%- else %}\n"
+    "                {{- '<role>ASSISTANT</role>\\n' + content }}\n"
+    "            {%- endif %}\n"
+    "        {%- else %}\n"
+    "            {{- '<role>ASSISTANT</role>\\n' + content }}\n"
+    "        {%- endif %}"
+)
+_BAILING_NEW_BLOCK = (
+    "{%- if reasoning_content != '' or had_think_tags %}\n"
+    "                {{- '<role>ASSISTANT</role>\\n' + '<think>\\n'"
+    " + reasoning_content.strip('\\n') + '\\n</think>\\n\\n'"
+    " + content.lstrip('\\n') }}\n"
+    "            {%- else %}\n"
+    "                {{- '<role>ASSISTANT</role>\\n' + content }}\n"
+    "            {%- endif %}"
+)
+
+# Qwen3 uses `loop.last or (not loop.last and reasoning_content)` so the
+# last turn always renders <think> even with empty reasoning.  We
+# preserve `loop.last` and add `had_think_tags` for inline-empty support.
+_QWEN3_OLD_BLOCK = (
+    "{%- if loop.index0 > ns.last_query_index %}\n"
+    "            {%- if loop.last or (not loop.last and reasoning_content) %}\n"
+    "                {{- '<|im_start|>' + message.role + '\\n<think>\\n'"
+    " + reasoning_content.strip('\\n') + '\\n</think>\\n\\n'"
+    " + content.lstrip('\\n') }}\n"
+    "            {%- else %}\n"
+    "                {{- '<|im_start|>' + message.role + '\\n' + content }}\n"
+    "            {%- endif %}\n"
+    "        {%- else %}\n"
+    "            {{- '<|im_start|>' + message.role + '\\n' + content }}\n"
+    "        {%- endif %}"
+)
+_QWEN3_NEW_BLOCK = (
+    "{%- if loop.last or reasoning_content != '' or had_think_tags %}\n"
+    "                {{- '<|im_start|>' + message.role + '\\n<think>\\n'"
+    " + reasoning_content.strip('\\n') + '\\n</think>\\n\\n'"
+    " + content.lstrip('\\n') }}\n"
+    "            {%- else %}\n"
+    "                {{- '<|im_start|>' + message.role + '\\n' + content }}\n"
+    "            {%- endif %}"
+)
+
+_OLD_DETECT = "{%- set reasoning_content = '' %}"
+_NEW_DETECT = (
+    "{%- set reasoning_content = '' %}\n"
+    "        {%- set had_think_tags = ('</think>' in content) %}"
+)
+
+
+def _patch_chat_template_for_training(tokenizer):
+    """Patch Bailing/Qwen3 chat templates to render ``<think>`` uniformly.
+
+    Detects template family by matching known render blocks:
+    - Bailing: ``<role>ASSISTANT</role>`` markers
+    - Qwen3: ``<|im_start|>assistant`` markers
+
+    Other templates (e.g. plain ChatML without ``last_query_index``)
+    are left unchanged.  If the template has ``last_query_index`` but
+    neither known block matches, logs a warning.
+    """
+    template = getattr(tokenizer, "chat_template", None)
+    if not template or "last_query_index" not in template:
+        return
+
+    if _BAILING_OLD_BLOCK in template:
+        family = "Bailing"
+        patched = template.replace(_BAILING_OLD_BLOCK, _BAILING_NEW_BLOCK)
+    elif _QWEN3_OLD_BLOCK in template:
+        family = "Qwen3"
+        patched = template.replace(_QWEN3_OLD_BLOCK, _QWEN3_NEW_BLOCK)
+    else:
+        logger.warning(
+            "Chat template has last_query_index but matches neither "
+            "Bailing nor Qwen3 render block. Patch skipped — empty "
+            "<think> may be discarded, multi-user turns may lack <think>."
+        )
+        return
+
+    patched = patched.replace(_OLD_DETECT, _NEW_DETECT)
+
+    tokenizer.chat_template = patched
+    logger.info(
+        f"Patched {family} chat template for training: removed "
+        "last_query_index gate, added had_think_tags detection."
+    )
+
+
+_TEMPLATE_PATTERNS = [
+    # ChatML (Qwen, etc.):  <|im_start|>assistant\n ... <|im_end|>
+    (r"<\|im_start\|>assistant\n", r"<\|im_end\|>"),
+    # Llama 3:  <|start_header_id|>assistant<|end_header_id|>\n\n ... <|eot_id|>
+    (r"<\|start_header_id\|>assistant<\|end_header_id\|>\n\n", r"<\|eot_id\|>"),
+    # GLM:  <|assistant|> ... (ends at next <|user|>, <|observation|>, or end of string)
+    (r"<\|assistant\|>", r"(?=<\|user\|>|<\|observation\|>|\Z)"),
+]
+
+
+def _parse_tool_call_arguments(messages):
+    """Parse JSON-string arguments in tool_calls to dicts.
+
+    OpenAI returns tool_call arguments as JSON strings, but some chat
+    templates (e.g. GLM-4.x / GLM-5.x) expect parsed dicts. Most other
+    templates (Qwen / ChatML, Llama 3, Bailing, ...) accept the standard
+    OpenAI string form, so this conversion must be opt-in.
+    """
+    patched = []
+    for m in messages:
+        tool_calls = m.get("tool_calls")
+        if not tool_calls:
+            patched.append(m)
+            continue
+        new_tcs = []
+        for tc in tool_calls:
+            fn = tc.get("function", tc)
+            args = fn.get("arguments")
+            if isinstance(args, str):
+                try:
+                    parsed = json.loads(args)
+                except (json.JSONDecodeError, TypeError):
+                    parsed = args
+                fn = {**fn, "arguments": parsed}
+                tc = {**tc, "function": fn} if "function" in tc else fn
+            new_tcs.append(tc)
+        patched.append({**m, "tool_calls": new_tcs})
+    return patched
+
+
+def _render_tokenize_mask(
+    messages,
+    tokenizer,
+    assistant_pattern,
+    tools=None,
+    *,
+    split_mode="pair",
+    error_indices=None,
+    parse_tool_call_args=False,
+):
+    """Render, tokenize, and build loss_mask for a message list.
+
+    In **pair mode** (default), only the **last** assistant turn gets
+    ``loss_mask=1``.  In **trajectory mode**, **all** assistant turns
+    get ``loss_mask=1`` except those at indices in *error_indices*.
+
+    When *parse_tool_call_args* is True, JSON-string ``tool_calls`` arguments
+    are converted to dicts before rendering (required by GLM chat templates;
+    other templates such as Qwen / Llama / Bailing must keep the OpenAI
+    string form).
+
+    Returns:
+        Tuple of ``(full_text, input_ids, loss_mask, offset_mapping)``, or
+        ``None`` if ``apply_chat_template`` fails.
+    """
+    # 1) Render the full template text.
+    try:
+        kwargs = {"tokenize": False}
+        if tools is not None:
+            kwargs["tools"] = tools
+        if parse_tool_call_args:
+            messages = _parse_tool_call_arguments(messages)
+        full_text = tokenizer.apply_chat_template(messages, **kwargs)
+    except Exception as e:
+        logger.warning(
+            "apply_chat_template failed: %s. Skipping sample.",
+            e,
+        )
+        return None
+
+    # 2) Tokenize with offset mapping so we can map char→token.
+    encoding = tokenizer(
+        full_text, add_special_tokens=False, return_offsets_mapping=True
+    )
+    input_ids = encoding["input_ids"]
+    offset_mapping = encoding["offset_mapping"]
+
+    # 3) Build loss_mask.
+    loss_mask = [0] * len(input_ids)
+
+    if split_mode == "trajectory":
+        # Trajectory mode: mask ALL assistant segments, skip error_indices.
+        skip = set(error_indices) if error_indices else set()
+        matches = list(assistant_pattern.finditer(full_text))
+
+        # Verify regex matches correspond 1:1 to assistant messages.
+        n_asst = sum(1 for m in messages if m.get("role") == "assistant")
+        if len(matches) != n_asst:
+            logger.warning(
+                "Segment count mismatch: %d assistant messages but %d regex "
+                "matches in rendered text. Training all matched segments "
+                "(error masking disabled for this sample).",
+                n_asst,
+                len(matches),
+            )
+            skip = set()
+
+        for seg_idx, m in enumerate(matches):
+            if seg_idx in skip:
+                continue
+            rs, re_ = m.start(1), m.end(0)
+            for tok_idx, (cs, ce) in enumerate(offset_mapping):
+                if ce > rs and cs < re_:
+                    loss_mask[tok_idx] = 1
+    else:
+        # Pair mode: mask only the LAST assistant segment.
+        last_match = None
+        for m in assistant_pattern.finditer(full_text):
+            last_match = m
+        if last_match is not None:
+            rs, re_ = last_match.start(1), last_match.end(0)
+            for tok_idx, (cs, ce) in enumerate(offset_mapping):
+                if ce > rs and cs < re_:
+                    loss_mask[tok_idx] = 1
+
+    return full_text, input_ids, loss_mask, offset_mapping
+
+
+class _TokenizeAndMask:
+    """Picklable callable for ``Dataset.map(num_proc=N)``."""
+
+    def __init__(
+        self,
+        tokenizer,
+        assistant_pattern,
+        max_length=None,
+        *,
+        split_mode="pair",
+        parse_tool_call_args=False,
+    ):
+        self.tokenizer = tokenizer
+        self.assistant_pattern = assistant_pattern
+        self.max_length = max_length
+        self.split_mode = split_mode
+        self.parse_tool_call_args = parse_tool_call_args
+
+    def __call__(self, sample):
+        error_indices = (
+            sample.get("error_indices", []) if self.split_mode == "trajectory" else None
+        )
+        tools_json = sample.get("tools_json")
+        tools = json.loads(tools_json) if tools_json else None
+        result = _render_tokenize_mask(
+            sample["messages"],
+            self.tokenizer,
+            self.assistant_pattern,
+            tools,
+            split_mode=self.split_mode,
+            error_indices=error_indices,
+            parse_tool_call_args=self.parse_tool_call_args,
+        )
+        if result is None:
+            return {"input_ids": [], "loss_mask": []}
+
+        _full_text, input_ids, loss_mask, _offset_mapping = result
+
+        # Early exit: overlength or empty → return empty so a single
+        # filter pass removes it together with template-failure empties.
+        if self.max_length is not None and len(input_ids) > self.max_length:
+            return {"input_ids": [], "loss_mask": []}
+
+        return {"input_ids": input_ids, "loss_mask": loss_mask}
+
+
+def _detect_template_pattern(tokenizer, tools=None):
+    """Detect the assistant role delimiter used by this tokenizer's template.
+
+    When *tools* is provided the probe is rendered with ``tools=`` so that
+    the detected delimiters match the actual training text (some templates
+    alter the system block when tools are present).
+
+    Strategy:
+        1. Try known ``_TEMPLATE_PATTERNS`` (fast, battle-tested).
+        2. Fall back to double-probe diff: render the template with a known
+           marker and with empty content, then diff the two strings to extract
+           the exact header and end-of-turn delimiters.
+
+    Raises:
+        ValueError: If both strategies fail to detect a usable pattern.
+    """
+    _PROBE_CONTENT = "PROBE_MARKER"
+
+    extra_kwargs = {}
+    if tools is not None:
+        extra_kwargs["tools"] = tools
+
+    probe_msgs = [
+        {"role": "user", "content": "x"},
+        {"role": "assistant", "content": _PROBE_CONTENT},
+    ]
+    probe_text = tokenizer.apply_chat_template(
+        probe_msgs, tokenize=False, **extra_kwargs
+    )
+
+    # --- Strategy 1: known patterns ---
+    for hdr_re, eot_re in _TEMPLATE_PATTERNS:
+        if re.search(hdr_re, probe_text):
+            pattern = re.compile(hdr_re + r"(.*?)" + eot_re, re.DOTALL)
+            logger.info(
+                f"Detected template style (known pattern): "
+                f"header_re={hdr_re!r}, eot_re={eot_re!r}"
+            )
+            return pattern
+
+    # --- Strategy 2: double-probe diff ---
+    try:
+        probe_empty = [
+            {"role": "user", "content": "x"},
+            {"role": "assistant", "content": ""},
+        ]
+        text_empty = tokenizer.apply_chat_template(
+            probe_empty, tokenize=False, **extra_kwargs
+        )
+
+        marker_idx = probe_text.index(_PROBE_CONTENT)
+        header = probe_text[:marker_idx]
+        tail = probe_text[marker_idx + len(_PROBE_CONTENT) :]
+
+        if text_empty == header + tail:
+            # Extract the assistant-specific header by removing the shared
+            # user-only prefix.
+            user_only = tokenizer.apply_chat_template(
+                [{"role": "user", "content": "x"}],
+                tokenize=False,
+                **extra_kwargs,
+            )
+            asst_header = header[len(user_only) :]
+            # end-of-turn delimiter: strip leading newlines, then take
+            # up to the first newline (or the full string if none).
+            eot_stripped = tail.lstrip("\n")
+            eot = eot_stripped.split("\n")[0] if "\n" in eot_stripped else eot_stripped
+
+            if asst_header and eot:
+                hdr_re = re.escape(asst_header)
+                eot_re = re.escape(eot)
+                pattern = re.compile(hdr_re + r"(.*?)" + eot_re, re.DOTALL)
+                logger.info(
+                    f"Detected template style (probe diff): "
+                    f"header={asst_header!r}, eot={eot!r}"
+                )
+                return pattern
+    except (ValueError, IndexError):
+        pass  # PROBE_CONTENT not found in rendered text, skip
+
+    raise ValueError(
+        "Could not detect chat template assistant delimiters. "
+        "Unable to build a reliable loss mask. "
+        f"Probe text: {probe_text[:200]!r}"
+    )
+
+
+def _dump_samples(
+    samples,
+    tokenizer,
+    assistant_pattern,
+    tools_list,
+    dump_dir,
+    n_samples,
+    *,
+    split_mode="pair",
+    error_indices_list=None,
+    parse_tool_call_args=False,
+):
+    """Dump sampled message lists as ``.txt`` + ``.json`` for inspection.
+
+    Args:
+        samples: List of message-list samples (pairs or full trajectories).
+        tokenizer: Tokenizer with ``apply_chat_template`` support.
+        assistant_pattern: Compiled regex from ``_detect_template_pattern``.
+        tools_list: Per-sample tool definitions (parallel to *samples*),
+            or ``None`` when no tools are available.
+        dump_dir: Directory to write files into (created if needed).
+        n_samples: Number of random samples to dump.  ``-1`` dumps all.
+        split_mode: ``"trajectory"`` for trajectory-mode loss masking.
+        error_indices_list: Per-sample error segment indices (trajectory mode).
+    """
+    import random as _random
+
+    os.makedirs(dump_dir, exist_ok=True)
+
+    if n_samples == -1 or n_samples >= len(samples):
+        indices = list(range(len(samples)))
+    else:
+        indices = sorted(_random.sample(range(len(samples)), n_samples))
+
+    n_written = 0
+    for i in indices:
+        sample = samples[i]
+        sample_tools = tools_list[i] if tools_list else None
+        err_idxs = (
+            error_indices_list[i]
+            if split_mode == "trajectory" and error_indices_list
+            else None
+        )
+
+        result = _render_tokenize_mask(
+            sample,
+            tokenizer,
+            assistant_pattern,
+            sample_tools,
+            split_mode=split_mode,
+            error_indices=err_idxs,
+            parse_tool_call_args=parse_tool_call_args,
+        )
+        if result is None:
+            continue
+
+        full_text, input_ids, loss_mask, offset_mapping = result
+        n_loss = sum(loss_mask)
+        base = os.path.join(dump_dir, f"sample_{i}")
+
+        # --- .txt ---
+        with open(base + ".txt", "w", encoding="utf-8") as fout:
+            fout.write(
+                f"Sample {i}: {len(sample)} messages, "
+                f"{len(input_ids)} tokens, loss=1: {n_loss}\n"
+            )
+            fout.write(f"Last msg role: {sample[-1]['role']}\n")
+            fout.write(f"{'=' * 72}\n\n")
+
+            fout.write("--- Rendered Text ---\n")
+            fout.write(full_text)
+            fout.write("\n\n")
+
+            fout.write("--- Token / Loss Mask ---\n")
+            fout.write(f"{'Idx':>6} | {'TokenID':>8} | Loss | Token Text\n")
+            fout.write(f"{'-' * 6}-+-{'-' * 8}-+------+{'-' * 40}\n")
+            for t in range(len(input_ids)):
+                cs, ce = offset_mapping[t]
+                tok_text = repr(full_text[cs:ce])
+                fout.write(
+                    f"{t:>6} | {input_ids[t]:>8} | {loss_mask[t]:>4} | {tok_text}\n"
+                )
+
+        # --- .json ---
+        tokens_list = []
+        for t in range(len(input_ids)):
+            cs, ce = offset_mapping[t]
+            tokens_list.append(
+                {
+                    "idx": t,
+                    "token_id": input_ids[t],
+                    "text": full_text[cs:ce],
+                    "loss": loss_mask[t],
+                }
+            )
+        record = {
+            "sample_index": i,
+            "n_messages": len(sample),
+            "n_tokens": len(input_ids),
+            "n_loss_tokens": n_loss,
+            "rendered_text": full_text,
+            "tokens": tokens_list,
+        }
+        with open(base + ".json", "w", encoding="utf-8") as fout:
+            json.dump(record, fout, ensure_ascii=False)
+
+        n_written += 1
+
+    logger.info(f"Dumped {n_written} samples to {dump_dir}/")
+
+
+# ============================================================
+# 6. Pipeline — loading, processing, distributed cache, public API
+# ============================================================
+
+
+def _load_trajectory_pairs(
+    path: str,
+    filter_errors: bool = True,
+    strip_all_thinking: bool = False,
+    filter_empty_tool_calls: bool = False,
+    filter_bare_text_tool_calls: bool = False,
+    truncate_task_notifications: bool = False,
+    max_no_thinking_ratio: float | None = None,
+    random_strip_thinking_prob: float = 0.0,
+    random_strip_thinking_seed: int = 42,
+    n_thinking_variants: int = 1,
+):
+    """Load trajectory JSONL and split into progressive pairs.
+
+    When *n_thinking_variants* > 1, each trajectory is split K times:
+    variant 0 preserves all thinking, variants 1~K-1 randomly strip.
+
+    Supports nested (``conversations`` wrapper) and flat JSONL formats
+    (auto-detected per record via ``_iter_jsonl_records``).
+
+    Returns:
+        Tuple of ``(all_pairs, tools)`` where *tools* is ``None`` when no
+        tool definitions are found.
+    """
+    all_pairs = []
+    all_tools = []
+    records_in = 0
+    total_filtered_errors = 0
+    total_filtered_empty_tc = 0
+    total_filtered_bare_tc = 0
+    total_truncated = 0
+    total_stripped_thinking = 0
+
+    augment = n_thinking_variants > 1
+    rng = (
+        random.Random(random_strip_thinking_seed)
+        if random_strip_thinking_prob > 0.0
+        else None
+    )
+
+    if augment and random_strip_thinking_prob <= 0.0:
+        logger.warning(
+            "n_thinking_variants=%d but random_strip_thinking_prob=0; "
+            "all variants will be identical.",
+            n_thinking_variants,
+        )
+
+    # Stats collectors for augmentation logging.
+    thinking_turns_per_traj = []
+    total_asst_turns_per_traj = []
+    patterns_per_traj = []
+
+    for record_idx, messages, record_tools in _iter_jsonl_records(path):
+        records_in = record_idx
+
+        if truncate_task_notifications:
+            truncated = _truncate_at_task_notification(messages)
+            if len(truncated) < len(messages):
+                total_truncated += 1
+                messages = truncated
+
+        shared_kwargs = dict(
+            filter_errors=filter_errors,
+            strip_all_thinking=strip_all_thinking,
+            filter_empty_tool_calls=filter_empty_tool_calls,
+            filter_bare_text_tool_calls=filter_bare_text_tool_calls,
+        )
+
+        if augment:
+            # Variant 0: preserve all thinking.
+            pairs_orig, n_err, n_empty_tc, n_bare_tc, _ = _split_and_filter(
+                messages, **shared_kwargs, random_strip_thinking_prob=0.0, rng=None
+            )
+            total_filtered_errors += n_err
+            total_filtered_empty_tc += n_empty_tc
+            total_filtered_bare_tc += n_bare_tc
+            all_pairs.extend(pairs_orig)
+            all_tools.extend([record_tools] * len(pairs_orig))
+            # Collect stats.
+            segments = _find_segments(messages)
+            n_think = sum(1 for s, _ in segments if _msg_has_thinking(messages[s]))
+            n_asst = len(segments)
+            thinking_turns_per_traj.append(n_think)
+            total_asst_turns_per_traj.append(n_asst)
+
+            # Variants 1 ~ K-1: random strip.
+            variant_patterns = {frozenset()}  # original = no strip
+            for _k in range(n_thinking_variants - 1):
+                pairs_aug, _, _, _, n_stripped = _split_and_filter(
+                    messages,
+                    **shared_kwargs,
+                    random_strip_thinking_prob=random_strip_thinking_prob,
+                    rng=rng,
+                )
+                total_stripped_thinking += n_stripped
+                all_pairs.extend(pairs_aug)
+                all_tools.extend([record_tools] * len(pairs_aug))
+                # Approximate pattern: record which pairs had their target stripped.
+                # For stats, use the count as a proxy since _split_and_filter
+                # doesn't return per-pair strip info.
+                variant_patterns.add(frozenset([n_stripped]))
+            patterns_per_traj.append(variant_patterns)
+        else:
+            # Single variant (original behavior).
+            pairs, n_err, n_empty_tc, n_bare_tc, n_stripped = _split_and_filter(
+                messages,
+                **shared_kwargs,
+                random_strip_thinking_prob=random_strip_thinking_prob,
+                rng=rng,
+            )
+            total_filtered_errors += n_err
+            total_filtered_empty_tc += n_empty_tc
+            total_filtered_bare_tc += n_bare_tc
+            total_stripped_thinking += n_stripped
+            all_pairs.extend(pairs)
+            all_tools.extend([record_tools] * len(pairs))
+
+    # Log extracted tools summary.
+    n_with_tools = sum(1 for t in all_tools if t is not None)
+    if n_with_tools > 0:
+        all_tool_names = set()
+        for t_list in all_tools:
+            if t_list is not None:
+                for t in t_list:
+                    all_tool_names.add(t.get("function", {}).get("name", "?"))
+        logger.info(
+            f"Extracted tools from {n_with_tools}/{len(all_tools)} pairs: "
+            f"{sorted(all_tool_names)}"
+        )
+
+    filter_parts = []
+    if total_truncated:
+        filter_parts.append(
+            f"{total_truncated} trajectories truncated at task-notification"
+        )
+    if total_filtered_errors:
+        filter_parts.append(f"{total_filtered_errors} with tool errors")
+    if total_filtered_empty_tc:
+        filter_parts.append(f"{total_filtered_empty_tc} empty-content tool calls")
+    if total_filtered_bare_tc:
+        filter_parts.append(f"{total_filtered_bare_tc} bare-text tool calls")
+    if total_stripped_thinking:
+        filter_parts.append(f"{total_stripped_thinking} thinking blocks stripped")
+    filter_msg = ", ".join(filter_parts) if filter_parts else "none"
+
+    logger.info(
+        f"Loaded {records_in} trajectories, "
+        f"generated {len(all_pairs)} pairs "
+        f"(filtered: {filter_msg})"
+    )
+
+    if augment and patterns_per_traj:
+        _log_thinking_augmentation_stats(
+            n_thinking_variants,
+            random_strip_thinking_prob,
+            records_in,
+            thinking_turns_per_traj,
+            total_asst_turns_per_traj,
+            patterns_per_traj,
+        )
+
+    # Balance thinking / no-thinking pair ratio.
+    all_pairs, all_tools = _balance_thinking_pairs(
+        all_pairs, max_no_thinking_ratio, tools_list=all_tools
+    )
+
+    return all_pairs, all_tools
+
+
+def _load_presplit_pairs(
+    path: str,
+    strip_all_thinking: bool = False,
+    random_strip_thinking_prob: float = 0.0,
+    random_strip_thinking_seed: int = 42,
+    n_thinking_variants: int = 1,
+):
+    """Load pre-split pair JSONL where each line is ``{"messages": [...]}``.
+
+    Messages are cleaned but no splitting or error-filtering is performed.
+    By default, thinking is stripped from context assistant turns but
+    preserved for the last assistant turn (the training target).  Set
+    *strip_all_thinking* to strip from every assistant turn.
+
+    When *n_thinking_variants* > 1, each pair is augmented: variant 0
+    preserves thinking, variants 1~K-1 randomly strip the target turn.
+
+    Also extracts per-record ``tools`` definitions so that each pair
+    carries its own tools, same as ``_load_trajectory_pairs``.
+
+    Returns:
+        Tuple of ``(all_pairs, all_tools)`` where *all_tools* is a
+        parallel list of per-sample tool definitions (may be ``None``).
+    """
+    all_pairs = []
+    all_tools = []
+    n_stripped = 0
+    augment = n_thinking_variants > 1
+
+    rng = (
+        random.Random(random_strip_thinking_seed)
+        if random_strip_thinking_prob > 0.0
+        else None
+    )
+
+    def _build_pair(messages, last_asst, strip_target):
+        pair = []
+        for idx, m in enumerate(messages):
+            is_target = m.get("role") == "assistant" and idx == last_asst
+            strip = strip_all_thinking or not is_target or strip_target
+            pair.append(_clean_message(m, strip_thinking=strip))
+        return pair
+
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            messages = record.get("messages", [])
+            if not messages:
+                continue
+
+            record_tools = record.get("tools")
+
+            # Find the last assistant index so we can preserve its thinking.
+            last_asst = None
+            for i, m in enumerate(messages):
+                if m.get("role") == "assistant":
+                    last_asst = i
+
+            has_thinking = (
+                last_asst is not None
+                and not strip_all_thinking
+                and _msg_has_thinking(messages[last_asst])
+            )
+
+            if augment:
+                # Variant 0: preserve all thinking.
+                all_pairs.append(_build_pair(messages, last_asst, strip_target=False))
+                all_tools.append(record_tools)
+
+                # Variants 1 ~ K-1: random strip.
+                for _k in range(n_thinking_variants - 1):
+                    do_strip = (
+                        has_thinking
+                        and rng is not None
+                        and rng.random() < random_strip_thinking_prob
+                    )
+                    if do_strip:
+                        n_stripped += 1
+                    all_pairs.append(
+                        _build_pair(messages, last_asst, strip_target=do_strip)
+                    )
+                    all_tools.append(record_tools)
+            else:
+                # Single variant (original behavior).
+                strip_target = (
+                    has_thinking
+                    and rng is not None
+                    and rng.random() < random_strip_thinking_prob
+                )
+                if strip_target:
+                    n_stripped += 1
+                all_pairs.append(
+                    _build_pair(messages, last_asst, strip_target=strip_target)
+                )
+                all_tools.append(record_tools)
+
+    # Log extracted tools summary.
+    n_with_tools = sum(1 for t in all_tools if t is not None)
+    if n_with_tools > 0:
+        all_tool_names = set()
+        for t_list in all_tools:
+            if t_list is not None:
+                for t in t_list:
+                    all_tool_names.add(t.get("function", {}).get("name", "?"))
+        logger.info(
+            f"Extracted tools from {n_with_tools}/{len(all_tools)} pairs: "
+            f"{sorted(all_tool_names)}"
+        )
+
+    strip_msg = f", {n_stripped} thinking blocks stripped" if n_stripped else ""
+    logger.info(f"Loaded {len(all_pairs)} pre-split pairs from {path}{strip_msg}")
+    return all_pairs, all_tools
+
+
+def _load_full_trajectories(
+    path: str,
+    filter_errors: bool = True,
+    filter_empty_tool_calls: bool = False,
+    filter_bare_text_tool_calls: bool = False,
+    truncate_task_notifications: bool = False,
+    random_strip_thinking_prob: float = 0.0,
+    random_strip_thinking_seed: int = 42,
+    n_thinking_variants: int = 1,
+):
+    """Load trajectory JSONL for trajectory-level training.
+
+    Each trajectory becomes a single training sample with all assistant
+    turns as targets (``loss_mask=1``).  When *filter_errors* is True,
+    assistant segments with error tool responses are identified so
+    tokenization can mask them (``loss_mask=0``) instead of discarding
+    the entire trajectory.
+
+    When *n_thinking_variants* > 1, each trajectory is augmented into
+    K variants: the first preserves all thinking, the remaining K-1
+    randomly strip thinking turns with *random_strip_thinking_prob*.
+
+    Supports nested (``conversations`` wrapper) and flat JSONL formats
+    (auto-detected per record via ``_iter_jsonl_records``).
+
+    Returns:
+        Tuple of ``(trajectories, error_indices_list, all_tools)`` where
+        *trajectories* is a list of cleaned message lists,
+        *error_indices_list* is a list of error segment index lists,
+        and *all_tools* is a parallel list of per-sample tool definitions.
+    """
+    trajectories = []
+    error_indices_list = []
+    all_tools = []
+    records_in = 0
+    total_truncated = 0
+    total_masked_errors = 0
+    total_masked_empty_tc = 0
+    total_masked_bare_tc = 0
+    total_stripped_thinking = 0
+
+    augment = n_thinking_variants > 1
+    rng = (
+        random.Random(random_strip_thinking_seed)
+        if random_strip_thinking_prob > 0.0
+        else None
+    )
+
+    if augment and random_strip_thinking_prob <= 0.0:
+        logger.warning(
+            "n_thinking_variants=%d but random_strip_thinking_prob=0; "
+            "all variants will be identical.",
+            n_thinking_variants,
+        )
+
+    # Stats collectors for augmentation logging.
+    thinking_turns_per_traj = []
+    total_asst_turns_per_traj = []
+    patterns_per_traj = []
+
+    for record_idx, messages, record_tools in _iter_jsonl_records(path):
+        records_in = record_idx
+
+        if truncate_task_notifications:
+            truncated = _truncate_at_task_notification(messages)
+            if len(truncated) < len(messages):
+                total_truncated += 1
+                messages = truncated
+
+        shared_kwargs = dict(
+            filter_errors=filter_errors,
+            filter_empty_tool_calls=filter_empty_tool_calls,
+            filter_bare_text_tool_calls=filter_bare_text_tool_calls,
+        )
+
+        if augment:
+            # Variant 0: preserve all thinking (no stripping).
+            result_orig = _prepare_trajectory(
+                messages, **shared_kwargs, random_strip_thinking_prob=0.0, rng=None
+            )
+            if result_orig is None:
+                continue
+            cleaned_orig, masked_idxs, n_err, n_empty_tc, n_bare_tc, _ = result_orig
+            trajectories.append(cleaned_orig)
+            error_indices_list.append(masked_idxs)
+            all_tools.append(record_tools)
+            total_masked_errors += n_err
+            total_masked_empty_tc += n_empty_tc
+            total_masked_bare_tc += n_bare_tc
+
+            # Collect stats: count thinking turns in this trajectory.
+            segments = _find_segments(messages)
+            n_think = sum(1 for s, _ in segments if _msg_has_thinking(messages[s]))
+            n_asst = len(segments)
+            thinking_turns_per_traj.append(n_think)
+            total_asst_turns_per_traj.append(n_asst)
+
+            # Variants 1 ~ K-1: random strip thinking.
+            variant_patterns = {frozenset()}  # original = empty pattern
+            for _k in range(n_thinking_variants - 1):
+                result_aug = _prepare_trajectory(
+                    messages,
+                    **shared_kwargs,
+                    random_strip_thinking_prob=random_strip_thinking_prob,
+                    rng=rng,
+                )
+                if result_aug is None:
+                    continue
+                cleaned_aug, _, _, _, _, strip_pattern = result_aug
+                trajectories.append(cleaned_aug)
+                error_indices_list.append(masked_idxs)  # reuse
+                all_tools.append(record_tools)
+                total_stripped_thinking += len(strip_pattern)
+                variant_patterns.add(strip_pattern)
+            patterns_per_traj.append(variant_patterns)
+        else:
+            # Single variant (original behavior).
+            result = _prepare_trajectory(
+                messages,
+                **shared_kwargs,
+                random_strip_thinking_prob=random_strip_thinking_prob,
+                rng=rng,
+            )
+            if result is None:
+                continue
+            cleaned, masked_idxs, n_err, n_empty_tc, n_bare_tc, strip_pattern = result
+            trajectories.append(cleaned)
+            error_indices_list.append(masked_idxs)
+            all_tools.append(record_tools)
+            total_masked_errors += n_err
+            total_masked_empty_tc += n_empty_tc
+            total_masked_bare_tc += n_bare_tc
+            total_stripped_thinking += len(strip_pattern)
+
+    # Log extracted tools summary.
+    n_with_tools = sum(1 for t in all_tools if t is not None)
+    if n_with_tools > 0:
+        all_tool_names = set()
+        for t_list in all_tools:
+            if t_list is not None:
+                for t in t_list:
+                    all_tool_names.add(t.get("function", {}).get("name", "?"))
+        logger.info(
+            f"Extracted tools from {n_with_tools}/{len(all_tools)} "
+            f"trajectories: {sorted(all_tool_names)}"
+        )
+
+    parts = []
+    if total_truncated:
+        parts.append(f"{total_truncated} trajectories truncated at task-notification")
+    if total_masked_errors:
+        parts.append(f"{total_masked_errors} with tool errors")
+    if total_masked_empty_tc:
+        parts.append(f"{total_masked_empty_tc} empty-content tool calls")
+    if total_masked_bare_tc:
+        parts.append(f"{total_masked_bare_tc} bare-text tool calls")
+    if total_stripped_thinking:
+        parts.append(f"{total_stripped_thinking} thinking blocks stripped")
+    mask_msg = ", ".join(parts) if parts else "none"
+
+    logger.info(
+        f"Loaded {records_in} trajectories, "
+        f"kept {len(trajectories)} for training "
+        f"(masked: {mask_msg})"
+    )
+
+    if augment and patterns_per_traj:
+        _log_thinking_augmentation_stats(
+            n_thinking_variants,
+            random_strip_thinking_prob,
+            records_in,
+            thinking_turns_per_traj,
+            total_asst_turns_per_traj,
+            patterns_per_traj,
+        )
+
+    return trajectories, error_indices_list, all_tools
+
+
+def _tokenize_samples(
+    messages_list,
+    tools_list,
+    tokenizer,
+    *,
+    split_mode: str = "pair",
+    error_indices_list: list | None = None,
+    max_length: int | None = None,
+    num_proc: int | None = None,
+    no_tools: bool = False,
+    dump_dir: str | None = None,
+    dump_n_samples: int = 0,
+    parse_tool_call_args: bool = False,
+):
+    """Tokenize message lists into a training-ready Dataset.
+
+    Works for both progressive pairs (``split_mode="pair"``) and
+    full trajectories (``split_mode="trajectory"``).
+
+    In pair mode, only the last assistant turn per sample gets
+    ``loss_mask=1``.  In trajectory mode, all assistant turns get
+    ``loss_mask=1`` except those at error segment indices.
+
+    Args:
+        tools_list: Per-sample tool definitions (parallel to
+            *messages_list*).  Each element is either ``None`` or a
+            list of tool dicts.
+    """
+    if num_proc is None:
+        num_proc = max(1, min(os.cpu_count() or 1, DATASET_NUM_PROC))
+
+    # Find representative tools for template detection.
+    first_tools = None
+    if tools_list:
+        first_tools = next((t for t in tools_list if t is not None), None)
+
+    if no_tools:
+        tools_list = None
+        first_tools = None
+        logger.info("Tool definitions disabled (no_tools=True)")
+    elif first_tools is not None:
+        all_tool_names = set()
+        for t_list in tools_list:
+            if t_list is not None:
+                for t in t_list:
+                    all_tool_names.add(t.get("function", {}).get("name", "?"))
+        logger.info(f"Using tools for chat template: {sorted(all_tool_names)}")
+
+    if not messages_list:
+        raise ValueError("No valid samples to tokenize")
+
+    # Build dataset columns.
+    data = {"messages": messages_list}
+    # Serialize per-sample tools as JSON strings for the Dataset column.
+    data["tools_json"] = (
+        [json.dumps(t) if t else "" for t in tools_list]
+        if tools_list
+        else [""] * len(messages_list)
+    )
+    remove_cols = ["messages", "tools_json"]
+    if split_mode == "trajectory":
+        data["error_indices"] = error_indices_list or [[] for _ in messages_list]
+        remove_cols.append("error_indices")
+
+    dataset = Dataset.from_dict(data)
+    _patch_chat_template_for_training(tokenizer)
+    assistant_pattern = _detect_template_pattern(tokenizer, tools=first_tools)
+
+    # Dump samples for inspection before the heavy map() pass.
+    if dump_dir and dump_n_samples != 0:
+        _dump_samples(
+            messages_list,
+            tokenizer,
+            assistant_pattern,
+            tools_list,
+            dump_dir,
+            dump_n_samples,
+            split_mode=split_mode,
+            error_indices_list=error_indices_list,
+            parse_tool_call_args=parse_tool_call_args,
+        )
+
+    process_fn = _TokenizeAndMask(
+        tokenizer,
+        assistant_pattern,
+        max_length=max_length,
+        split_mode=split_mode,
+        parse_tool_call_args=parse_tool_call_args,
+    )
+
+    dataset = dataset.map(process_fn, num_proc=num_proc).remove_columns(remove_cols)
+
+    # Single filter pass: removes both apply_chat_template-failure empties and
+    # overlength samples (which _TokenizeAndMask also marks as empty).
+    before_filter = len(dataset)
+    dataset = dataset.filter(lambda x: len(x["input_ids"]) > 0, num_proc=num_proc)
+    n_filtered = before_filter - len(dataset)
+    if n_filtered > 0:
+        logger.info(
+            f"Filtered {n_filtered} samples "
+            f"(empty from template failures or exceeding max_length={max_length})"
+        )
+
+    logger.info(f"Final dataset: {len(dataset)} samples")
+    return dataset
+
+
+def _process_swe_sft(
+    path: str,
+    tokenizer,
+    *,
+    max_length: int | None = None,
+    num_proc: int | None = None,
+    pre_split: bool = False,
+    filter_errors: bool = True,
+    strip_all_thinking: bool = False,
+    filter_empty_tool_calls: bool = False,
+    filter_bare_text_tool_calls: bool = False,
+    truncate_task_notifications: bool = False,
+    no_tools: bool = False,
+    max_no_thinking_ratio: float | None = None,
+    split_mode: str = "pair",
+    random_strip_thinking_prob: float = 0.0,
+    random_strip_thinking_seed: int = 42,
+    n_thinking_variants: int = 1,
+    dump_dir: str | None = None,
+    dump_n_samples: int = 0,
+    parse_tool_call_args: bool = False,
+):
+    """Load JSONL, split into pairs, tokenize, and filter.
+
+    Combines file loading with ``_tokenize_samples`` so that the rank-0-only
+    path and the single-process path share the same logic.
+
+    When *split_mode* is ``"trajectory"``, the full trajectory is kept as a
+    single training sample with all assistant turns as targets.
+    """
+    error_indices_list = None
+
+    if split_mode == "trajectory":
+        messages_list, error_indices_list, tools_list = _load_full_trajectories(
+            path,
+            filter_errors=filter_errors,
+            filter_empty_tool_calls=filter_empty_tool_calls,
+            filter_bare_text_tool_calls=filter_bare_text_tool_calls,
+            truncate_task_notifications=truncate_task_notifications,
+            random_strip_thinking_prob=random_strip_thinking_prob,
+            random_strip_thinking_seed=random_strip_thinking_seed,
+            n_thinking_variants=n_thinking_variants,
+        )
+    elif pre_split:
+        messages_list, tools_list = _load_presplit_pairs(
+            path,
+            strip_all_thinking=strip_all_thinking,
+            random_strip_thinking_prob=random_strip_thinking_prob,
+            random_strip_thinking_seed=random_strip_thinking_seed,
+            n_thinking_variants=n_thinking_variants,
+        )
+    else:
+        messages_list, tools_list = _load_trajectory_pairs(
+            path,
+            filter_errors=filter_errors,
+            strip_all_thinking=strip_all_thinking,
+            filter_empty_tool_calls=filter_empty_tool_calls,
+            filter_bare_text_tool_calls=filter_bare_text_tool_calls,
+            truncate_task_notifications=truncate_task_notifications,
+            max_no_thinking_ratio=max_no_thinking_ratio,
+            random_strip_thinking_prob=random_strip_thinking_prob,
+            random_strip_thinking_seed=random_strip_thinking_seed,
+            n_thinking_variants=n_thinking_variants,
+        )
+
+    return _tokenize_samples(
+        messages_list,
+        tools_list,
+        tokenizer,
+        split_mode=split_mode,
+        error_indices_list=error_indices_list,
+        max_length=max_length,
+        num_proc=num_proc,
+        no_tools=no_tools,
+        dump_dir=dump_dir,
+        dump_n_samples=dump_n_samples,
+        parse_tool_call_args=parse_tool_call_args,
+    )
+
+
+def get_swe_sft_dataset(
+    path: str,
+    split: str | None = None,
+    tokenizer=None,
+    max_length: int | None = None,
+    num_proc: int | None = None,
+    pre_split: bool = False,
+    filter_errors: bool = True,
+    strip_all_thinking: bool = False,
+    filter_empty_tool_calls: bool = False,
+    filter_bare_text_tool_calls: bool = False,
+    truncate_task_notifications: bool = False,
+    no_tools: bool = False,
+    skip_pretokenized_filter: bool = False,
+    max_no_thinking_ratio: float | None = None,
+    split_mode: str = "pair",
+    random_strip_thinking_prob: float = 0.0,
+    random_strip_thinking_seed: int = 42,
+    n_thinking_variants: int = 1,
+    cache_dir: str | None = None,
+    dump_dir: str | None = None,
+    dump_samples: int = 0,
+    parse_tool_call_args: bool = False,
+):
+    """Load SWE trajectory data and convert to SFT training pairs.
+
+    By default, tool definitions are auto-extracted from the training data's
+    ``conversations[].tools`` field and passed to ``apply_chat_template``
+    so that the tokenizer renders tool definitions in the system prompt
+    (e.g. Qwen3 ``# Tools`` block), matching the eval-time format.
+    Set *no_tools* to skip this and render without tool definitions.
+
+    When *split_mode* is ``"trajectory"``, the full trajectory is kept as a
+    single training sample with all assistant turns as targets
+    (``loss_mask=1``).  Error segments are masked (``loss_mask=0``)
+    when *filter_errors* is True, instead of being discarded.
+    Thinking is preserved by default but can be randomly stripped
+    per-turn via *random_strip_thinking_prob* (both modes).
+
+    In distributed (SPMD) mode, only rank 0 performs the heavy processing
+    (JSONL loading, pair splitting, tokenization) and saves the result as
+    an Arrow dataset to *cache_dir*.  Other ranks wait for rank 0 to
+    finish and then load the cached dataset directly via memory-mapped I/O.
+
+    Args:
+        path: Path to the JSONL file containing SWE trajectories, or a
+            directory containing a pre-tokenized Arrow dataset (saved by
+            ``python -m areal.dataset.swe_sft --save-tokenized``).
+        split: Unused, kept for API compatibility.
+        tokenizer: Tokenizer with ``apply_chat_template`` support.
+            Not required when loading a pre-tokenized dataset.
+        max_length: Max token length.  Longer sequences are filtered out.
+        num_proc: Number of parallel workers for tokenization.
+            Defaults to ``min(os.cpu_count(), DATASET_NUM_PROC)``.
+        pre_split: If True, treat input as pre-split pairs (each line is
+            ``{"messages": [...]}``) instead of full trajectories.
+        filter_errors: If True (default), discard pairs whose current segment
+            contains a tool result with ``is_error=True``.  In trajectory
+            mode, sets ``loss_mask=0`` for error segments instead.
+            Set to False to keep/train all regardless of tool errors.
+        strip_all_thinking: If True, strip ``<think>...</think>`` from every
+            assistant turn including the training target.
+            Ignored in trajectory mode (thinking is always preserved).
+        filter_empty_tool_calls: If True, discard pairs whose training-target
+            assistant turn has no text content but has tool_calls.
+        filter_bare_text_tool_calls: If True, discard pairs whose
+            training-target assistant turn has text without ``<think>``
+            tags and has tool_calls.
+        truncate_task_notifications: If True, truncate trajectories at the
+            first ``<task-notification>`` that follows a pure-text assistant
+            turn, removing noise from background task completions.
+        no_tools: If True, do not pass tool definitions to
+            ``apply_chat_template`` even if the data contains them.
+        skip_pretokenized_filter: If True, skip the ``max_length`` filter
+            when loading a pre-tokenized dataset.  Useful when the dataset
+            was already filtered during pretokenization and you want to
+            avoid NFS cache conflicts from concurrent ``dataset.filter()``
+            calls across ranks.
+        max_no_thinking_ratio: Maximum ratio of non-thinking pairs to thinking
+            pairs.  For example, ``1.0`` gives 1:1, ``2.0`` gives 1:2.
+            ``None`` (default) disables balancing.
+        split_mode: ``"pair"`` (default) splits trajectories into
+            progressive pairs.  ``"trajectory"`` keeps the full trajectory
+            as a single sample — all assistant turns are targets with
+            ``loss_mask=1``, error segments are masked instead of filtered.
+        random_strip_thinking_prob: Probability of stripping thinking from
+            each target assistant turn.  0.0 (default) = no stripping,
+            1.0 = strip all.  Works in both pair and trajectory mode.
+        random_strip_thinking_seed: Random seed for reproducible thinking
+            stripping decisions.
+        n_thinking_variants: Number of thinking-pattern variants per
+            trajectory.  ``1`` (default) = no augmentation.  ``K > 1``
+            = augment each trajectory into K variants: the first
+            preserves all thinking, the rest randomly strip with
+            *random_strip_thinking_prob*.
+        cache_dir: Directory to save/load the processed Arrow dataset.
+            When set in distributed mode, rank 0 processes the data and
+            saves here; other ranks load from this directory.  If the
+            directory already contains a completed cache (``.done`` marker),
+            all ranks load from it directly without reprocessing.
+        dump_dir: Directory to write sample dump files (``.txt`` + ``.json``).
+            Only rank 0 writes.  Set to None to disable.
+        dump_samples: Number of random samples to dump.  ``-1`` = all,
+            ``0`` = disabled.
+        parse_tool_call_args: If True, convert OpenAI JSON-string
+            ``tool_calls.arguments`` to dicts before ``apply_chat_template``.
+            Required by GLM-4.x / GLM-5.x templates; leave at the default
+            (False) for Qwen / Llama / Bailing.
+
+    Returns:
+        A HuggingFace ``Dataset`` with ``input_ids`` and ``loss_mask`` columns.
+    """
+    from datasets import load_from_disk
+
+    # Pre-tokenized Arrow dataset: load directly, skip all processing.
+    if os.path.isdir(path):
+        logger.info(f"Loading pre-tokenized dataset from {path}")
+        dataset = load_from_disk(path)
+
+        if max_length is not None and not skip_pretokenized_filter:
+            before_filter = len(dataset)
+            dataset = dataset.filter(
+                lambda x: len(x["input_ids"]) <= max_length, num_proc=num_proc
+            )
+            logger.info(
+                f"Filtered {before_filter - len(dataset)} samples "
+                f"exceeding max_length={max_length}"
+            )
+
+        logger.info(f"Final dataset: {len(dataset)} samples")
+        return dataset
+
+    # --- Shared kwargs for _process_swe_sft ---
+    process_kwargs = dict(
+        max_length=max_length,
+        num_proc=num_proc,
+        pre_split=pre_split,
+        filter_errors=filter_errors,
+        strip_all_thinking=strip_all_thinking,
+        filter_empty_tool_calls=filter_empty_tool_calls,
+        filter_bare_text_tool_calls=filter_bare_text_tool_calls,
+        truncate_task_notifications=truncate_task_notifications,
+        no_tools=no_tools,
+        max_no_thinking_ratio=max_no_thinking_ratio,
+        split_mode=split_mode,
+        random_strip_thinking_prob=random_strip_thinking_prob,
+        random_strip_thinking_seed=random_strip_thinking_seed,
+        n_thinking_variants=n_thinking_variants,
+        dump_dir=dump_dir,
+        dump_n_samples=dump_samples,
+        parse_tool_call_args=parse_tool_call_args,
+    )
+
+    # --- Distributed rank-0-only processing ---
+    rank = int(os.getenv("RANK", "0"))
+    world_size = int(os.getenv("WORLD_SIZE", "1"))
+
+    if cache_dir is not None and world_size > 1:
+        done_marker = os.path.join(cache_dir, ".done")
+
+        def _filter_by_max_length(ds):
+            if max_length is None:
+                return ds
+            before = len(ds)
+            keep = [i for i in range(len(ds)) if len(ds[i]["input_ids"]) <= max_length]
+            ds = ds.select(keep)
+            if len(ds) < before:
+                logger.info(
+                    f"Rank {rank}: filtered {before - len(ds)} samples "
+                    f"exceeding max_length={max_length}"
+                )
+            return ds
+
+        # Fast path: cache from a previous run (or rank 0 already finished).
+        if os.path.exists(done_marker):
+            logger.info(
+                f"Rank {rank}: loading cached processed dataset from {cache_dir}"
+            )
+            dataset = load_from_disk(cache_dir)
+            dataset = _filter_by_max_length(dataset)
+            logger.info(f"Final dataset: {len(dataset)} samples")
+            return dataset
+
+        if rank == 0:
+            # Rank 0: do the heavy processing and save for other ranks.
+            dataset = _process_swe_sft(path, tokenizer, **process_kwargs)
+            os.makedirs(cache_dir, exist_ok=True)
+            dataset.save_to_disk(cache_dir)
+            # Write marker AFTER save completes so readers see a consistent dir.
+            with open(done_marker, "w") as f:
+                f.write(str(len(dataset)))
+            logger.info(
+                f"Rank 0: saved processed dataset "
+                f"({len(dataset)} samples) to {cache_dir}"
+            )
+            dataset = _filter_by_max_length(dataset)
+            return dataset
+        else:
+            # Other ranks: wait for rank 0, then load.
+            logger.info(f"Rank {rank}: waiting for rank 0 to process dataset...")
+            _wait_for_marker(done_marker)
+            dataset = load_from_disk(cache_dir)
+            dataset = _filter_by_max_length(dataset)
+            logger.info(f"Rank {rank}: loaded cached dataset ({len(dataset)} samples)")
+            return dataset
+
+    # --- Non-distributed or no cache_dir: process in current process ---
+    return _process_swe_sft(path, tokenizer, **process_kwargs)
+
+
+# ============================================================
+# 7. CLI — ``python -m areal.dataset.swe_sft``
+# ============================================================
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    from transformers import AutoTokenizer
+
+    parser = argparse.ArgumentParser(
+        description="Verify SWE SFT pair generation and loss masking.",
+    )
+    parser.add_argument("path", help="Path to SWE trajectory JSONL file")
+    parser.add_argument(
+        "--tokenizer",
+        default="Qwen/Qwen3-8B",
+        help="HuggingFace tokenizer name or path (default: Qwen/Qwen3-8B)",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=None,
+        help="Filter samples exceeding this token length",
+    )
+    parser.add_argument(
+        "--num-samples",
+        "-n",
+        type=int,
+        default=None,
+        help="Number of pairs to process.  Controls loading, tokenization,"
+        " display, and export.  Default: all pairs.",
+    )
+    parser.add_argument(
+        "--num-proc",
+        type=int,
+        default=None,
+        help=f"Number of parallel workers (default: min(cpu_count, {DATASET_NUM_PROC}))",
+    )
+    parser.add_argument(
+        "--save-pairs",
+        "-o",
+        default=None,
+        metavar="FILE",
+        help='Save cleaned pairs to FILE (JSONL, each line: {"messages": [...]}).',
+    )
+    parser.add_argument(
+        "--pre-split",
+        action="store_true",
+        help='Input is already in pair format (each line: {"messages": [...]}).'
+        " Skip trajectory splitting and error filtering.",
+    )
+    parser.add_argument(
+        "--no-filter-errors",
+        action="store_true",
+        help="Keep pairs whose current segment contains tool results with "
+        "is_error=True (by default these are discarded).",
+    )
+    parser.add_argument(
+        "--save-tokenized",
+        default=None,
+        metavar="DIR",
+        help="Save the tokenized dataset to DIR (Arrow format). "
+        "The saved directory can be used directly as the dataset path "
+        "during training, skipping all processing.",
+    )
+    parser.add_argument(
+        "--strip-all-thinking",
+        action="store_true",
+        help="Strip <think>...</think> from ALL assistant turns including "
+        "the training target. By default only context turns are stripped.",
+    )
+    parser.add_argument(
+        "--no-tools",
+        action="store_true",
+        help="Do not pass tool definitions to apply_chat_template. "
+        "By default, tools are auto-extracted from the data and rendered "
+        "in the system prompt (e.g. Qwen3 '# Tools' block).",
+    )
+    parser.add_argument(
+        "--parse-tool-call-args",
+        action="store_true",
+        help="Convert OpenAI JSON-string tool_calls.arguments to dicts "
+        "before apply_chat_template. Required by GLM-4.x / GLM-5.x "
+        "templates; leave off for Qwen / Llama / Bailing (which expect "
+        "the standard string form).",
+    )
+    parser.add_argument(
+        "--filter-empty-tool-calls",
+        action="store_true",
+        help="Discard pairs whose training-target assistant turn has no "
+        "text content but has tool_calls (silent tool invocations).",
+    )
+    parser.add_argument(
+        "--filter-bare-text-tool-calls",
+        action="store_true",
+        help="Discard pairs whose training-target assistant turn has text "
+        "content without <think> tags and has tool_calls.",
+    )
+    parser.add_argument(
+        "--truncate-task-notifications",
+        action="store_true",
+        help="Truncate trajectories at the first <task-notification> that "
+        "follows a pure-text assistant turn. Removes noise from background "
+        "task completions (e.g. pip install finishing after the model's summary).",
+    )
+    parser.add_argument(
+        "--max-no-thinking-ratio",
+        type=float,
+        default=None,
+        help="Maximum ratio of non-thinking pairs to thinking pairs. "
+        "E.g. 1.0 = 1:1 balance, 2.0 = at most 2x non-thinking per "
+        "thinking pair. Non-thinking pairs are randomly downsampled. "
+        "Default: no balancing.",
+    )
+    parser.add_argument(
+        "--split-mode",
+        choices=["pair", "trajectory"],
+        default="pair",
+        help="Sample construction mode. 'pair' (default): split trajectories "
+        "into progressive pairs. 'trajectory': keep the full trajectory "
+        "as a single sample with all assistant turns as targets.",
+    )
+    parser.add_argument(
+        "--random-strip-thinking-prob",
+        type=float,
+        default=0.0,
+        help="Probability of stripping thinking from each target assistant "
+        "turn. 0.0 = no stripping (default), 1.0 = strip all. "
+        "Works in both pair mode and trajectory mode.",
+    )
+    parser.add_argument(
+        "--random-strip-thinking-seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducible thinking stripping decisions (default: 42).",
+    )
+    parser.add_argument(
+        "--n-thinking-variants",
+        type=int,
+        default=1,
+        help="Number of thinking-pattern variants per trajectory. "
+        "1 = no augmentation (default). K > 1 = augment each trajectory "
+        "into K variants: the first preserves all thinking, the rest "
+        "randomly strip with --random-strip-thinking-prob.",
+    )
+    parser.add_argument(
+        "--save-trajectories",
+        default=None,
+        metavar="FILE",
+        help="Save preprocessed trajectories to FILE (JSONL, original format) "
+        "after applying trajectory-level operations (e.g. "
+        "--truncate-task-notifications) but before pair splitting. "
+        "Each line preserves the original record structure with the "
+        "messages field updated.",
+    )
+    parser.add_argument(
+        "--dump-samples",
+        default=None,
+        metavar="DIR",
+        help="Save sampled pairs to DIR, one file per pair. Each file "
+        "contains the rendered text and a token-by-token table with "
+        "token id, decoded text, and loss_mask.",
+    )
+    parser.add_argument(
+        "--dump-n",
+        type=int,
+        default=None,
+        help="Number of pairs to dump when --dump-samples is set. "
+        "Default: all pairs. -1 also means all.",
+    )
+    args = parser.parse_args()
+
+    filter_errors = not args.no_filter_errors
+    strip_all_thinking = args.strip_all_thinking
+    filter_empty_tool_calls = args.filter_empty_tool_calls
+    filter_bare_text_tool_calls = args.filter_bare_text_tool_calls
+    truncate_task_notifications = args.truncate_task_notifications
+    max_no_thinking_ratio = args.max_no_thinking_ratio
+
+    # --- Fast path: save preprocessed trajectories ---
+    if args.save_trajectories:
+        records_in = 0
+        records_out = 0
+        n_truncated = 0
+        with (
+            open(args.path, encoding="utf-8") as fin,
+            open(args.save_trajectories, "w", encoding="utf-8") as fout,
+        ):
+            for line in fin:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                records_in += 1
+
+                messages, _ = _extract_messages(record, records_in)
+
+                if truncate_task_notifications and messages:
+                    truncated = _truncate_at_task_notification(messages)
+                    if len(truncated) < len(messages):
+                        n_truncated += 1
+                        _set_messages(record, truncated)
+
+                fout.write(json.dumps(record, ensure_ascii=False) + "\n")
+                records_out += 1
+
+        parts = []
+        if n_truncated:
+            parts.append(f"{n_truncated} truncated at task-notification")
+        op_msg = ", ".join(parts) if parts else "no changes"
+        print(
+            f"Saved {records_out}/{records_in} trajectories "
+            f"to {args.save_trajectories} ({op_msg})"
+        )
+        sys.exit(0)
+
+    # --- Load ---
+    split_mode = args.split_mode
+    error_indices_list = None
+
+    if split_mode == "trajectory":
+        samples, error_indices_list, tools_list = _load_full_trajectories(
+            args.path,
+            filter_errors=filter_errors,
+            filter_empty_tool_calls=filter_empty_tool_calls,
+            filter_bare_text_tool_calls=filter_bare_text_tool_calls,
+            truncate_task_notifications=truncate_task_notifications,
+            random_strip_thinking_prob=args.random_strip_thinking_prob,
+            random_strip_thinking_seed=args.random_strip_thinking_seed,
+            n_thinking_variants=args.n_thinking_variants,
+        )
+        label = "trajectories"
+    elif args.pre_split:
+        samples, tools_list = _load_presplit_pairs(
+            args.path,
+            strip_all_thinking=strip_all_thinking,
+            random_strip_thinking_prob=args.random_strip_thinking_prob,
+            random_strip_thinking_seed=args.random_strip_thinking_seed,
+            n_thinking_variants=args.n_thinking_variants,
+        )
+        label = "pairs"
+    else:
+        samples, tools_list = _load_trajectory_pairs(
+            args.path,
+            filter_errors=filter_errors,
+            strip_all_thinking=strip_all_thinking,
+            filter_empty_tool_calls=filter_empty_tool_calls,
+            filter_bare_text_tool_calls=filter_bare_text_tool_calls,
+            truncate_task_notifications=truncate_task_notifications,
+            max_no_thinking_ratio=max_no_thinking_ratio,
+            random_strip_thinking_prob=args.random_strip_thinking_prob,
+            random_strip_thinking_seed=args.random_strip_thinking_seed,
+            n_thinking_variants=args.n_thinking_variants,
+        )
+        label = "pairs"
+
+    # --- Slice + stats ---
+    total = len(samples)
+    if args.num_samples is not None:
+        samples = samples[: args.num_samples]
+        tools_list = tools_list[: args.num_samples] if tools_list else tools_list
+        if error_indices_list is not None:
+            error_indices_list = error_indices_list[: args.num_samples]
+
+    print(f"Total {label}:  {total}")
+    if args.num_samples is not None:
+        print(f"Using:          {len(samples)}")
+
+    if samples:
+        lengths = [len(s) for s in samples]
+        print(
+            f"Messages/sample: min={min(lengths)}, "
+            f"max={max(lengths)}, avg={sum(lengths) / len(lengths):.1f}"
+        )
+    if error_indices_list is not None:
+        n_masked = sum(len(e) for e in error_indices_list)
+        print(f"Masked segments: {n_masked} (loss=0)")
+
+    # --- Save cleaned samples as JSONL ---
+    if args.save_pairs:
+        with open(args.save_pairs, "w", encoding="utf-8") as fout:
+            err_iter = error_indices_list or [None] * len(samples)
+            tl_iter = tools_list if tools_list else [None] * len(samples)
+            for sample, sample_tools, err_idxs in zip(samples, tl_iter, err_iter):
+                record = {"messages": sample}
+                if sample_tools is not None:
+                    record["tools"] = sample_tools
+                if err_idxs:
+                    record["error_indices"] = err_idxs
+                fout.write(json.dumps(record, ensure_ascii=False) + "\n")
+        print(f"Wrote {len(samples)} {label} to {args.save_pairs}")
+
+    # --- Tokenize / Dump ---
+    dump_dir = args.dump_samples if args.dump_samples else None
+    need_tokenize = args.save_tokenized
+
+    # When --save-tokenized is set, auto-dump 50 samples alongside it
+    # unless the user explicitly set --dump-samples or --dump-n 0.
+    if need_tokenize and not dump_dir and args.dump_n != 0:
+        dump_dir = os.path.join(args.save_tokenized, "dumped_samples")
+
+    if not need_tokenize and not dump_dir:
+        sys.exit(0)
+
+    tok = AutoTokenizer.from_pretrained(args.tokenizer, trust_remote_code=True)
+    _patch_chat_template_for_training(tok)
+    if args.dump_n is not None:
+        dump_n = args.dump_n
+    elif args.dump_samples:
+        # Explicit --dump-samples without --dump-n: dump all
+        dump_n = -1 if args.num_samples is None else args.num_samples
+    elif need_tokenize:
+        # Auto-dump with --save-tokenized: default 50
+        dump_n = 50
+    else:
+        dump_n = -1
+
+    # Dump can run independently without full tokenization.
+    if dump_dir and dump_n != 0:
+        dump_tools = None if args.no_tools else tools_list
+        first_tools = None
+        if dump_tools:
+            first_tools = next((t for t in dump_tools if t is not None), None)
+        assistant_pattern = _detect_template_pattern(tok, tools=first_tools)
+        _dump_samples(
+            samples,
+            tok,
+            assistant_pattern,
+            dump_tools,
+            dump_dir,
+            dump_n,
+            split_mode=split_mode,
+            error_indices_list=error_indices_list,
+            parse_tool_call_args=args.parse_tool_call_args,
+        )
+
+    if not need_tokenize:
+        sys.exit(0)
+
+    ds = _tokenize_samples(
+        samples,
+        tools_list,
+        tok,
+        split_mode=split_mode,
+        error_indices_list=error_indices_list,
+        max_length=args.max_length,
+        num_proc=args.num_proc,
+        no_tools=args.no_tools,
+        parse_tool_call_args=args.parse_tool_call_args,
+    )
+
+    print(f"\nTokenized: {len(ds)} samples")
+    if args.save_tokenized:
+        ds.save_to_disk(args.save_tokenized)
+        print(f"Saved tokenized dataset ({len(ds)} samples) to {args.save_tokenized}")

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -560,6 +560,44 @@ class MegatronEngine(TrainEngine):
                     distribute_saved_activations=self.mcore_config.distribute_saved_activations,
                     recompute_modules=self.mcore_config.recompute_modules,
                 )
+
+            # Set MoE configuration overrides (aux-loss-free balancing, z-loss).
+            moe_extra_args: dict = {
+                "moe_token_dispatcher_type": self.mcore_config.moe_token_dispatcher_type,
+                "moe_permute_fusion": self.mcore_config.moe_permute_fusion,
+                "moe_router_fusion": self.mcore_config.moe_router_fusion,
+                "moe_shared_expert_overlap": self.mcore_config.moe_shared_expert_overlap,
+                "moe_router_bias_update_rate": self.mcore_config.moe_router_bias_update_rate,
+            }
+            if self.mcore_config.moe_router_dtype is not None:
+                moe_extra_args["moe_router_dtype"] = self.mcore_config.moe_router_dtype
+            if self.mcore_config.moe_z_loss_coeff is not None:
+                moe_extra_args["moe_z_loss_coeff"] = self.mcore_config.moe_z_loss_coeff
+            if self.mcore_config.moe_enable_deepep:
+                moe_extra_args["moe_enable_deepep"] = True
+            # Filter out args not accepted by the target TransformerConfig class.
+            accepted = {
+                f.name for f in dataclasses.fields(self.bridge.TransformerConfigClass)
+            }
+            moe_extra_args = {k: v for k, v in moe_extra_args.items() if k in accepted}
+            self.bridge.set_extra_args(**moe_extra_args)
+
+            # Set precision and loss configuration (may not be supported by all
+            # model configs, e.g. MLATransformerConfig rejects enable_fp32_lm_head).
+            precision_args = {}
+            if self.mcore_config.enable_fp32_lm_head:
+                precision_args["enable_fp32_lm_head"] = True
+            if self.mcore_config.cross_entropy_loss_fusion:
+                precision_args["cross_entropy_loss_fusion"] = True
+            if precision_args:
+                try:
+                    self.bridge.set_extra_args(**precision_args)
+                except TypeError as e:
+                    self.logger.warning(
+                        f"Some precision args not supported by this model config: {e}. "
+                        f"Skipping: {list(precision_args.keys())}"
+                    )
+
             self.logger.info(
                 "Using mbridge to create models and hf model save/load in MegatronEngine."
             )
@@ -841,6 +879,7 @@ class MegatronEngine(TrainEngine):
             [torch.Tensor, dict[str, Any]], torch.Tensor | None
         ],
         forward_only: bool = False,
+        gather_cp_output: bool = False,
     ) -> None:
         self._ensure_ready()
 
@@ -872,7 +911,11 @@ class MegatronEngine(TrainEngine):
                     tree_attn_keys = list(tree_kwargs.keys())
 
             cp_size = mpu.get_context_parallel_world_size()
-            cp_local = cp_size > 1
+            # forward_batch (compute_logp / compute_values) 传 gather_cp_output=True,
+            # 使 CP-local 输出在 forward 内 gather 回全长,匹配下游用的全长 labels /
+            # output_seqlens(修复 compute_logp 在 CP>1 时 split_with_sizes 不匹配的 bug)。
+            # train/eval 保持 default False -> CP-local loss 路径(_cp_local_labels)不变。
+            cp_local = cp_size > 1 and not gather_cp_output
 
             output = packed_context_parallel_forward(
                 model,
@@ -1077,7 +1120,9 @@ class MegatronEngine(TrainEngine):
             outputs.append(result)
             return None
 
-        self.forward_backward_batch(mb_list, process_output, forward_only=True)
+        self.forward_backward_batch(
+            mb_list, process_output, forward_only=True, gather_cp_output=True
+        )
 
         # Step 4: Aggregate, reorder, and broadcast outputs
         res = None
@@ -2298,6 +2343,8 @@ class MegatronEngine(TrainEngine):
                 )
                 vocab_min_logits = output.detach().min(-1).values.float()
                 vocab_max_logits = output.detach().max(-1).values.float()
+                vocab_mean_logits = output.detach().float().mean(-1)
+                vocab_norm_logits = output.detach().float().norm(dim=-1)
                 if cp_padded_cu_seqlens is not None:
                     logprobs = reassemble_cp_packed_logprobs(
                         logprobs, cp_padded_cu_seqlens
@@ -2310,6 +2357,12 @@ class MegatronEngine(TrainEngine):
                     )
                     vocab_max_logits = reassemble_cp_packed_logprobs(
                         vocab_max_logits, cp_padded_cu_seqlens
+                    )
+                    vocab_mean_logits = reassemble_cp_packed_logprobs(
+                        vocab_mean_logits, cp_padded_cu_seqlens
+                    )
+                    vocab_norm_logits = reassemble_cp_packed_logprobs(
+                        vocab_norm_logits, cp_padded_cu_seqlens
                     )
                     cp_padding_length = inputs.get("_cp_padding_length", 0)
                     cp_old_cu_seqlens = inputs.get("_cp_old_cu_seqlens")
@@ -2337,6 +2390,18 @@ class MegatronEngine(TrainEngine):
                         cp_padded_cu_seqlens,
                         cp_old_cu_seqlens,
                     )
+                    vocab_mean_logits = unpad_logits(
+                        vocab_mean_logits,
+                        cp_padding_length,
+                        cp_padded_cu_seqlens,
+                        cp_old_cu_seqlens,
+                    )
+                    vocab_norm_logits = unpad_logits(
+                        vocab_norm_logits,
+                        cp_padding_length,
+                        cp_padded_cu_seqlens,
+                        cp_old_cu_seqlens,
+                    )
                     inputs = {
                         k: v for k, v in inputs.items() if not k.startswith("_cp_")
                     }
@@ -2346,6 +2411,8 @@ class MegatronEngine(TrainEngine):
                 inputs,
                 vocab_min_logits=vocab_min_logits,
                 vocab_max_logits=vocab_max_logits,
+                vocab_mean_logits=vocab_mean_logits,
+                vocab_norm_logits=vocab_norm_logits,
             )
         else:
             values = output.squeeze(-1)

--- a/areal/experimental/openai/cache.py
+++ b/areal/experimental/openai/cache.py
@@ -1,17 +1,53 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+import os
 import threading
+import time
 from collections import OrderedDict
-from typing import Any
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
 
 from areal.experimental.openai.types import InteractionWithTokenLogpReward
 from areal.utils import logging
 
 logger = logging.getLogger("OpenAICache")
 
+_MISMATCH_DUMP_DIR = os.environ.get(
+    "CC_MISMATCH_DUMP_DIR", "/tmp/cache_mismatch_dumps"
+)
+
+
+@runtime_checkable
+class PrefixMatcher(Protocol):
+    """Protocol for custom message prefix matching functions."""
+
+    def __call__(self, a: list[dict], b: list[dict]) -> bool: ...
+
+
+def default_prefix_matcher(a: list[dict], b: list[dict]) -> bool:
+    """Default exact prefix matcher: ``b[:len(a)] == a``."""
+    if len(a) > len(b):
+        return False
+    return b[: len(a)] == a
+
 
 class InteractionCache(OrderedDict[str, InteractionWithTokenLogpReward]):
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        *args,
+        session_id: str = "unknown",
+        prefix_matcher: PrefixMatcher
+        | Callable[[list[dict], list[dict]], bool]
+        | None = None,
+        **kwargs,
+    ):
+        self._match_fail_count = 0
+        self._session_id = session_id
+        self._prefix_matcher: Callable[[list[dict], list[dict]], bool] = (
+            prefix_matcher if prefix_matcher is not None else default_prefix_matcher
+        )
         super().__init__(*args, **kwargs)
         self._apply_reward_discount_called = False
         self._total_reward = 0.0
@@ -29,7 +65,10 @@ class InteractionCache(OrderedDict[str, InteractionWithTokenLogpReward]):
         assert len(self) == 0, (
             f"InteractionCache must be empty when deep-copied, but has {len(self)} items"
         )
-        new = InteractionCache()
+        new = InteractionCache(
+            session_id=self._session_id,
+            prefix_matcher=self._prefix_matcher,
+        )
         memo[id(self)] = new
         return new
 
@@ -115,12 +154,6 @@ class InteractionCache(OrderedDict[str, InteractionWithTokenLogpReward]):
                 "Interaction messages must be set to find parent relationship."
             )
 
-        def _is_prefix(a: list[dict], b: list[dict]) -> bool:
-            # True if a is a prefix of b
-            if len(a) > len(b):
-                return False
-            return b[: len(a)] == a
-
         def _is_similar_on_last_message(
             a: list[dict], b: list[dict]
         ) -> tuple[bool, dict[str, Any] | None, dict[str, Any] | None]:
@@ -143,13 +176,12 @@ class InteractionCache(OrderedDict[str, InteractionWithTokenLogpReward]):
             }
             return True, diff_a_message, diff_b_message
 
-        # Construct parent-child relationships using longest prefix rule
-        # Sort potential parents by message length to find the longest prefix match first.
+        # Construct parent-child relationships using longest prefix rule.
         interactions = sorted(
             self.values(), key=lambda x: len(x.messages), reverse=True
         )
+        child_msgs = value.messages
 
-        # Find parent for the new interaction
         for parent in interactions:
             # Skip interactions that are still being processed (output_message_list not set yet)
             # This can happen with concurrent requests where a streaming request hasn't
@@ -157,23 +189,93 @@ class InteractionCache(OrderedDict[str, InteractionWithTokenLogpReward]):
             if parent.output_message_list is None or parent.messages is None:
                 continue
             parent_data = parent.messages + parent.output_message_list
-            if _is_prefix(parent_data, value.messages):
+            if self._prefix_matcher(parent_data, child_msgs):
                 value.parent = parent
                 break
-            elif _is_prefix(parent.messages, value.messages):
+            elif self._prefix_matcher(parent.messages, child_msgs):
+                self._match_fail_count += 1
+
+                logger.warning(
+                    "Prefix mismatch (occurrence %d, session=%s): "
+                    "parent.messages (len=%d) is a prefix of child (len=%d), "
+                    "but parent_data (messages+output, len=%d) is not.",
+                    self._match_fail_count,
+                    self._session_id,
+                    len(parent.messages),
+                    len(child_msgs),
+                    len(parent_data),
+                )
+                self._dump_mismatch(
+                    parent_data=parent_data,
+                    child_msgs=child_msgs,
+                    parent_id=parent.interaction_id,
+                    child_key=key,
+                )
+
                 is_similar, diff_a, diff_b = _is_similar_on_last_message(
-                    parent_data, value.messages
+                    parent_data, child_msgs
                 )
                 if is_similar:
                     logger.warning(
                         "Found a parent interaction with similar last message content, "
-                        "but not a strict prefix match. If you wish to use concat mode and build a conversation tree:\n"
+                        "but not a strict prefix match (occurrence %d, "
+                        "session=%s, parent_len=%d, child_len=%d). "
+                        "If you wish to use concat mode and build a conversation tree:\n"
                         "1. For completion, append `chat_completion.choices[0].message.model_dump()` to your messages.\n"
                         "2. For response, extend `[o.model_dump() for o in response.output]` to your messages.\n"
-                        f"Different keys in parent last message: {diff_a}\n"
-                        f"Different keys in child last message: {diff_b}\n"
+                        "Different keys in parent last message: %s\n"
+                        "Different keys in child last message: %s",
+                        self._match_fail_count,
+                        self._session_id,
+                        len(parent_data),
+                        len(child_msgs),
+                        diff_a,
+                        diff_b,
                     )
         super().__setitem__(key, value)
+
+    def _dump_mismatch(
+        self,
+        parent_data: list[dict],
+        child_msgs: list[dict],
+        parent_id: str | None,
+        child_key: str,
+    ) -> None:
+        """Dump mismatched parent/child messages to a JSON file for debugging."""
+        try:
+            dump_dir = Path(_MISMATCH_DUMP_DIR)
+            dump_dir.mkdir(parents=True, exist_ok=True)
+
+            ts = time.strftime("%Y%m%d_%H%M%S")
+            filename = (
+                f"mismatch_{self._session_id}_{self._match_fail_count}_{ts}.json"
+            )
+            dump_path = dump_dir / filename
+
+            first_diff_idx = None
+            for i, (pm, cm) in enumerate(zip(parent_data, child_msgs)):
+                if pm != cm:
+                    first_diff_idx = i
+                    break
+
+            dump = {
+                "session_id": self._session_id,
+                "occurrence": self._match_fail_count,
+                "parent_id": parent_id,
+                "child_key": child_key,
+                "parent_len": len(parent_data),
+                "child_len": len(child_msgs),
+                "first_diff_idx": first_diff_idx,
+                "parent_data": parent_data,
+                "child_msgs": child_msgs,
+            }
+
+            with open(dump_path, "w", encoding="utf-8") as f:
+                json.dump(dump, f, indent=2, ensure_ascii=False, default=str)
+
+            logger.info("Mismatch dump saved to %s", dump_path)
+        except Exception as e:
+            logger.warning("Failed to dump mismatch: %s", e)
 
     def export_interactions(
         self, style: str, reward_discount: float | None = None

--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -720,6 +720,9 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
             n_samples=n,
             temperature=temp,
             max_new_tokens=max_new_tokens,
+            max_tokens=max_total_tokens_final
+            if max_total_tokens_final is not None
+            else len(prompt_token_ids) + max_new_tokens,
             top_p=top_p_val,
             stop=stop_tokens,
             greedy=temp == 0,
@@ -859,9 +862,17 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
                 )
 
             # Tool calls chunks (if any)
+            # Split each tool call into two chunks (name then arguments) to
+            # match standard OpenAI streaming behavior. LiteLLM's Anthropic
+            # streaming adapter treats the first chunk with a function name as
+            # a content_block_start trigger and discards the processed delta
+            # from that same chunk. If name and arguments are combined in a
+            # single chunk, the arguments are lost and Anthropic clients see
+            # input={}.
             if tool_calls:
                 for idx, tool_call in enumerate(tool_calls):
                     tool_call = cast(ChatCompletionMessageFunctionToolCall, tool_call)
+                    # Chunk 1: name + id, with empty arguments.
                     yield ChatCompletionChunk(
                         id=completion_id,
                         choices=[
@@ -874,6 +885,30 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
                                             type="function",
                                             function=ChoiceDeltaToolCallFunction(
                                                 name=tool_call.function.name,
+                                                arguments="",
+                                            ),
+                                        )
+                                    ]
+                                ),
+                                index=0,
+                                finish_reason=None,
+                            )
+                        ],
+                        created=current_time,
+                        model="None",
+                        object="chat.completion.chunk",
+                    )
+                    # Chunk 2: arguments only, emitted as input_json_delta by
+                    # Anthropic adapters after the tool_use block has started.
+                    yield ChatCompletionChunk(
+                        id=completion_id,
+                        choices=[
+                            ChunkChoice(
+                                delta=ChoiceDelta(
+                                    tool_calls=[
+                                        ChoiceDeltaToolCall(
+                                            index=idx,
+                                            function=ChoiceDeltaToolCallFunction(
                                                 arguments=tool_call.function.arguments,
                                             ),
                                         )
@@ -1081,6 +1116,9 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
             n_samples=1,
             temperature=temp,
             max_new_tokens=max_new_tokens,
+            max_tokens=self.engine_max_tokens
+            if self.engine_max_tokens is not None
+            else len(prompt_token_ids) + max_new_tokens,
             top_p=top_p_val,
             stop=stop,
             greedy=temp == 0,

--- a/areal/experimental/openai/proxy/proxy_rollout_server.py
+++ b/areal/experimental/openai/proxy/proxy_rollout_server.py
@@ -110,6 +110,14 @@ _admin_api_key: str = secrets.token_urlsafe(32)
 _api_key_to_session: dict[str, str] = {}
 _session_to_api_key: dict[str, str] = {}  # Reverse mapping for O(1) cleanup
 
+# Pluggable message preprocessors loaded from config at setup time.
+# Applied in order after Anthropic-to-OpenAI translation, before content
+# reaches the ArealOpenAI client.
+_message_preprocessors: list = []
+
+# Pluggable prefix matcher for InteractionCache parent-child matching.
+_prefix_matcher = None
+
 # Server address (set at startup)
 _server_host: str = "0.0.0.0"
 _server_port: int = 8000
@@ -262,6 +270,7 @@ async def alloc_ports(raw_request: Request):
 
 def _setup_openai_client():
     global _openai_client, _session_timeout_seconds, _admin_api_key
+    global _message_preprocessors, _prefix_matcher
     config = _engine.config
     tokenizer = load_hf_tokenizer(config.tokenizer_path)
     agent_cfg = config.agent
@@ -291,6 +300,18 @@ def _setup_openai_client():
     # Only commit the key to the global after validation has passed.
     with _lock:
         _admin_api_key = agent_cfg.admin_api_key
+
+    _message_preprocessors = []
+    for path in agent_cfg.message_preprocessors:
+        cls = import_from_string(path)
+        _message_preprocessors.append(cls())
+        logger.info("Loaded message preprocessor: %s", path)
+
+    if agent_cfg.prefix_matcher:
+        _prefix_matcher = import_from_string(agent_cfg.prefix_matcher)
+        logger.info("Loaded prefix matcher: %s", agent_cfg.prefix_matcher)
+    else:
+        _prefix_matcher = None
 
 
 @app.post("/configure")
@@ -464,7 +485,10 @@ def start_session(request: StartSessionRequest) -> StartSessionResponse:
                 session_api_key = secrets.token_urlsafe(32)
 
         _capacity -= 1
-        _session_cache[session_id] = SessionData(session_id=session_id)
+        _session_cache[session_id] = SessionData(
+            session_id=session_id,
+            prefix_matcher=_prefix_matcher,
+        )
         _api_key_to_session[session_api_key] = session_id
         _session_to_api_key[session_id] = session_api_key
 
@@ -698,6 +722,19 @@ async def responses(
     )
 
 
+def _flatten_content_lists(messages: list[dict]) -> None:
+    """Flatten Anthropic content block lists to strings in-place."""
+    for msg in messages:
+        if isinstance(msg.get("content"), list):
+            text_parts = []
+            for block in msg["content"]:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text_parts.append(block.get("text", ""))
+                elif isinstance(block, str):
+                    text_parts.append(block)
+            msg["content"] = "\n".join(text_parts)
+
+
 def _translate_anthropic_to_openai_request(anthropic_request: dict[str, Any]) -> dict:
     """Translate an Anthropic Messages API request to OpenAI format."""
     openai_request = _adapter.translate_completion_input_params(
@@ -707,20 +744,10 @@ def _translate_anthropic_to_openai_request(anthropic_request: dict[str, Any]) ->
         raise ValueError("Failed to translate request")
     openai_request = dict(openai_request)
 
-    # Fix message content if it's a list (Anthropic format with content blocks)
-    # LiteLLM's adapter may not properly convert content from list to string
-    # Claude Code CLI sends content as: [{"type":"text","text":"...","cache_control":{...}}, ...]
     if "messages" in openai_request:
-        for msg in openai_request["messages"]:
-            if isinstance(msg.get("content"), list):
-                # Convert list of content blocks to string
-                text_parts = []
-                for block in msg["content"]:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text_parts.append(block.get("text", ""))
-                    elif isinstance(block, str):
-                        text_parts.append(block)
-                msg["content"] = "\n".join(text_parts)
+        _flatten_content_lists(openai_request["messages"])
+        for preprocessor in _message_preprocessors:
+            openai_request["messages"] = preprocessor(openai_request["messages"])
 
     return openai_request
 

--- a/areal/experimental/openai/proxy/server.py
+++ b/areal/experimental/openai/proxy/server.py
@@ -66,11 +66,14 @@ class ExportTrajectoriesResponse(BaseModel):
 class SessionData:
     """Data associated with a single RL session."""
 
-    def __init__(self, session_id: str):
+    def __init__(self, session_id: str, prefix_matcher=None):
         self.session_id = session_id
 
         self._completed = False
-        self._completions = InteractionCache()
+        self._completions = InteractionCache(
+            session_id=session_id,
+            prefix_matcher=prefix_matcher,
+        )
         self._completed_event = threading.Event()
         self._start_time = time.time()
         self._last_access_time = time.time()

--- a/areal/experimental/openai/tool_call_parser.py
+++ b/areal/experimental/openai/tool_call_parser.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+import re
 import traceback
 import uuid
 from types import SimpleNamespace
@@ -14,6 +16,19 @@ from openai.types.responses.response_function_tool_call import ResponseFunctionT
 from areal.utils import logging
 
 logger = logging.getLogger("ToolCallParser")
+
+_QWEN3_CODER_TOOL_CALL_RE = re.compile(
+    r"<tool_call>\s*(?P<body>.*?)\s*</tool_call>",
+    re.DOTALL,
+)
+_QWEN3_CODER_FUNCTION_RE = re.compile(
+    r"<function=(?P<name>[^>\s]+)>\s*(?P<body>.*?)\s*</function>",
+    re.DOTALL,
+)
+_QWEN3_CODER_PARAMETER_RE = re.compile(
+    r"<parameter=(?P<name>[^>\s]+)>(?P<value>.*?)</parameter>",
+    re.DOTALL,
+)
 
 _SGLANG_TO_VLLM_TOOL_PARSER: dict[str, str] = {
     "qwen": "qwen3_xml",
@@ -56,6 +71,168 @@ def _detect_think_and_return_ori_think(
     normal_text = splits[1]
 
     return think_start_token + reasoning_text + think_end_token, normal_text
+
+
+def _iter_tool_definitions(tools: list[Any]) -> list[dict[str, Any]]:
+    """Return OpenAI chat/responses tool definitions in a common shape."""
+    tool_defs: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        if isinstance(tool.get("function"), dict):
+            tool_defs.append(tool["function"])
+        elif tool.get("type") == "function":
+            tool_defs.append(tool)
+    return tool_defs
+
+
+def _tool_argument_schemas(tools: list[Any]) -> dict[str, dict[str, dict[str, Any]]]:
+    schemas: dict[str, dict[str, dict[str, Any]]] = {}
+    for tool_def in _iter_tool_definitions(tools):
+        name = tool_def.get("name")
+        parameters = tool_def.get("parameters")
+        if not isinstance(name, str) or not isinstance(parameters, dict):
+            continue
+        properties = parameters.get("properties")
+        if isinstance(properties, dict):
+            schemas[name] = {
+                key: value
+                for key, value in properties.items()
+                if isinstance(value, dict)
+            }
+    return schemas
+
+
+def _clean_qwen3_coder_parameter(raw_value: str) -> str:
+    if raw_value.startswith("\n"):
+        raw_value = raw_value[1:]
+    if raw_value.endswith("\n"):
+        raw_value = raw_value[:-1]
+    return raw_value
+
+
+def _coerce_qwen3_coder_parameter(
+    value: str,
+    schema: dict[str, Any] | None,
+) -> Any:
+    if not schema:
+        return value
+
+    typ = schema.get("type")
+    if isinstance(typ, list):
+        typ = next((t for t in typ if t != "null"), None)
+    stripped = value.strip()
+
+    try:
+        if typ == "boolean":
+            lowered = stripped.lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+        if typ == "integer":
+            return int(stripped)
+        if typ == "number":
+            return float(stripped)
+        if typ in {"array", "object"}:
+            return json.loads(stripped)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return value
+
+    return value
+
+
+def _build_tool_call(
+    name: str,
+    arguments: str,
+    use_responses: bool,
+) -> ChatCompletionMessageFunctionToolCall | ResponseFunctionToolCall:
+    if use_responses:
+        return ResponseFunctionToolCall(
+            type="function_call",
+            id=f"fc-{uuid.uuid4().hex[:24]}",
+            call_id=f"call_{uuid.uuid4().hex[:24]}",
+            name=name,
+            arguments=arguments,
+            status="completed",
+        )
+    return ChatCompletionMessageFunctionToolCall(
+        type="function",
+        id=f"call_{uuid.uuid4().hex[:24]}",
+        function=Function(name=name, arguments=arguments),
+    )
+
+
+def _process_tool_calls_qwen3_coder_xml(
+    text: str,
+    tools: list[Any],
+    finish_reason: str,
+    use_responses: bool = False,
+) -> tuple[
+    list[ChatCompletionMessageFunctionToolCall | ResponseFunctionToolCall] | None,
+    str,
+    str,
+]:
+    """Parse Qwen3-Coder XML tool calls with ``<parameter=...>`` tags.
+
+    SGLang's qwen3_coder parser recognizes the tool name in this format but
+    can return empty arguments for Claude Code style parameters.  That makes
+    Anthropic tool_use.input become ``{}``, so Claude Code rejects calls like
+    Bash/Read/Write as missing required parameters.
+    """
+
+    reasoning_text, content_text = _detect_think_and_return_ori_think(
+        text, "<think>", "</think>"
+    )
+    arg_schemas = _tool_argument_schemas(tools)
+
+    tool_calls: list[ChatCompletionMessageFunctionToolCall | ResponseFunctionToolCall]
+    tool_calls = []
+    remove_spans: list[tuple[int, int]] = []
+
+    for tool_match in _QWEN3_CODER_TOOL_CALL_RE.finditer(content_text):
+        block_calls: list[
+            ChatCompletionMessageFunctionToolCall | ResponseFunctionToolCall
+        ] = []
+        body = tool_match.group("body")
+        for fn_match in _QWEN3_CODER_FUNCTION_RE.finditer(body):
+            tool_name = fn_match.group("name")
+            fn_body = fn_match.group("body")
+            args: dict[str, Any] = {}
+            for param_match in _QWEN3_CODER_PARAMETER_RE.finditer(fn_body):
+                param_name = param_match.group("name")
+                param_value = _clean_qwen3_coder_parameter(
+                    param_match.group("value")
+                )
+                args[param_name] = _coerce_qwen3_coder_parameter(
+                    param_value,
+                    arg_schemas.get(tool_name, {}).get(param_name),
+                )
+
+            arguments = json.dumps(args, ensure_ascii=False)
+            block_calls.append(
+                _build_tool_call(tool_name, arguments, use_responses)
+            )
+
+        if block_calls:
+            tool_calls.extend(block_calls)
+            remove_spans.append(tool_match.span())
+
+    if not tool_calls:
+        return None, text, finish_reason
+
+    if finish_reason == "stop":
+        finish_reason = "tool_calls"
+
+    chunks: list[str] = []
+    last = 0
+    for start, end in remove_spans:
+        chunks.append(content_text[last:start])
+        last = end
+    chunks.append(content_text[last:])
+    cleaned_text = "".join(chunks).replace("<|im_end|>", "")
+
+    return tool_calls, reasoning_text + cleaned_text, finish_reason
 
 
 def _process_tool_calls_sglang(
@@ -267,6 +444,16 @@ def process_tool_calls(
     str,
 ]:
     """Process tool calls in the response"""
+    if tool_call_parser == "qwen3_coder":
+        tool_calls, output_text, finish_reason = _process_tool_calls_qwen3_coder_xml(
+            text,
+            tools,
+            finish_reason,
+            use_responses,
+        )
+        if tool_calls is not None:
+            return tool_calls, output_text, finish_reason
+
     try:
         return _process_tool_calls_sglang(
             text,

--- a/areal/infra/launcher/local.py
+++ b/areal/infra/launcher/local.py
@@ -31,6 +31,7 @@ from areal.infra.utils.launcher import (
     JobState,
     get_scheduling_spec,
     get_thread_env_vars,
+    run_post_exit_hook,
     validate_config_for_launcher,
     wait_llm_server_addrs,
 )
@@ -372,6 +373,7 @@ def local_main(config, run_id: int = 0):
             )
         except (TimeoutError, KeyboardInterrupt) as e:
             launcher.stop_all(signal="SIGINT")
+            run_post_exit_hook(config)
             raise e
 
     if config.get("enable_offload", False):
@@ -422,6 +424,7 @@ def local_main(config, run_id: int = 0):
         )
     except (KeyboardInterrupt, JobException, TimeoutError) as e:
         launcher.stop_all("SIGTERM")
+        run_post_exit_hook(config)
         # NOTE: For local launcher, We cannot distinguish between a completed job and a failed job.
         # So we will always try to recover the job if it is finished or failed.
         recover_states = [JobState.FAILED, JobState.NOT_FOUND, JobState.COMPLETED]

--- a/areal/infra/launcher/ray.py
+++ b/areal/infra/launcher/ray.py
@@ -34,6 +34,7 @@ from areal.infra.utils.launcher import (
     JobState,
     get_scheduling_spec,
     get_thread_env_vars,
+    run_post_exit_hook,
     validate_config_for_distributed_launcher,
     wait_llm_server_addrs,
 )
@@ -490,6 +491,7 @@ def ray_main(config, run_id: int = 0):
             launcher.stop_all(
                 force=False
             )  # force=False will send KeyboardInterrupt to sglang_server.main() to further clean all sglang-related processes
+            run_post_exit_hook(config)
             raise e
     elif allocation_mode.gen_backend == "vllm":
         config.vllm = to_structured_cfg(config.vllm, vLLMConfig)
@@ -532,6 +534,7 @@ def ray_main(config, run_id: int = 0):
             )
         except (TimeoutError, KeyboardInterrupt) as e:
             launcher.stop_all(force=True)
+            run_post_exit_hook(config)
             raise e
 
     if config.get("enable_offload", False):
@@ -626,6 +629,7 @@ def ray_main(config, run_id: int = 0):
         # Note: For trainer processes, we use force=True because the trainer doesn't
         # handle KeyboardInterrupt properly when force=False.
         launcher.stop_all(force=True, pattern="trainer")
+        run_post_exit_hook(config)
         recover_states = [JobState.FAILED]
         if isinstance(e, JobException):
             recover_this = (

--- a/areal/infra/launcher/slurm.py
+++ b/areal/infra/launcher/slurm.py
@@ -29,6 +29,7 @@ from areal.infra.utils.launcher import (
     JobState,
     get_scheduling_spec,
     get_thread_env_vars,
+    run_post_exit_hook,
     validate_config_for_distributed_launcher,
     wait_llm_server_addrs,
 )
@@ -572,6 +573,7 @@ def slurm_main(config, run_id: int = 0):
             )
         except (TimeoutError, KeyboardInterrupt) as e:
             launcher.stop_all(force=True)
+            run_post_exit_hook(config)
             raise e
 
     trainer_n_nodes = n_nodes - n_backend_nodes
@@ -675,6 +677,7 @@ def slurm_main(config, run_id: int = 0):
         )
     except (KeyboardInterrupt, JobException, TimeoutError) as e:
         launcher.stop_all(force=True)
+        run_post_exit_hook(config)
         recover_states = [JobState.FAILED, JobState.NOT_FOUND]
         if isinstance(e, JobException):
             recover_this = (

--- a/areal/infra/utils/launcher.py
+++ b/areal/infra/utils/launcher.py
@@ -5,6 +5,7 @@ import enum
 import getpass
 import os
 import pathlib
+import subprocess
 import sys
 import time
 
@@ -274,3 +275,58 @@ def validate_config_for_distributed_launcher(config):
             )
         if allocation_mode.gen.tp_size > config.cluster.n_gpus_per_node:
             raise ValueError("Currently only support vLLM TP size <= #GPUs per node.")
+
+
+def run_post_exit_hook(config) -> None:
+    """Run the post-exit hook command if configured.
+
+    Executes ``config.post_exit_hook`` as a shell command with a 600-second
+    timeout. The ``LOG_DIR`` environment variable is injected so the hook
+    can locate experiment logs. Failures (timeout, non-zero exit, exceptions)
+    are logged as warnings but never propagate — they must not block recovery.
+
+    Args:
+        config: Experiment configuration with ``post_exit_hook``,
+            ``experiment_name``, ``trial_name``, and ``cluster.fileroot``.
+    """
+    hook_cmd = getattr(config, "post_exit_hook", "")
+    if not hook_cmd or not hook_cmd.strip():
+        return
+
+    hook_cmd = hook_cmd.strip()
+    logger.info(f"Running post-exit hook: {hook_cmd}")
+
+    env = os.environ.copy()
+    try:
+        log_dir = os.path.join(
+            config.cluster.fileroot,
+            "logs",
+            getpass.getuser(),
+            config.experiment_name,
+            config.trial_name,
+        )
+        env["LOG_DIR"] = log_dir
+    except Exception:
+        pass
+
+    try:
+        result = subprocess.run(
+            hook_cmd,
+            shell=True,
+            timeout=600,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if result.stdout:
+            logger.info(f"Post-exit hook stdout: {result.stdout.strip()}")
+        if result.stderr:
+            logger.warning(f"Post-exit hook stderr: {result.stderr.strip()}")
+        if result.returncode != 0:
+            logger.warning(f"Post-exit hook exited with code {result.returncode}")
+        else:
+            logger.info("Post-exit hook completed successfully")
+    except subprocess.TimeoutExpired:
+        logger.warning(f"Post-exit hook timed out after 600s: {hook_cmd}")
+    except Exception as e:
+        logger.warning(f"Post-exit hook failed: {e}")

--- a/areal/models/mcore/bailing_moe.py
+++ b/areal/models/mcore/bailing_moe.py
@@ -200,6 +200,14 @@ def hf_to_mcore_config_bailing_moe(
         # YaRN RoPE scaling parameters (explicitly set to prevent HybridEngine default drift)
         "mscale": 0.707,
         "mscale_all_dim": 0.707,
+        # original_max_position_embeddings: YaRN nests it inside rope_scaling; non-YaRN
+        # configs may have it at the top level. Fall back to max_position_embeddings.
+        # mcore 0.16 default (4096) is wrong for long-context models.
+        "original_max_position_embeddings": (
+            rope_scaling.get("original_max_position_embeddings")
+            or getattr(hf_config, "original_max_position_embeddings", None)
+            or getattr(hf_config, "max_position_embeddings", 4096)
+        ),
     }
 
     # MoE-specific parameters
@@ -222,6 +230,10 @@ def hf_to_mcore_config_bailing_moe(
         "moe_router_load_balancing_type": "none",
         "moe_grouped_gemm": True,
         "moe_router_dtype": "fp32",
+        # Auxiliary-loss-free load balancing (DeepSeek V3 style) + router z-loss.
+        # 0.0 disables bias updates by default; engine config can override.
+        "moe_router_bias_update_rate": 0.0,
+        "moe_z_loss_coeff": 3.5e-6,
     }
 
     # Merge all args

--- a/areal/models/mcore/bailing_moe_bridge.py
+++ b/areal/models/mcore/bailing_moe_bridge.py
@@ -174,6 +174,16 @@ class BailingMoeBridge(LLMBridge):
                 "factor", 1.0
             ),
             apply_rope_fusion=False,
+            # original_max_position_embeddings: YaRN nests it in rope_scaling; fall back
+            # to the top-level field / max_position_embeddings. mcore 0.16 default (4096)
+            # is wrong for long-context models.
+            original_max_position_embeddings=(
+                (getattr(hf_config, "rope_scaling", None) or {}).get(
+                    "original_max_position_embeddings"
+                )
+                or getattr(hf_config, "original_max_position_embeddings", None)
+                or getattr(hf_config, "max_position_embeddings", 4096)
+            ),
             # MoE parameters
             moe_ffn_hidden_size=getattr(hf_config, "moe_intermediate_size", None),
             moe_token_dispatcher_type="alltoall",
@@ -192,6 +202,9 @@ class BailingMoeBridge(LLMBridge):
             moe_layer_freq=moe_layer_freq,
             # Other
             moe_router_dtype="fp32",
+            # Auxiliary-loss-free load balancing (DeepSeek V3 style) + router z-loss.
+            moe_router_bias_update_rate=0.0,
+            moe_z_loss_coeff=3.5e-6,
             persist_layer_norm=True,
             bias_activation_fusion=True,
             bias_dropout_fusion=True,

--- a/areal/trainer/dpo/dpo_engine.py
+++ b/areal/trainer/dpo/dpo_engine.py
@@ -153,6 +153,8 @@ def compute_dpo_loss(
     loss_type: str = "sigmoid",
     vocab_min_logits: torch.Tensor | None = None,
     vocab_max_logits: torch.Tensor | None = None,
+    vocab_mean_logits: torch.Tensor | None = None,
+    vocab_norm_logits: torch.Tensor | None = None,
 ) -> torch.Tensor:
     device = logprobs.device
     cu_seqlens = input_["cu_seqlens"].to(device=device, dtype=torch.long)

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -426,6 +426,8 @@ def grpo_loss_fn(
     use_decoupled_loss: bool = False,
     vocab_min_logits: torch.Tensor | None = None,
     vocab_max_logits: torch.Tensor | None = None,
+    vocab_mean_logits: torch.Tensor | None = None,
+    vocab_norm_logits: torch.Tensor | None = None,
 ):
     """Loss function for actor step, all inputs should be splitted into
     pipeline micro batches, returns loss and logging stats."""

--- a/areal/trainer/sft/lm_engine.py
+++ b/areal/trainer/sft/lm_engine.py
@@ -84,9 +84,21 @@ def compute_packed_sft_loss(
     input_: dict[str, Any],
     vocab_min_logits: torch.Tensor | None = None,
     vocab_max_logits: torch.Tensor | None = None,
+    vocab_mean_logits: torch.Tensor | None = None,
+    vocab_norm_logits: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Compute SFT loss from logprobs."""
-    del entropy  # SFT does not use entropy
+    """Compute SFT loss from logprobs.
+
+    CP NOTE: MegatronEngine reassembles the CP-local per-token scalars
+    (logprobs / entropy / vocab_*) into full sequences via
+    ``reassemble_cp_packed_logprobs`` (a 1D all-gather over the CP group) *before*
+    calling this loss. The vocab reduction along the V dim happens earlier, so the
+    all-gather only moves per-token scalars, not the full logits — this is the
+    OOM-avoiding CP path. Consequently the tensors here are already full-sequence
+    and CP-replicated; the default DP-only reduce at export time yields the correct
+    global values. We must NOT additionally reduce across CP (that would multiply
+    sums by cp_size). See ``reassemble_cp_packed_logprobs`` and #1242.
+    """
     cu_seqlens: torch.Tensor = input_["cu_seqlens"]
     loss_mask = input_["loss_mask"].bool()
 
@@ -103,11 +115,8 @@ def compute_packed_sft_loss(
             logp = logprobs[cu_seqlens[i] : cu_seqlens[i + 1]]
             valid_tokens = int(m.count_nonzero().item())
             if valid_tokens == 0:
-                # This is a padded dummy sequence created in `padded_mb_input`.
-                # When Ulysses SP is enabled, padded inputs are passed into the loss function.
-                # So we skip it.
+                # Padded dummy sequence created in `padded_mb_input`; skip it.
                 continue
-
             n_seqs[i] = True
             seqlogp[i] = torch.where(m, logp.detach(), 0.0).sum() / valid_tokens
 
@@ -120,11 +129,22 @@ def compute_packed_sft_loss(
     )
     stats_tracker.stat(ppl=(-seqlogp).exp().float(), denominator="n_seqs")
     stats_tracker.stat(loss=-logprobs.detach(), denominator="n_valid_tokens")
+    stats_tracker.stat(
+        entropy=torch.where(loss_mask, entropy.detach().float(), 0.0),
+        denominator="n_valid_tokens",
+    )
 
     if vocab_min_logits is not None and vocab_max_logits is not None:
         stats_tracker.stat(
             vocab_min_logits=vocab_min_logits,
             vocab_max_logits=vocab_max_logits,
+            denominator="n_tokens",
+        )
+
+    if vocab_mean_logits is not None and vocab_norm_logits is not None:
+        stats_tracker.stat(
+            vocab_mean_logits=vocab_mean_logits,
+            vocab_norm_logits=vocab_norm_logits,
             denominator="n_tokens",
         )
 

--- a/areal/utils/logging.py
+++ b/areal/utils/logging.py
@@ -111,6 +111,8 @@ LOGGER_COLORS_EXACT = {
     "ToolCallParser": "light_purple",
     "TokenLogpReward": "light_purple",
     "ProxyUtils": "light_purple",
+    "AReaL-SWEAgent": "light_purple",
+    "SWETrain": "light_green",
     # Agent Service - purple
     "AgentGateway": "light_purple",
     "AgentBridge": "light_purple",

--- a/areal/utils/stats_tracker.py
+++ b/areal/utils/stats_tracker.py
@@ -36,6 +36,11 @@ class DistributedStatsTracker:
             self.scope_stack.append(name.strip("/"))
         self.denominators = {}  # key -> denominator key
         self.reduce_types = {}  # key -> ReduceType
+        # Per-key override of the reduce_group. If set, its value takes
+        # precedence over the `reduce_group` passed to `export`. This is used,
+        # e.g., to make CP-local SFT stats (loss/entropy/vocab_*) reduce across
+        # DP + CP so the reported numbers are CP-invariant (#1242 follow-up).
+        self.reduce_groups = {}  # key -> dist.ProcessGroup
 
         self.stats = defaultdict(list)
 
@@ -93,7 +98,7 @@ class DistributedStatsTracker:
                 self._set_reduce_type(full_key, ReduceType.SCALAR)
                 self.stats[full_key].append(time.perf_counter() - start_time)
 
-    def denominator(self, **kwargs):
+    def denominator(self, *, reduce_group=None, **kwargs):
         with self.lock:
             for key, value in kwargs.items():
                 if not isinstance(value, torch.Tensor) or value.dtype != torch.bool:
@@ -105,21 +110,34 @@ class DistributedStatsTracker:
                 full_key = self._get_full_key(key)
                 self._set_reduce_type(full_key, ReduceType.SUM)
                 self.stats[full_key].append(value.detach().clone())
+                if reduce_group is not None:
+                    self.reduce_groups[full_key] = reduce_group
 
-    def scalar(self, **kwargs):
+    def scalar(self, *, reduce_group=None, **kwargs):
         with self.lock:
             for key, value in kwargs.items():
                 full_key = self._get_full_key(key)
                 self._set_reduce_type(full_key, ReduceType.SCALAR)
                 self.stats[full_key].append(float(value))
+                if reduce_group is not None:
+                    self.reduce_groups[full_key] = reduce_group
 
     def stat(
         self,
         denominator: str,
         reduce_type: ReduceType | None = None,
+        *,
+        reduce_group=None,
         **kwargs,
     ):
-        """Record multiple values from a dictionary"""
+        """Record multiple values from a dictionary.
+
+        If `reduce_group` is provided, it overrides the `reduce_group` passed
+        to `export` for these specific keys. This enables recording stats that
+        must be reduced across a different topology than the default (e.g.,
+        loss/vocab_* under CP-local loss need DP+CP reduce while n_seqs stays
+        DP-only).
+        """
         with self.lock:
             for key, value in kwargs.items():
                 if not isinstance(value, torch.Tensor) or value.dtype != torch.float:
@@ -143,11 +161,17 @@ class DistributedStatsTracker:
                     reduce_type = ReduceType.AVG_MIN_MAX
                 self._set_reduce_type(full_key, reduce_type)
                 self.stats[full_key].append(value.detach().clone())
+                if reduce_group is not None:
+                    self.reduce_groups[full_key] = reduce_group
 
     def _set_reduce_type(self, key, reduce_type):
         if not isinstance(reduce_type, ReduceType):
             raise ValueError("reduce_type must be a ReduceType enum")
         self.reduce_types[key] = reduce_type
+
+    def _effective_reduce_group(self, key, default_reduce_group):
+        """Return the per-key reduce_group override if any, else the default."""
+        return self.reduce_groups.get(key, default_reduce_group)
 
     def export(self, key=None, reduce_group=None, reset=True) -> dict[str, float]:
         """Get aggregated statistics"""
@@ -159,7 +183,9 @@ class DistributedStatsTracker:
                     if full_key in self.denominators:
                         self.denominators.pop(full_key)
                     if full_key in self.reduce_types:
-                        self.denominators.pop(full_key)
+                        self.reduce_types.pop(full_key)
+                    if full_key in self.reduce_groups:
+                        self.reduce_groups.pop(full_key)
                     self.stats.pop(full_key)
                 return result
 
@@ -176,6 +202,7 @@ class DistributedStatsTracker:
             if reset:
                 self.denominators = {}
                 self.reduce_types = {}
+                self.reduce_groups = {}
                 self.stats = defaultdict(list)
             results = {
                 k: v.cpu().item() if torch.is_tensor(v) else v
@@ -208,9 +235,10 @@ class DistributedStatsTracker:
                 sum(self.stats[key]), dtype=torch.float32, device=device
             )
             cnt = torch.tensor(len(self.stats[key]), dtype=torch.float32, device=device)
-            if reduce_group is not None:
-                dist.all_reduce(value, group=reduce_group)
-                dist.all_reduce(cnt, group=reduce_group)
+            effective_group = self._effective_reduce_group(key, reduce_group)
+            if effective_group is not None:
+                dist.all_reduce(value, group=effective_group)
+                dist.all_reduce(cnt, group=effective_group)
             result[key] = float(value / cnt)
             result[key + "__count"] = int(cnt)
         else:
@@ -223,10 +251,11 @@ class DistributedStatsTracker:
 
     def _sum_of(self, key, reduce_group):
         values = self.stats[key]
+        effective_group = self._effective_reduce_group(key, reduce_group)
         if key not in self.denominators:
             x = sum([x.sum() for x in values])
-            if reduce_group is not None:
-                dist.all_reduce(x, group=reduce_group)
+            if effective_group is not None:
+                dist.all_reduce(x, group=effective_group)
         else:
             denominator = self.denominators[key]
             if denominator not in self.stats:
@@ -237,8 +266,8 @@ class DistributedStatsTracker:
             for v, d in zip(values, self.stats[denominator]):
                 xs.append(torch.where(d, v, 0.0).sum())
             x = sum(xs)
-            if reduce_group is not None:
-                dist.all_reduce(x, group=reduce_group)
+            if effective_group is not None:
+                dist.all_reduce(x, group=effective_group)
         return float(x)
 
     def _avg_of(self, key, reduce_group):
@@ -253,9 +282,10 @@ class DistributedStatsTracker:
             ds.append(d.sum())
         x = sum(xs)
         d = sum(ds)
-        if reduce_group is not None:
-            dist.all_reduce(x, group=reduce_group)
-            dist.all_reduce(d, group=reduce_group)
+        effective_group = self._effective_reduce_group(key, reduce_group)
+        if effective_group is not None:
+            dist.all_reduce(x, group=effective_group)
+            dist.all_reduce(d, group=effective_group)
         if d == 0:
             return None
         return x / d
@@ -269,8 +299,9 @@ class DistributedStatsTracker:
         for v, d in zip(values, self.stats[denominator]):
             xs.append(torch.where(d, v, float("inf")).min())
         x = min(xs)
-        if reduce_group is not None:
-            dist.all_reduce(x, group=reduce_group, op=dist.ReduceOp.MIN)
+        effective_group = self._effective_reduce_group(key, reduce_group)
+        if effective_group is not None:
+            dist.all_reduce(x, group=effective_group, op=dist.ReduceOp.MIN)
         if torch.isinf(x):
             return None
         return float(x)
@@ -284,8 +315,9 @@ class DistributedStatsTracker:
         for v, d in zip(values, self.stats[denominator]):
             xs.append(torch.where(d, v, -float("inf")).max())
         x = max(xs)
-        if reduce_group is not None:
-            dist.all_reduce(x, group=reduce_group, op=dist.ReduceOp.MAX)
+        effective_group = self._effective_reduce_group(key, reduce_group)
+        if effective_group is not None:
+            dist.all_reduce(x, group=effective_group, op=dist.ReduceOp.MAX)
         if torch.isinf(x):
             return None
         return float(x)

--- a/examples/swe/README.md
+++ b/examples/swe/README.md
@@ -1,0 +1,87 @@
+# SWE-bench RL training with AReaL-SWEAgent
+
+This example runs SWE-bench coding-agent RL (GRPO) in AReaL. The actual agent
+loop, sandboxing and reward computation live in a **separate repository**,
+[AReaL-SWEAgent](https://github.com/areal-project/AReaL-SWEAgent): for each
+SWE-bench instance it edits code inside an isolated sandbox, grades the patch,
+and returns a reward for the RL loop. AReaL serves the policy being trained and
+drives rollouts through its OpenAI-compatible proxy.
+
+```
+AReaL (this repo)                         AReaL-SWEAgent (separate checkout)
+  PPOTrainer / rollout proxy  ──▶  run_agent_with_reward()  ──▶  sandbox + grade
+        ▲                                                              │
+        └──────────────── reward, stats ◀──────────────────────────────┘
+```
+
+## 1. Get AReaL-SWEAgent
+
+Clone it next to AReaL (the default lookup path is `../AReaL-SWEAgent`) and
+install its dependencies into the same environment AReaL workers run in:
+
+```bash
+git clone https://github.com/areal-project/AReaL-SWEAgent.git
+cd AReaL-SWEAgent
+pip install -r requirements.txt
+```
+
+AReaL imports it as the Python package `aweagent`; the repository directory name
+(`AReaL-SWEAgent`) and the package name (`aweagent`) intentionally differ.
+
+## 2. Point AReaL at the checkout
+
+AReaL discovers the checkout in this order (first match wins):
+
+1. `econfig.agent_root` in your YAML (legacy alias: `econfig.swe_agent_root`).
+2. `AWEAGENT_ROOT` / `SWE_AGENT_ROOT` environment variable.
+3. `../AReaL-SWEAgent` relative to the AReaL repo root.
+
+In a multi-node / containerized setup the checkout must be importable on every
+worker, so put it on shared storage and set both the env var and `PYTHONPATH`,
+e.g. in the worker `scheduling_spec.env_vars`:
+
+```yaml
+env_vars:
+  AWEAGENT_ROOT: "/path/to/AReaL-SWEAgent"
+  SWE_AGENT_ROOT: "/path/to/AReaL-SWEAgent"
+  PYTHONPATH: "/path/to/AReaL-SWEAgent:/path/to/AReaL"
+  # URL of the AEnvironment sandbox service used by AReaL-SWEAgent.
+  AENV_SYSTEM_URL: "http://your-aenv-service:8080"
+```
+
+## 3. Configure the agent (econfig)
+
+The SWE example reads an `econfig` block (see `examples/swe/utils.py`):
+
+| Field | Meaning |
+| --- | --- |
+| `agent_type` | Agent to run: `swe` (built-in tool-use) or `cc` (Claude Code). |
+| `agent_config` | Generic config name under `AReaL-SWEAgent/aweagent/configs/`. Overrides the per-type fields below when set. |
+| `swe_agent_config` | Config used when `agent_type=swe` (default `1_0_0/min-swe-agent-train-top1`). |
+| `cc_agent_config` | Config used when `agent_type=cc`. |
+| `agent_root` | Path to the AReaL-SWEAgent checkout (see section 2). |
+| `step_limit` | Max agent interaction steps per episode. |
+| `max_completion_tokens` | Max completion tokens per agent LLM call. |
+| `timeout` | Max wall-clock time per episode (seconds). |
+
+## 4. Dataset format
+
+`train_swe_rl.py` loads a JSONL file (`train_dataset.path`) where each line is a
+SWE-bench instance with at least:
+
+- `instance_id` — e.g. `django__django-10097`
+- `problem_statement` — the GitHub issue text
+- `eval_script` — shell script used by AReaL-SWEAgent to grade the patch
+
+## 5. Run
+
+Edit the placeholder paths in `qwen3_30b_a3b_grpo.yaml` (model,
+dataset, `AWEAGENT_ROOT`, caches, sandbox/W&B endpoints), then launch:
+
+```bash
+python -m examples.swe.train_swe_rl --config examples/swe/qwen3_30b_a3b_grpo.yaml
+```
+
+With `scheduler.type=slurm`, AReaL launches the rollout / actor / proxy workers;
+each rollout calls into AReaL-SWEAgent, which runs the agent in a sandbox and
+returns the reward.

--- a/examples/swe/agent.py
+++ b/examples/swe/agent.py
@@ -1,0 +1,260 @@
+"""AReaL-SWEAgent workflow for AReaL proxy mode.
+
+This module runs AReaL-SWEAgent-backed SWE-bench agents through AReaL's proxy
+server during RL training. AReaL-SWEAgent stays in a separate checkout and is
+discovered through ``AWEAGENT_ROOT`` or ``SWE_AGENT_ROOT``. AReaL passes the
+proxy ``base_url`` and per-rollout ``api_key`` explicitly as kwargs instead
+of mutating process-wide ``os.environ`` - the latter races across concurrent
+rollouts and routes requests to the wrong proxy session.
+"""
+
+import asyncio
+import os
+import sys
+import time
+from typing import Any
+
+from areal.utils import logging
+
+logger = logging.getLogger("AReaL-SWEAgent")
+
+_DEFAULT_AGENT_CONFIGS = {
+    "swe": "1_0_0/min-swe-agent-train-top1",
+    "cc": "train_cc_time3600",
+    "oh": "eval_oh",
+    "opencode": "eval_opencode",
+    "codex": "eval_codex",
+}
+
+
+def _default_aweagent_root() -> str:
+    """Return the default sibling checkout path for AReaL-SWEAgent."""
+    areal_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    return os.path.join(os.path.dirname(areal_root), "AReaL-SWEAgent")
+
+
+def _ensure_aweagent_importable(aweagent_root: str = "") -> str:
+    """Add the AReaL-SWEAgent checkout root to ``sys.path``.
+
+    Resolution order:
+    1. Explicit ``aweagent_root`` argument (``econfig.agent_root`` /
+       ``econfig.aweagent_root`` / ``econfig.swe_agent_root``).
+    2. ``AWEAGENT_ROOT`` / ``SWE_AGENT_ROOT`` / ``SWEAGENT_ROOT`` env vars.
+    3. ``../AReaL-SWEAgent`` relative to the AReaL repository root.
+
+    Returns the resolved AReaL-SWEAgent checkout root.
+    """
+    if aweagent_root:
+        root = os.path.abspath(aweagent_root)
+    elif (
+        os.getenv("AWEAGENT_ROOT")
+        or os.getenv("SWE_AGENT_ROOT")
+        or os.getenv("SWEAGENT_ROOT")
+    ):
+        root = os.path.abspath(
+            os.getenv("AWEAGENT_ROOT")
+            or os.getenv("SWE_AGENT_ROOT")
+            or os.getenv("SWEAGENT_ROOT")
+        )
+    else:
+        root = _default_aweagent_root()
+
+    if os.path.isdir(root) and root not in sys.path:
+        sys.path.insert(0, root)
+        logger.info(f"Added AReaL-SWEAgent root to sys.path: {root}")
+    elif not os.path.isdir(root):
+        logger.warning(
+            f"AReaL-SWEAgent root does not exist: {root}. "
+            "Set AWEAGENT_ROOT (or SWE_AGENT_ROOT) env var or econfig.agent_root "
+            "(or the legacy econfig.swe_agent_root) to the correct path."
+        )
+    return root
+
+
+def _configured_aweagent_root(econfig: dict[str, Any]) -> str:
+    return (
+        econfig.get("agent_root")
+        or econfig.get("aweagent_root")
+        or econfig.get("swe_agent_root")
+        or ""
+    )
+
+
+def _configured_agent_type(econfig: dict[str, Any]) -> str:
+    agent_type = str(econfig.get("agent_type") or "swe").strip().lower()
+    if not agent_type:
+        raise ValueError("econfig.agent_type must not be empty")
+    return agent_type
+
+
+def _configured_agent_config(econfig: dict[str, Any], agent_type: str) -> str:
+    return (
+        econfig.get("agent_config")
+        or econfig.get(f"{agent_type}_agent_config")
+        or econfig.get("swe_agent_config")
+        or _DEFAULT_AGENT_CONFIGS.get(agent_type)
+        or agent_type
+    )
+
+
+class SWEAgentWorkflow:
+    """AReaL-SWEAgent workflow for AReaL proxy mode.
+
+    This workflow runs an AReaL-SWEAgent agent type (``swe``, ``cc``, ``oh``,
+    ``opencode``, or ``codex``) on SWE-bench style records in sandboxed
+    environments. The agent's LLM calls are routed through AReaL's proxy
+    server for on-policy RL training.
+
+    The workflow delegates to AReaL-SWEAgent's ``run_agent_with_reward``, passing
+    the AReaL proxy URL + per-rollout API key as explicit kwargs so that the
+    current rollout's endpoint/key are used without process-wide env races.
+
+    Args:
+        econfig: Environment configuration dict. Key fields include
+            ``agent_type``, ``agent_config``, ``swe_agent_config``,
+            ``cc_agent_config``, ``agent_root`` / ``swe_agent_root``,
+            ``llm_model``, ``opencode_provider``, ``codex_provider``,
+            and ``timeout``.
+        gen_args: Generation arguments (unused; token limits come from
+            the AReaL-SWEAgent config YAML).
+        timeout: Maximum time allowed for a single episode (default: 1800s).
+    """
+
+    def __init__(
+        self,
+        econfig: dict | None = None,
+        gen_args: dict | None = None,
+        timeout: float = 1800.0,
+    ):
+        if econfig is None:
+            econfig = {}
+        self.econfig = econfig
+        self.gen_args = gen_args or {}
+        self.timeout = econfig.get("timeout", timeout)
+
+        # Ensure AReaL-SWEAgent is importable at construction time so we get an early
+        # warning if the path is wrong, rather than failing mid-training.
+        _ensure_aweagent_importable(_configured_aweagent_root(econfig))
+
+    async def run(
+        self, data: dict[str, Any], **extra_kwargs: Any
+    ) -> dict[str, float] | float:
+        """Run one SWE-bench style agent episode.
+
+        Args:
+            data: Input data containing SWE-bench instance fields:
+                - instance_id (str): SWE-bench instance ID
+                - problem_statement (str): The GitHub issue description
+                - eval_script (str): Shell script for reward evaluation
+            **extra_kwargs: Additional kwargs injected by AReaL proxy infra:
+                - base_url (str): Proxy server URL for the agent LLM.
+                - api_key (str): Per-rollout API key for the proxy session.
+
+        Returns:
+            float: The reward from the episode (0.0 or 1.0).
+        """
+        base_url: str | None = extra_kwargs.get("base_url", None)
+        if base_url is None:
+            raise ValueError("base_url is required for SWEAgentWorkflow")
+
+        api_key: str = extra_kwargs.get("api_key", os.getenv("OPENAI_API_KEY", "dummy"))
+
+        econfig = self.econfig.copy()
+        if "econfig" in data:
+            econfig.update(data["econfig"])
+
+        agent_type = _configured_agent_type(econfig)
+        config_name = _configured_agent_config(econfig, agent_type)
+        llm_model = econfig.get("llm_model") or os.getenv("LLM_MODEL") or None
+        opencode_provider = (
+            econfig.get("opencode_provider") or os.getenv("OPENCODE_PROVIDER") or None
+        )
+        codex_provider = (
+            econfig.get("codex_provider") or os.getenv("CODEX_PROVIDER") or None
+        )
+        instance_id = data.get("instance_id", "unknown")
+
+        logger.info(
+            f"Starting {agent_type} episode: "
+            f"instance_id={instance_id}, config={config_name}"
+        )
+        start_time = time.time()
+
+        try:
+            reward = await asyncio.wait_for(
+                self._run_episode(
+                    data=data,
+                    agent_type=agent_type,
+                    config_name=config_name,
+                    base_url=base_url,
+                    api_key=api_key,
+                    llm_model=llm_model,
+                    opencode_provider=opencode_provider,
+                    codex_provider=codex_provider,
+                ),
+                timeout=self.timeout,
+            )
+        except TimeoutError:
+            elapsed = time.time() - start_time
+            logger.error(
+                f"TIMEOUT: Instance {instance_id} exceeded {self.timeout}s "
+                f"(elapsed: {elapsed:.1f}s). Discarding trajectory."
+            )
+            raise
+
+        elapsed = time.time() - start_time
+        logger.info(
+            f"Finished {agent_type} episode: instance_id={instance_id}, "
+            f"reward={reward}, elapsed={elapsed:.1f}s"
+        )
+        return float(reward)
+
+    async def _run_episode(
+        self,
+        data: dict[str, Any],
+        agent_type: str,
+        config_name: str,
+        base_url: str,
+        api_key: str,
+        llm_model: str | None,
+        opencode_provider: str | None,
+        codex_provider: str | None,
+    ) -> float:
+        """Execute one episode through AReaL-SWEAgent and return the reward.
+
+        Delegates to ``aweagent.lifecycle.run_agent_with_reward``, which
+        handles env creation, the agent loop, reward computation, and trace
+        persistence. ``base_url`` / ``api_key`` are forwarded as explicit
+        kwargs (NOT via ``os.environ``) so concurrent rollouts can't read a
+        foreign session's key.
+        """
+        # Imported lazily - AReaL-SWEAgent is only added to sys.path at run time.
+        from aweagent.lifecycle import (
+            run_agent_with_reward,  # type: ignore[import-not-found]
+        )
+
+        result_dir = os.getenv("LOG_DIR", "./logs")
+        try:
+            reward, _ = await run_agent_with_reward(
+                data,
+                agent_type=agent_type,
+                agent_config=config_name,
+                result_dir=result_dir,
+                override_api_key=api_key,
+                override_base_url=base_url,
+                override_llm_model=llm_model,
+                override_opencode_provider=opencode_provider,
+                override_codex_provider=codex_provider,
+            )
+        except Exception as e:
+            import traceback
+
+            instance_id = data.get("instance_id", "unknown")
+            logger.error(
+                f"[{instance_id}] Episode error: {e}\n{traceback.format_exc()}"
+            )
+            return 0.0
+
+        return float(reward)

--- a/examples/swe/filter_function.py
+++ b/examples/swe/filter_function.py
@@ -1,0 +1,26 @@
+from areal.utils import stats_tracker
+
+
+def filter_function(sample):
+    # Use original_rewards if available for filtering and statistics
+    rewards = (
+        sample["original_rewards"]
+        if "original_rewards" in sample
+        else sample["rewards"]
+    )
+    reward0 = rewards[0]
+    accept = any(r != reward0 for r in rewards)
+
+    # Track rejection statistics
+    if not accept:
+        stats_tracker.get("rollout").scalar(rejected_by_failed_or_perfect=1)
+        # Distinguish all-correct vs all-wrong
+        all_positive = all(r > 0 for r in rewards)
+        stats_tracker.get("rollout").scalar(rejected_by_all_correct=int(all_positive))
+        stats_tracker.get("rollout").scalar(rejected_by_all_wrong=int(not all_positive))
+    else:
+        stats_tracker.get("rollout").scalar(rejected_by_failed_or_perfect=0)
+        stats_tracker.get("rollout").scalar(rejected_by_all_correct=0)
+        stats_tracker.get("rollout").scalar(rejected_by_all_wrong=0)
+
+    return accept

--- a/examples/swe/prefix_matchers.py
+++ b/examples/swe/prefix_matchers.py
@@ -1,0 +1,58 @@
+"""Custom prefix matchers for InteractionCache parent-child matching.
+
+The default cache matcher requires exact message equality. SWE-bench agents,
+especially Claude Code style agents routed through Anthropic-compatible APIs,
+can rewrite tool arguments or tool output formatting between turns while still
+representing the same conversation. The matcher here keeps concat export stable
+for those known rewrites.
+"""
+
+from __future__ import annotations
+
+
+def _tool_call_ids(tool_calls: list[dict]) -> list[str]:
+    """Extract ordered tool_call IDs from a tool_calls list."""
+    return [tc.get("id", "") for tc in tool_calls if isinstance(tc, dict)]
+
+
+def _messages_match(a: dict, b: dict) -> bool:
+    """Check whether two message dicts are semantically equivalent."""
+    if a.get("role") != b.get("role"):
+        return False
+
+    role = a.get("role")
+
+    if role == "tool":
+        return a.get("tool_call_id") == b.get("tool_call_id")
+
+    if a.get("content", "") != b.get("content", ""):
+        return False
+
+    if a.get("thinking") != b.get("thinking"):
+        return False
+
+    a_tc = a.get("tool_calls")
+    b_tc = b.get("tool_calls")
+    if a_tc is not None or b_tc is not None:
+        if a_tc is None or b_tc is None:
+            return False
+        if not isinstance(a_tc, list) or not isinstance(b_tc, list):
+            return a_tc == b_tc
+        if len(a_tc) != len(b_tc):
+            return False
+        if _tool_call_ids(a_tc) != _tool_call_ids(b_tc):
+            return False
+
+    return True
+
+
+def swe_prefix_matcher(a: list[dict], b: list[dict]) -> bool:
+    """Return True if ``a`` is a semantic prefix of ``b``."""
+    if len(a) > len(b):
+        return False
+    for am, bm in zip(a, b):
+        if am == bm:
+            continue
+        if not _messages_match(am, bm):
+            return False
+    return True

--- a/examples/swe/preprocessors.py
+++ b/examples/swe/preprocessors.py
@@ -1,0 +1,124 @@
+"""Message preprocessors for SWE-bench agent rollouts.
+
+Preprocessors transform messages after Anthropic-to-OpenAI translation and
+before they reach AReaL's OpenAI client. They remove volatile Claude Code
+metadata that otherwise breaks prefix-based parent matching in concat export.
+"""
+
+import json
+import re
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MessagePreprocessor(Protocol):
+    """Protocol for message preprocessors."""
+
+    def __call__(self, messages: list[dict]) -> list[dict]: ...
+
+
+class StripAnthropicBillingHeader:
+    """Remove per-request Anthropic billing header lines from system prompts."""
+
+    _PATTERN = re.compile(r"^x-anthropic-billing-header:[^\n]*\n?", re.MULTILINE)
+
+    def __call__(self, messages: list[dict]) -> list[dict]:
+        if not messages:
+            return messages
+        first = messages[0]
+        if first.get("role") == "system" and isinstance(first.get("content"), str):
+            first["content"] = self._PATTERN.sub("", first["content"])
+        return messages
+
+
+class NormalizeSystemReminder:
+    """Remove volatile ``currentDate`` lines from system reminders."""
+
+    _PATTERN = re.compile(
+        r"# currentDate\nToday's date is \d{4}-\d{2}-\d{2}\.\n?",
+    )
+
+    def __call__(self, messages: list[dict]) -> list[dict]:
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, str) and "currentDate" in content:
+                msg["content"] = self._PATTERN.sub("", content)
+        return messages
+
+
+class StripAllSystemReminders:
+    """Remove all ``<system-reminder>...</system-reminder>`` blocks."""
+
+    _PATTERN = re.compile(r"<system-reminder>[\s\S]*?</system-reminder>")
+
+    def __call__(self, messages: list[dict]) -> list[dict]:
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, str) and "<system-reminder>" in content:
+                msg["content"] = self._PATTERN.sub("", content)
+        return messages
+
+
+class StripAnthropicCacheFields:
+    """Strip Anthropic-specific fields that are not preserved in stored output."""
+
+    def __call__(self, messages: list[dict]) -> list[dict]:
+        for msg in messages:
+            msg.pop("cache_control", None)
+            msg.pop("thinking_blocks", None)
+            if "tool_calls" in msg:
+                for tc in msg["tool_calls"]:
+                    if isinstance(tc, dict):
+                        tc.pop("cache_control", None)
+                        tc.pop("provider_specific_fields", None)
+                        fn = tc.get("function")
+                        if isinstance(fn, dict):
+                            fn.pop("cache_control", None)
+        return messages
+
+
+class NormalizeToolCallArguments:
+    """Normalize tool_call arguments for deterministic comparison."""
+
+    _TOOL_ARG_DEFAULTS: dict[tuple[str, str], object] = {
+        ("Edit", "replace_all"): False,
+    }
+
+    @classmethod
+    def _normalize_tool_arguments(
+        cls,
+        tool_name: str | None,
+        args_dict: dict,
+    ) -> dict:
+        if tool_name is not None:
+            for (tn, field), default in cls._TOOL_ARG_DEFAULTS.items():
+                if tn == tool_name and args_dict.get(field) == default:
+                    args_dict.pop(field, None)
+        return args_dict
+
+    def __call__(self, messages: list[dict]) -> list[dict]:
+        for msg in messages:
+            if "tool_calls" in msg:
+                for tc in msg["tool_calls"]:
+                    if isinstance(tc, dict):
+                        fn = tc.get("function")
+                        if isinstance(fn, dict):
+                            tool_name = fn.get("name")
+                            args = fn.get("arguments")
+                            if isinstance(args, str):
+                                try:
+                                    parsed = json.loads(args)
+                                    parsed = self._normalize_tool_arguments(
+                                        tool_name,
+                                        parsed,
+                                    )
+                                    fn["arguments"] = json.dumps(
+                                        parsed,
+                                        sort_keys=True,
+                                        ensure_ascii=False,
+                                    )
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
+                if msg.get("role") == "assistant" and "content" not in msg:
+                    msg["content"] = ""
+        return messages

--- a/examples/swe/qwen3_30b_a3b_grpo.yaml
+++ b/examples/swe/qwen3_30b_a3b_grpo.yaml
@@ -1,0 +1,291 @@
+experiment_name: qwen3_30b_a3b_grpo
+trial_name: trial0
+
+seed: 42
+enable_offload: true
+total_train_epochs: 10
+total_train_steps: 100
+tokenizer_path: ${actor.path}
+
+# Clean up external SWE sandbox instances after the run (LOG_DIR is injected).
+post_exit_hook: 'AWE_ROOT=\${AWEAGENT_ROOT:-\${SWE_AGENT_ROOT:-/path/to/AReaL-SWEAgent}}; cd "$AWE_ROOT" && PYTHONPATH=$PWD:$PYTHONPATH pip install -q -r requirements.txt && AENV_SYSTEM_URL=\${AENV_SYSTEM_URL} python -m aweagent.maintenance.clean_instances'
+
+cluster:
+  # 4 nodes x 8 GPUs: 2 for rollout (SGLang), 2 for actor (Megatron).
+  n_nodes: 4
+  n_gpus_per_node: 8
+  fileroot: /tmp/areal/experiments
+  name_resolve:
+    type: nfs
+    nfs_record_root: /tmp/areal/name_resolve
+
+scheduler:
+  type: slurm
+
+gconfig:
+  n_samples: 4
+  min_new_tokens: 0
+  max_new_tokens: 131071
+  max_tokens: 131071
+  greedy: false
+  temperature: 1.0
+  top_p: 1.0
+  top_k: 1000000
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  backend: "sglang:d4t8p1"
+  max_concurrent_rollouts: 32
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 4
+  enable_rollout_tracing: true
+  scheduling_spec: ${actor.scheduling_spec}
+  fileroot: ${cluster.fileroot}
+  tokenizer_path: ${tokenizer_path}
+  dump_to_file: true
+  setup_timeout: 900.0
+  request_timeout: 20000.0
+  request_retries: 3
+  pause_grace_period: 30
+  agent:
+    mode: inline
+    # admin_api_key is injected by the launcher; not stored in YAML.
+    admin_api_key: ${oc.env:SWE_RL_ADMIN_API_KEY}
+    tool_call_parser: qwen3_coder
+    reasoning_parser: qwen3
+    chat_template_type: concat
+    engine_max_tokens: ${gconfig.max_tokens}
+    export_style: concat
+    turn_discount: 1.0
+    session_timeout_seconds: 3600
+    prefix_matcher: examples.swe.prefix_matchers.swe_prefix_matcher
+    message_preprocessors:
+      - examples.swe.preprocessors.StripAnthropicBillingHeader
+      - examples.swe.preprocessors.StripAllSystemReminders
+      - examples.swe.preprocessors.StripAnthropicCacheFields
+      - examples.swe.preprocessors.NormalizeToolCallArguments
+
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  # attn DP4 PP1 TP4 CP2; ffn DP4 PP1 EP8. CP=2 shards long sequences.
+  backend: "megatron:(attn:d4p1t4c2|ffn:d4p1e8)"
+  path: /path/to/Qwen3-Coder-30B-A3B-Instruct
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: true
+  dtype: bfloat16
+  grad_reduce_dtype: float32
+  mb_spec:
+    n_mbs: 1
+    granularity: 1
+    max_tokens_per_mb: 131072
+    n_mbs_divisor: 1
+  optimizer:
+    type: adam
+    lr: 3.0e-6
+    weight_decay: 0.01
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1.0e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+  megatron:
+    wrap_with_ddp: true
+    ddp:
+      grad_reduce_in_fp32: true
+      overlap_grad_reduce: true
+      overlap_param_gather: false
+      use_distributed_optimizer: true
+    use_deterministic_algorithms: true
+    enable_fp32_lm_head: false
+    cross_entropy_loss_fusion: false
+    recompute_granularity: full
+    recompute_method: uniform
+    recompute_num_layers: 1
+    moe_router_dtype: fp32
+    moe_token_dispatcher_type: alltoall
+    moe_router_bias_update_rate: 0.0
+  eps_clip: 0.2
+  eps_clip_higher: 0.28
+  temperature: ${gconfig.temperature}
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: false
+  prox_logp_method: recompute
+  use_decoupled_loss: true
+  rejection_sampling:
+    level: token
+    action: mask
+    metric: ratio
+    upper: 5.0
+  discount: 1.0
+  gae_lambda: 1.0
+  reward_scaling: 1.0
+  reward_bias: 0.0
+  reward_clip: 5.0
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+    eps: 1.0e-5
+  adv_norm:
+    mean_level: null
+    std_level: null
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_spec:
+    - task_type: worker
+      port_count: 2
+      gpu: 1
+      cpu: 4
+      mem: 32
+      exclusive: true
+      reservation: null
+      nodelist: null
+      exclude: null
+      image: /path/to/areal.sif
+      cmd: python3 -m areal.infra.rpc.rpc_server
+      env_vars:
+        NCCL_TIMEOUT: 600
+        PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+        # Point HOME and caches at shared storage to avoid filling the
+        # container's small default HOME during JIT compilation.
+        HOME: "/path/to/cache/home"
+        HF_HOME: "/path/to/cache/hf"
+        XDG_CACHE_HOME: "/path/to/cache/xdg"
+        # Workers must import both AReaL and the external AReaL-SWEAgent.
+        PYTHONPATH: "/path/to/AReaL-SWEAgent:/path/to/AReaL"
+        AENV_SYSTEM_URL: "http://your-aenv-service:8080"
+        SWE_AGENT_ROOT: "/path/to/AReaL-SWEAgent"
+        AWEAGENT_ROOT: "/path/to/AReaL-SWEAgent"
+        OPENAI_MODEL: "Qwen3-Coder-30B-A3B-Instruct"
+      additional_bash_cmds:
+        # Install AReaL-SWEAgent's aenv/fastmcp into the venv the workers use.
+        - "/opt/.venv/bin/python -m ensurepip --upgrade >/dev/null 2>&1 || true"
+        - "/opt/.venv/bin/python -m pip install --no-deps aenvironment==0.1.8rc2 || echo 'WARN: aenvironment install failed'"
+        - "/opt/.venv/bin/python -m pip install 'fastmcp<3' || echo 'WARN: fastmcp install failed'"
+        - "/opt/.venv/bin/python -c 'import aenv, aweagent' || echo 'WARN: aenv/aweagent import failed'"
+
+ref:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  backend: ${actor.backend}
+  path: ${actor.path}
+  init_from_scratch: false
+  disable_dropout: false
+  dtype: ${actor.dtype}
+  mb_spec:
+    n_mbs: 1
+    granularity: 1
+    max_tokens_per_mb: 131072
+    n_mbs_divisor: 1
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+# SWE-bench agent environment. Set agent_type=cc to train Claude Code through
+# the same proxy path. agent_root points at the external AReaL-SWEAgent checkout.
+econfig:
+  dataset_path: ""
+  agent_type: swe
+  agent_config: ""
+  swe_agent_config: 1_0_0/min-swe-agent-train-top1
+  cc_agent_config: train_cc_time3600
+  agent_root: /path/to/AReaL-SWEAgent
+  swe_agent_root: /path/to/AReaL-SWEAgent
+  llm_model: ""
+  opencode_provider: ""
+  codex_provider: ""
+  max_completion_tokens: 131071
+  timeout: 3600.0
+
+sglang:
+  model_path: ${actor.path}
+  random_seed: ${seed}
+  skip_tokenizer_init: true
+  dtype: ${actor.dtype}
+  context_length: 131072
+  max_prefill_tokens: 131071
+  max_running_requests: 16
+  mem_fraction_static: 0.85
+  chunked_prefill_size: 8192
+  cuda_graph_max_bs: 16
+  schedule_policy: fcfs
+  attention_backend: fa3
+  log_level: info
+  log_requests: false
+  sampling_backend: pytorch
+  enable_memory_saver: false
+  disable_radix_cache: false
+  triton_attention_num_kv_splits: 16
+  disable_custom_all_reduce: true
+  disable_cuda_graph: false
+
+# Datasets: SWE-bench style jsonl with instance_id / problem_statement /
+# eval_script per line.
+train_dataset:
+  batch_size: 4
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  path: /path/to/swe_bench_rl.jsonl
+  type: rl
+  max_length: 32768
+  drop_last: true
+
+valid_dataset:
+  batch_size: 4
+  shuffle: true
+  pin_memory: true
+  num_workers: 4
+  path: /path/to/swe_bench_rl.jsonl
+  type: rl
+
+# Utilities
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: 10
+  freq_secs: null
+
+recover:
+  mode: auto
+  retries: 3
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_secs: 7200
+  no_save_optim: false
+  no_load_optim: false
+  freq_steps: 10
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: null
+  freq_steps: null
+  freq_secs: null
+
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: disabled
+
+perf_tracer:
+  enabled: false
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  session_tracer:
+    enabled: false

--- a/examples/swe/train_swe_rl.py
+++ b/examples/swe/train_swe_rl.py
@@ -1,0 +1,216 @@
+"""Training script for SWE-bench agent RL with AReaL proxy mode."""
+
+import json
+import sys
+import warnings
+from pathlib import Path
+from typing import Any
+
+from datasets import Dataset
+
+from examples.swe.utils import SWEPPOConfig
+
+from areal import PPOTrainer
+from areal.api.cli_args import load_expr_config
+from areal.utils import logging
+
+logger = logging.getLogger("SWETrain")
+
+
+def get_swe_dataset(
+    dataset_path: str,
+    split: str = "train",
+    min_items: int = 64,
+) -> Dataset:
+    """Create a HuggingFace Dataset from a SWE-bench JSONL file.
+
+    Each line in the JSONL file should be a SWE-bench instance with at minimum:
+    - instance_id: The SWE-bench instance ID (e.g., "django__django-10097")
+    - problem_statement: The GitHub issue description
+    - eval_script: Shell script to evaluate the agent's fix
+
+    Args:
+        dataset_path: Path to the SWE-bench JSONL file.
+        split: Informational split label (not used for filtering).
+        min_items: Minimum dataset size; items are duplicated if fewer exist.
+
+    Returns:
+        HuggingFace Dataset of SWE-bench instances.
+    """
+    path = Path(dataset_path)
+    if not path.exists():
+        raise FileNotFoundError(f"SWE-bench dataset not found: {dataset_path}")
+
+    dataset_items = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            item = json.loads(line)
+            if "instance_id" not in item:
+                logger.warning(f"Skipping item missing 'instance_id': {line[:100]}")
+                continue
+            if "problem_statement" not in item:
+                logger.warning(
+                    "Skipping item missing 'problem_statement': "
+                    f"{item.get('instance_id')}"
+                )
+                continue
+            dataset_items.append(item)
+
+    if not dataset_items:
+        raise ValueError(f"No valid items found in dataset: {dataset_path}")
+
+    # Duplicate dataset if fewer than min_items for efficient batching
+    if len(dataset_items) < min_items:
+        original_items = dataset_items.copy()
+        while len(dataset_items) < min_items:
+            dataset_items.extend(original_items)
+
+    dataset = Dataset.from_list(dataset_items)
+    logger.info(
+        f"Created SWE dataset with {len(dataset)} items "
+        f"from {dataset_path} (split={split})"
+    )
+    return dataset
+
+
+def group_filter(x: dict[str, Any]):
+    """Filter out groups where all rollouts already solved the task."""
+    return x["rewards"].mean() <= 0.95
+
+
+def _install_aweagent_deps_on_ray_nodes(aweagent_root: str):
+    """Install AReaL-SWEAgent dependencies on all Ray GPU nodes.
+
+    Each node runs in a separate container with its own venv,
+    so we must ensure packages like ``aenv`` are installed everywhere.
+    """
+    if not aweagent_root:
+        aweagent_root = str(Path(__file__).resolve().parents[2].parent / "AReaL-SWEAgent")
+    try:
+        import ray
+
+        if not ray.is_initialized():
+            return
+
+        @ray.remote(num_gpus=0)
+        def _install():
+            import os
+            import socket
+            import subprocess
+
+            ip = socket.gethostbyname(socket.gethostname())
+            req_path = os.path.join(aweagent_root, "requirements.txt")
+            result = subprocess.run(
+                ["uv", "pip", "install", "-r", req_path],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            return (
+                ip,
+                result.returncode,
+                result.stderr[-200:] if result.stderr else "",
+            )
+
+        nodes = [
+            n
+            for n in ray.nodes()
+            if n.get("Alive") and n.get("Resources", {}).get("GPU", 0) > 0
+        ]
+        refs = []
+        for node in nodes:
+            node_ip = node["NodeManagerAddress"]
+            refs.append(_install.options(resources={f"node:{node_ip}": 0.01}).remote())
+
+        results = ray.get(refs, timeout=180)
+        for ip, rc, err in results:
+            if rc != 0:
+                logger.warning(f"Failed to install AReaL-SWEAgent deps on {ip}: {err}")
+            else:
+                logger.info(f"AReaL-SWEAgent deps installed on {ip}")
+    except Exception as e:
+        logger.warning(f"Could not install AReaL-SWEAgent deps on Ray nodes: {e}")
+
+
+def _resolve_aweagent_root(econfig) -> str:
+    return (
+        getattr(econfig, "agent_root", "")
+        or getattr(econfig, "aweagent_root", "")
+        or getattr(econfig, "swe_agent_root", "")
+    )
+
+
+def main(args):
+    warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
+
+    config, _ = load_expr_config(args, SWEPPOConfig)
+    econfig = config.econfig
+
+    # When using Ray scheduler, ensure SWEAgent deps are on all nodes
+    if config.scheduler.type == "ray":
+        import ray
+
+        ray.init(address="auto", ignore_reinit_error=True)
+        _install_aweagent_deps_on_ray_nodes(_resolve_aweagent_root(econfig))
+
+    # Resolve dataset paths from config
+    train_path = config.train_dataset.path
+    valid_path = config.valid_dataset.path
+
+    def resolve_path(p: str) -> str:
+        if Path(p).is_absolute() or Path(p).exists():
+            return p
+        if econfig.dataset_path:
+            candidate = Path(econfig.dataset_path) / p
+            if candidate.exists():
+                return str(candidate)
+        return p
+
+    train_dataset = get_swe_dataset(
+        dataset_path=resolve_path(train_path),
+        split="train",
+    )
+    valid_dataset = get_swe_dataset(
+        dataset_path=resolve_path(valid_path),
+        split="test",
+    )
+
+    # Build workflow kwargs
+    from dataclasses import asdict
+
+    econfig_dict = asdict(econfig)
+    workflow_kwargs = dict(
+        econfig=econfig_dict,
+        gen_args=dict(
+            temperature=config.gconfig.temperature,
+            max_completion_tokens=config.gconfig.max_new_tokens,
+        ),
+        timeout=econfig.timeout,
+    )
+
+    # Eval workflow with lower temperature for deterministic evaluation
+    eval_workflow_kwargs = workflow_kwargs.copy()
+    eval_workflow_kwargs["gen_args"] = dict(
+        temperature=0.0,
+        max_completion_tokens=config.gconfig.max_new_tokens,
+    )
+
+    with PPOTrainer(
+        config,
+        train_dataset=train_dataset,
+        valid_dataset=valid_dataset,
+    ) as trainer:
+        trainer.train(
+            workflow="examples.swe.agent.SWEAgentWorkflow",
+            workflow_kwargs=workflow_kwargs,
+            eval_workflow=None,
+            eval_workflow_kwargs=eval_workflow_kwargs,
+            dynamic_filter_fn=getattr(config, "should_accept_fn", None),
+        )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/examples/swe/utils.py
+++ b/examples/swe/utils.py
@@ -1,0 +1,125 @@
+"""Utilities for SWE-bench agent training with AReaL."""
+
+from dataclasses import dataclass, field
+
+from areal.api.cli_args import PPOConfig
+
+
+@dataclass
+class SWEEnvConfig:
+    """Environment configuration for AReaL-SWEAgent-backed SWE-bench training.
+
+    Attributes:
+        dataset_path: Path to the SWE-bench JSONL dataset file.
+        agent_type: AReaL-SWEAgent agent type to train, e.g. ``swe`` or ``cc``.
+        agent_config: Generic AReaL-SWEAgent config name. When set, this overrides
+            the compatibility fields below.
+        swe_agent_config: Compatibility config field for ``agent_type=swe``.
+        cc_agent_config: Compatibility config field for ``agent_type=cc``.
+        agent_root: Root directory of the external AReaL-SWEAgent checkout.
+        swe_agent_root: Legacy alias for ``agent_root``.
+        llm_model: Optional LLM model override for OH/OpenCode/Codex agents.
+        opencode_provider: Optional OpenCode provider override.
+        codex_provider: Optional Codex provider override.
+        step_limit: Maximum number of agent interaction steps per episode.
+        max_completion_tokens: Maximum completion tokens for the agent LLM.
+        timeout: Maximum time allowed for a single episode in seconds.
+    """
+
+    dataset_path: str = field(
+        default="",
+        metadata={"help": "Path to the SWE-bench JSONL dataset file."},
+    )
+    agent_type: str = field(
+        default="swe",
+        metadata={
+            "help": (
+                "AReaL-SWEAgent agent type to run. Supported by AReaL-SWEAgent main: "
+                "'swe', 'cc', 'oh', 'opencode', and 'codex'."
+            )
+        },
+    )
+    agent_config: str = field(
+        default="",
+        metadata={
+            "help": (
+                "Generic AReaL-SWEAgent YAML config name. When non-empty, overrides "
+                "swe_agent_config / cc_agent_config."
+            )
+        },
+    )
+    swe_agent_config: str = field(
+        default="1_0_0/min-swe-agent-train-top1",
+        metadata={
+            "help": (
+                "Name of the AReaL-SWEAgent YAML config under the external AReaL-SWEAgent "
+                "checkout. Defaults to the Qwen SWE-RL training config."
+            )
+        },
+    )
+    cc_agent_config: str = field(
+        default="train_cc_time3600",
+        metadata={
+            "help": (
+                "Name of the AReaL-SWEAgent YAML config used when agent_type='cc'. "
+                "Kept separate for compatibility with swe/main configs."
+            )
+        },
+    )
+    agent_root: str = field(
+        default="",
+        metadata={
+            "help": (
+                "Root directory of the external AReaL-SWEAgent checkout. Defaults to "
+                "../AReaL-SWEAgent relative to the AReaL repository when unset."
+            )
+        },
+    )
+    swe_agent_root: str = field(
+        default="",
+        metadata={
+            "help": (
+                "Legacy alias for agent_root / AWEAGENT_ROOT. Kept so older "
+                "SWE launch scripts keep working."
+            )
+        },
+    )
+    llm_model: str = field(
+        default="",
+        metadata={
+            "help": "Optional model name override for OH/OpenCode/Codex agents."
+        },
+    )
+    opencode_provider: str = field(
+        default="",
+        metadata={"help": "Optional provider override for OpenCode agents."},
+    )
+    codex_provider: str = field(
+        default="",
+        metadata={"help": "Optional provider override for Codex agents."},
+    )
+    step_limit: int = field(
+        default=100,
+        metadata={"help": "Maximum number of agent interaction steps per episode."},
+    )
+    max_completion_tokens: int = field(
+        default=16384,
+        metadata={"help": "Maximum completion tokens for the agent LLM."},
+    )
+    timeout: float = field(
+        default=1800.0,
+        metadata={"help": "Maximum time allowed for a single episode in seconds."},
+    )
+
+
+@dataclass
+class SWEPPOConfig(PPOConfig):
+    """PPO configuration with SWE-bench-specific settings."""
+
+    econfig: SWEEnvConfig = field(default_factory=SWEEnvConfig)
+    should_accept_fn: str | None = field(
+        default=None,
+        metadata={
+            "help": "Import path of the filter function for accepting rollout samples."
+        },
+    )

--- a/tests/experimental/openai/test_client_streaming.py
+++ b/tests/experimental/openai/test_client_streaming.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from openai.types.chat.chat_completion_message_function_tool_call import (
+    ChatCompletionMessageFunctionToolCall,
+    Function,
+)
+
+import areal.experimental.openai.client as client_module
+from areal.api import ModelResponse
+from areal.experimental.openai.cache import InteractionCache
+from areal.experimental.openai.client import AsyncCompletionsWithReward
+
+
+class _FakeTokenizer:
+    eos_token_id = 0
+    pad_token_id = 0
+
+    def decode(self, tokens):
+        return "ok"
+
+
+class _RecordingEngine:
+    def __init__(self):
+        self.request = None
+
+    async def agenerate(self, req):
+        self.request = req
+        return ModelResponse(
+            input_tokens=req.input_ids,
+            output_tokens=[1],
+            output_logprobs=[0.0],
+            output_versions=[0],
+            stop_reason="length",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_stream_splits_tool_call_name_and_arguments():
+    """Streaming tool calls should emit name/id before argument deltas."""
+    tool_call = ChatCompletionMessageFunctionToolCall(
+        id="call_123",
+        type="function",
+        function=Function(
+            name="Bash",
+            arguments='{"command": "ls -la /testbed"}',
+        ),
+    )
+    response = ModelResponse(
+        input_tokens=[1, 2, 3],
+        output_tokens=[4, 5],
+        output_logprobs=[0.0, 0.0],
+        output_versions=[0, 0],
+        stop_reason="tool_calls",
+    )
+
+    stream = AsyncCompletionsWithReward._create_stream(
+        object(),
+        completion_id="chatcmpl-test",
+        current_time=123,
+        output_text="",
+        tool_calls=[tool_call],
+        response=response,
+    )
+    chunks = [chunk async for chunk in stream]
+
+    tool_chunks = [
+        chunk
+        for chunk in chunks
+        if chunk.choices[0].delta.tool_calls is not None
+        and len(chunk.choices[0].delta.tool_calls) > 0
+    ]
+    assert len(tool_chunks) == 2
+
+    first_delta = tool_chunks[0].choices[0].delta.tool_calls[0]
+    assert first_delta.index == 0
+    assert first_delta.id == "call_123"
+    assert first_delta.type == "function"
+    assert first_delta.function is not None
+    assert first_delta.function.name == "Bash"
+    assert first_delta.function.arguments == ""
+
+    second_delta = tool_chunks[1].choices[0].delta.tool_calls[0]
+    assert second_delta.index == 0
+    assert second_delta.id is None
+    assert second_delta.type is None
+    assert second_delta.function is not None
+    assert second_delta.function.name is None
+    assert second_delta.function.arguments == '{"command": "ls -la /testbed"}'
+
+    assert chunks[-1].choices[0].finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_chat_create_sets_generation_max_tokens_from_engine_limit(monkeypatch):
+    prompt_tokens = list(range(33_000))
+    monkeypatch.setattr(
+        client_module,
+        "apply_chat_template",
+        lambda *args, **kwargs: prompt_tokens,
+    )
+    engine = _RecordingEngine()
+    client = AsyncCompletionsWithReward.__new__(AsyncCompletionsWithReward)
+    client.engine = engine
+    client.tokenizer = _FakeTokenizer()
+    client.tool_call_parser = "qwen3"
+    client.reasoning_parser = "qwen3"
+    client._cache = InteractionCache()
+    client.engine_max_tokens = 131_071
+    client.chat_template_type = "hf"
+    client.lora_name = ""
+
+    await client.create(
+        messages=[{"role": "user", "content": "hello"}],
+        max_completion_tokens=32_000,
+        store=False,
+    )
+
+    assert engine.request is not None
+    assert engine.request.gconfig.max_new_tokens == 32_000
+    assert engine.request.gconfig.max_tokens == 131_071

--- a/tests/experimental/openai/test_client_with_tool.py
+++ b/tests/experimental/openai/test_client_with_tool.py
@@ -232,16 +232,23 @@ async def test_streaming_with_tool_calling(openai_client):
         and len(chunk.choices[0].delta.tool_calls) > 0
     ]
 
-    # Verify tool calls are present and properly structured
+    # Verify tool calls are present and split into name/id and arguments chunks.
     if tool_call_chunks:
-        for chunk in tool_call_chunks:
-            for tool_call in chunk.choices[0].delta.tool_calls:
-                # Verify tool_call has required fields (simplified access after our fix)
-                assert tool_call.id is not None
-                assert tool_call.type == "function"
-                assert tool_call.function is not None
-                assert tool_call.function.name is not None
-                assert tool_call.function.arguments is not None
+        assert len(tool_call_chunks) % 2 == 0
+        for first_chunk, second_chunk in zip(
+            tool_call_chunks[::2], tool_call_chunks[1::2], strict=True
+        ):
+            first_tool_call = first_chunk.choices[0].delta.tool_calls[0]
+            second_tool_call = second_chunk.choices[0].delta.tool_calls[0]
+            assert first_tool_call.id is not None
+            assert first_tool_call.type == "function"
+            assert first_tool_call.function is not None
+            assert first_tool_call.function.name is not None
+            assert first_tool_call.function.arguments == ""
+            assert second_tool_call.index == first_tool_call.index
+            assert second_tool_call.function is not None
+            assert second_tool_call.function.arguments is not None
+            assert len(second_tool_call.function.arguments) > 0
 
     # Find the final chunk with finish_reason
     final_chunks = [

--- a/tests/experimental/openai/test_tool_call_parser.py
+++ b/tests/experimental/openai/test_tool_call_parser.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -69,6 +70,52 @@ TEXT_WITH_TOOL_CALL_IN_THINKING = (
     '<tool_call>\n{"name": "search", "arguments": {"query": "director of The Preacher\'s Wife country"}}\n</tool_call><|im_end|>'
 )
 
+QWEN3_CODER_TOOLS: list[ChatCompletionToolParam] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "Bash",
+            "description": "Run a shell command.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "timeout": {"type": "integer"},
+                },
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Write",
+            "description": "Write a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["file_path", "content"],
+            },
+        },
+    },
+]
+
+QWEN3_CODER_TEXT = """I'll inspect the repository.
+
+<tool_call>
+<function=Bash>
+<parameter=command>
+ls -la
+</parameter>
+<parameter=timeout>
+120
+</parameter>
+</function>
+</tool_call><|im_end|>"""
+
 
 def _assert_tool_calls(tool_calls, new_text: str, new_finish_reason: str) -> None:
     assert new_finish_reason == "tool_calls"
@@ -99,6 +146,30 @@ def _run_process_tool_calls(text: str):
         use_responses=False,
         tokenizer=object(),
     )
+
+
+def test_process_tool_calls_qwen3_coder_xml_parameters_without_sglang():
+    tool_calls, new_text, new_finish_reason = parser_module.process_tool_calls(
+        text=QWEN3_CODER_TEXT,
+        tools=QWEN3_CODER_TOOLS,
+        tool_call_parser="qwen3_coder",
+        reasoning_parser="qwen3",
+        finish_reason="stop",
+        use_responses=False,
+        tokenizer=object(),
+    )
+
+    assert new_finish_reason == "tool_calls"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == "Bash"
+    assert json.loads(tool_calls[0].function.arguments) == {
+        "command": "ls -la",
+        "timeout": 120,
+    }
+    assert "<tool_call>" not in new_text
+    assert "<|im_end|>" not in new_text
+    assert "I'll inspect the repository." in new_text
 
 
 @pytest.mark.sglang

--- a/tests/test_swe_agent_proxy_utils.py
+++ b/tests/test_swe_agent_proxy_utils.py
@@ -1,0 +1,112 @@
+"""Tests for SWE-bench agent proxy helpers."""
+
+from areal.experimental.openai.cache import InteractionCache
+from areal.experimental.openai.types import InteractionWithTokenLogpReward
+from examples.swe.prefix_matchers import swe_prefix_matcher
+from examples.swe.preprocessors import (
+    NormalizeToolCallArguments,
+    StripAllSystemReminders,
+    StripAnthropicBillingHeader,
+    StripAnthropicCacheFields,
+)
+
+
+def _interaction(
+    interaction_id: str,
+    messages: list[dict],
+    output_message_list: list[dict],
+) -> InteractionWithTokenLogpReward:
+    interaction = InteractionWithTokenLogpReward(
+        chat_template_type="concat",
+        messages=messages,
+        output_message_list=output_message_list,
+    )
+    interaction.interaction_id = interaction_id
+    return interaction
+
+
+def test_swe_prefix_matcher_ignores_tool_output_content():
+    parent = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "old cwd"},
+    ]
+    child = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "new cwd"},
+        {"role": "user", "content": "next"},
+    ]
+
+    assert swe_prefix_matcher(parent, child)
+
+
+def test_interaction_cache_accepts_custom_prefix_matcher():
+    cache = InteractionCache(session_id="test", prefix_matcher=swe_prefix_matcher)
+    parent_messages = [{"role": "user", "content": "start"}]
+    parent_output = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "old cwd"},
+    ]
+    child_messages = parent_messages + [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "new cwd"},
+        {"role": "user", "content": "next"},
+    ]
+
+    parent = _interaction("parent", parent_messages, parent_output)
+    child = _interaction(
+        "child",
+        child_messages,
+        [{"role": "assistant", "content": "done"}],
+    )
+
+    cache["parent"] = parent
+    cache["child"] = child
+
+    assert child.parent is parent
+
+
+def test_swe_message_preprocessors_remove_volatile_anthropic_fields():
+    messages = [
+        {
+            "role": "system",
+            "content": "x-anthropic-billing-header: cch=abc\nkeep",
+        },
+        {
+            "role": "user",
+            "content": "<system-reminder>volatile</system-reminder>task",
+            "cache_control": {"type": "ephemeral"},
+        },
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "cache_control": {},
+                    "provider_specific_fields": {"signature": "x"},
+                    "function": {
+                        "name": "Edit",
+                        "arguments": '{"replace_all": false, "file_path": "a.py"}',
+                        "cache_control": {},
+                    },
+                }
+            ],
+        },
+    ]
+
+    for preprocessor in (
+        StripAnthropicBillingHeader(),
+        StripAllSystemReminders(),
+        StripAnthropicCacheFields(),
+        NormalizeToolCallArguments(),
+    ):
+        messages = preprocessor(messages)
+
+    assert messages[0]["content"] == "keep"
+    assert messages[1]["content"] == "task"
+    assert "cache_control" not in messages[1]
+    tool_call = messages[2]["tool_calls"][0]
+    assert "cache_control" not in tool_call
+    assert "provider_specific_fields" not in tool_call
+    assert "cache_control" not in tool_call["function"]
+    assert tool_call["function"]["arguments"] == '{"file_path": "a.py"}'
+    assert messages[2]["content"] == ""


### PR DESCRIPTION
## Summary

Adds an end-to-end **SWE-bench RL training workflow** to AReaL. The agent loop,
sandboxing and reward computation live in a separate repository,
[AReaL-SWEAgent](https://github.com/areal-project/AReaL-SWEAgent); AReaL serves
the policy being trained and drives rollouts through its OpenAI-compatible
proxy. See `examples/swe/README.md` for setup and usage.

> **Draft** — opening early for design feedback. See "Open items" below.

## Commits (review by commit)

1. `feat(swe): add SWE-bench RL training workflow` — `examples/swe/` entrypoint
   (`train_swe_rl.py`), the AReaL-SWEAgent rollout workflow (`agent.py`),
   message preprocessors / prefix matcher, rollout filter, a runnable
   Qwen3-Coder GRPO example config, README, and the SWE SFT dataset loader.
2. `feat(swe): add SWE agent proxy, message preprocessors and tool-call support`
   — OpenAI-compatible proxy rollout server extensions and tool-call parsing,
   with tests.
3. `feat(swe): add Megatron context-parallel and vocab-statistics training
   support` — CP output gather, vocab statistics across PPO/DPO/SFT, per-key
   reduce groups, vLLM sampling forwarding, and Bailing MoE config adaptations.
4. `feat(swe): propagate SWE runtime env through launchers` — forward the
   agent runtime env through the local/ray/slurm launchers.

## External dependency

Requires the AReaL-SWEAgent checkout (imported as the `aweagent` package),
discovered via `econfig.agent_root` / `AWEAGENT_ROOT` / `../AReaL-SWEAgent`.

## Tests

- `tests/experimental/openai/*` — proxy client / tool-call parser unit tests.
- `tests/test_swe_agent_proxy_utils.py` — proxy utility tests.
- End-to-end SWE rollout depends on the external sandbox service and is not
  covered by unit tests; the example config documents how to run it.

## Open items (before merge)

- [ ] AReaL-SWEAgent repository needs to be public so reviewers can run it.
- [ ] Depends on / overlaps with #1453 (reuse_train_logp) and #1454
      (variable-size group reward norm) in `cli_args.py` / `actor.py`; will
      rebase once those land.
- [ ] Example config paths are placeholders; fill in for your cluster.
