### PR TITLE
feat(rl): add version-checked online held-out evaluation

### DIFF
--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -153,13 +153,6 @@ class PPOTrainer:
         agent_cfg = config.rollout.agent
         self._online_mode = agent_cfg is not None and agent_cfg.mode == "online"
 
-        if self._online_mode and config.valid_dataset is not None:
-            raise ValueError(
-                "valid_dataset must not be set when using online RL mode "
-                "(agent.mode='online'). Online mode does not support "
-                "validation datasets."
-            )
-
         # -- Dataset loading --------------------------------------------------
         if not self._online_mode and train_dataset is None:
             raise ValueError(
@@ -220,23 +213,11 @@ class PPOTrainer:
         else:
             assert train_dataset is not None
             if is_single_controller() and isinstance(train_dataset, RDataset):
-                ds_cfg = DataServiceConfig.from_dataset_config(
-                    config.train_dataset, seed=config.seed
+                self._connect_rdataset(
+                    train_dataset,
+                    config.train_dataset,
+                    split="train",
                 )
-                assert self.scheduler is not None
-                controller = DataController(ds_cfg, self.scheduler)
-                controller.initialize(
-                    role="data", num_dataset_workers=ds_cfg.num_workers
-                )
-                self.data_controller = controller
-                train_dataset.connect(
-                    controller,
-                    dataset_id=f"{config.experiment_name}_{config.trial_name}_train",
-                    tokenizer_or_processor_path=config.tokenizer_path,
-                    shuffle=config.train_dataset.shuffle,
-                    drop_last=config.train_dataset.drop_last,
-                )
-                self._train_rdataset = train_dataset
 
             self.train_dataloader = self._create_dataloader(
                 train_dataset,
@@ -249,15 +230,11 @@ class PPOTrainer:
         if self.config.valid_dataset is not None and valid_dataset is not None:
             assert self.config.valid_dataset is not None
             if is_single_controller() and isinstance(valid_dataset, RDataset):
-                assert self.data_controller is not None
-                valid_dataset.connect(
-                    self.data_controller,
-                    dataset_id=f"{config.experiment_name}_{config.trial_name}_valid",
-                    tokenizer_or_processor_path=config.tokenizer_path,
-                    shuffle=self.config.valid_dataset.shuffle,
-                    drop_last=self.config.valid_dataset.drop_last,
+                self._connect_rdataset(
+                    valid_dataset,
+                    self.config.valid_dataset,
+                    split="valid",
                 )
-                self._valid_rdataset = valid_dataset
 
             self.valid_dataloader = self._create_dataloader(
                 valid_dataset,
@@ -431,6 +408,37 @@ class PPOTrainer:
 
         self._config_perf_tracer()
         self._apply_initial_offload_policy()
+
+    def _connect_rdataset(
+        self,
+        dataset: RDataset,
+        dataset_config: TrainDatasetConfig | ValidDatasetConfig,
+        *,
+        split: str,
+    ) -> None:
+        if self.data_controller is None:
+            ds_cfg = DataServiceConfig.from_dataset_config(
+                dataset_config, seed=self.config.seed
+            )
+            assert self.scheduler is not None
+            controller = DataController(ds_cfg, self.scheduler)
+            controller.initialize(role="data", num_dataset_workers=ds_cfg.num_workers)
+            self.data_controller = controller
+
+        dataset.connect(
+            self.data_controller,
+            dataset_id=(
+                f"{self.config.experiment_name}_{self.config.trial_name}_{split}"
+            ),
+            tokenizer_or_processor_path=self.config.tokenizer_path,
+            shuffle=dataset_config.shuffle,
+            drop_last=dataset_config.drop_last,
+        )
+        if split == "train":
+            self._train_rdataset = dataset
+        else:
+            assert split == "valid"
+            self._valid_rdataset = dataset
 
     @staticmethod
     def _is_colocation(strategy: SchedulingStrategy | None) -> bool:

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -588,6 +588,16 @@ class PPOTrainer:
         total_epochs: int | None = None,
     ):
         config = self.config
+        if (
+            self._online_mode
+            and self.valid_dataloader is not None
+            and eval_workflow is None
+        ):
+            raise ValueError(
+                "eval_workflow must be specified for online training when "
+                "validation data is configured."
+            )
+
         start_step = (
             self.recover_info.last_step_info.next().global_step
             if self.recover_info is not None
@@ -1261,7 +1271,14 @@ class PPOTrainer:
                         is_eval=True,
                     )
                     cnt += 1
-            self.eval_rollout.wait(cnt, timeout=None)
+            results = self.eval_rollout.wait(cnt, timeout=None)
+            if self._online_mode:
+                rejected = sum(result is None for result in results)
+                if rejected:
+                    raise RuntimeError(
+                        "Online evaluation incomplete: "
+                        f"rejected={rejected}, expected={cnt}"
+                    )
 
         if not is_single_controller():
             dist.barrier(group=self.actor.cpu_group)

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -287,7 +287,10 @@ class PPOTrainer:
         )
 
         self.eval_rollout = None
-        if not self._online_mode:
+        if self._should_initialize_eval_rollout(
+            online_mode=self._online_mode,
+            has_valid_dataloader=self.valid_dataloader is not None,
+        ):
             self.eval_rollout = self._init_rollout(
                 config.rollout, is_eval=True, lora_path=initial_lora_path
             )
@@ -439,6 +442,12 @@ class PPOTrainer:
         else:
             assert split == "valid"
             self._valid_rdataset = dataset
+
+    @staticmethod
+    def _should_initialize_eval_rollout(
+        *, online_mode: bool, has_valid_dataloader: bool
+    ) -> bool:
+        return not online_mode or has_valid_dataloader
 
     @staticmethod
     def _is_colocation(strategy: SchedulingStrategy | None) -> bool:

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -1283,6 +1283,7 @@ class PPOTrainer:
     ):
         if self.actor.is_data_parallel_head():
             results = []
+            evaluation_error: BaseException | None = None
             try:
                 cnt = 0
                 for data in self.valid_dataloader:
@@ -1307,10 +1308,21 @@ class PPOTrainer:
                             "Online evaluation incomplete: "
                             f"rejected={rejected}, expected={cnt}"
                         )
+            except BaseException as exc:
+                evaluation_error = exc
+                raise
             finally:
                 accepted = [result for result in results if result is not None]
                 if accepted and is_single_controller():
-                    self.actor.clear_batches(*accepted)
+                    try:
+                        self.actor.clear_batches(*accepted)
+                    except Exception:
+                        if evaluation_error is None:
+                            raise
+                        logger.exception(
+                            "Failed to clear evaluation trajectory shards while "
+                            "preserving the original evaluation error"
+                        )
 
         if not is_single_controller():
             dist.barrier(group=self.actor.cpu_group)

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -152,6 +152,13 @@ class PPOTrainer:
 
         agent_cfg = config.rollout.agent
         self._online_mode = agent_cfg is not None and agent_cfg.mode == "online"
+        self._validate_online_eval_controller_version(
+            online_mode=self._online_mode,
+            has_valid_dataset=(
+                config.valid_dataset is not None and valid_dataset is not None
+            ),
+            rollout_version=config.rollout._version,
+        )
 
         # -- Dataset loading --------------------------------------------------
         if not self._online_mode and train_dataset is None:
@@ -444,6 +451,15 @@ class PPOTrainer:
             self._valid_rdataset = dataset
 
     @staticmethod
+    def _validate_online_eval_controller_version(
+        *, online_mode: bool, has_valid_dataset: bool, rollout_version: str
+    ) -> None:
+        if online_mode and has_valid_dataset and rollout_version != "v2":
+            raise ValueError(
+                "Online held-out evaluation requires rollout._version='v2'."
+            )
+
+    @staticmethod
     def _should_initialize_eval_rollout(
         *, online_mode: bool, has_valid_dataloader: bool
     ) -> bool:
@@ -588,6 +604,12 @@ class PPOTrainer:
         total_epochs: int | None = None,
     ):
         config = self.config
+        if (
+            self._online_mode
+            and self.valid_dataloader is not None
+            and len(self.valid_dataloader) == 0
+        ):
+            raise ValueError("Online validation dataloader is empty.")
         if (
             self._online_mode
             and self.valid_dataloader is not None
@@ -1260,25 +1282,35 @@ class PPOTrainer:
         eval_workflow_kwargs,
     ):
         if self.actor.is_data_parallel_head():
-            cnt = 0
-            for data in self.valid_dataloader:
-                for item in data:
-                    self.eval_rollout.submit(
-                        item,
-                        eval_workflow,
-                        eval_workflow_kwargs,
-                        group_size=self.config.eval_gconfig.n_samples,
-                        is_eval=True,
-                    )
-                    cnt += 1
-            results = self.eval_rollout.wait(cnt, timeout=None)
-            if self._online_mode:
-                rejected = sum(result is None for result in results)
-                if rejected:
+            results = []
+            try:
+                cnt = 0
+                for data in self.valid_dataloader:
+                    for item in data:
+                        self.eval_rollout.submit(
+                            item,
+                            eval_workflow,
+                            eval_workflow_kwargs,
+                            group_size=self.config.eval_gconfig.n_samples,
+                            is_eval=True,
+                        )
+                        cnt += 1
+                if self._online_mode and cnt == 0:
                     raise RuntimeError(
-                        "Online evaluation incomplete: "
-                        f"rejected={rejected}, expected={cnt}"
+                        "Online evaluation is empty: no validation items were submitted."
                     )
+                results = self.eval_rollout.wait(cnt, timeout=None)
+                if self._online_mode:
+                    rejected = sum(result is None for result in results)
+                    if rejected:
+                        raise RuntimeError(
+                            "Online evaluation incomplete: "
+                            f"rejected={rejected}, expected={cnt}"
+                        )
+            finally:
+                accepted = [result for result in results if result is not None]
+                if accepted and is_single_controller():
+                    self.actor.clear_batches(*accepted)
 
         if not is_single_controller():
             dist.barrier(group=self.actor.cpu_group)

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -1066,11 +1066,13 @@ class RolloutControllerV2:
         group_size: int = 1,
     ) -> int:
         self._ensure_initialized()
+        expected_policy_version = self.get_version() if is_eval else None
         resolved_workflow = self._resolve_workflow(
             workflow,
             workflow_kwargs,
             group_size,
         )
