### PR TITLE
fix(megatron): use dp_reshardable optimizer sharding and load optimizer state correctly

### DIFF
--- a/areal/engine/megatron_utils/checkpointer.py
+++ b/areal/engine/megatron_utils/checkpointer.py
@@ -278,6 +278,7 @@ class MegatronCheckpointManager:
         with_model: bool = True,
         with_optimizer: bool = True,
         with_rng: bool = True,
+        is_loading: bool = False,
     ):
         # For save dist checkpointing
         state_dict = {}
@@ -298,7 +299,24 @@ class MegatronCheckpointManager:
         # Optimizer State Dict
         if with_optimizer:
             torch.distributed.barrier()
-            optimizer_sharded_states = self.optimizer.sharded_state_dict(state_dict)
+            # megatron-core v0.14+ removed flattened_range support (Megatron-LM
+            # PR #2126), but the sharded_state_dict default
+            # (fully_sharded_model_space) still emits it, so saving optimizer
+            # state fails on the pinned 0.17.0. dp_reshardable is upstream's
+            # current default. Trade-off: the optimizer state (not the model
+            # weights) becomes reshardable only along DP -- load hard-asserts
+            # the same bucket layout (per_bucket_numel_unpadded), so save and
+            # load must use identical TP/PP. Fine today since recover enforces
+            # the same topology; switch to fully_reshardable if cross-topology
+            # resume is ever needed (also flattened_range-free, at the cost of
+            # gathering optimizer state). is_loading=True pre-allocates
+            # exp_avg/exp_avg_sq so the load template requests them --
+            # otherwise DCP silently drops the moments on resume.
+            optimizer_sharded_states = self.optimizer.sharded_state_dict(
+                state_dict,
+                is_loading=is_loading,
+                metadata={"distrib_optim_sharding_type": "dp_reshardable"},
+            )
             state_dict["optimizer"] = optimizer_sharded_states
 
             if self.lr_scheduler is not None:
@@ -353,7 +371,7 @@ class MegatronCheckpointManager:
 
         # Get State Dict for loading
         sharded_state_dict = self.generate_state_dict(
-            with_model, with_optimizer, with_rng
+            with_model, with_optimizer, with_rng, is_loading=True
         )
         # Load Dist Checkpointing
         state_dict = load_dist_checkpointing(

--- a/tests/test_megatron_async_save.py
+++ b/tests/test_megatron_async_save.py
@@ -260,3 +260,42 @@ def test_sync_save_emits_no_async_metrics(patched_checkpointer, tmp_path):
         manager.save_checkpoint(str(tmp_path / "step0"))
 
     stats_scalar.assert_not_called()
+
+
+def test_generate_state_dict_requests_dp_reshardable_sharding(patched_checkpointer):
+    _, manager, _ = patched_checkpointer
+
+    with patch("torch.distributed.barrier"):
+        state_dict = manager.generate_state_dict(
+            with_model=False, with_optimizer=True, with_rng=False
+        )
+
+    kwargs = manager.optimizer.sharded_state_dict.call_args.kwargs
+    assert kwargs["metadata"] == {"distrib_optim_sharding_type": "dp_reshardable"}
+    assert kwargs["is_loading"] is False
+    assert "optimizer" in state_dict
+
+
+def test_load_checkpoint_builds_optimizer_template_with_is_loading(
+    patched_checkpointer, tmp_path
+):
+    mod, manager, _ = patched_checkpointer
+
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("torch.distributed.barrier"),
+        patch.object(
+            mod, "load_dist_checkpointing", return_value={"optimizer": {"step": 1}}
+        ),
+    ):
+        manager.load_checkpoint(
+            str(tmp_path / "step0"),
+            with_model=False,
+            with_optimizer=True,
+            with_rng=False,
+        )
+
+    kwargs = manager.optimizer.sharded_state_dict.call_args.kwargs
+    assert kwargs["is_loading"] is True
+    assert kwargs["metadata"] == {"distrib_optim_sharding_type": "dp_reshardable"}
+    manager.optimizer.load_state_dict.assert_called_once_with({"step": 1})


### PR DESCRIPTION
## Description

Fix Megatron checkpointing with the distributed optimizer on megatron-core 0.17.0: saving crashed outright, and loading silently dropped the optimizer moments.

**Save:** since the `dist_checkpointing` refactor in megatron-core v0.14, `flattened_range` is legacy, non-reconstructable metadata and is no longer supported as a persistable layout; the remaining code paths were removed upstream in [Megatron-LM PR #2126](https://github.com/NVIDIA/Megatron-LM/pull/2126), and `ShardedTensor.validate_metadata_integrity()` now rejects it (see the [upstream checkpoint-compatibility docs](https://github.com/NVIDIA/Megatron-LM/blob/main/docs/api-guide/core/dist_checkpointing.md#checkpoint-compatibility-and-optimizer-state-formats)). The `DistributedOptimizer.sharded_state_dict` API still **defaults** to `fully_sharded_model_space`, which emits `flattened_range`, so saving optimizer state fails on the pinned megatron-core 0.17.0:

```
megatron.core.dist_checkpointing.core.CheckpointingException:
ShardedTensor.flattened_range is not supported.
```

This PR requests `dp_reshardable` sharding — the optimizer state format upstream now uses by default for new checkpoints.

**Load:** `load_checkpoint` now passes `is_loading=True` when building the load-side template. megatron-core pre-allocates the optimizer state (`exp_avg`/`exp_avg_sq`) only when `is_loading=True` (`distrib_optimizer.py:1276`); without it, a freshly built optimizer produces a template that only requests `param`, and DCP **silently** skips the moments — training resumes with a reset optimizer state at full learning rate.

## Related Issue

N/A — hit while running SWE-bench RL training with the Megatron backend.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

**Production evidence for the load-side bug:** in a large-scale RL run (128 GPUs, MoE model), recovery through this load path looked healthy for ~20 steps, then showed repeated grad-norm spikes (up to 2.1e6) and entropy collapse (0.45 → 0.03) within ~70 steps. A control run from the same weights with a fresh optimizer plus LR warmup stayed stable. Checkpoint inspection confirmed the save side wrote `exp_avg`/`exp_avg_sq` correctly — only the load template was missing them, so DCP dropped the moments without any error.

**Trade-off (documented in the code comment):** with `dp_reshardable`, the optimizer state — not the model weights — reshards only along DP; load hard-asserts the same bucket layout (`per_bucket_numel_unpadded`), so save and load must use identical TP/PP. This is fine today since recover enforces the same topology; `fully_reshardable` is the `flattened_range`-free alternative that keeps TP/PP resharding, at the cost of gathering optimizer state.

**Tests:** `tests/test_megatron_async_save.py` gains two unit tests that call the real `generate_state_dict` with a mocked optimizer (no GPU), asserting the `dp_reshardable` metadata on the save path and `is_loading=True` on the load path — `pytest tests/test_megatron_async_save.py` → 7 passed, 2 skipped (the 2 skips are pre-existing).