### PR TITLE
fix(openai): parse tool_call arguments from JSON string to dict before chat template

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -343,6 +343,43 @@ def _build_messages_list(item: dict) -> list[dict]:
     return messages_list
 
 
+def _parse_tool_call_arguments(messages: list[dict]) -> list[dict]:
+    """Return a new message list with tool_call arguments parsed from JSON strings
+    to dicts. Some chat templates (e.g. GLM-5.1) iterate over arguments with
+    .items(), which fails when arguments is a JSON string per OpenAI API convention.
+
+    Only creates new dicts where modifications are needed; unaffected messages
+    are shared with the input list to avoid expensive deep copies.
+    """
+    result = []
+    for msg in messages:
+        tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else None
+        if not tool_calls:
+            result.append(msg)
+            continue
+        new_tool_calls = []
+        modified = False
+        for tc in tool_calls:
+            fn = tc.get("function") if isinstance(tc, dict) else None
+            if fn is None:
+                new_tool_calls.append(tc)
+                continue
+            args = fn.get("arguments")
+            if isinstance(args, str):
+                try:
+                    parsed = json.loads(args)
+                    tc = {**tc, "function": {**fn, "arguments": parsed}}
+                    modified = True
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            new_tool_calls.append(tc)
+        if modified:
+            result.append({**msg, "tool_calls": new_tool_calls})
+        else:
+            result.append(msg)
+    return result
+
+
 def concat_prompt_token_ids_with_parent(
     message_list: list[dict],
     parent: InteractionWithTokenLogpReward | None,
@@ -385,6 +422,7 @@ def concat_prompt_token_ids_with_parent(
         parent_tokens += [eos_token_id]
 
     all_message_list += message_list
+    all_message_list = _parse_tool_call_arguments(all_message_list)
 
     all_tokens = apply_chat_template(
         tokenizer,
@@ -610,6 +648,7 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
         has_images = len(image_data) > 0
 
         tokenizer_messages = messages_for_tokenizer if has_images else messages_list
+        tokenizer_messages = _parse_tool_call_arguments(tokenizer_messages)
         if self.chat_template_type == "hf":
             prompt_token_ids = apply_chat_template(
                 self.tokenizer,
@@ -1018,6 +1057,7 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
         has_images = len(image_data) > 0
 
         tokenizer_messages = messages_for_tokenizer if has_images else messages_list
+        tokenizer_messages = _parse_tool_call_arguments(tokenizer_messages)
         if self.chat_template_type == "hf":
             prompt_token_ids = apply_chat_template(
                 self.tokenizer,

--- a/tests/experimental/openai/test_parse_tool_call_arguments.py
+++ b/tests/experimental/openai/test_parse_tool_call_arguments.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from areal.experimental.openai.client import _parse_tool_call_arguments
+
+
+def test_string_arguments_are_parsed_to_dict():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "Bash", "arguments": '{"command": "ls"}'}}
+            ],
+        }
+    ]
+
+    out = _parse_tool_call_arguments(messages)
+
+    assert out[0]["tool_calls"][0]["function"]["arguments"] == {"command": "ls"}
+
+
+def test_non_string_arguments_are_left_unchanged():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "Bash", "arguments": {"command": "ls"}}}
+            ],
+        }
+    ]
+
+    out = _parse_tool_call_arguments(messages)
+
+    assert out[0] is messages[0]
+    assert out[0]["tool_calls"][0]["function"]["arguments"] == {"command": "ls"}
+
+
+def test_invalid_json_arguments_are_left_unchanged():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": "Bash", "arguments": "not json"}}],
+        }
+    ]
+
+    out = _parse_tool_call_arguments(messages)
+
+    assert out[0]["tool_calls"][0]["function"]["arguments"] == "not json"
+
+
+def test_messages_without_tool_calls_pass_through():
+    messages = [{"role": "user", "content": "hi"}]
+
+    out = _parse_tool_call_arguments(messages)
+
+    assert out[0] is messages[0]


### PR DESCRIPTION
## What

Normalize tool_call `arguments` from a JSON string to a dict before applying the chat template in the OpenAI-compatible client.

## Why

Per the OpenAI API convention, `tool_calls[].function.arguments` is a JSON **string**. Some chat templates iterate over the arguments with `.items()` (e.g. GLM-5.1), which raises when `arguments` is a string. This also matters for parsing the tool calls returned by Claude Code (cc) agents through the proxy: their assistant messages carry string-encoded tool-call arguments that must be dicts for these templates to render.

## Changes

- Add `_parse_tool_call_arguments(messages)` in `areal/experimental/openai/client.py`: returns a message list where string `arguments` are `json.loads`-ed to dicts. It only allocates new dicts where a change is needed (unaffected messages are shared, no deep copy) and leaves non-string or invalid-JSON arguments untouched.
- Apply it before `apply_chat_template` in `concat_prompt_token_ids_with_parent` and in the completions/responses tokenizer paths.
- Add unit tests for string parsing, non-string pass-through, invalid-JSON pass-through, and messages without tool_calls.

## Testing

- `pytest tests/experimental/openai/test_parse_tool_call_arguments.py` — 4 passed.