+        resolved_workflow.expected_policy_version = expected_policy_version
         resolved_accept_fn = self._resolve_should_accept_fn(should_accept_fn)
         return self.workflow_executor.submit(
             data,

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -414,7 +414,7 @@ class RolloutControllerV2:
         if self.external_mode:
             logger.info("External mode — skipping inference server launch")
         elif server_infos is not None:
-            self._server_infos = server_infos
+            self._server_infos = list(server_infos)
             self._inf_addrs = [
                 f"http://{format_hostport(info.host, info.port)}"
                 for info in server_infos

--- a/areal/v2/inference_service/controller/workflow.py
+++ b/areal/v2/inference_service/controller/workflow.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import aiohttp
 import httpx
 import openai
+import torch
 
 from areal.api.workflow_api import RolloutWorkflow
 from areal.infra import workflow_context
@@ -41,6 +42,45 @@ _CONNECTION_ERROR_TYPES: tuple[type[BaseException], ...] = (
     OSError,
     openai.APIConnectionError,
 )
+
+
+def validate_trajectory_policy_version(
+    traj: dict[str, Any], expected_policy_version: int
+) -> None:
+    """Require every loss-bearing token to come from the expected policy."""
+    for field in ("versions", "loss_mask"):
+        if field not in traj:
+            raise ValueError(
+                f"trajectory is missing required provenance field '{field}'"
+            )
+
+    provenance = RTensor.localize(
+        {
+            "versions": traj["versions"],
+            "loss_mask": traj["loss_mask"],
+        }
+    )
+    versions = provenance["versions"]
+    loss_mask = provenance["loss_mask"]
+
+    if not isinstance(versions, torch.Tensor) or not isinstance(
+        loss_mask, torch.Tensor
+    ):
+        raise ValueError("trajectory versions and loss_mask must be PyTorch tensors")
+    if versions.shape != loss_mask.shape:
+        raise ValueError("trajectory versions and loss_mask must have the same shape")
+
+    selected_versions = versions[loss_mask == 1]
+    if selected_versions.numel() == 0:
+        raise ValueError("trajectory has no loss-bearing tokens")
+
+    observed_versions = sorted(torch.unique(selected_versions.detach().cpu()).tolist())
+    if not torch.all(selected_versions == expected_policy_version).item():
+        raise ValueError(
+            "trajectory policy provenance mismatch: "
+            f"expected policy version {expected_policy_version}, "
+            f"observed {observed_versions} on loss-bearing tokens"
+        )
 
 
 class InferenceServiceWorkflow(RolloutWorkflow):
@@ -232,9 +272,15 @@ class InferenceServiceWorkflow(RolloutWorkflow):
             )
             return None
 
+        if self.expected_policy_version is not None:
+            validate_trajectory_policy_version(traj, self.expected_policy_version)
+
         tracker = stats_tracker.get(workflow_context.stat_scope())
         for r in results:
-            tracker.scalar(reward=r)
+            metrics: dict[str, float | int | None] = {"reward": r}
+            if self.expected_policy_version is not None:
+                metrics["policy_version"] = self.expected_policy_version
+            tracker.scalar(**metrics)
 
         return traj
 
@@ -275,5 +321,11 @@ class InferenceServiceWorkflow(RolloutWorkflow):
             )
             return None
 
-        stats_tracker.get(workflow_context.stat_scope()).scalar(reward=last_reward)
+        if self.expected_policy_version is not None:
+            validate_trajectory_policy_version(traj, self.expected_policy_version)
+
+        metrics: dict[str, float | int] = {"reward": last_reward}
+        if self.expected_policy_version is not None:
+            metrics["policy_version"] = self.expected_policy_version
+        stats_tracker.get(workflow_context.stat_scope()).scalar(**metrics)
         return traj

--- a/areal/v2/inference_service/controller/workflow.py
+++ b/areal/v2/inference_service/controller/workflow.py
@@ -67,6 +67,8 @@ def validate_trajectory_policy_version(
         loss_mask, torch.Tensor
     ):
         raise ValueError("trajectory versions and loss_mask must be PyTorch tensors")
+    if versions.dtype not in (torch.int8, torch.int16, torch.int32, torch.int64):
+        raise ValueError("trajectory versions must use a signed integer dtype")
     if versions.shape != loss_mask.shape:
         raise ValueError("trajectory versions and loss_mask must have the same shape")
 
@@ -81,6 +83,28 @@ def validate_trajectory_policy_version(
             f"expected policy version {expected_policy_version}, "
             f"observed {observed_versions} on loss-bearing tokens"
         )
+
+
+async def _clear_trajectory_rtensors(traj: dict[str, Any]) -> None:
+    """Best-effort cleanup for an exported trajectory that will be discarded."""
+    shards_by_node = RTensor.collect_shards(traj)
+    if not shards_by_node:
+        return
+
+    results = await asyncio.gather(
+        *(
+            RTensor.clear_node(node_addr, shard_ids)
+            for node_addr, shard_ids in shards_by_node.items()
+        ),
+        return_exceptions=True,
+    )
+    for node_addr, result in zip(shards_by_node, results, strict=True):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "Failed to clear rejected trajectory shards on %s: %s",
+                node_addr,
+                result,
+            )
 
 
 class InferenceServiceWorkflow(RolloutWorkflow):
@@ -259,30 +283,40 @@ class InferenceServiceWorkflow(RolloutWorkflow):
             session_ids,
             group_id=group_id,
         )
-        if not traj:
-            return None
+        keep_trajectory = False
+        try:
+            if not traj:
+                return None
 
-        n_failed = sum(r is None for r in results)
-        if n_failed > 0:
-            logger.warning(
-                "Abandoning group %s: %d/%d sessions failed",
-                group_id,
-                n_failed,
-                len(sessions),
-            )
-            return None
+            n_failed = sum(r is None for r in results)
+            if n_failed > 0:
+                logger.warning(
+                    "Abandoning group %s: %d/%d sessions failed",
+                    group_id,
+                    n_failed,
+                    len(sessions),
+                )
+                return None
 
-        if self.expected_policy_version is not None:
-            validate_trajectory_policy_version(traj, self.expected_policy_version)
-
-        tracker = stats_tracker.get(workflow_context.stat_scope())
-        for r in results:
-            metrics: dict[str, float | int | None] = {"reward": r}
             if self.expected_policy_version is not None:
-                metrics["policy_version"] = self.expected_policy_version
-            tracker.scalar(**metrics)
+                await asyncio.to_thread(
+                    validate_trajectory_policy_version,
+                    traj,
+                    self.expected_policy_version,
+                )
 
-        return traj
+            tracker = stats_tracker.get(workflow_context.stat_scope())
+            for r in results:
+                metrics: dict[str, float | int | None] = {"reward": r}
+                if self.expected_policy_version is not None:
+                    metrics["policy_version"] = self.expected_policy_version
+                tracker.scalar(**metrics)
+
+            keep_trajectory = True
+            return traj
+        finally:
+            if not keep_trajectory:
+                await _clear_trajectory_rtensors(traj)
 
     async def _run_online(
         self,
@@ -300,32 +334,43 @@ class InferenceServiceWorkflow(RolloutWorkflow):
             [export_request["session_id"]],
             trajectory_id=export_request["trajectory_id"],
         )
-        if not traj:
-            return None
+        keep_trajectory = False
+        try:
+            if not traj:
+                return None
 
-        rewards_tensor = traj.get("rewards")
-        if isinstance(rewards_tensor, RTensor):
-            rewards_tensor = rewards_tensor.to_local()
+            rewards_tensor = traj.get("rewards")
+            if isinstance(rewards_tensor, RTensor):
+                rewards_tensor = rewards_tensor.to_local()
 
-        if rewards_tensor is not None and len(rewards_tensor) > 0:
-            last_reward = float(rewards_tensor[-1])
-        elif (
-            "interactions" in traj
-            and traj["interactions"]
-            and traj["interactions"][-1].get("reward") is not None
-        ):
-            last_reward = float(traj["interactions"][-1]["reward"])
-        else:
-            logger.warning(
-                "Exported trajectory is missing rewards. This trajectory will be rejected."
-            )
-            return None
+            if rewards_tensor is not None and len(rewards_tensor) > 0:
+                last_reward = float(rewards_tensor[-1])
+            elif (
+                "interactions" in traj
+                and traj["interactions"]
+                and traj["interactions"][-1].get("reward") is not None
+            ):
+                last_reward = float(traj["interactions"][-1]["reward"])
+            else:
+                logger.warning(
+                    "Exported trajectory is missing rewards. "
+                    "This trajectory will be rejected."
+                )
+                return None
 
-        if self.expected_policy_version is not None:
-            validate_trajectory_policy_version(traj, self.expected_policy_version)
+            if self.expected_policy_version is not None:
+                await asyncio.to_thread(
+                    validate_trajectory_policy_version,
+                    traj,
+                    self.expected_policy_version,
+                )
 
-        metrics: dict[str, float | int] = {"reward": last_reward}
-        if self.expected_policy_version is not None:
-            metrics["policy_version"] = self.expected_policy_version
-        stats_tracker.get(workflow_context.stat_scope()).scalar(**metrics)
-        return traj
+            metrics: dict[str, float | int] = {"reward": last_reward}
+            if self.expected_policy_version is not None:
+                metrics["policy_version"] = self.expected_policy_version
+            stats_tracker.get(workflow_context.stat_scope()).scalar(**metrics)
+            keep_trajectory = True
+            return traj
+        finally:
+            if not keep_trajectory:
+                await _clear_trajectory_rtensors(traj)

--- a/areal/v2/inference_service/controller/workflow.py
+++ b/areal/v2/inference_service/controller/workflow.py
@@ -15,6 +15,7 @@ from areal.infra.rpc.rtensor import RTensor
 from areal.infra.rpc.serialization import deserialize_value
 from areal.infra.utils.http import async_http_retry
 from areal.utils import logging, stats_tracker
+from areal.v2.inference_service.data_proxy.session import TrajectoryDeliveryMode
 
 if TYPE_CHECKING:
     from areal.api.engine_api import InferenceEngine
@@ -69,11 +70,16 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         session: aiohttp.ClientSession,
         task_id: str,
         group_size: int = 1,
+        delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK,
     ) -> tuple[str | None, list[tuple[str, str]]]:
         """Start one or more sessions. Returns (group_id, [(session_id, api_key), ...])."""
         url = f"{self.gateway_addr}/{_RL_START_SESSION_PATHNAME}"
         headers = {"Authorization": f"Bearer {self._admin_api_key}"}
-        payload: dict[str, Any] = {"task_id": task_id, "group_size": group_size}
+        payload: dict[str, Any] = {
+            "task_id": task_id,
+            "group_size": group_size,
+            "delivery_mode": delivery_mode.value,
+        }
         async with session.post(url, json=payload, headers=headers) as resp:
             resp.raise_for_status()
             data = await resp.json()
@@ -142,7 +148,10 @@ class InferenceServiceWorkflow(RolloutWorkflow):
     ) -> dict[str, InteractionWithTokenLogpReward] | None:
         task_id = workflow_context.get().task_id
         group_id, sessions = await self._start_session(
-            http_session, str(task_id), group_size=self.group_size
+            http_session,
+            str(task_id),
+            group_size=self.group_size,
+            delivery_mode=TrajectoryDeliveryMode.PULL,
         )
 
         assert self.agent is not None

