### PR TITLE
fix(hermes): preserve singleton online reward signal

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1689,11 +1689,15 @@ class PPOActorConfig(TrainEngineConfig):
 
     def __post_init__(self):
         """Validate PPO actor configuration."""
-        if (
-            self.reward_norm is not None
-            and self.reward_norm.mean_level == "group"
-            and self.reward_norm.group_size == 1
-        ):
+        reward_norm = self.reward_norm
+        if isinstance(reward_norm, (dict, DictConfig)):
+            reward_mean_level = reward_norm.get("mean_level")
+            reward_group_size = reward_norm.get("group_size")
+        else:
+            reward_mean_level = getattr(reward_norm, "mean_level", None)
+            reward_group_size = getattr(reward_norm, "group_size", None)
+
+        if reward_mean_level == "group" and reward_group_size == 1:
             warnings.warn(
                 "PPO reward_norm uses mean_level='group' with group_size=1: "
                 "singleton group centering erases the task reward. Disable reward "

--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1689,6 +1689,19 @@ class PPOActorConfig(TrainEngineConfig):
 
     def __post_init__(self):
         """Validate PPO actor configuration."""
+        if (
+            self.reward_norm is not None
+            and self.reward_norm.mean_level == "group"
+            and self.reward_norm.group_size == 1
+        ):
+            warnings.warn(
+                "PPO reward_norm uses mean_level='group' with group_size=1: "
+                "singleton group centering erases the task reward. Disable reward "
+                "centering (mean_level=None) or use group_size >= 2.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         from areal.utils.constants import ProxLogpMethod
 
         if (

--- a/examples/hermes/README.md
+++ b/examples/hermes/README.md
@@ -102,9 +102,11 @@ keys); CLI flags override it. The explicit form below just documents those defau
 > Online mode currently trains on one independently rewarded trajectory per group.
 > Centering that singleton group reward subtracts the reward from itself, while
 > centering the flat token advantages from a one-trajectory batch likewise makes every
-> advantage zero. Either operation erases the task-conditioned learning signal. To use
-> GRPO-style group centering instead, sample at least two trajectories from the same
-> task and preserve their shared group identity through training.
+> advantage zero. Either operation erases the task-conditioned learning signal. Using
+> GRPO-style group centering instead requires at least two trajectories from the same
+> task and a workflow that supports grouped rollouts/session grouping and preserves
+> their shared group identity through training. Changing `n_samples` alone is
+> insufficient; the current online one-sample path does not support this directly.
 
 ```bash
 uv run python3 examples/hermes/train.py \

--- a/examples/hermes/README.md
+++ b/examples/hermes/README.md
@@ -97,6 +97,15 @@ The five steps below are run from the repo root.
 `config.yaml` holds the defaults (v2 controllers, 1 node × 2 GPUs, `batch_size=1`, admin
 keys); CLI flags override it. The explicit form below just documents those defaults:
 
+> **Why reward/advantage normalization is disabled here**
+>
+> Online mode currently trains on one independently rewarded trajectory per group.
+> Centering that singleton group reward subtracts the reward from itself, while
+> centering the flat token advantages from a one-trajectory batch likewise makes every
+> advantage zero. Either operation erases the task-conditioned learning signal. To use
+> GRPO-style group centering instead, sample at least two trajectories from the same
+> task and preserve their shared group identity through training.
+
 ```bash
 uv run python3 examples/hermes/train.py \
     --config examples/hermes/config.yaml \

--- a/examples/hermes/config.yaml
+++ b/examples/hermes/config.yaml
@@ -81,13 +81,11 @@ actor:
   rejection_sampling:
     metric: ratio
     upper: 5.0
-  reward_norm:
-    mean_level: group
-    std_level: group
-    group_size: ${gconfig.n_samples}
-  adv_norm:
-    mean_level: batch
-    std_level: batch
+  # Online mode currently consumes one independently rewarded trajectory per
+  # group. Centering a singleton reward or flat singleton advantage would erase
+  # the task-conditioned learning signal.
+  reward_norm: null
+  adv_norm: null
   weight_update_mode: xccl
   max_new_tokens: ${gconfig.max_new_tokens}
   scheduling_spec:

--- a/tests/test_adv_norm_config.py
+++ b/tests/test_adv_norm_config.py
@@ -1,15 +1,49 @@
+import warnings
 from dataclasses import asdict
 from unittest.mock import patch
 
 import pytest
 import torch
 
-from areal.api.cli_args import NormConfig
+from areal.api.cli_args import NormConfig, PPOActorConfig
 from areal.utils.data import Normalization
 
 # =============================================================================
 # NormConfig Tests
 # =============================================================================
+
+
+def test_ppo_actor_warns_when_reward_group_centering_is_singleton():
+    with pytest.warns(
+        UserWarning, match="singleton group centering erases the task reward"
+    ):
+        PPOActorConfig(
+            reward_norm=NormConfig(
+                mean_level="group", std_level="group", group_size=1
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "reward_norm",
+    [
+        None,
+        NormConfig(mean_level=None, std_level="group", group_size=1),
+        NormConfig(mean_level="group", std_level="group", group_size=2),
+        NormConfig(mean_level="batch", std_level="batch", group_size=1),
+    ],
+)
+def test_ppo_actor_does_not_warn_without_singleton_reward_group_centering(
+    reward_norm,
+):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        PPOActorConfig(reward_norm=reward_norm)
+
+    assert not any(
+        "singleton group centering erases the task reward" in str(warning.message)
+        for warning in caught
+    )
 
 
 def test_adv_norm_config_inheritance():

--- a/tests/test_adv_norm_config.py
+++ b/tests/test_adv_norm_config.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from omegaconf import OmegaConf
 
 from areal.api.cli_args import NormConfig, PPOActorConfig
 from areal.utils.data import Normalization
@@ -13,13 +14,24 @@ from areal.utils.data import Normalization
 # =============================================================================
 
 
-def test_ppo_actor_warns_when_reward_group_centering_is_singleton():
+@pytest.mark.parametrize(
+    "reward_norm",
+    [
+        NormConfig(mean_level="group", std_level="group", group_size=1),
+        {"mean_level": "group", "std_level": "group", "group_size": 1},
+        OmegaConf.create(
+            {"mean_level": "group", "std_level": "group", "group_size": 1}
+        ),
+    ],
+    ids=["norm-config", "dict", "dict-config"],
+)
+def test_ppo_actor_warns_for_all_supported_singleton_reward_config_shapes(
+    reward_norm,
+):
     with pytest.warns(
         UserWarning, match="singleton group centering erases the task reward"
     ):
-        PPOActorConfig(
-            reward_norm=NormConfig(mean_level="group", std_level="group", group_size=1)
-        )
+        PPOActorConfig(reward_norm=reward_norm)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_adv_norm_config.py
+++ b/tests/test_adv_norm_config.py
@@ -18,9 +18,7 @@ def test_ppo_actor_warns_when_reward_group_centering_is_singleton():
         UserWarning, match="singleton group centering erases the task reward"
     ):
         PPOActorConfig(
-            reward_norm=NormConfig(
-                mean_level="group", std_level="group", group_size=1
-            )
+            reward_norm=NormConfig(mean_level="group", std_level="group", group_size=1)
         )
 
 

--- a/tests/test_hermes_reward_signal.py
+++ b/tests/test_hermes_reward_signal.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import torch
+import yaml
+
+_CONFIG_PATH = Path("examples/hermes/config.yaml")
+
+
+def _load_config() -> dict:
+    return yaml.safe_load(_CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def test_hermes_singleton_online_config_preserves_outcome_signal():
+    config = _load_config()
+    actor = config["actor"]
+
+    assert config["gconfig"]["n_samples"] == 1
+    assert config["train_dataset"]["batch_size"] == 1
+    assert actor.get("reward_norm") is None
+    assert actor.get("adv_norm") is None
+
+    outcomes = torch.tensor([0.0, 1.0])
+    signed_rewards = (outcomes + actor["reward_bias"]) * actor["reward_scaling"]
+    flat_token_advantages = signed_rewards[:, None].expand(-1, 3)
+
+    assert signed_rewards[0] < 0 < signed_rewards[1]
+    assert torch.count_nonzero(flat_token_advantages).item() == 6
+    assert not torch.equal(flat_token_advantages[0], flat_token_advantages[1])

--- a/tests/test_hermes_reward_signal.py
+++ b/tests/test_hermes_reward_signal.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import torch
 import yaml
 
+from areal.api.cli_args import PPOActorConfig
+
 _CONFIG_PATH = Path(__file__).resolve().parents[1] / "examples/hermes/config.yaml"
 
 
@@ -20,9 +22,10 @@ def test_hermes_singleton_online_config_preserves_each_outcome_signal():
     assert actor.get("adv_norm") is None
 
     counterfactual_outcomes = torch.tensor([0.0, 1.0])
-    signed_rewards = (counterfactual_outcomes + actor["reward_bias"]) * actor[
-        "reward_scaling"
-    ]
+    actor_defaults = PPOActorConfig()
+    reward_bias = actor.get("reward_bias", actor_defaults.reward_bias)
+    reward_scaling = actor.get("reward_scaling", actor_defaults.reward_scaling)
+    signed_rewards = (counterfactual_outcomes + reward_bias) * reward_scaling
 
     for signed_reward in signed_rewards:
         single_trajectory_token_advantages = signed_reward.expand(3)

--- a/tests/test_hermes_reward_signal.py
+++ b/tests/test_hermes_reward_signal.py
@@ -3,14 +3,14 @@ from pathlib import Path
 import torch
 import yaml
 
-_CONFIG_PATH = Path("examples/hermes/config.yaml")
+_CONFIG_PATH = Path(__file__).resolve().parents[1] / "examples/hermes/config.yaml"
 
 
 def _load_config() -> dict:
     return yaml.safe_load(_CONFIG_PATH.read_text(encoding="utf-8"))
 
 
-def test_hermes_singleton_online_config_preserves_outcome_signal():
+def test_hermes_singleton_online_config_preserves_each_outcome_signal():
     config = _load_config()
     actor = config["actor"]
 
@@ -19,10 +19,14 @@ def test_hermes_singleton_online_config_preserves_outcome_signal():
     assert actor.get("reward_norm") is None
     assert actor.get("adv_norm") is None
 
-    outcomes = torch.tensor([0.0, 1.0])
-    signed_rewards = (outcomes + actor["reward_bias"]) * actor["reward_scaling"]
-    flat_token_advantages = signed_rewards[:, None].expand(-1, 3)
+    counterfactual_outcomes = torch.tensor([0.0, 1.0])
+    signed_rewards = (counterfactual_outcomes + actor["reward_bias"]) * actor[
+        "reward_scaling"
+    ]
+
+    for signed_reward in signed_rewards:
+        single_trajectory_token_advantages = signed_reward.expand(3)
+        assert torch.count_nonzero(single_trajectory_token_advantages).item() == 3
 
     assert signed_rewards[0] < 0 < signed_rewards[1]
-    assert torch.count_nonzero(flat_token_advantages).item() == 6
-    assert not torch.equal(flat_token_advantages[0], flat_token_advantages[1])
+    assert not torch.equal(signed_rewards[0], signed_rewards[1])


### PR DESCRIPTION
## Summary

- warn when PPO reward centering is configured with nominal singleton groups,
  which deterministically removes the outcome reward;
- disable reward and advantage centering in the official one-trajectory Hermes
  online example while preserving its existing `0/1 -> -5/+5` signed mapping;
- add a real-config regression test and document why grouped normalization needs
  at least two samples from the same task.

## Root cause

The Hermes example combines `n_samples=1`, `batch_size=1`, group-mean reward
normalization, and batch-mean advantage normalization. A singleton reward is
centered by itself, so both incorrect and correct outcome rewards become zero.
With the example's flat terminal return, advantage centering can erase the
signal again.

`Normalization` itself is unchanged: zero is the mathematically consistent
result for a dynamic singleton group. This PR instead detects the statically
degenerate PPO reward configuration and corrects the example that selects it.

## Compatibility

- The new behavior is a `UserWarning`, not a hard error.
- Non-singleton GRPO normalization is unchanged.
- Dynamic under-filled singleton groups retain their existing behavior.
- Existing online session, reward, and weight-update APIs are unchanged.

## Validation

- `pytest -q tests/test_hermes_reward_signal.py tests/test_adv_norm_config.py tests/test_reward_norm_variable_group.py` — **212 passed**
- `pre-commit run --files areal/api/cli_args.py examples/hermes/config.yaml examples/hermes/README.md tests/test_adv_norm_config.py tests/test_hermes_reward_signal.py` — **passed**
- `git diff --check` — **passed**

Fixes #1473
