### PR TITLE
fix(v2): honor full-model disk weight updates

### DIFF
--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -75,6 +75,54 @@ if TYPE_CHECKING:
 logger = logging.getLogger("RLTrainer")
 
 
+def _validate_v2_disk_weight_update(config: PPOConfig) -> None:
+    """Validate backends used by the v2 disk weight-update gateway."""
+    uses_disk = config.actor.use_lora or config.actor.weight_update_mode == "disk"
+    if (
+        config.actor._version != "v2"
+        or config.rollout._version != "v2"
+        or not uses_disk
+    ):
+        return
+
+    rollout_backend = config.rollout.backend.partition(":")[0]
+    if rollout_backend != "sglang" or config.rollout.api_url is not None:
+        raise ValueError(
+            "v2 disk weight updates currently only support a local SGLang "
+            "rollout backend. Use local SGLang or use AWEX for full-parameter "
+            "updates."
+        )
+
+
+def _build_v2_weight_update_meta(config: PPOConfig) -> WeightUpdateMeta:
+    """Build weight-update metadata for v2 train and rollout controllers."""
+    _validate_v2_disk_weight_update(config)
+    if not config.actor.use_lora and config.actor.weight_update_mode != "disk":
+        return WeightUpdateMeta.from_awex()
+
+    disk_kwargs: dict[str, Any] = {
+        "experiment_name": config.experiment_name,
+        "trial_name": config.trial_name,
+        "file_root": config.cluster.fileroot,
+        "name": "default",
+        "clear_checkpoint_after_load": True,
+    }
+    if config.actor.use_lora:
+        disk_kwargs.update(
+            {
+                "use_lora": config.actor.use_lora,
+                "lora_name": config.gconfig.lora_name,
+                "base_model_name": config.actor.path,
+                # Keep enough recent adapter versions for off-policy
+                # rollouts (max_head_offpolicyness) plus a safety margin;
+                # older versions are unloaded to bound sglang VRAM and
+                # avoid the adapter-accumulation hang.
+                "lora_keep_versions": config.rollout.max_head_offpolicyness + 2,
+            }
+        )
+    return WeightUpdateMeta.from_disk(**disk_kwargs)
+
+
 class _EmptyDataLoader:
     """Minimal dataloader for online mode that yields empty dicts.
 
@@ -324,29 +372,11 @@ class PPOTrainer:
         self._proxy_started = False
 
         # Prepare weight update meta and connect to inference engine.
-        # v2 controllers pick transport from use_lora: LoRA must go through
-        # disk (P2P transports cannot carry PEFT-wrapped tensors); non-LoRA
-        # uses awex. v1 keeps the legacy weight_update_mode dispatch.
+        # In v2, LoRA must go through disk because P2P transports cannot carry
+        # PEFT-wrapped tensors. Full-parameter updates use disk when explicitly
+        # requested and AWEX otherwise. v1 keeps the legacy dispatch below.
         if self.config.actor._version == "v2":
-            if config.actor.use_lora:
-                disk_kwargs: dict[str, Any] = {
-                    "experiment_name": config.experiment_name,
-                    "trial_name": config.trial_name,
-                    "file_root": config.cluster.fileroot,
-                    "name": "default",
-                    "clear_checkpoint_after_load": True,
-                    "use_lora": config.actor.use_lora,
-                    "lora_name": config.gconfig.lora_name,
-                    "base_model_name": config.actor.path,
-                    # Keep enough recent adapter versions for off-policy
-                    # rollouts (max_head_offpolicyness) plus a safety margin;
-                    # older versions are unloaded to bound sglang VRAM and
-                    # avoid the adapter-accumulation hang.
-                    "lora_keep_versions": config.rollout.max_head_offpolicyness + 2,
-                }
-                self.weight_update_meta = WeightUpdateMeta.from_disk(**disk_kwargs)
-            else:
-                self.weight_update_meta = WeightUpdateMeta.from_awex()
+            self.weight_update_meta = _build_v2_weight_update_meta(config)
         elif self.config.actor.weight_update_mode == "disk":
             disk_kwargs = {
                 "experiment_name": config.experiment_name,
@@ -1294,6 +1324,9 @@ class PPOTrainer:
         """validate config for incompatible settings before weight initialization, to avoid wasted resources on spawning workers and loading models."""
         rollout_backend = self.rollout_alloc.backend
         actor_backend = self.actor_alloc.backend
+
+        _validate_v2_disk_weight_update(self.config)
+
         requires_train_engine_offload = any(
             (
                 self._should_offload_rollout,
@@ -1329,6 +1362,12 @@ class PPOTrainer:
             and self.config.actor.use_lora
             and rollout_backend == "sglang"
         ):
+            if self.config.actor._version == "v2":
+                raise ValueError(
+                    "Megatron actor with LoRA is not supported with SGLang rollout "
+                    "in RL trainer v2. Use an FSDP actor with local SGLang, or "
+                    "disable LoRA."
+                )
             raise ValueError(
                 "Megatron actor with LoRA is not supported with SGLang rollout in "
                 "RL trainer. Please use vLLM rollout backend, or disable LoRA, or "

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -85,7 +85,9 @@ def _validate_v2_disk_weight_update(config: PPOConfig) -> None:
     ):
         return
 
-    rollout_backend = config.rollout.backend.partition(":")[0]
+    rollout_backend = (
+        config.rollout.backend.partition(":")[0] if config.rollout.backend else ""
+    )
     if rollout_backend != "sglang" or config.rollout.api_url is not None:
         raise ValueError(
             "v2 disk weight updates currently only support a local SGLang "

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import os
+import shutil
 import sys
 import threading
 import time
@@ -22,10 +24,31 @@ from areal.utils.network import format_hostport, gethostip
 if TYPE_CHECKING:
     from areal.api import ParallelStrategy, TrainEngine
     from areal.api.cli_args import TrainEngineConfig
-    from areal.api.io_struct import FinetuneSpec
+    from areal.api.io_struct import FinetuneSpec, WeightUpdateMeta
     from areal.api.scheduler_api import Scheduler, Worker
 
 logger = logging.getLogger("GatewayTrainController")
+
+
+def _disk_gateway_save_root(meta: WeightUpdateMeta) -> str:
+    """Return the root whose versioned child matches ``meta.with_version``."""
+    if meta.path is None:
+        raise ValueError("Disk weight update requires a checkpoint path")
+    return os.path.dirname(meta.path)
+
+
+def _validate_disk_rollout(rollout: Any) -> None:
+    """Reject disk updates that the v2 gateway cannot deliver safely."""
+    rollout_alloc = rollout.rollout_alloc
+    if (
+        rollout.external_mode
+        or rollout_alloc is None
+        or rollout_alloc.backend != "sglang"
+    ):
+        raise ValueError(
+            "v2 disk weight updates currently only support a local SGLang "
+            "rollout backend"
+        )
 
 
 class GatewayTrainController:
@@ -56,6 +79,7 @@ class GatewayTrainController:
         self._own_process_group = False
         self.rollout: Any | None = None
         self._weight_update_ctrl: Any | None = None
+        self._disk_weight_update_root: str | None = None
 
         # Version management
         self._version_lock = Lock()
@@ -953,13 +977,21 @@ class GatewayTrainController:
                 f"Ensure _version='v2' is set on InferenceEngineConfig."
             )
 
-        self.rollout = rollout
-
         if meta.type not in ("awex", "disk"):
             raise ValueError(
                 f"GatewayTrainController supports 'awex' or 'disk' weight "
                 f"updates, got '{meta.type}'"
             )
+        if meta.type == "disk":
+            _validate_disk_rollout(rollout)
+
+        inference_urls: list[str] = rollout.inference_worker_urls
+        if meta.type == "disk" and not inference_urls:
+            raise RuntimeError(
+                "v2 disk weight updates require at least one local inference worker"
+            )
+
+        self.rollout = rollout
 
         ctrl = WeightUpdateController(
             WeightUpdateControllerConfig(
@@ -973,8 +1005,8 @@ class GatewayTrainController:
         )
         ctrl.initialize()
 
-        inference_urls: list[str] = rollout.inference_worker_urls
         pair_name = f"{self._role}-rollout"
+        self._disk_weight_update_root = None
 
         if meta.type == "awex":
             # NCCL rendezvous master must live on the rank-0 process's node.
@@ -997,16 +1029,18 @@ class GatewayTrainController:
                 nccl_master_port=port_data["ports"][0],
             )
         else:  # disk
+            save_root = _disk_gateway_save_root(meta)
             ctrl.connect(
                 pair_name=pair_name,
                 train_worker_urls=self._worker_addrs,
                 inference_worker_urls=inference_urls,
                 mode="disk",
-                save_path=meta.path or "",
+                save_path=save_root,
                 use_lora=meta.use_lora,
                 lora_name=meta.lora_name,
                 lora_keep_versions=meta.lora_keep_versions,
             )
+            self._disk_weight_update_root = save_root
         self._weight_update_ctrl = ctrl
         logger.info(
             "WeightUpdateController connected (pair=%s, train=%d, inf=%d)",
@@ -1020,18 +1054,72 @@ class GatewayTrainController:
             raise RuntimeError(
                 "connect_engine() must be called before update_weights()"
             )
-        self.rollout.pause_generation()
         assert meta.version is not None and meta.version > 0, (
             f"meta.version must be a positive integer, got {meta.version}"
         )
-        result = self._weight_update_ctrl.update_weights(version=meta.version)
-        self.rollout.continue_generation()
-        logger.info(
-            "Weight update v%d completed (%s, %.0fms)",
-            meta.version,
-            result.status,
-            result.duration_ms,
-        )
+        if (
+            meta.type == "disk"
+            and meta.clear_checkpoint_after_load
+            and self._disk_weight_update_root is None
+        ):
+            raise RuntimeError(
+                "Disk weight-update root is unavailable; connect_engine() "
+                "must complete before updating weights"
+            )
+        primary_error: BaseException | None = None
+        pause_completed = False
+        update_succeeded = False
+        try:
+            self.rollout.pause_generation()
+            pause_completed = True
+            result = self._weight_update_ctrl.update_weights(version=meta.version)
+            if result.status != "ok":
+                raise RuntimeError(
+                    f"Weight update v{meta.version} failed: "
+                    f"{result.error or 'unknown gateway error'}"
+                )
+            update_succeeded = True
+            if meta.type == "disk" and meta.clear_checkpoint_after_load:
+                assert self._disk_weight_update_root is not None
+                checkpoint_path = os.path.join(
+                    self._disk_weight_update_root,
+                    f"weight_update_v{meta.version}",
+                )
+                try:
+                    shutil.rmtree(checkpoint_path)
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    logger.warning(
+                        "Failed to remove disk weight-update checkpoint %s: %s",
+                        checkpoint_path,
+                        exc,
+                    )
+            logger.info(
+                "Weight update v%d completed (%s, %.0fms)",
+                meta.version,
+                result.status,
+                result.duration_ms,
+            )
+        except BaseException as exc:
+            primary_error = exc
+            raise
+        finally:
+            if not pause_completed or update_succeeded:
+                try:
+                    self.rollout.continue_generation()
+                except BaseException:
+                    if primary_error is None:
+                        raise
+                    logger.exception(
+                        "Failed to resume generation while propagating %s",
+                        type(primary_error).__name__,
+                    )
+            else:
+                logger.error(
+                    "Weight update did not complete; leaving rollout generation "
+                    "paused to avoid serving mixed model versions"
+                )
 
     def prepare_batch(
         self,

--- a/tests/test_rl_trainer.py
+++ b/tests/test_rl_trainer.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from areal.trainer.rl_trainer import PPOTrainer, _build_v2_weight_update_meta
+
+
+def _make_config(*, use_lora: bool, weight_update_mode: str):
+    return SimpleNamespace(
+        experiment_name="test-experiment",
+        trial_name="test-trial",
+        cluster=SimpleNamespace(fileroot="/tmp/areal-tests"),
+        actor=SimpleNamespace(
+            _version="v2",
+            use_lora=use_lora,
+            weight_update_mode=weight_update_mode,
+            path="test-model",
+            scheduling_strategy=SimpleNamespace(type="separation", target=None),
+        ),
+        gconfig=SimpleNamespace(lora_name="test-adapter"),
+        rollout=SimpleNamespace(
+            _version="v2",
+            api_url=None,
+            backend="sglang:d1",
+            max_head_offpolicyness=2,
+            return_routed_experts=False,
+            scheduling_strategy=SimpleNamespace(type="separation", target=None),
+        ),
+        enable_offload=True,
+    )
+
+
+def test_v2_full_parameter_explicit_disk_mode_is_honored():
+    config = _make_config(use_lora=False, weight_update_mode="disk")
+
+    meta = _build_v2_weight_update_meta(config)
+
+    assert meta.type == "disk"
+    assert meta.use_lora is False
+
+
+def test_v2_full_parameter_xccl_mode_uses_awex():
+    config = _make_config(use_lora=False, weight_update_mode="xccl")
+
+    meta = _build_v2_weight_update_meta(config)
+
+    assert meta.type == "awex"
+
+
+def test_v2_lora_uses_disk_regardless_of_configured_mode():
+    config = _make_config(use_lora=True, weight_update_mode="xccl")
+
+    meta = _build_v2_weight_update_meta(config)
+
+    assert meta.type == "disk"
+    assert meta.use_lora is True
+    assert meta.lora_name == "test-adapter"
+    assert meta.lora_keep_versions == 4
+
+
+def test_v2_disk_mode_rejects_vllm_backend():
+    config = _make_config(use_lora=False, weight_update_mode="disk")
+    config.rollout.backend = "vllm:d1"
+
+    with pytest.raises(ValueError, match="local SGLang"):
+        _build_v2_weight_update_meta(config)
+
+
+def test_v2_disk_mode_rejects_external_model():
+    config = _make_config(use_lora=False, weight_update_mode="disk")
+    config.rollout.api_url = "https://example.com/v1"
+
+    with pytest.raises(ValueError, match="local SGLang"):
+        _build_v2_weight_update_meta(config)
+
+
+def test_v2_megatron_lora_error_recommends_supported_backend_pair():
+    config = _make_config(use_lora=True, weight_update_mode="xccl")
+    trainer = PPOTrainer.__new__(PPOTrainer)
+    trainer.config = config
+    trainer.actor_alloc = SimpleNamespace(backend="megatron")
+    trainer.rollout_alloc = SimpleNamespace(backend="sglang")
+    trainer._should_offload_rollout = False
+    trainer._should_offload_actor = False
+    trainer._should_offload_critic = False
+    trainer._should_offload_ref = False
+    trainer._should_offload_teacher = False
+
+    with pytest.raises(ValueError, match="FSDP actor with local SGLang"):
+        trainer._validate_cfg()

--- a/tests/test_rl_trainer.py
+++ b/tests/test_rl_trainer.py
@@ -70,6 +70,7 @@ def test_v2_disk_mode_rejects_vllm_backend():
 
 def test_v2_disk_mode_rejects_external_model():
     config = _make_config(use_lora=False, weight_update_mode="disk")
+    config.rollout.backend = None
     config.rollout.api_url = "https://example.com/v1"
 
     with pytest.raises(ValueError, match="local SGLang"):

--- a/tests/v2/training_service/test_controller_unit.py
+++ b/tests/v2/training_service/test_controller_unit.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
+from areal.api.io_struct import WeightUpdateMeta
+from areal.v2.inference_service.controller.controller import RolloutControllerV2
 from areal.v2.training_service.controller.controller import (
     GatewayTrainController,
+    _disk_gateway_save_root,
 )
+from areal.v2.weight_update.gateway.config import WeightUpdateResult
 
 MODULE = "areal.v2.training_service.controller.controller"
 
@@ -162,3 +168,197 @@ class TestGatewayTrainControllerInitialization:
         assert controller._gateway_addr == "http://127.0.0.1:18080"
         assert controller.api_key is not None
         assert controller.api_key.startswith("ak-train-role-")
+
+
+class TestGatewayTrainControllerWeightUpdate:
+    @staticmethod
+    def _prepare_controller(result=None, error=None):
+        controller = _make_controller()
+        controller.rollout = MagicMock()
+        controller._weight_update_ctrl = MagicMock()
+        controller._weight_update_ctrl.update_weights.side_effect = error
+        if error is None:
+            controller._weight_update_ctrl.update_weights.return_value = result
+        return controller
+
+    def test_failed_result_raises_and_keeps_generation_paused(self):
+        result = WeightUpdateResult(
+            status="error",
+            version=1,
+            duration_ms=10,
+            error="inference load failed",
+        )
+        controller = self._prepare_controller(result=result)
+        meta = WeightUpdateMeta(
+            type="disk",
+            path="/tmp/weights",
+            version=1,
+            clear_checkpoint_after_load=False,
+        )
+
+        with pytest.raises(RuntimeError, match="inference load failed"):
+            controller.update_weights(meta)
+
+        controller.rollout.pause_generation.assert_called_once_with()
+        controller.rollout.continue_generation.assert_not_called()
+
+    def test_gateway_exception_keeps_generation_paused(self):
+        controller = self._prepare_controller(error=TimeoutError("gateway timeout"))
+        meta = WeightUpdateMeta(
+            type="disk",
+            path="/tmp/weights",
+            version=1,
+            clear_checkpoint_after_load=False,
+        )
+
+        with pytest.raises(TimeoutError, match="gateway timeout"):
+            controller.update_weights(meta)
+
+        controller.rollout.pause_generation.assert_called_once_with()
+        controller.rollout.continue_generation.assert_not_called()
+
+    def test_pause_exception_attempts_resume(self):
+        controller = self._prepare_controller()
+        controller.rollout.pause_generation.side_effect = RuntimeError("pause failed")
+        meta = WeightUpdateMeta(
+            type="disk",
+            path="/tmp/weights",
+            version=1,
+            clear_checkpoint_after_load=False,
+        )
+
+        with pytest.raises(RuntimeError, match="pause failed"):
+            controller.update_weights(meta)
+
+        controller.rollout.continue_generation.assert_called_once_with()
+
+    def test_resume_exception_does_not_mask_pause_exception(self):
+        controller = self._prepare_controller()
+        controller.rollout.pause_generation.side_effect = RuntimeError("pause failed")
+        controller.rollout.continue_generation.side_effect = RuntimeError(
+            "resume failed"
+        )
+        meta = WeightUpdateMeta(
+            type="disk",
+            path="/tmp/weights",
+            version=1,
+            clear_checkpoint_after_load=False,
+        )
+
+        with pytest.raises(RuntimeError, match="pause failed"):
+            controller.update_weights(meta)
+
+    def test_successful_disk_update_removes_versioned_checkpoint(self, tmp_path):
+        checkpoint_path = tmp_path / "weight_update_v1"
+        checkpoint_path.mkdir()
+        result = WeightUpdateResult(
+            status="ok",
+            version=1,
+            duration_ms=10,
+        )
+        controller = self._prepare_controller(result=result)
+        controller._disk_weight_update_root = str(tmp_path)
+        meta = WeightUpdateMeta(
+            type="disk",
+            path=str(checkpoint_path),
+            version=1,
+            clear_checkpoint_after_load=True,
+        )
+
+        controller.update_weights(meta)
+
+        assert not checkpoint_path.exists()
+        controller.rollout.continue_generation.assert_called_once_with()
+
+    def test_disk_cleanup_uses_connected_root_not_update_meta_path(self, tmp_path):
+        checkpoint_path = tmp_path / "weight_update_v1"
+        checkpoint_path.mkdir()
+        unrelated_path = tmp_path / "unrelated"
+        unrelated_path.mkdir()
+        result = WeightUpdateResult(
+            status="ok",
+            version=1,
+            duration_ms=10,
+        )
+        controller = self._prepare_controller(result=result)
+        controller._disk_weight_update_root = str(tmp_path)
+        meta = WeightUpdateMeta(
+            type="disk",
+            path=str(unrelated_path),
+            version=1,
+            clear_checkpoint_after_load=True,
+        )
+
+        controller.update_weights(meta)
+
+        assert not checkpoint_path.exists()
+        assert unrelated_path.exists()
+
+    def test_disk_gateway_save_root_matches_versioned_meta_path(self, tmp_path):
+        meta = WeightUpdateMeta.from_disk(
+            experiment_name="test-exp",
+            trial_name="trial-0",
+            file_root=str(tmp_path),
+        )
+
+        save_root = _disk_gateway_save_root(meta)
+
+        assert os.path.join(save_root, "weight_update_v3") == meta.with_version(3).path
+
+    def test_connect_engine_uses_canonical_disk_save_root(self, tmp_path):
+        controller = _make_controller()
+        controller._worker_addrs = ["http://train:8000"]
+        rollout = RolloutControllerV2.__new__(RolloutControllerV2)
+        rollout.config = SimpleNamespace(api_url=None)
+        rollout.rollout_alloc = SimpleNamespace(backend="sglang")
+        rollout._init_future = None
+        rollout._inf_addrs = ["http://infer:9000"]
+        meta = WeightUpdateMeta.from_disk(
+            experiment_name="test-exp",
+            trial_name="trial-0",
+            file_root=str(tmp_path),
+        )
+
+        with (
+            patch(
+                "areal.v2.weight_update.controller.controller."
+                "WeightUpdateController.initialize"
+            ),
+            patch(
+                "areal.v2.weight_update.controller.controller."
+                "WeightUpdateController.connect"
+            ) as mock_connect,
+        ):
+            controller.connect_engine(rollout, meta)
+
+        expected_root = os.path.dirname(meta.path)
+        assert controller._disk_weight_update_root == expected_root
+        assert mock_connect.call_args.kwargs["save_path"] == expected_root
+
+    @pytest.mark.parametrize(
+        ("backend", "api_url"),
+        [("vllm", None), (None, "https://example.com/v1")],
+    )
+    def test_connect_engine_rejects_unsupported_disk_rollout(self, backend, api_url):
+        controller = _make_controller()
+        rollout = RolloutControllerV2.__new__(RolloutControllerV2)
+        rollout.config = SimpleNamespace(api_url=api_url)
+        rollout.rollout_alloc = (
+            SimpleNamespace(backend=backend) if backend is not None else None
+        )
+        rollout._init_future = None
+        rollout._inf_addrs = []
+        meta = WeightUpdateMeta(type="disk", path="/tmp/weight_update")
+
+        with (
+            patch(
+                "areal.v2.weight_update.controller.controller."
+                "WeightUpdateController.initialize"
+            ),
+            patch(
+                "areal.v2.weight_update.controller.controller."
+                "WeightUpdateController.connect"
+            ),
+            pytest.raises(ValueError, match="local SGLang"),
+        ):
+            controller.connect_engine(rollout, meta)


### PR DESCRIPTION
## Description

Make v2 full-parameter RL honor an explicit `actor.weight_update_mode=disk`
for non-colocated local SGLang rollouts.

The previous v2 dispatch always selected AWEX for non-LoRA actors, even though
`weight_update_mode` publicly accepts `disk` and the v2 gateway already implements
full-model disk transfer. This change:

- preserves AWEX as the default and preserves mandatory disk transport for LoRA;
- selects disk for a full-parameter v2 actor when explicitly configured;
- rejects vLLM and external-model disk updates at both the trainer and transport
  boundaries because the current v2 disk gateway exposes SGLang-specific endpoints;
- aligns the gateway save root with `WeightUpdateMeta.with_version()`, then cleans a
  successfully loaded versioned checkpoint from that canonical root;
- treats gateway `status=error` as an exception and fails closed after an uncertain
  update, avoiding mixed-version rollout traffic;
- compensates a failed pause attempt, preserves the primary exception if resume also
  fails, and reports non-`FileNotFoundError` cleanup failures.

This PR intentionally does **not** enable actor/rollout colocation or single-GPU v2
training. That scheduling integration remains separate work.

## Related Issue

Related to #1439. The issue reports an AWEX timeout; this PR addresses the deterministic
transport-selection and lifecycle problems around the explicit disk alternative, not
every possible AWEX timeout.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable; no public option or supported topology was added)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

N/A

## Additional Context

Validation run:

```text
uv run pytest tests/test_rl_trainer.py \
  tests/v2/training_service/test_controller_unit.py \
  tests/v2/weight_update tests/test_sglang_lora_unload.py tests/v2/cli -q

81 passed, 33 skipped
```

The skipped cases require CUDA and/or multiple GPUs. The existing v2 disk E2E covers
separated FSDP-to-SGLang transfers on 2/4/8 GPUs; a dedicated Megatron-to-SGLang disk
E2E is still a residual coverage gap.

```text
uv run pre-commit run --all-files

All hooks passed.
```