--- a/areal/v2/inference_service/controller/workflow.py
+++ b/areal/v2/inference_service/controller/workflow.py
@@ -54,6 +54,7 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         export_style: str = "individual",
         timeout: float | None = None,
         group_size: int = 1,
+        expected_policy_version: int | None = None,
     ):
         self.controller = controller
         self.agent = agent
@@ -63,6 +64,7 @@ class InferenceServiceWorkflow(RolloutWorkflow):
         self.export_style = export_style
         self.timeout = timeout
         self.group_size = group_size
+        self.expected_policy_version = expected_policy_version
 
     @async_http_retry
     async def _start_session(

--- a/areal/v2/inference_service/controller/workflow.py
+++ b/areal/v2/inference_service/controller/workflow.py
@@ -231,6 +231,7 @@ class InferenceServiceWorkflow(RolloutWorkflow):
                     base_url=self.gateway_addr,
                     http_client=http_client,
                     api_key=session_api_key,
+                    policy_version=self.expected_policy_version,
                 )
                 if isinstance(rewards, dict):
                     final_reward = float(

--- a/areal/v2/inference_service/data_proxy/app.py
+++ b/areal/v2/inference_service/data_proxy/app.py
@@ -472,7 +472,9 @@ def create_app(config: DataProxyConfig) -> FastAPI:
         for i in range(group_size):
             try:
                 session_id, session_api_key = store.start_session(
-                    body.task_id, body.api_key if i == 0 else None
+                    body.task_id,
+                    body.api_key if i == 0 else None,
+                    delivery_mode=body.delivery_mode,
                 )
             except ValueError as e:
                 raise HTTPException(status_code=409, detail=str(e))

--- a/areal/v2/inference_service/data_proxy/session.py
+++ b/areal/v2/inference_service/data_proxy/session.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel
@@ -26,17 +27,28 @@ SESSION_TIMEOUT_SECONDS = 3600
 # =============================================================================
 
 
+class TrajectoryDeliveryMode(str, Enum):
+    """How completed trajectories are delivered to the session consumer."""
+
+    CALLBACK = "callback"
+    PULL = "pull"
+
+
 class StartSessionRequest(BaseModel):
     """Request to start one or more offline RL sessions.
 
     When ``group_size`` is greater than 1, the data proxy creates multiple
     sessions atomically. The response always contains a flat ``sessions``
     list — single-session is just ``group_size=1``.
+
+    Completed trajectories use callback delivery by default. Set
+    ``delivery_mode`` to ``pull`` when the client will explicitly export them.
     """
 
     task_id: str
     api_key: str | None = None  # Reuse a previously-issued key (refresh)
     group_size: int = 1
+    delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK
 
 
 class SessionCredentials(BaseModel):

--- a/areal/v2/inference_service/data_proxy/session.py
+++ b/areal/v2/inference_service/data_proxy/session.py
@@ -119,8 +119,12 @@ class ReadyTrajectory:
     interaction_id: str
     completions: InteractionCache
     created_at: float
-    needs_online_callback: bool = False
+    delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK
     callback_delivered: bool = False
+
+    @property
+    def needs_online_callback(self) -> bool:
+        return self.delivery_mode is TrajectoryDeliveryMode.CALLBACK
 
 
 # =============================================================================
@@ -145,8 +149,10 @@ class SessionData:
         self,
         session_id: str,
         set_reward_finish_timeout: float = 0.0,
+        delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK,
     ):
         self.session_id = session_id
+        self.delivery_mode = delivery_mode
         self._set_reward_finish_timeout = set_reward_finish_timeout
         self._last_access_time = time.time()
         self._lock = threading.Lock()
@@ -214,7 +220,7 @@ class SessionData:
             interaction_id=resolved_interaction_id,
             completions=completions,
             created_at=now,
-            needs_online_callback=True,
+            delivery_mode=self.delivery_mode,
         )
         self._ready_trajectories[trajectory_id] = ready
         self._active_completions = InteractionCache()
