### PR TITLE
test(ppo): update singleton leave-one-out group expectation

### DIFF
--- a/tests/test_adv_norm_config.py
+++ b/tests/test_adv_norm_config.py
@@ -874,11 +874,15 @@ def test_group_size_edge_cases():
     adv_norm = Normalization(config)
 
     normalized = adv_norm(advantages, loss_mask)
-    # With group size 1 and leave-one-out, each element should remain approximately unchanged
-    # because mean=0 (no other elements) and std=1 (for stability), so result ≈ (x-0)/1 = x
+
+    # With singleton leave-one-out groups, there is no peer baseline.
+    # We use the sample itself as the baseline, so each singleton group
+    # normalizes to zero instead of passing through the raw advantage.
     assert torch.allclose(
-        normalized, advantages, atol=1e-3
-    )  # Should remain approximately unchanged
+        normalized,
+        torch.zeros_like(advantages),
+        atol=1e-6,
+    )
 
 
 def test_precision_and_numerical_stability():


### PR DESCRIPTION
## What

Update `test_group_size_edge_cases` in `tests/test_adv_norm_config.py` to match the singleton leave-one-out behavior introduced in #1454.

## Why

Before #1454, a group of size 1 with `mean_leave1out=True` passed the raw advantage through (mean 0, std 1). #1454 changed this: a singleton leave-one-out group has no peer baseline, so it uses the sample itself as the baseline and normalizes to **zero**. The pre-existing test still asserted the old passthrough behavior and now fails on `main`.

## Changes

- Assert that a `group_size=1`, `mean_leave1out=True` group normalizes to zeros instead of `≈ advantages`.

## Testing

- `pytest tests/test_adv_norm_config.py` — 198 passed.