### PR TITLE
fix(v2): separate callback and pull trajectory delivery

### DIFF
--- a/areal/v2/inference_service/controller/workflow.py
+++ b/areal/v2/inference_service/controller/workflow.py
@@ -15,6 +15,7 @@ from areal.infra.rpc.rtensor import RTensor
 from areal.infra.rpc.serialization import deserialize_value
 from areal.infra.utils.http import async_http_retry
 from areal.utils import logging, stats_tracker
+from areal.v2.inference_service.data_proxy.session import TrajectoryDeliveryMode
 
 if TYPE_CHECKING:
     from areal.api.engine_api import InferenceEngine
@@ -69,11 +70,16 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         session: aiohttp.ClientSession,
         task_id: str,
         group_size: int = 1,
+        delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK,
     ) -> tuple[str | None, list[tuple[str, str]]]:
         """Start one or more sessions. Returns (group_id, [(session_id, api_key), ...])."""
         url = f"{self.gateway_addr}/{_RL_START_SESSION_PATHNAME}"
         headers = {"Authorization": f"Bearer {self._admin_api_key}"}
-        payload: dict[str, Any] = {"task_id": task_id, "group_size": group_size}
+        payload: dict[str, Any] = {
+            "task_id": task_id,
+            "group_size": group_size,
+            "delivery_mode": delivery_mode.value,
+        }
         async with session.post(url, json=payload, headers=headers) as resp:
             resp.raise_for_status()
             data = await resp.json()
@@ -142,7 +148,10 @@ class InferenceServiceWorkflow(RolloutWorkflow):
     ) -> dict[str, InteractionWithTokenLogpReward] | None:
         task_id = workflow_context.get().task_id
         group_id, sessions = await self._start_session(
-            http_session, str(task_id), group_size=self.group_size
+            http_session,
+            str(task_id),
+            group_size=self.group_size,
+            delivery_mode=TrajectoryDeliveryMode.PULL,
         )
 
         assert self.agent is not None

--- a/areal/v2/inference_service/data_proxy/app.py
+++ b/areal/v2/inference_service/data_proxy/app.py
@@ -472,7 +472,9 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         for i in range(group_size):
             try:
                 session_id, session_api_key = store.start_session(
-                    body.task_id, body.api_key if i == 0 else None
+                    body.task_id,
+                    body.api_key if i == 0 else None,
+                    delivery_mode=body.delivery_mode,
                 )
             except ValueError as e:
                 raise HTTPException(status_code=409, detail=str(e))

--- a/areal/v2/inference_service/data_proxy/session.py
+++ b/areal/v2/inference_service/data_proxy/session.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel
@@ -26,17 +27,28 @@ SESSION_TIMEOUT_SECONDS = 3600
 # =============================================================================
 
 
+class TrajectoryDeliveryMode(str, Enum):
+    """How completed trajectories are delivered to the session consumer."""
+
+    CALLBACK = "callback"
+    PULL = "pull"
+
+
 class StartSessionRequest(BaseModel):
     """Request to start one or more offline RL sessions.
 
     When ``group_size`` is greater than 1, the data proxy creates multiple
     sessions atomically. The response always contains a flat ``sessions``
     list — single-session is just ``group_size=1``.
+
+    Completed trajectories use callback delivery by default. Set
+    ``delivery_mode`` to ``pull`` when the client will explicitly export them.
     """
 
     task_id: str
     api_key: str | None = None  # Reuse a previously-issued key (refresh)
     group_size: int = 1
+    delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK
 
 
 class SessionCredentials(BaseModel):

--- a/areal/v2/inference_service/data_proxy/session.py
+++ b/areal/v2/inference_service/data_proxy/session.py
@@ -119,8 +119,12 @@ class ReadyTrajectory:
     interaction_id: str
     completions: InteractionCache
     created_at: float
-    needs_online_callback: bool = False
+    delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK
     callback_delivered: bool = False
+
+    @property
+    def needs_online_callback(self) -> bool:
+        return self.delivery_mode is TrajectoryDeliveryMode.CALLBACK
 
 
 # =============================================================================