@@ -400,7 +406,10 @@ class SessionStore:
         return self._admin_api_key
 
     def start_session(
-        self, task_id: str, api_key: str | None = None
+        self,
+        task_id: str,
+        api_key: str | None = None,
+        delivery_mode: TrajectoryDeliveryMode = TrajectoryDeliveryMode.CALLBACK,
     ) -> tuple[str, str]:
         """Start a new session, returning (session_id, session_api_key).
 
@@ -437,6 +446,7 @@ class SessionStore:
             self._sessions[session_id] = SessionData(
                 session_id=session_id,
                 set_reward_finish_timeout=self._set_reward_finish_timeout,
+                delivery_mode=delivery_mode,
             )
             self._api_key_to_session[session_api_key] = session_id
             self._session_to_api_key[session_id] = session_api_key

--- a/docs/en/tutorial/online_proxy.md
+++ b/docs/en/tutorial/online_proxy.md
@@ -189,11 +189,25 @@ for each agent session.**
 After enough data has been accumulated in AReaL's buffer, AReaL will automatically enter
 the training stage.
 
-## Fixed Held-Out Evaluation
+## Fixed Held-Out Evaluation (V2 Only)
 
 Online training data is driven by external applications, but evaluation should use a
 fixed dataset that is never admitted to the PPO training FIFO. Pass that dataset to
 `PPOTrainer` and provide a separate inline evaluation agent:
+
+This integrity-checked path requires both the actor and rollout V2 controllers:
+
+```yaml
+actor:
+  _version: v2
+rollout:
+  _version: v2
+  agent:
+    mode: online
+```
+
+The validation dataset must contain at least one batch. AReaL fails before starting the
+online proxy when V2 is not enabled or the configured validation dataloader is empty.
 
 ```python
 valid_dataset = get_custom_dataset(

--- a/docs/en/tutorial/online_proxy.md
+++ b/docs/en/tutorial/online_proxy.md
@@ -189,6 +189,49 @@ for each agent session.**
 After enough data has been accumulated in AReaL's buffer, AReaL will automatically enter
 the training stage.
 
+## Fixed Held-Out Evaluation
+
+Online training data is driven by external applications, but evaluation should use a
+fixed dataset that is never admitted to the PPO training FIFO. Pass that dataset to
+`PPOTrainer` and provide a separate inline evaluation agent:
+
+```python
+valid_dataset = get_custom_dataset(
+    split="test",
+    dataset_config=config.valid_dataset,
+)
+
+with PPOTrainer(
+    config,
+    train_dataset=None,
+    valid_dataset=valid_dataset,
+) as trainer:
+    trainer.train(
+        workflow=None,
+        eval_workflow=MyEvaluationAgent,
+        eval_workflow_kwargs={"temperature": 0.0},
+    )
+```
+
+The main online controller continues to receive externally completed trajectories by
+callback. Evaluation uses a separate controller with its own Router, Data Proxy,
+Gateway, and session state; only the inference servers are shared. Evaluation sessions
+are explicitly pulled by the evaluation workflow, so their trajectories cannot satisfy
+an online training waiter.
+
+Evaluation metrics are version checked. When a held-out task is submitted, AReaL
+captures the controller's current policy version. A reward is recorded only if every
+generated token selected by `loss_mask` carries that exact version in the exported
+trajectory. Missing, mixed, or stale token versions reject the trajectory, and any
+rejected item aborts the complete online evaluation round instead of publishing a metric
+over a smaller, selected subset.
+
+> **Version-0 baseline:** `eval_before_train` schedules the first evaluation when the
+> PPO loop first reaches its evaluation point, which is after the first optimizer and
+> weight-update step. If an experiment needs an untrained version-0 baseline, run a
+> separate frozen evaluation arm with the same validation split, decoding settings, and
+> reward function before starting online training.
+
 ## FAQ
 
 > Q: When will the updated model be loaded for inference?

--- a/docs/zh/tutorial/online_proxy.md
+++ b/docs/zh/tutorial/online_proxy.md
@@ -175,6 +175,39 @@ curl http://<gateway>/rl/end_session \
 
 当 AReaL 缓冲区中积累了足够的数据后，AReaL 将自动进入训练阶段。
 
+## 固定留出集评测
+
+在线训练数据由外部应用驱动，但评测应使用固定数据集，并且这些样本绝不能进入 PPO 训练 FIFO。将该数据集传给
+`PPOTrainer`，同时提供一个独立的进程内评测智能体：
+
+```python
+valid_dataset = get_custom_dataset(
+    split="test",
+    dataset_config=config.valid_dataset,
+)
+
+with PPOTrainer(
+    config,
+    train_dataset=None,
+    valid_dataset=valid_dataset,
+) as trainer:
+    trainer.train(
+        workflow=None,
+        eval_workflow=MyEvaluationAgent,
+        eval_workflow_kwargs={"temperature": 0.0},
+    )
+```
+
+在线训练主控制器仍通过 callback 接收外部完成的轨迹。评测使用单独的控制器，拥有独立的 Router、Data Proxy、Gateway
+和会话状态；两者只共享推理服务器。评测工作流会主动 pull 自己的会话轨迹，因此评测样本不会满足在线训练的等待队列。
+
+评测指标会经过策略版本校验。提交留出集任务时，AReaL 会捕获控制器当时的策略版本。只有导出轨迹中所有被 `loss_mask` 选中的生成 token
+都携带这个精确版本时，reward 才会被记录。缺失、混合或过期的 token
+版本都会使该轨迹被拒绝；只要有一个样本被拒绝，整个在线评测轮次都会失败，而不会在一个更小、经过选择的子集上发布指标。
+
+> **版本 0 基线：** `eval_before_train` 会让 PPO 循环第一次到达评测点时执行评测，但这个评测点位于第一次优化器更新和权重更新之后。
+> 如果实验需要未训练的版本 0 基线，应在在线训练开始前单独运行一个冻结评测组，并保持验证集、解码设置和奖励函数完全一致。
+
 ## FAQ
 
 > Q: 更新后的模型何时会被加载用于推理？

--- a/docs/zh/tutorial/online_proxy.md
+++ b/docs/zh/tutorial/online_proxy.md
@@ -175,10 +175,23 @@ curl http://<gateway>/rl/end_session \
 
 当 AReaL 缓冲区中积累了足够的数据后，AReaL 将自动进入训练阶段。
 
-## 固定留出集评测
+## 固定留出集评测（仅限 V2）
 
 在线训练数据由外部应用驱动，但评测应使用固定数据集，并且这些样本绝不能进入 PPO 训练 FIFO。将该数据集传给
 `PPOTrainer`，同时提供一个独立的进程内评测智能体：
+
+这条带完整性校验的评测链路要求 actor 与 rollout 同时使用 V2 控制器：
+
+```yaml
+actor:
+  _version: v2
+rollout:
+  _version: v2
+  agent:
+    mode: online
+```
+
+验证数据集必须至少包含一个 batch。未启用 V2 或已配置的验证 dataloader 为空时，AReaL 会在启动在线代理前直接失败。
 
 ```python
 valid_dataset = get_custom_dataset(

--- a/tests/test_rl_trainer_online_eval.py
+++ b/tests/test_rl_trainer_online_eval.py
@@ -201,6 +201,23 @@ class TestOnlineEvalIntegrity:
             sentinel.accepted_trajectory
         )
 
+    def test_incomplete_eval_error_survives_cleanup_failure(self, monkeypatch):
+        monkeypatch.setattr(rl_trainer, "is_single_controller", lambda: True)
+        trainer = _eval_trainer(
+            online_mode=True,
+            wait_results=[sentinel.accepted_trajectory, None],
+        )
+        trainer.actor.clear_batches.side_effect = RuntimeError("cleanup failed")
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"Online evaluation incomplete: rejected=1, expected=2",
+        ):
+            trainer._evaluate_fn(
+                eval_workflow=sentinel.workflow,
+                eval_workflow_kwargs={},
+            )
+
     def test_all_valid_online_eval_results_complete_normally(self, monkeypatch):
         monkeypatch.setattr(rl_trainer, "is_single_controller", lambda: True)
         trainer = _eval_trainer(

--- a/tests/test_rl_trainer_online_eval.py
+++ b/tests/test_rl_trainer_online_eval.py
@@ -82,3 +82,23 @@ class TestOnlineEvalDataController:
         )
         assert trainer.data_controller is existing_controller
         assert trainer._train_rdataset is dataset
+
+
+class TestEvalRolloutTopology:
+    def test_eval_rollout_topology_online_without_valid_data_is_disabled(self):
+        assert not PPOTrainer._should_initialize_eval_rollout(
+            online_mode=True,
+            has_valid_dataloader=False,
+        )
+
+    def test_eval_rollout_topology_online_with_valid_data_is_enabled(self):
+        assert PPOTrainer._should_initialize_eval_rollout(
+            online_mode=True,
+            has_valid_dataloader=True,
+        )
+
+    def test_eval_rollout_topology_offline_remains_enabled(self):
+        assert PPOTrainer._should_initialize_eval_rollout(
+            online_mode=False,
+            has_valid_dataloader=False,
+        )

--- a/tests/test_rl_trainer_online_eval.py
+++ b/tests/test_rl_trainer_online_eval.py
@@ -99,6 +99,14 @@ class TestOnlineEvalDataController:
 
 
 class TestEvalRolloutTopology:
+    def test_online_validation_requires_v2_rollout(self):
+        with pytest.raises(ValueError, match=r"rollout\._version.*v2"):
+            PPOTrainer._validate_online_eval_controller_version(
+                online_mode=True,
+                has_valid_dataset=True,
+                rollout_version="v1",
+            )
+
     def test_eval_rollout_topology_online_without_valid_data_is_disabled(self):
         assert not PPOTrainer._should_initialize_eval_rollout(
             online_mode=True,
@@ -119,6 +127,34 @@ class TestEvalRolloutTopology:
 
 
 class TestOnlineEvalIntegrity:
+    def test_online_empty_validation_fails_before_training_side_effects(self):
+        trainer = PPOTrainer.__new__(PPOTrainer)
+        trainer.config = SimpleNamespace(
+            total_train_epochs=1,
+            total_train_steps=1,
+            rollout=SimpleNamespace(agent=SimpleNamespace(mode="online")),
+            gconfig=SimpleNamespace(n_samples=1),
+            dynamic_bs=False,
+        )
+        trainer._online_mode = True
+        trainer.valid_dataloader = []
+        trainer.train_dataloader = [[{}]]
+        trainer.recover_info = None
+        trainer._should_offload_rollout = False
+        trainer._ensure_proxy_started = MagicMock(
+            side_effect=AssertionError("proxy must not start before eval preflight")
+        )
+        trainer.actor = MagicMock()
+        trainer.actor.prepare_batch.side_effect = AssertionError(
+            "training batch must not be consumed before eval preflight"
+        )
+
+        with pytest.raises(ValueError, match=r"validation.*empty"):
+            trainer.train(workflow=None, eval_workflow=sentinel.workflow)
+
+        trainer._ensure_proxy_started.assert_not_called()
+        trainer.actor.prepare_batch.assert_not_called()
+
     def test_online_validation_requires_eval_workflow_before_training_side_effects(
         self,
     ):
@@ -161,6 +197,9 @@ class TestOnlineEvalIntegrity:
             trainer._evaluate_fn(
                 eval_workflow=sentinel.workflow, eval_workflow_kwargs={}
             )
+        trainer.actor.clear_batches.assert_called_once_with(
+            sentinel.accepted_trajectory
+        )
 
     def test_all_valid_online_eval_results_complete_normally(self, monkeypatch):
         monkeypatch.setattr(rl_trainer, "is_single_controller", lambda: True)
@@ -175,6 +214,24 @@ class TestOnlineEvalIntegrity:
         )
 
         assert result is None
+        trainer.actor.clear_batches.assert_called_once_with(
+            sentinel.trajectory_one,
+            sentinel.trajectory_two,
+        )
+
+    def test_online_empty_eval_fails_closed_inside_evaluate_fn(self, monkeypatch):
+        monkeypatch.setattr(rl_trainer, "is_single_controller", lambda: True)
+        trainer = _eval_trainer(online_mode=True, wait_results=[])
+        trainer.valid_dataloader = []
+
+        with pytest.raises(RuntimeError, match=r"Online evaluation.*empty"):
+            trainer._evaluate_fn(
+                eval_workflow=sentinel.workflow,
+                eval_workflow_kwargs={},
+            )
+
+        trainer.eval_rollout.wait.assert_not_called()
+        trainer.actor.clear_batches.assert_not_called()
 
     def test_offline_incomplete_eval_preserves_current_behavior(self, monkeypatch):
         monkeypatch.setattr(rl_trainer, "is_single_controller", lambda: True)
@@ -189,3 +246,26 @@ class TestOnlineEvalIntegrity:
         )
 
         assert result is None
+        trainer.actor.clear_batches.assert_called_once_with(
+            sentinel.accepted_trajectory
+        )
+
+    def test_spmd_eval_does_not_clear_controller_rtensors(self, monkeypatch):
+        monkeypatch.setattr(rl_trainer, "is_single_controller", lambda: False)
+        barrier = MagicMock()
+        synchronize = MagicMock()
+        monkeypatch.setattr(rl_trainer.dist, "barrier", barrier)
+        monkeypatch.setattr(rl_trainer.current_platform, "synchronize", synchronize)
+        trainer = _eval_trainer(
+            online_mode=False,
+            wait_results=[sentinel.accepted_trajectory, None],
+        )
+
+        trainer._evaluate_fn(
+            eval_workflow=sentinel.workflow,
+            eval_workflow_kwargs={},
+        )
+
+        trainer.actor.clear_batches.assert_not_called()
+        barrier.assert_called_once_with(group=trainer.actor.cpu_group)
+        synchronize.assert_called_once_with()

--- a/tests/test_rl_trainer_online_eval.py
+++ b/tests/test_rl_trainer_online_eval.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, sentinel
+
+from areal.trainer import rl_trainer
+from areal.trainer.rl_trainer import PPOTrainer
+
+
+def _bare_trainer() -> PPOTrainer:
+    trainer = PPOTrainer.__new__(PPOTrainer)
+    trainer.config = SimpleNamespace(
+        seed=17,
+        experiment_name="online-eval",
+        trial_name="trial-0",
+        tokenizer_path="tokenizer-path",
+    )
+    trainer.scheduler = sentinel.scheduler
+    trainer.data_controller = None
+    trainer._train_rdataset = None
+    trainer._valid_rdataset = None
+    return trainer
+
+
+class TestOnlineEvalDataController:
+    def test_data_controller_is_created_from_valid_config(self, monkeypatch):
+        trainer = _bare_trainer()
+        valid_config = SimpleNamespace(shuffle=False, drop_last=True)
+        service_config = SimpleNamespace(num_workers=3)
+        dataset = MagicMock()
+        controller = MagicMock()
+        controller_factory = MagicMock(return_value=controller)
+        from_dataset_config = MagicMock(return_value=service_config)
+        monkeypatch.setattr(rl_trainer, "DataController", controller_factory)
+        monkeypatch.setattr(
+            rl_trainer.DataServiceConfig,
+            "from_dataset_config",
+            from_dataset_config,
+        )
+
+        trainer._connect_rdataset(dataset, valid_config, split="valid")
+
+        from_dataset_config.assert_called_once_with(valid_config, seed=17)
+        controller_factory.assert_called_once_with(service_config, sentinel.scheduler)
+        controller.initialize.assert_called_once_with(
+            role="data", num_dataset_workers=3
+        )
+        dataset.connect.assert_called_once_with(
+            controller,
+            dataset_id="online-eval_trial-0_valid",
+            tokenizer_or_processor_path="tokenizer-path",
+            shuffle=False,
+            drop_last=True,
+        )
+        assert trainer.data_controller is controller
+        assert trainer._valid_rdataset is dataset
+
+    def test_data_controller_is_reused_for_train_config(self, monkeypatch):
+        trainer = _bare_trainer()
+        existing_controller = MagicMock()
+        trainer.data_controller = existing_controller
+        train_config = SimpleNamespace(shuffle=True, drop_last=False)
+        dataset = MagicMock()
+        controller_factory = MagicMock()
+        from_dataset_config = MagicMock()
+        monkeypatch.setattr(rl_trainer, "DataController", controller_factory)
+        monkeypatch.setattr(
+            rl_trainer.DataServiceConfig,
+            "from_dataset_config",
+            from_dataset_config,
+        )
+
+        trainer._connect_rdataset(dataset, train_config, split="train")
+
+        controller_factory.assert_not_called()
+        from_dataset_config.assert_not_called()
+        existing_controller.initialize.assert_not_called()
+        dataset.connect.assert_called_once_with(
+            existing_controller,
+            dataset_id="online-eval_trial-0_train",
+            tokenizer_or_processor_path="tokenizer-path",
+            shuffle=True,
+            drop_last=False,
+        )
+        assert trainer.data_controller is existing_controller
+        assert trainer._train_rdataset is dataset

--- a/tests/test_rl_trainer_online_eval.py
+++ b/tests/test_rl_trainer_online_eval.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, sentinel
 
+import pytest
+
 from areal.trainer import rl_trainer
 from areal.trainer.rl_trainer import PPOTrainer
 
@@ -17,6 +19,18 @@ def _bare_trainer() -> PPOTrainer:
     trainer.data_controller = None
     trainer._train_rdataset = None
     trainer._valid_rdataset = None
+    return trainer
+
+
+def _eval_trainer(*, online_mode: bool, wait_results: list[object]) -> PPOTrainer:
+    trainer = PPOTrainer.__new__(PPOTrainer)
+    trainer._online_mode = online_mode
+    trainer.config = SimpleNamespace(eval_gconfig=SimpleNamespace(n_samples=1))
+    trainer.actor = MagicMock()
+    trainer.actor.is_data_parallel_head.return_value = True
+    trainer.valid_dataloader = [[{"question": "one"}, {"question": "two"}]]
+    trainer.eval_rollout = MagicMock()
+    trainer.eval_rollout.wait.return_value = wait_results
     return trainer
 
 
@@ -102,3 +116,76 @@ class TestEvalRolloutTopology:
             online_mode=False,
             has_valid_dataloader=False,
         )
+
+
+class TestOnlineEvalIntegrity:
+    def test_online_validation_requires_eval_workflow_before_training_side_effects(
+        self,
+    ):
+        trainer = PPOTrainer.__new__(PPOTrainer)
+        trainer.config = SimpleNamespace(
+            total_train_epochs=1,
+            total_train_steps=1,
+            rollout=SimpleNamespace(agent=SimpleNamespace(mode="online")),
+            gconfig=SimpleNamespace(n_samples=1),
+            dynamic_bs=False,
+        )
+        trainer._online_mode = True
+        trainer.valid_dataloader = [[{"question": "held-out"}]]
+        trainer.train_dataloader = [[{}]]
+        trainer.recover_info = None
+        trainer._should_offload_rollout = False
+        trainer._ensure_proxy_started = MagicMock()
+        trainer.actor = MagicMock()
+        trainer.actor.prepare_batch.side_effect = AssertionError(
+            "training batch must not be consumed before eval preflight"
+        )
+
+        with pytest.raises(ValueError, match="eval_workflow"):
+            trainer.train(workflow=None, eval_workflow=None)
+
+        trainer._ensure_proxy_started.assert_not_called()
+        trainer.actor.prepare_batch.assert_not_called()
+
+    def test_incomplete_eval_reports_rejected_and_expected_counts(self, monkeypatch):
+        monkeypatch.setattr(rl_trainer, "is_single_controller", lambda: True)
+        trainer = _eval_trainer(
+            online_mode=True,
+            wait_results=[sentinel.accepted_trajectory, None],
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"rejected=1, expected=2",
+        ):
+            trainer._evaluate_fn(
+                eval_workflow=sentinel.workflow, eval_workflow_kwargs={}
+            )
+
+    def test_all_valid_online_eval_results_complete_normally(self, monkeypatch):
+        monkeypatch.setattr(rl_trainer, "is_single_controller", lambda: True)
+        trainer = _eval_trainer(
+            online_mode=True,
+            wait_results=[sentinel.trajectory_one, sentinel.trajectory_two],
+        )
+
+        result = trainer._evaluate_fn(
+            eval_workflow=sentinel.workflow,
+            eval_workflow_kwargs={},
+        )
+
+        assert result is None
+
+    def test_offline_incomplete_eval_preserves_current_behavior(self, monkeypatch):
+        monkeypatch.setattr(rl_trainer, "is_single_controller", lambda: True)
+        trainer = _eval_trainer(
+            online_mode=False,
+            wait_results=[sentinel.accepted_trajectory, None],
+        )
+
+        result = trainer._evaluate_fn(
+            eval_workflow=sentinel.workflow,
+            eval_workflow_kwargs={},
+        )
+
+        assert result is None

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -421,9 +421,10 @@ class TestRolloutControllerV2Construction:
         controller = RolloutControllerV2(config=cfg, scheduler=scheduler)
         controller._callback_host = "127.0.0.1"
         controller._callback_port = 19000
-        server_infos = [
-            LocalInfServerInfo(host="127.0.0.1", port=30000, process=MagicMock())
-        ]
+        borrowed_server_info = LocalInfServerInfo(
+            host="127.0.0.1", port=30000, process=MagicMock()
+        )
+        server_infos = [borrowed_server_info]
 
         with patch.object(controller, "_async_fork_on_guard") as mock_fork:
             mock_fork.side_effect = [
@@ -439,6 +440,8 @@ class TestRolloutControllerV2Construction:
 
         assert controller.server_infos == server_infos
         assert controller.server_infos is not server_infos
+        controller.server_infos.clear()
+        assert server_infos == [borrowed_server_info]
 
         data_proxy_calls = [
             c for c in mock_fork.call_args_list if c.kwargs.get("role") == "data-proxy"
@@ -572,6 +575,26 @@ class TestInferenceServiceWorkflow:
             "rewards": torch.tensor([0.0, reward]),
             "versions": torch.tensor([-1, policy_version], dtype=torch.int32),
             "loss_mask": torch.tensor([0, 1], dtype=torch.int32),
+        }
+
+    @staticmethod
+    def _versioned_rtensor_trajectory(
+        policy_version: int, reward: float = 1.25
+    ) -> dict[str, RTensor]:
+        node_addr = "storage.test:9999"
+        return {
+            "rewards": RTensor(
+                shard=TensorShardInfo(shard_id="rewards", node_addr=node_addr),
+                data=torch.tensor([0.0, reward]),
+            ),
+            "versions": RTensor(
+                shard=TensorShardInfo(shard_id="versions", node_addr=node_addr),
+                data=torch.tensor([-1, policy_version], dtype=torch.int32),
+            ),
+            "loss_mask": RTensor(
+                shard=TensorShardInfo(shard_id="loss-mask", node_addr=node_addr),
+                data=torch.tensor([0, 1], dtype=torch.int32),
+            ),
         }
 
     @pytest.mark.asyncio
@@ -735,10 +758,11 @@ class TestInferenceServiceWorkflow:
             return_value=("group-1", [("session-1", "key-1")])
         )
         workflow._set_last_reward = AsyncMock(return_value=None)
-        workflow._export_interactions = AsyncMock(
-            return_value=self._versioned_trajectory(7)
-        )
+        traj = self._versioned_rtensor_trajectory(7)
+        workflow._export_interactions = AsyncMock(return_value=traj)
         tracker = MagicMock()
+        to_thread = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+        clear_node = AsyncMock()
 
         with (
             patch(
@@ -747,6 +771,8 @@ class TestInferenceServiceWorkflow:
             patch(
                 "areal.v2.inference_service.controller.workflow.stats_tracker"
             ) as mock_st,
+            patch.object(workflow_module.asyncio, "to_thread", to_thread),
+            patch.object(RTensor, "clear_node", clear_node),
         ):
             mock_wf_ctx.get.return_value = MagicMock(task_id=42)
             mock_wf_ctx.get_httpx_client = AsyncMock(return_value=MagicMock())
@@ -756,6 +782,12 @@ class TestInferenceServiceWorkflow:
             result = await workflow._run_offline(MagicMock(), {})
 
         assert result is not None
+        to_thread.assert_awaited_once_with(
+            workflow_module.validate_trajectory_policy_version,
+            traj,
+            7,
+        )
+        clear_node.assert_not_awaited()
         tracker.scalar.assert_called_once_with(reward=1.25, policy_version=7)
 
     @pytest.mark.asyncio
@@ -774,10 +806,10 @@ class TestInferenceServiceWorkflow:
             return_value=("group-1", [("session-1", "key-1")])
         )
         workflow._set_last_reward = AsyncMock(return_value=None)
-        workflow._export_interactions = AsyncMock(
-            return_value=self._versioned_trajectory(6)
-        )
+        traj = self._versioned_rtensor_trajectory(6)
+        workflow._export_interactions = AsyncMock(return_value=traj)
         tracker = MagicMock()
+        clear_node = AsyncMock()
 
         with (
             patch(
@@ -786,6 +818,7 @@ class TestInferenceServiceWorkflow:
             patch(
                 "areal.v2.inference_service.controller.workflow.stats_tracker"
             ) as mock_st,
+            patch.object(RTensor, "clear_node", clear_node),
         ):
             mock_wf_ctx.get.return_value = MagicMock(task_id=42)
             mock_wf_ctx.get_httpx_client = AsyncMock(return_value=MagicMock())
@@ -796,6 +829,46 @@ class TestInferenceServiceWorkflow:
                 await workflow._run_offline(MagicMock(), {})
 
         tracker.scalar.assert_not_called()
+        clear_node.assert_awaited_once_with(
+            "storage.test:9999",
+            ["rewards", "versions", "loss-mask"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_offline_mode_clears_exported_trajectory_when_group_fails(self):
+        class FailingAgent:
+            async def run(self, data, **kwargs):
+                raise RuntimeError("agent failed")
+
+        workflow = InferenceServiceWorkflow(
+            controller=MagicMock(),
+            agent=FailingAgent(),
+            gateway_addr="http://test:8080",
+        )
+        workflow._start_session = AsyncMock(
+            return_value=("group-1", [("session-1", "key-1")])
+        )
+        workflow._set_last_reward = AsyncMock(return_value=None)
+        traj = self._versioned_rtensor_trajectory(7)
+        workflow._export_interactions = AsyncMock(return_value=traj)
+        clear_node = AsyncMock()
+
+        with (
+            patch(
+                "areal.v2.inference_service.controller.workflow.workflow_context"
+            ) as mock_wf_ctx,
+            patch.object(RTensor, "clear_node", clear_node),
+        ):
+            mock_wf_ctx.get.return_value = MagicMock(task_id=42)
+            mock_wf_ctx.get_httpx_client = AsyncMock(return_value=MagicMock())
+
+            result = await workflow._run_offline(MagicMock(), {})
+
+        assert result is None
+        clear_node.assert_awaited_once_with(
+            "storage.test:9999",
+            ["rewards", "versions", "loss-mask"],
+        )
 
     @pytest.mark.asyncio
     async def test_offline_mode_without_expectation_accepts_missing_versions(self):
@@ -845,10 +918,11 @@ class TestInferenceServiceWorkflow:
             gateway_addr="http://test:8080",
             expected_policy_version=7,
         )
-        workflow._export_interactions = AsyncMock(
-            return_value=self._versioned_trajectory(7)
-        )
+        traj = self._versioned_rtensor_trajectory(7)
+        workflow._export_interactions = AsyncMock(return_value=traj)
         tracker = MagicMock()
+        to_thread = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+        clear_node = AsyncMock()
 
         with (
             patch(
@@ -857,6 +931,8 @@ class TestInferenceServiceWorkflow:
             patch(
                 "areal.v2.inference_service.controller.workflow.stats_tracker"
             ) as mock_st,
+            patch.object(workflow_module.asyncio, "to_thread", to_thread),
+            patch.object(RTensor, "clear_node", clear_node),
         ):
             mock_wf_ctx.stat_scope.return_value = "eval-rollout"
             mock_st.get.return_value = tracker
@@ -864,6 +940,12 @@ class TestInferenceServiceWorkflow:
             result = await workflow._run_online(MagicMock())
 
         assert result is not None
+        to_thread.assert_awaited_once_with(
+            workflow_module.validate_trajectory_policy_version,
+            traj,
+            7,
+        )
+        clear_node.assert_not_awaited()
         tracker.scalar.assert_called_once_with(reward=1.25, policy_version=7)
 
     @pytest.mark.asyncio
@@ -877,10 +959,10 @@ class TestInferenceServiceWorkflow:
             gateway_addr="http://test:8080",
             expected_policy_version=7,
         )
-        workflow._export_interactions = AsyncMock(
-            return_value=self._versioned_trajectory(6)
-        )
+        traj = self._versioned_rtensor_trajectory(6)
+        workflow._export_interactions = AsyncMock(return_value=traj)
         tracker = MagicMock()
+        clear_node = AsyncMock()
 
         with (
             patch(
@@ -889,6 +971,7 @@ class TestInferenceServiceWorkflow:
             patch(
                 "areal.v2.inference_service.controller.workflow.stats_tracker"
             ) as mock_st,
+            patch.object(RTensor, "clear_node", clear_node),
         ):
             mock_wf_ctx.stat_scope.return_value = "eval-rollout"
             mock_st.get.return_value = tracker
@@ -897,6 +980,40 @@ class TestInferenceServiceWorkflow:
                 await workflow._run_online(MagicMock())
 
         tracker.scalar.assert_not_called()
+        clear_node.assert_awaited_once_with(
+            "storage.test:9999",
+            ["rewards", "versions", "loss-mask"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_online_mode_clears_exported_trajectory_when_reward_is_missing(self):
+        controller = MagicMock()
+        controller.wait_for_online_trajectory = AsyncMock(
+            return_value={"session_id": "session-1", "trajectory_id": 3}
+        )
+        workflow = InferenceServiceWorkflow(
+            controller=controller,
+            gateway_addr="http://test:8080",
+        )
+        traj = {
+            "input_ids": RTensor(
+                shard=TensorShardInfo(
+                    shard_id="input-ids", node_addr="storage.test:9999"
+                ),
+                data=torch.tensor([1, 2], dtype=torch.int64),
+            )
+        }
+        workflow._export_interactions = AsyncMock(return_value=traj)
+        clear_node = AsyncMock()
+
+        with patch.object(RTensor, "clear_node", clear_node):
+            result = await workflow._run_online(MagicMock())
+
+        assert result is None
+        clear_node.assert_awaited_once_with(
+            "storage.test:9999",
+            ["input-ids"],
+        )
 
     @pytest.mark.asyncio
     async def test_online_mode_without_expectation_accepts_missing_versions(self):
@@ -990,6 +1107,15 @@ class TestValidateTrajectoryPolicyVersion:
         traj = self._trajectory(versions=[-1, 7, 7], loss_mask=[0, 1])
 
         with pytest.raises(ValueError, match="same shape"):
+            workflow_module.validate_trajectory_policy_version(traj, 7)
+
+    def test_validate_trajectory_policy_version_rejects_floating_versions(self):
+        traj = {
+            "versions": torch.tensor([-1.0, 7.0], dtype=torch.float32),
+            "loss_mask": torch.tensor([0, 1], dtype=torch.int32),
+        }
+
+        with pytest.raises(ValueError, match="signed integer dtype"):
             workflow_module.validate_trajectory_policy_version(traj, 7)
 
     def test_validate_trajectory_policy_version_rejects_no_loss_tokens(self):

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -205,6 +205,50 @@ class TestControllerWorkflowResolution:
             )
 
 
+class TestSubmitPolicyVersionSnapshot:
+    @staticmethod
+    def _make_controller(version: int = 7) -> RolloutControllerV2:
+        controller = RolloutControllerV2(
+            config=InferenceEngineConfig(backend="sglang:d1", admin_api_key="test-key"),
+            scheduler=MagicMock(n_gpus_per_node=8),
+        )
+        controller._gateway_addr = "http://test:8080"
+        controller._workflow_executor = MagicMock()
+        controller._version = version
+        return controller
+
+    def test_eval_submit_snapshots_current_policy_version(self):
+        controller = self._make_controller(version=7)
+
+        controller.submit(data={}, workflow=None, is_eval=True)
+
+        resolved = controller.workflow_executor.submit.call_args.kwargs["workflow"]
+        controller._version = 8
+        assert isinstance(resolved, InferenceServiceWorkflow)
+        assert resolved.expected_policy_version == 7
+
+    def test_training_submit_has_no_expected_policy_version(self):
+        controller = self._make_controller(version=7)
+
+        controller.submit(data={}, workflow=None, is_eval=False)
+
+        resolved = controller.workflow_executor.submit.call_args.kwargs["workflow"]
+        assert resolved.expected_policy_version is None
+
+    def test_workflow_kwargs_cannot_spoof_expected_policy_version(self):
+        controller = self._make_controller(version=7)
+
+        controller.submit(
+            data={},
+            workflow=None,
+            workflow_kwargs={"expected_policy_version": 999},
+            is_eval=True,
+        )
+
+        resolved = controller.workflow_executor.submit.call_args.kwargs["workflow"]
+        assert resolved.expected_policy_version == 7
+
+
 # =============================================================================
 # RolloutControllerV2 — API surface
 # =============================================================================
@@ -374,9 +418,7 @@ class TestRolloutControllerV2Construction:
         controller._callback_host = "127.0.0.1"
         controller._callback_port = 19000
         server_infos = [
-            LocalInfServerInfo(
-                host="127.0.0.1", port=30000, process=MagicMock()
-            )
+            LocalInfServerInfo(host="127.0.0.1", port=30000, process=MagicMock())
         ]
 
         with patch.object(controller, "_async_fork_on_guard") as mock_fork:

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -15,6 +15,7 @@ from areal.v2.inference_service.controller.controller import (
 from areal.v2.inference_service.controller.workflow import (
     InferenceServiceWorkflow,
 )
+from areal.v2.inference_service.data_proxy.session import TrajectoryDeliveryMode
 
 
 def _make_scheduler(n_gpus_per_node: int = 8) -> MagicMock:
@@ -513,6 +514,41 @@ class TestOnlineCallbackFlow:
 
 
 class TestInferenceServiceWorkflow:
+    @pytest.mark.asyncio
+    async def test_start_session_serializes_pull_delivery(self):
+        workflow = InferenceServiceWorkflow(
+            controller=MagicMock(),
+            gateway_addr="http://test:8080",
+            admin_api_key="test-key",
+        )
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json = AsyncMock(
+            return_value={
+                "group_id": "grp",
+                "sessions": [{"session_id": "s", "session_api_key": "k"}],
+            }
+        )
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_http_session = MagicMock()
+        mock_http_session.post = MagicMock(return_value=mock_cm)
+
+        result = await workflow._start_session(
+            mock_http_session,
+            "42",
+            group_size=1,
+            delivery_mode=TrajectoryDeliveryMode.PULL,
+        )
+
+        assert result == ("grp", [("s", "k")])
+        mock_http_session.post.assert_called_once_with(
+            "http://test:8080/rl/start_session",
+            json={"task_id": "42", "group_size": 1, "delivery_mode": "pull"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+
     @pytest.mark.skip(reason="pending /export_trajectories traj schema migration")
     @pytest.mark.asyncio
     async def test_online_mode_waits_on_controller(self):
@@ -612,7 +648,12 @@ class TestInferenceServiceWorkflow:
 
         assert result is not None
         assert "chatcmpl-1" in result
-        workflow._start_session.assert_awaited_once()
+        workflow._start_session.assert_awaited_once_with(
+            mock_http_session,
+            "42",
+            group_size=1,
+            delivery_mode=TrajectoryDeliveryMode.PULL,
+        )
         workflow._set_last_reward.assert_awaited_once()
         workflow._export_interactions.assert_awaited_once_with(
             mock_http_session, ["sess-1"], group_id="grp-test-1"

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -373,6 +373,11 @@ class TestRolloutControllerV2Construction:
         controller = RolloutControllerV2(config=cfg, scheduler=scheduler)
         controller._callback_host = "127.0.0.1"
         controller._callback_port = 19000
+        server_infos = [
+            LocalInfServerInfo(
+                host="127.0.0.1", port=30000, process=MagicMock()
+            )
+        ]
 
         with patch.object(controller, "_async_fork_on_guard") as mock_fork:
             mock_fork.side_effect = [
@@ -383,12 +388,11 @@ class TestRolloutControllerV2Construction:
 
             await controller._async_initialize(
                 server_args=None,
-                server_infos=[
-                    LocalInfServerInfo(
-                        host="127.0.0.1", port=30000, process=MagicMock()
-                    )
-                ],
+                server_infos=server_infos,
             )
+
+        assert controller.server_infos == server_infos
+        assert controller.server_infos is not server_infos
 
         data_proxy_calls = [
             c for c in mock_fork.call_args_list if c.kwargs.get("role") == "data-proxy"

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -746,11 +746,13 @@ class TestInferenceServiceWorkflow:
     async def test_offline_mode_records_reward_with_expected_policy_version(self):
         class MockAgent:
             async def run(self, data, **kwargs):
+                self.observed_policy_version = kwargs.get("policy_version")
                 return 1.25
 
+        agent = MockAgent()
         workflow = InferenceServiceWorkflow(
             controller=MagicMock(),
-            agent=MockAgent(),
+            agent=agent,
             gateway_addr="http://test:8080",
             expected_policy_version=7,
         )
@@ -782,6 +784,7 @@ class TestInferenceServiceWorkflow:
             result = await workflow._run_offline(MagicMock(), {})
 
         assert result is not None
+        assert agent.observed_policy_version == 7
         to_thread.assert_awaited_once_with(
             workflow_module.validate_trajectory_policy_version,
             traj,

--- a/tests/v2/inference_service/test_controller.py
+++ b/tests/v2/inference_service/test_controller.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+import torch
 
 from areal.api.cli_args import AgentConfig, InferenceEngineConfig
+from areal.infra.rpc.rtensor import RTensor, TensorShardInfo
+from areal.v2.inference_service.controller import workflow as workflow_module
 from areal.v2.inference_service.controller.controller import (
     RolloutControllerV2,
 )
@@ -560,6 +564,16 @@ class TestOnlineCallbackFlow:
 
 
 class TestInferenceServiceWorkflow:
+    @staticmethod
+    def _versioned_trajectory(
+        policy_version: int, reward: float = 1.25
+    ) -> dict[str, torch.Tensor]:
+        return {
+            "rewards": torch.tensor([0.0, reward]),
+            "versions": torch.tensor([-1, policy_version], dtype=torch.int32),
+            "loss_mask": torch.tensor([0, 1], dtype=torch.int32),
+        }
+
     @pytest.mark.asyncio
     async def test_start_session_serializes_pull_delivery(self):
         workflow = InferenceServiceWorkflow(
@@ -704,6 +718,303 @@ class TestInferenceServiceWorkflow:
         workflow._export_interactions.assert_awaited_once_with(
             mock_http_session, ["sess-1"], group_id="grp-test-1"
         )
+
+    @pytest.mark.asyncio
+    async def test_offline_mode_records_reward_with_expected_policy_version(self):
+        class MockAgent:
+            async def run(self, data, **kwargs):
+                return 1.25
+
+        workflow = InferenceServiceWorkflow(
+            controller=MagicMock(),
+            agent=MockAgent(),
+            gateway_addr="http://test:8080",
+            expected_policy_version=7,
+        )
+        workflow._start_session = AsyncMock(
+            return_value=("group-1", [("session-1", "key-1")])
+        )
+        workflow._set_last_reward = AsyncMock(return_value=None)
+        workflow._export_interactions = AsyncMock(
+            return_value=self._versioned_trajectory(7)
+        )
+        tracker = MagicMock()
+
+        with (
+            patch(
+                "areal.v2.inference_service.controller.workflow.workflow_context"
+            ) as mock_wf_ctx,
+            patch(
+                "areal.v2.inference_service.controller.workflow.stats_tracker"
+            ) as mock_st,
+        ):
+            mock_wf_ctx.get.return_value = MagicMock(task_id=42)
+            mock_wf_ctx.get_httpx_client = AsyncMock(return_value=MagicMock())
+            mock_wf_ctx.stat_scope.return_value = "eval-rollout"
+            mock_st.get.return_value = tracker
+
+            result = await workflow._run_offline(MagicMock(), {})
+
+        assert result is not None
+        tracker.scalar.assert_called_once_with(reward=1.25, policy_version=7)
+
+    @pytest.mark.asyncio
+    async def test_offline_mode_rejects_version_before_recording_metrics(self):
+        class MockAgent:
+            async def run(self, data, **kwargs):
+                return 1.25
+
+        workflow = InferenceServiceWorkflow(
+            controller=MagicMock(),
+            agent=MockAgent(),
+            gateway_addr="http://test:8080",
+            expected_policy_version=7,
+        )
+        workflow._start_session = AsyncMock(
+            return_value=("group-1", [("session-1", "key-1")])
+        )
+        workflow._set_last_reward = AsyncMock(return_value=None)
+        workflow._export_interactions = AsyncMock(
+            return_value=self._versioned_trajectory(6)
+        )
+        tracker = MagicMock()
+
+        with (
+            patch(
+                "areal.v2.inference_service.controller.workflow.workflow_context"
+            ) as mock_wf_ctx,
+            patch(
+                "areal.v2.inference_service.controller.workflow.stats_tracker"
+            ) as mock_st,
+        ):
+            mock_wf_ctx.get.return_value = MagicMock(task_id=42)
+            mock_wf_ctx.get_httpx_client = AsyncMock(return_value=MagicMock())
+            mock_wf_ctx.stat_scope.return_value = "eval-rollout"
+            mock_st.get.return_value = tracker
+
+            with pytest.raises(ValueError, match="expected policy version 7"):
+                await workflow._run_offline(MagicMock(), {})
+
+        tracker.scalar.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_offline_mode_without_expectation_accepts_missing_versions(self):
+        class MockAgent:
+            async def run(self, data, **kwargs):
+                return 1.25
+
+        workflow = InferenceServiceWorkflow(
+            controller=MagicMock(),
+            agent=MockAgent(),
+            gateway_addr="http://test:8080",
+            expected_policy_version=None,
+        )
+        workflow._start_session = AsyncMock(
+            return_value=("group-1", [("session-1", "key-1")])
+        )
+        workflow._set_last_reward = AsyncMock(return_value=None)
+        workflow._export_interactions = AsyncMock(return_value={"input_ids": []})
+        tracker = MagicMock()
+
+        with (
+            patch(
+                "areal.v2.inference_service.controller.workflow.workflow_context"
+            ) as mock_wf_ctx,
+            patch(
+                "areal.v2.inference_service.controller.workflow.stats_tracker"
+            ) as mock_st,
+        ):
+            mock_wf_ctx.get.return_value = MagicMock(task_id=42)
+            mock_wf_ctx.get_httpx_client = AsyncMock(return_value=MagicMock())
+            mock_wf_ctx.stat_scope.return_value = "rollout"
+            mock_st.get.return_value = tracker
+
+            result = await workflow._run_offline(MagicMock(), {})
+
+        assert result is not None
+        tracker.scalar.assert_called_once_with(reward=1.25)
+
+    @pytest.mark.asyncio
+    async def test_online_mode_records_reward_with_expected_policy_version(self):
+        controller = MagicMock()
+        controller.wait_for_online_trajectory = AsyncMock(
+            return_value={"session_id": "session-1", "trajectory_id": 3}
+        )
+        workflow = InferenceServiceWorkflow(
+            controller=controller,
+            gateway_addr="http://test:8080",
+            expected_policy_version=7,
+        )
+        workflow._export_interactions = AsyncMock(
+            return_value=self._versioned_trajectory(7)
+        )
+        tracker = MagicMock()
+
+        with (
+            patch(
+                "areal.v2.inference_service.controller.workflow.workflow_context"
+            ) as mock_wf_ctx,
+            patch(
+                "areal.v2.inference_service.controller.workflow.stats_tracker"
+            ) as mock_st,
+        ):
+            mock_wf_ctx.stat_scope.return_value = "eval-rollout"
+            mock_st.get.return_value = tracker
+
+            result = await workflow._run_online(MagicMock())
+
+        assert result is not None
+        tracker.scalar.assert_called_once_with(reward=1.25, policy_version=7)
+
+    @pytest.mark.asyncio
+    async def test_online_mode_rejects_version_before_recording_metrics(self):
+        controller = MagicMock()
+        controller.wait_for_online_trajectory = AsyncMock(
+            return_value={"session_id": "session-1", "trajectory_id": 3}
+        )
+        workflow = InferenceServiceWorkflow(
+            controller=controller,
+            gateway_addr="http://test:8080",
+            expected_policy_version=7,
+        )
+        workflow._export_interactions = AsyncMock(
+            return_value=self._versioned_trajectory(6)
+        )
+        tracker = MagicMock()
+
+        with (
+            patch(
+                "areal.v2.inference_service.controller.workflow.workflow_context"
+            ) as mock_wf_ctx,
+            patch(
+                "areal.v2.inference_service.controller.workflow.stats_tracker"
+            ) as mock_st,
+        ):
+            mock_wf_ctx.stat_scope.return_value = "eval-rollout"
+            mock_st.get.return_value = tracker
+
+            with pytest.raises(ValueError, match="expected policy version 7"):
+                await workflow._run_online(MagicMock())
+
+        tracker.scalar.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_online_mode_without_expectation_accepts_missing_versions(self):
+        controller = MagicMock()
+        controller.wait_for_online_trajectory = AsyncMock(
+            return_value={"session_id": "session-1", "trajectory_id": 3}
+        )
+        workflow = InferenceServiceWorkflow(
+            controller=controller,
+            gateway_addr="http://test:8080",
+            expected_policy_version=None,
+        )
+        workflow._export_interactions = AsyncMock(
+            return_value={"rewards": torch.tensor([0.0, 1.25])}
+        )
+        tracker = MagicMock()
+
+        with (
+            patch(
+                "areal.v2.inference_service.controller.workflow.workflow_context"
+            ) as mock_wf_ctx,
+            patch(
+                "areal.v2.inference_service.controller.workflow.stats_tracker"
+            ) as mock_st,
+        ):
+            mock_wf_ctx.stat_scope.return_value = "rollout"
+            mock_st.get.return_value = tracker
+
+            result = await workflow._run_online(MagicMock())
+
+        assert result is not None
+        tracker.scalar.assert_called_once_with(reward=1.25)
+
+
+class TestValidateTrajectoryPolicyVersion:
+    @staticmethod
+    def _trajectory(
+        versions: list[int], loss_mask: list[int]
+    ) -> dict[str, torch.Tensor]:
+        return {
+            "versions": torch.tensor(versions, dtype=torch.int32),
+            "loss_mask": torch.tensor(loss_mask, dtype=torch.int32),
+        }
+
+    def test_validate_trajectory_policy_version_accepts_expected_loss_tokens(self):
+        traj = self._trajectory(
+            versions=[-1, -1, 7, 7],
+            loss_mask=[0, 0, 1, 1],
+        )
+
+        workflow_module.validate_trajectory_policy_version(traj, 7)
+
+    def test_validate_trajectory_policy_version_ignores_untrained_positions(self):
+        traj = self._trajectory(
+            versions=[999, -1, 7, 123],
+            loss_mask=[0, 0, 1, 0],
+        )
+
+        workflow_module.validate_trajectory_policy_version(traj, 7)
+
+    @pytest.mark.parametrize(
+        "versions, observed",
+        [
+            ([-1, 7, 6], "[6, 7]"),
+            ([-1, 6, 6], "[6]"),
+        ],
+        ids=["mixed", "all-stale"],
+    )
+    def test_validate_trajectory_policy_version_rejects_mixed_or_stale_versions(
+        self, versions: list[int], observed: str
+    ):
+        traj = self._trajectory(versions=versions, loss_mask=[0, 1, 1])
+
+        with pytest.raises(
+            ValueError,
+            match=rf"expected policy version 7.*observed {re.escape(observed)}",
+        ):
+            workflow_module.validate_trajectory_policy_version(traj, 7)
+
+    @pytest.mark.parametrize("missing_key", ["versions", "loss_mask"])
+    def test_validate_trajectory_policy_version_rejects_missing_field(
+        self, missing_key: str
+    ):
+        traj = self._trajectory(versions=[-1, 7], loss_mask=[0, 1])
+        del traj[missing_key]
+
+        with pytest.raises(ValueError, match=rf"missing.*{missing_key}"):
+            workflow_module.validate_trajectory_policy_version(traj, 7)
+
+    def test_validate_trajectory_policy_version_rejects_shape_mismatch(self):
+        traj = self._trajectory(versions=[-1, 7, 7], loss_mask=[0, 1])
+
+        with pytest.raises(ValueError, match="same shape"):
+            workflow_module.validate_trajectory_policy_version(traj, 7)
+
+    def test_validate_trajectory_policy_version_rejects_no_loss_tokens(self):
+        traj = self._trajectory(versions=[-1, 7], loss_mask=[0, 0])
+
+        with pytest.raises(ValueError, match="no loss-bearing tokens"):
+            workflow_module.validate_trajectory_policy_version(traj, 7)
+
+    def test_validate_trajectory_policy_version_accepts_local_rtensors(self):
+        traj = {
+            "versions": RTensor(
+                shard=TensorShardInfo(shard_id="versions", node_addr="unused"),
+                data=torch.tensor([-1, 7, 7], dtype=torch.int32),
+            ),
+            "loss_mask": RTensor(
+                shard=TensorShardInfo(shard_id="loss-mask", node_addr="unused"),
+                data=torch.tensor([0, 1, 1], dtype=torch.int32),
+            ),
+        }
+
+        with patch(
+            "areal.infra.rpc.rtensor.get_backend",
+            side_effect=AssertionError("local RTensor must not fetch"),
+        ):
+            workflow_module.validate_trajectory_policy_version(traj, 7)
 
 
 # =============================================================================

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 import pytest_asyncio
+from pydantic import ValidationError
 
 from areal.v2.inference_service.data_proxy.app import (
     _flush_ready_trajectories,
@@ -177,8 +178,16 @@ def test_start_session_request_parses_pull_delivery_mode():
     assert request.delivery_mode is TrajectoryDeliveryMode.PULL
 
 
+def test_start_session_request_serializes_pull_delivery_mode_as_string():
+    request = StartSessionRequest(
+        task_id="task-1", delivery_mode=TrajectoryDeliveryMode.PULL
+    )
+
+    assert request.model_dump(mode="json")["delivery_mode"] == "pull"
+
+
 def test_start_session_request_rejects_unknown_delivery_mode():
-    with pytest.raises(ValueError, match="delivery_mode"):
+    with pytest.raises(ValidationError, match="delivery_mode"):
         StartSessionRequest(task_id="task-1", delivery_mode="broadcast")
 
 

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -418,6 +418,35 @@ async def test_start_session_with_admin_key(client):
 
 
 @pytest.mark.asyncio
+async def test_start_session_endpoint_persists_pull_delivery_mode(client):
+    response = await client.post(
+        "/rl/start_session",
+        json={"task_id": "pull-task", "delivery_mode": "pull", "group_size": 2},
+        headers=admin_headers(),
+    )
+
+    assert response.status_code == 201
+    session_ids = [item["session_id"] for item in response.json()["sessions"]]
+    assert len(session_ids) == 2
+    store: SessionStore = client._transport.app.state.session_store
+    for session_id in session_ids:
+        session = store.get_session(session_id)
+        assert isinstance(session, SessionData)
+        assert session.delivery_mode is TrajectoryDeliveryMode.PULL
+
+
+@pytest.mark.asyncio
+async def test_start_session_endpoint_rejects_unknown_delivery_mode(client):
+    response = await client.post(
+        "/rl/start_session",
+        json={"task_id": "invalid-task", "delivery_mode": "broadcast"},
+        headers=admin_headers(),
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_start_session_without_admin_key(client):
     resp = await client.post(
         "/rl/start_session",

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -16,6 +16,7 @@ from areal.v2.inference_service.data_proxy.app import (
 )
 from areal.v2.inference_service.data_proxy.config import DataProxyConfig
 from areal.v2.inference_service.data_proxy.session import (
+    ReadyNotification,
     SessionData,
     SessionStore,
     StartSessionRequest,
@@ -161,6 +162,19 @@ def session_headers(api_key: str):
     return {"Authorization": f"Bearer {api_key}"}
 
 
+def _add_fake_interaction(
+    session: SessionData, interaction_id: str = "fake-id"
+) -> None:
+    from areal.experimental.openai.types import InteractionWithTokenLogpReward
+
+    interaction = InteractionWithTokenLogpReward(
+        messages=[{"role": "user", "content": "hi"}]
+    )
+    interaction.interaction_id = interaction_id
+    interaction.output_message_list = [{"role": "assistant", "content": "hello"}]
+    session.active_completions[interaction_id] = interaction
+
+
 # =============================================================================
 # SessionStore unit tests
 # =============================================================================
@@ -192,6 +206,58 @@ def test_start_session_request_rejects_unknown_delivery_mode():
 
 
 class TestSessionStore:
+    def test_default_delivery_remains_callback(self):
+        store = SessionStore()
+        session_id, _ = store.start_session("callback-task")
+        session = store.get_session(session_id)
+        assert isinstance(session, SessionData)
+        _add_fake_interaction(session)
+
+        session.set_reward(interaction_id="fake-id", reward=1.0)
+
+        assert store.pending_online_callbacks() == [
+            ReadyNotification(session_id=session_id, trajectory_id=0)
+        ]
+
+    def test_pull_delivery_exports_without_callback(self):
+        store = SessionStore()
+        session_id, _ = store.start_session(
+            "pull-task", delivery_mode=TrajectoryDeliveryMode.PULL
+        )
+        session = store.get_session(session_id)
+        assert isinstance(session, SessionData)
+        _add_fake_interaction(session)
+
+        result = session.set_reward(interaction_id="fake-id", reward=1.0)
+
+        assert result.ready_transition is True
+        assert store.pending_online_callbacks() == []
+        trajectory_id, interactions = session.export_trajectory(
+            discount=1.0, style="individual"
+        )
+        assert trajectory_id == 0
+        assert list(interactions) == ["fake-id"]
+
+    def test_cross_delivery_modes_only_callback_session_enqueues_notification(self):
+        store = SessionStore()
+        callback_session_id, _ = store.start_session("callback-task")
+        pull_session_id, _ = store.start_session(
+            "pull-task", delivery_mode=TrajectoryDeliveryMode.PULL
+        )
+        callback_session = store.get_session(callback_session_id)
+        pull_session = store.get_session(pull_session_id)
+        assert isinstance(callback_session, SessionData)
+        assert isinstance(pull_session, SessionData)
+        _add_fake_interaction(callback_session)
+        _add_fake_interaction(pull_session)
+
+        pull_session.set_reward(interaction_id="fake-id", reward=1.0)
+        callback_session.set_reward(interaction_id="fake-id", reward=1.0)
+
+        assert store.pending_online_callbacks() == [
+            ReadyNotification(session_id=callback_session_id, trajectory_id=0)
+        ]
+
     def test_start_session_returns_ids(self):
         store = SessionStore()
         session_id, api_key = store.start_session("task-1")

--- a/tests/v2/inference_service/test_data_proxy_chat.py
+++ b/tests/v2/inference_service/test_data_proxy_chat.py
@@ -17,6 +17,8 @@ from areal.v2.inference_service.data_proxy.config import DataProxyConfig
 from areal.v2.inference_service.data_proxy.session import (
     SessionData,
     SessionStore,
+    StartSessionRequest,
+    TrajectoryDeliveryMode,
 )
 
 # =============================================================================
@@ -161,6 +163,23 @@ def session_headers(api_key: str):
 # =============================================================================
 # SessionStore unit tests
 # =============================================================================
+
+
+def test_start_session_request_defaults_delivery_mode_to_callback():
+    request = StartSessionRequest(task_id="task-1")
+
+    assert request.delivery_mode is TrajectoryDeliveryMode.CALLBACK
+
+
+def test_start_session_request_parses_pull_delivery_mode():
+    request = StartSessionRequest(task_id="task-1", delivery_mode="pull")
+
+    assert request.delivery_mode is TrajectoryDeliveryMode.PULL
+
+
+def test_start_session_request_rejects_unknown_delivery_mode():
+    with pytest.raises(ValueError, match="delivery_mode"):
+        StartSessionRequest(task_id="task-1", delivery_mode="broadcast")
 
 
 class TestSessionStore:


### PR DESCRIPTION
## Description

Online RL currently reports training reward but rejects `valid_dataset`, so an
experiment cannot measure a fixed held-out task distribution while external
agents continue to produce PPO samples. This PR adds an integrity-checked V2
evaluation path.

### Evaluation topology

- allow online runs to connect a real validation dataset, including an RDataset
  that must create its own DataController when no train dataset exists;
- initialize a separate eval controller only when validation data is present;
- reuse inference servers while keeping Router, Data Proxy, Gateway, sessions,
  and waiter state independent;
- use pull-owned direct-export sessions from #1476, so held-out trajectories
  cannot enter the external online callback FIFO;
- fail before proxy/training side effects for V1 or empty validation setups.

### Checkpoint attribution

- snapshot the controller policy version at `submit(is_eval=True)`;
- require every token selected by `loss_mask == 1` to carry that exact version
  in the exported trajectory;
- reject missing, non-integer, empty, mixed, or stale provenance before reward
  is recorded;
- record `reward` and `policy_version` in the same scalar operation;
- abort the complete online eval if any task is rejected, rather than publishing
  a metric over a selected subset.

### Resource ownership

- fetch remote provenance through `asyncio.to_thread` so RTensor HTTP fetches do
  not block the WorkflowExecutor event loop;
- clear rejected/exported shards inside the workflow;
- clear accepted eval shards after the trainer consumes the results;
- keep borrowed inference-server metadata in a controller-local list so eval
  teardown cannot mutate the main controller's state.

## Dependency

This is a stacked draft on #1476. Once #1476 merges, I will rebase this branch so
the PR diff contains only the online held-out evaluation commits. #1478 is
complementary but is not a dependency.

## Related Issue

Fixes #1479

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass for every feature file
- [x] Relevant tests pass; new tests added for new functionality
- [x] English and Chinese online-RL guides updated
- [x] Branch is up to date with `main`
- [x] Independently reviewed for spec compliance and code quality
- [x] This PR was created by a coding agent
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

None. Online runs without a validation dataset retain their current topology and
behavior. The new online + validation combination is V2-only and fails explicitly
under V1 instead of silently publishing an unverified metric.

## Validation

Fresh Linux validation on spark2:

```text
209 passed, 6 skipped in 9.39s
```

The suite covers:

- `tests/test_rl_trainer_online_eval.py`
- `tests/infra/data_service/test_trainer_compat.py`
- `tests/v2/inference_service/test_controller.py`
- `tests/v2/inference_service/test_data_proxy_chat.py`
- `tests/v2/inference_service/test_data_proxy_version.py`
- `tests/v2/inference_service/test_inf_bridge.py`
- `tests/v2/inference_service/test_gateway.py`
- `tests/v2/inference_service/test_online_stack.py`

Additional evidence:

- trainer + data-service tests on macOS: `35 passed`;
- controller non-live tests on macOS: `56 passed, 1 skipped, 4 deselected`;
- all changed-file pre-commit hooks and `git diff --check` pass;
- TDD covered control/data version mismatch, RTensor cleanup, async offload,
  empty validation, partial evaluation, V1 rejection, and SPMD compatibility.

The four deselected macOS tests are the pre-existing live callback tests that
bind to a locally unreachable `28.0.0.1`; the same tests pass in the Linux suite.

## Explicit Non-goals

- promotion, rollback, or checkpoint-selection policy;
- changing evaluator cadence;
- treating `eval_before_train` as a true version-0 baseline (the PPO loop first
  reaches evaluation after an update);
- replay/ack semantics for exported trajectories;
- adding online proxy support to existing unsupported SPMD/Ray configurations.
