### PR TITLE
fix(rollout): stop controller-managed workers from dp-scaling staleness capacity

### DIFF
--- a/areal/infra/controller/rollout_controller.py
+++ b/areal/infra/controller/rollout_controller.py
@@ -267,6 +267,13 @@ class RolloutController:
         logger.info("Engine created on all workers!")
 
         logger.info("Calling engine initialization...")
+        # Workers are controller-managed: the controller handles staleness
+        # globally, so workers must NOT apply their own dp-scaled staleness
+        # constraints. Force train_data_parallel_size=1 unless explicitly
+        # configured; an explicit None must not survive, or workers fall back
+        # to dividing capacity by dist.get_world_size().
+        if kwargs.get("train_data_parallel_size") is None:
+            kwargs["train_data_parallel_size"] = 1
         if server_infos is not None:
             # Connecting to existing local servers for evaluation
             self.server_infos = server_infos


### PR DESCRIPTION
## Description

`RolloutController` manages staleness globally, but controller-managed workers also applied their own dp-scaled staleness constraint, dividing capacity by `dist.get_world_size()`. With N workers this shrinks effective rollout capacity by N and can stall generation.

Force `train_data_parallel_size=1` at engine initialization so workers under the controller do not re-scale capacity. The guard treats both a missing key and an explicit `None` as "not configured" (`kwargs.get(...) is None`), since an explicit `None` reaching the worker would fall back to world-size scaling in `WorkflowExecutor`; an explicitly configured non-None value is left untouched. Standalone (non-controller) usage is unaffected.

## Related Issue

N/A.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

No current caller passes `train_data_parallel_size` into `RolloutController.initialize` (the controller-path `init_kwargs` never contains the key, and the non-controller path passes an `int` property directly to the engine), so the `is None` guard is defensive hardening for future callers that may forward an `Optional[int]` config value.