@@ -145,8 +149,10 @@ class SessionData:
         self,
         session_id: str,
         set_reward_finish_timeout: float = 0.0,
+        delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK,
     ):
         self.session_id = session_id
+        self.delivery_mode = delivery_mode
         self._set_reward_finish_timeout = set_reward_finish_timeout
         self._last_access_time = time.time()
         self._lock = threading.Lock()
@@ -214,7 +220,7 @@ class SessionData:
             interaction_id=resolved_interaction_id,
             completions=completions,
             created_at=now,
-            needs_online_callback=True,
+            delivery_mode=self.delivery_mode,
         )
         self._ready_trajectories[trajectory_id] = ready
         self._active_completions = InteractionCache()
@@ -400,7 +406,10 @@ class SessionStore:
         return self._admin_api_key
 
     def start_session(
-        self, task_id: str, api_key: str | None = None
+        self,
+        task_id: str,
+        api_key: str | None = None,
+        delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK,
     ) -> tuple[str, str]:
         """Start a new session, returning (session_id, session_api_key).
 
@@ -437,6 +446,7 @@ class SessionStore:
             self._sessions[session_id] = SessionData(
                 session_id=session_id,
                 set_reward_finish_timeout=self._set_reward_finish_timeout,
+                delivery_mode=delivery_mode,
             )
             self._api_key_to_session[session_api_key] = session_id
             self._session_to_api_key[session_id] = session_api_key

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -15,6 +15,7 @@ from areal.v2.inference_service.controller.controller import (
 from areal.v2.inference_service.controller.workflow import (
     InferenceServiceWorkflow,
 )
+from areal.v2.inference_service.data_proxy.session import TrajectoryDeliveryMode
 
 
 def _make_scheduler(n_gpus_per_node: int = 8) -> MagicMock:
@@ -513,6 +514,41 @@ class TestOnlineCallbackFlow:
 
 
 class TestInferenceServiceWorkflow:
+    @pytest.mark.asyncio
+    async def test_start_session_serializes_pull_delivery(self):
+        workflow = InferenceServiceWorkflow(
+            controller=MagicMock(),
+            gateway_addr="http://test:8080",
+            admin_api_key="test-key",
+        )
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json = AsyncMock(
+            return_value={
+                "group_id": "grp",
+                "sessions": [{"session_id": "s", "session_api_key": "k"}],
+            }
+        )
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_http_session = MagicMock()
+        mock_http_session.post = MagicMock(return_value=mock_cm)
+
+        result = await workflow._start_session(
+            mock_http_session,
+            "42",
+            group_size=1,
+            delivery_mode=TrajectoryDeliveryMode.PULL,
+        )
+
+        assert result == ("grp", [("s", "k")])
+        mock_http_session.post.assert_called_once_with(
+            "http://test:8080/rl/start_session",
+            json={"task_id": "42", "group_size": 1, "delivery_mode": "pull"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+
     @pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
     @pytest.mark.asyncio
     async def test_online_mode_waits_on_controller(self):
@@ -612,7 +648,12 @@ class TestInferenceServiceWorkflow:
 
         assert result is not None
         assert "chatcmpl-1" in result
-        workflow._start_session.assert_awaited_once()
+        workflow._start_session.assert_awaited_once_with(
+            mock_http_session,
+            "42",
+            group_size=1,
+            delivery_mode=TrajectoryDeliveryMode.PULL,
+        )
         workflow._set_last_reward.assert_awaited_once()
         workflow._export_interactions.assert_awaited_once_with(
             mock_http_session, ["sess-1"], group_id="grp-test-1"

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 import pytest_asyncio
+from pydantic import ValidationError
 
 from areal.v2.inference_service.data_proxy.app import (
     _flush_ready_trajectories,
@@ -177,8 +178,16 @@ def test_start_session_request_parses_pull_delivery_mode():
     assert request.delivery_mode is TrajectoryDeliveryMode.PULL
 
 
+def test_start_session_request_serializes_pull_delivery_mode_as_string():
+    request = StartSessionRequest(
+        task_id="task-1", delivery_mode=TrajectoryDeliveryMode.PULL
+    )
+
+    assert request.model_dump(mode="json")["delivery_mode"] == "pull"
+
+
 def test_start_session_request_rejects_unknown_delivery_mode():
-    with pytest.raises(ValueError, match="delivery_mode"):
+    with pytest.raises(ValidationError, match="delivery_mode"):
         StartSessionRequest(task_id="task-1", delivery_mode="broadcast")
 
 

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -418,6 +418,35 @@ async def test_start_session_with_admin_key(client):
 
 
 @pytest.mark.asyncio
+async def test_start_session_endpoint_persists_pull_delivery_mode(client):
+    response = await client.post(
+        "/rl/start_session",
+        json={"task_id": "pull-task", "delivery_mode": "pull", "group_size": 2},
+        headers=admin_headers(),
+    )
+
+    assert response.status_code == 201
+    session_ids = [item["session_id"] for item in response.json()["sessions"]]
+    assert len(session_ids) == 2
+    store: SessionStore = client._transport.app.state.session_store
+    for session_id in session_ids:
+        session = store.get_session(session_id)
+        assert isinstance(session, SessionData)
+        assert session.delivery_mode is TrajectoryDeliveryMode.PULL
+
+
+@pytest.mark.asyncio
+async def test_start_session_endpoint_rejects_unknown_delivery_mode(client):
+    response = await client.post(
+        "/rl/start_session",
+        json={"task_id": "invalid-task", "delivery_mode": "broadcast"},
+        headers=admin_headers(),
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_start_session_without_admin_key(client):
     resp = await client.post(
         "/rl/start_session",

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -16,6 +16,7 @@ from areal.v2.inference_service.data_proxy.app import (
 )
 from areal.v2.inference_service.data_proxy.config import DataProxyConfig
 from areal.v2.inference_service.data_proxy.session import (
+    ReadyNotification,
     SessionData,
     SessionStore,
     StartSessionRequest,
@@ -161,6 +162,19 @@ def session_headers(api_key: str):
     return {"Authorization": f"Bearer {api_key}"}
 
 
+def _add_fake_interaction(
+    session: SessionData, interaction_id: str = "fake-id"
+) -> None:
+    from areal.experimental.openai.types import InteractionWithTokenLogpReward
+
+    interaction = InteractionWithTokenLogpReward(
+        messages=[{"role": "user", "content": "hi"}]
+    )
+    interaction.interaction_id = interaction_id
+    interaction.output_message_list = [{"role": "assistant", "content": "hello"}]
+    session.active_completions[interaction_id] = interaction
+
+
 # =============================================================================
 # SessionStore unit tests
 # =============================================================================
@@ -192,6 +206,58 @@ def test_start_session_request_rejects_unknown_delivery_mode():
 
 
 class TestSessionStore:
+    def test_default_delivery_remains_callback(self):
+        store = SessionStore()
+        session_id, _ = store.start_session("callback-task")
+        session = store.get_session(session_id)
+        assert isinstance(session, SessionData)
+        _add_fake_interaction(session)
+
+        session.set_reward(interaction_id="fake-id", reward=1.0)
+
+        assert store.pending_online_callbacks() == [
+            ReadyNotification(session_id=session_id, trajectory_id=0)
+        ]
+
+    def test_pull_delivery_exports_without_callback(self):
+        store = SessionStore()
+        session_id, _ = store.start_session(
+            "pull-task", delivery_mode=TrajectoryDeliveryMode.PULL
+        )
+        session = store.get_session(session_id)
+        assert isinstance(session, SessionData)
+        _add_fake_interaction(session)
+
+        result = session.set_reward(interaction_id="fake-id", reward=1.0)
+
+        assert result.ready_transition is True
+        assert store.pending_online_callbacks() == []
+        trajectory_id, interactions = session.export_trajectory(
+            discount=1.0, style="individual"
+        )
+        assert trajectory_id == 0
+        assert list(interactions) == ["fake-id"]
+
+    def test_cross_delivery_modes_only_callback_session_enqueues_notification(self):
+        store = SessionStore()
+        callback_session_id, _ = store.start_session("callback-task")
+        pull_session_id, _ = store.start_session(
+            "pull-task", delivery_mode=TrajectoryDeliveryMode.PULL
+        )
+        callback_session = store.get_session(callback_session_id)
+        pull_session = store.get_session(pull_session_id)
+        assert isinstance(callback_session, SessionData)
+        assert isinstance(pull_session, SessionData)
+        _add_fake_interaction(callback_session)
+        _add_fake_interaction(pull_session)
+
+        pull_session.set_reward(interaction_id="fake-id", reward=1.0)
+        callback_session.set_reward(interaction_id="fake-id", reward=1.0)
+
+        assert store.pending_online_callbacks() == [
+            ReadyNotification(session_id=callback_session_id, trajectory_id=0)
+        ]
+
     def test_start_session_returns_ids(self):
         store = SessionStore()
         session_id, api_key = store.start_session("task-1")

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -17,6 +17,8 @@ from areal.v2.inference_service.data_proxy.config import DataProxyConfig
 from areal.v2.inference_service.data_proxy.session import (
     SessionData,
     SessionStore,
+    StartSessionRequest,
+    TrajectoryDeliveryMode,
 )
 
 # =============================================================================
@@ -161,6 +163,23 @@ def session_headers(api_key: str):
 # =============================================================================
 # SessionStore unit tests
 # =============================================================================
+
+
+def test_start_session_request_defaults_delivery_mode_to_callback():
+    request = StartSessionRequest(task_id="task-1")
+
+    assert request.delivery_mode is TrajectoryDeliveryMode.CALLBACK
+
+
+def test_start_session_request_parses_pull_delivery_mode():
+    request = StartSessionRequest(task_id="task-1", delivery_mode="pull")
+
+    assert request.delivery_mode is TrajectoryDeliveryMode.PULL
+
+
+def test_start_session_request_rejects_unknown_delivery_mode():
+    with pytest.raises(ValueError, match="delivery_mode"):
+        StartSessionRequest(task_id="task-1", delivery_mode="broadcast")
 
 
 class TestSessionStore:


### PR DESCRIPTION
## Description

AReaL2 has two consumers for finalized trajectories: online training receives
them through the `online_ready` callback, while built-in workflows explicitly
pull them with `export_trajectories`. Previously every rewarded session entered
the callback queue, so a direct-export workflow could race the callback and
leak an evaluation/workflow-owned sample into an online trainer.

This PR makes trajectory delivery ownership explicit:

- add a `callback | pull` delivery mode to the session-start contract, with
  `callback` as the backward-compatible default;
- persist the mode in session state and snapshot it into each ready trajectory;
- derive callback eligibility from that immutable mode while keeping both modes
  exportable;
- propagate the mode through grouped HTTP session creation;
- make direct-export `InferenceServiceWorkflow` sessions request `pull`;
- add contract, lifecycle, endpoint, and workflow regression tests.

The change intentionally does not enable online held-out evaluation or add
policy-version checks yet. It establishes the single-owner delivery invariant
those follow-up changes need.

## Related Issue

Fixes #1475

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass for every changed file
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable: no user-facing configuration)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via independent code-review agents
- [x] This PR was created by a coding agent
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

None. Existing clients omit `delivery_mode` and retain callback delivery.

## Validation

- Linux (spark2): `119 passed, 6 skipped`
  - `tests/v2/inference_service/test_data_proxy_chat.py`
  - `tests/v2/inference_service/test_controller.py`
  - `tests/v2/inference_service/test_gateway.py`
  - `tests/v2/inference_service/test_online_stack.py`
- all pre-commit hooks pass for the five changed Python files
- `git diff --check` passes

## Additional Context

The delivery mode is the source of truth; `needs_online_callback` is a derived,
read-only property. This avoids maintaining two booleans that could drift into
an impossible state. A separate follow-up will use pull-owned sessions for
version-checked online held-out evaluation.
