### PR TITLE
fix(v2): export local workflow statistics

### DIFF
--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 from areal.api.cli_args import InferenceEngineConfig
 from areal.api.io_struct import LocalInfServerInfo
-from areal.utils import logging
+from areal.utils import logging, stats_tracker
 from areal.utils.network import format_hostport
 
 logger = logging.getLogger("RolloutControllerV2")
@@ -1457,8 +1457,8 @@ class RolloutControllerV2:
     # -- Stats -------------------------------------------------------------
 
     def export_stats(self) -> dict[str, float]:
-        """Return local WorkflowExecutor stats."""
-        return {}
+        """Export and reset statistics recorded by the local workflow executor."""
+        return stats_tracker.export_all()
 
     def config_perf_tracer(self, config: Any = None, role: str = "") -> None:
         """No-op — gateway does not have per-worker perf tracing."""

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 from areal.api.cli_args import AgentConfig, InferenceEngineConfig
+from areal.utils import stats_tracker
 from areal.v2.inference_service.controller.controller import (
     RolloutControllerV2,
 )
@@ -305,6 +306,25 @@ class TestRolloutControllerV2Construction:
         controller = RolloutControllerV2(config=cfg, scheduler=scheduler)
         stats = controller.export_stats()
         assert isinstance(stats, dict)
+
+    def test_export_stats_drains_local_workflow_metrics(self):
+        stats_tracker.export_all(reset=True)
+        try:
+            stats_tracker.get("rollout").scalar(reward=0.75)
+            controller = RolloutControllerV2(
+                config=InferenceEngineConfig(
+                    backend="sglang:d1", admin_api_key="test-key"
+                ),
+                scheduler=MagicMock(n_gpus_per_node=8),
+            )
+
+            assert controller.export_stats() == {
+                "rollout/reward": 0.75,
+                "rollout/reward__count": 1,
+            }
+            assert controller.export_stats() == {}
+        finally:
+            stats_tracker.export_all(reset=True)
 
     def test_proxy_gateway_addr(self):
         cfg = InferenceEngineConfig(backend="sglang:d1", admin_api_key="test-key")


### PR DESCRIPTION
## Description

`RolloutControllerV2` runs its `WorkflowExecutor` in the controller process, so
workflow metrics such as reward are recorded in that process's `stats_tracker`.
Its `export_stats()` implementation nevertheless returned `{}` unconditionally,
violating the controller API and making metric delivery depend on another local
controller draining the process-global tracker first.

This PR delegates V2 stats export to `stats_tracker.export_all()`, matching the
local ownership of the workflow executor and preserving the existing
export-and-reset contract. The regression test verifies both the exported reward
and that a second export is empty.

## Related Issue

Fixes #1477

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass for every changed file
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable: restores an existing API contract)
- [x] Branch is up to date with `main`
- [x] Self-reviewed and independently reviewed
- [x] This PR was created by a coding agent
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

None. The method now returns the metrics its API already promises to export.

## Validation

- TDD regression: failed on current main (`{}` instead of the recorded reward),
  then passed after the fix
- Linux (spark2): `39 passed, 1 skipped` for
  `tests/v2/inference_service/test_controller.py`
- macOS non-live subset: `35 passed, 1 skipped, 4 deselected`
- changed-file pre-commit hooks pass
- `git diff --check` passes

## Additional Context

The V1 remote engines already export their process-local workflow statistics via
`stats_tracker.export_all()`. In V2, that ownership moved to the controller
process together with `WorkflowExecutor`; this change follows that ownership.
The current trainer's actor controller may still drain shared process metrics
first, so a future controller-specific tracker would be needed for independent
multi-controller exports; that broader ownership refactor is outside this fix.
