### PR TITLE
[codex] preserve LD_PRELOAD in local launchers

### DIFF
--- a/areal/infra/launcher/local.py
+++ b/areal/infra/launcher/local.py
@@ -35,6 +35,7 @@ from areal.infra.utils.launcher import (
     validate_config_for_launcher,
     wait_llm_server_addrs,
 )
+from areal.infra.utils.proc import build_target_cmd
 from areal.utils import logging, name_resolve, names
 from areal.utils.network import find_free_ports
 from areal.utils.offload import get_tms_env_vars
@@ -143,11 +144,7 @@ class LocalLauncher:
                 env_vars[current_platform.device_control_env_var] = ",".join(
                     str(self._gpu_devices[j]) for j in visible_devices
                 )
-            c = (
-                " ".join(str(k) + "=" + str(v) for k, v in env_vars.items())
-                + " stdbuf -oL "
-                + cmd[i]
-            )
+            c = build_target_cmd(cmd[i], env_vars=env_vars, use_stdbuf=True)
             c = f"{c} 2>&1 | tee -a {self.log_path_of(job_name)}"
             logger.info("Starting local process with command: %s", c)
             process = subprocess.Popen(

--- a/areal/infra/utils/proc.py
+++ b/areal/infra/utils/proc.py
@@ -28,12 +28,14 @@ def build_target_cmd(
     *,
     env_vars: dict[str, str] | None = None,
     use_stdbuf: bool = False,
+    target_env: dict[str, str] | None = None,
 ) -> str:
     """Build a shell command with optional environment and line buffering.
 
     GNU ``stdbuf`` injects ``libstdbuf`` through ``LD_PRELOAD``. Avoid wrapping a
     target whose environment already specifies ``LD_PRELOAD`` so the target sees
-    the caller-provided value unchanged.
+    the caller-provided value unchanged. A ``None`` target environment follows
+    ``subprocess.Popen`` semantics and inherits ``os.environ``.
     """
     if isinstance(cmd, list):
         cmd_str = " ".join(shlex.quote(str(c)) for c in cmd)
@@ -47,7 +49,11 @@ def build_target_cmd(
                 f"{key}={shlex.quote(str(value))}" for key, value in env_vars.items()
             )
         )
-    if use_stdbuf and "LD_PRELOAD" not in (env_vars or {}):
+    inherited_env = os.environ if target_env is None else target_env
+    target_has_preload = (
+        "LD_PRELOAD" in (env_vars or {}) or "LD_PRELOAD" in inherited_env
+    )
+    if use_stdbuf and not target_has_preload:
         command_parts.append("stdbuf -oL")
     command_parts.append(cmd_str)
     return " ".join(command_parts)
@@ -94,11 +100,11 @@ def build_streaming_log_cmd(
     # Check if stdbuf is available (not present on macOS by default)
     _has_stdbuf = shutil.which("stdbuf") is not None
 
-    target_has_preload = "LD_PRELOAD" in (target_env or {})
     full_cmd = build_target_cmd(
         cmd,
         env_vars=env_vars,
-        use_stdbuf=_has_stdbuf and not target_has_preload,
+        use_stdbuf=_has_stdbuf,
+        target_env=target_env,
     )
 
     # Build log prefix for merged log

--- a/areal/infra/utils/proc.py
+++ b/areal/infra/utils/proc.py
@@ -60,6 +60,7 @@ def build_streaming_log_cmd(
     role: str,
     *,
     env_vars: dict[str, str] | None = None,
+    target_env: dict[str, str] | None = None,
 ) -> str:
     """Build a shell command that streams output to stdout and log files.
 
@@ -80,6 +81,10 @@ def build_streaming_log_cmd(
         Role name for log prefix (e.g., "actor", "master")
     env_vars : dict[str, str] | None
         Optional environment variables to prefix the command with KEY=VALUE
+    target_env : dict[str, str] | None
+        Optional environment passed directly to the target process. This is used
+        to preserve an inherited ``LD_PRELOAD`` when deciding whether ``stdbuf``
+        may safely wrap the target.
 
     Returns
     -------
@@ -89,7 +94,12 @@ def build_streaming_log_cmd(
     # Check if stdbuf is available (not present on macOS by default)
     _has_stdbuf = shutil.which("stdbuf") is not None
 
-    full_cmd = build_target_cmd(cmd, env_vars=env_vars, use_stdbuf=_has_stdbuf)
+    target_has_preload = "LD_PRELOAD" in (target_env or {})
+    full_cmd = build_target_cmd(
+        cmd,
+        env_vars=env_vars,
+        use_stdbuf=_has_stdbuf and not target_has_preload,
+    )
 
     # Build log prefix for merged log
     log_prefix = f"[{role}]".ljust(LOG_PREFIX_WIDTH)
@@ -138,7 +148,12 @@ def run_with_streaming_logs(
         The spawned process
     """
     shell_cmd = build_streaming_log_cmd(
-        cmd, str(log_file), str(merged_log), role, env_vars=env_vars_in_cmd
+        cmd,
+        str(log_file),
+        str(merged_log),
+        role,
+        env_vars=env_vars_in_cmd,
+        target_env=env,
     )
 
     return subprocess.Popen(

--- a/areal/infra/utils/proc.py
+++ b/areal/infra/utils/proc.py
@@ -23,6 +23,36 @@ if TYPE_CHECKING:
     from typing import IO
 
 
+def build_target_cmd(
+    cmd: str | list[str],
+    *,
+    env_vars: dict[str, str] | None = None,
+    use_stdbuf: bool = False,
+) -> str:
+    """Build a shell command with optional environment and line buffering.
+
+    GNU ``stdbuf`` injects ``libstdbuf`` through ``LD_PRELOAD``. Avoid wrapping a
+    target whose environment already specifies ``LD_PRELOAD`` so the target sees
+    the caller-provided value unchanged.
+    """
+    if isinstance(cmd, list):
+        cmd_str = " ".join(shlex.quote(str(c)) for c in cmd)
+    else:
+        cmd_str = cmd
+
+    command_parts = []
+    if env_vars:
+        command_parts.append(
+            " ".join(
+                f"{key}={shlex.quote(str(value))}" for key, value in env_vars.items()
+            )
+        )
+    if use_stdbuf and "LD_PRELOAD" not in (env_vars or {}):
+        command_parts.append("stdbuf -oL")
+    command_parts.append(cmd_str)
+    return " ".join(command_parts)
+
+
 def build_streaming_log_cmd(
     cmd: str | list[str],
     log_file: str | Path,
@@ -56,26 +86,10 @@ def build_streaming_log_cmd(
     str
         Shell command string ready for execution with bash
     """
-    # Escape command if it's a list
-    if isinstance(cmd, list):
-        cmd_str = " ".join(shlex.quote(str(c)) for c in cmd)
-    else:
-        cmd_str = cmd
-
     # Check if stdbuf is available (not present on macOS by default)
     _has_stdbuf = shutil.which("stdbuf") is not None
 
-    # Build prefix with env vars if provided
-    prefix_parts = []
-    if env_vars:
-        prefix_parts.append(
-            " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env_vars.items())
-        )
-    if _has_stdbuf:
-        prefix_parts.append(f"stdbuf -oL {cmd_str}")
-    else:
-        prefix_parts.append(cmd_str)
-    full_cmd = " ".join(prefix_parts)
+    full_cmd = build_target_cmd(cmd, env_vars=env_vars, use_stdbuf=_has_stdbuf)
 
     # Build log prefix for merged log
     log_prefix = f"[{role}]".ljust(LOG_PREFIX_WIDTH)

--- a/tests/infra/test_local_launcher.py
+++ b/tests/infra/test_local_launcher.py
@@ -64,3 +64,13 @@ def test_local_launcher_explicit_ld_preload_skips_stdbuf_and_quotes_value(launch
         "WORKER_LABEL='actor one' python train.py 2>&1 | tee -a "
     )
     assert "stdbuf" not in command.split(" 2>&1", maxsplit=1)[0]
+
+
+def test_local_launcher_inherited_ld_preload_skips_stdbuf(launcher, monkeypatch):
+    """A preload inherited by Popen is not extended by stdbuf."""
+    monkeypatch.setenv("LD_PRELOAD", "/opt/tms/torch_memory_saver.so")
+
+    command = _submitted_command(launcher, {"WORKER_LABEL": "actor"})
+
+    assert command.startswith("WORKER_LABEL=actor python train.py 2>&1 | tee -a ")
+    assert "stdbuf" not in command.split(" 2>&1", maxsplit=1)[0]

--- a/tests/infra/test_local_launcher.py
+++ b/tests/infra/test_local_launcher.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from unittest.mock import Mock, patch
+
+import pytest
+
+from areal.infra.launcher.local import LocalLauncher
+
+
+@pytest.fixture
+def launcher(tmp_path):
+    """Create a LocalLauncher without probing host GPU devices."""
+    local_launcher = object.__new__(LocalLauncher)
+    local_launcher.experiment_name = "experiment"
+    local_launcher.trial_name = "trial"
+    local_launcher.fileroot = str(tmp_path)
+    local_launcher._jobs = {}
+    local_launcher._job_counter = defaultdict(int)
+    local_launcher._job_states = {}
+    local_launcher._gpu_counter = 0
+    local_launcher._gpu_devices = []
+    local_launcher.wait = Mock()
+    yield local_launcher
+    local_launcher._jobs.clear()
+    local_launcher._job_counter.clear()
+
+
+def _submitted_command(launcher: LocalLauncher, env_vars: dict[str, str]) -> str:
+    process = Mock(pid=1234)
+    with patch(
+        "areal.infra.launcher.local.subprocess.Popen", return_value=process
+    ) as mock_popen:
+        launcher.submit(
+            job_name="trainer",
+            cmd="python train.py",
+            env_vars=env_vars,
+        )
+
+    return mock_popen.call_args.args[0]
+
+
+def test_local_launcher_regular_env_uses_stdbuf_and_quotes_value(launcher):
+    """Regular local jobs retain stdbuf and shell-safe environment values."""
+    command = _submitted_command(launcher, {"WORKER_LABEL": "actor one"})
+
+    assert command.startswith(
+        "WORKER_LABEL='actor one' stdbuf -oL python train.py 2>&1 | tee -a "
+    )
+
+
+def test_local_launcher_explicit_ld_preload_skips_stdbuf_and_quotes_value(launcher):
+    """TMS preloads are passed directly to the target local process."""
+    command = _submitted_command(
+        launcher,
+        {
+            "LD_PRELOAD": "/opt/tms hooks/tms preload.so",
+            "WORKER_LABEL": "actor one",
+        },
+    )
+
+    assert command.startswith(
+        "LD_PRELOAD='/opt/tms hooks/tms preload.so' "
+        "WORKER_LABEL='actor one' python train.py 2>&1 | tee -a "
+    )
+    assert "stdbuf" not in command.split(" 2>&1", maxsplit=1)[0]

--- a/tests/infra/test_proc.py
+++ b/tests/infra/test_proc.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from areal.infra.utils.proc import build_streaming_log_cmd
+from areal.infra.utils.proc import build_streaming_log_cmd, run_with_streaming_logs
 
 
 def _target_command(shell_command: str) -> str:
@@ -48,4 +48,32 @@ def test_build_streaming_log_cmd_explicit_ld_preload_skips_target_stdbuf(
         "WORKER_LABEL='actor one' python worker.py"
     )
     assert "stdbuf -oL sed" in command
+    mock_which.assert_called_once_with("stdbuf")
+
+
+@patch("areal.infra.utils.proc.subprocess.Popen")
+@patch("areal.infra.utils.proc.shutil.which", return_value="/usr/bin/stdbuf")
+def test_run_with_streaming_logs_inherited_ld_preload_skips_target_stdbuf(
+    mock_which,
+    mock_popen,
+):
+    """A preload supplied through Popen's environment is not changed by stdbuf."""
+    mock_popen.return_value = Mock()
+    child_env = {
+        "LD_PRELOAD": "/opt/tms/torch_memory_saver.so",
+        "WORKER_LABEL": "actor",
+    }
+
+    run_with_streaming_logs(
+        ["python", "worker.py"],
+        "/tmp/worker.log",
+        "/tmp/merged.log",
+        "actor",
+        env=child_env,
+    )
+
+    command = mock_popen.call_args.args[0]
+    assert _target_command(command) == "python worker.py"
+    assert "stdbuf -oL sed" in command
+    assert mock_popen.call_args.kwargs["env"] is child_env
     mock_which.assert_called_once_with("stdbuf")

--- a/tests/infra/test_proc.py
+++ b/tests/infra/test_proc.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from areal.infra.utils.proc import build_streaming_log_cmd
+
+
+def _target_command(shell_command: str) -> str:
+    return shell_command.split(" 2>&1", maxsplit=1)[0]
+
+
+@patch("areal.infra.utils.proc.shutil.which", return_value="/usr/bin/stdbuf")
+def test_build_streaming_log_cmd_regular_env_uses_stdbuf(mock_which):
+    """Regular target commands retain line buffering and quote env values."""
+    command = build_streaming_log_cmd(
+        ["python", "worker.py"],
+        "/tmp/worker.log",
+        "/tmp/merged.log",
+        "actor",
+        env_vars={"WORKER_LABEL": "actor one"},
+    )
+
+    assert (
+        _target_command(command)
+        == "WORKER_LABEL='actor one' stdbuf -oL python worker.py"
+    )
+    mock_which.assert_called_once_with("stdbuf")
+
+
+@patch("areal.infra.utils.proc.shutil.which", return_value="/usr/bin/stdbuf")
+def test_build_streaming_log_cmd_explicit_ld_preload_skips_target_stdbuf(
+    mock_which,
+):
+    """An explicit preload reaches the target unchanged while sed stays buffered."""
+    command = build_streaming_log_cmd(
+        ["python", "worker.py"],
+        "/tmp/worker.log",
+        "/tmp/merged.log",
+        "actor",
+        env_vars={
+            "LD_PRELOAD": "/opt/tms hooks/tms preload.so",
+            "WORKER_LABEL": "actor one",
+        },
+    )
+
+    assert _target_command(command) == (
+        "LD_PRELOAD='/opt/tms hooks/tms preload.so' "
+        "WORKER_LABEL='actor one' python worker.py"
+    )
+    assert "stdbuf -oL sed" in command
+    mock_which.assert_called_once_with("stdbuf")

--- a/tests/infra/test_proc.py
+++ b/tests/infra/test_proc.py
@@ -77,3 +77,54 @@ def test_run_with_streaming_logs_inherited_ld_preload_skips_target_stdbuf(
     assert "stdbuf -oL sed" in command
     assert mock_popen.call_args.kwargs["env"] is child_env
     mock_which.assert_called_once_with("stdbuf")
+
+
+@patch("areal.infra.utils.proc.subprocess.Popen")
+@patch("areal.infra.utils.proc.shutil.which", return_value="/usr/bin/stdbuf")
+def test_run_with_streaming_logs_parent_ld_preload_skips_target_stdbuf(
+    mock_which,
+    mock_popen,
+    monkeypatch,
+):
+    """Popen's default inherited environment is considered before wrapping."""
+    mock_popen.return_value = Mock()
+    monkeypatch.setenv("LD_PRELOAD", "/opt/tms/torch_memory_saver.so")
+
+    run_with_streaming_logs(
+        ["python", "worker.py"],
+        "/tmp/worker.log",
+        "/tmp/merged.log",
+        "actor",
+    )
+
+    command = mock_popen.call_args.args[0]
+    assert _target_command(command) == "python worker.py"
+    assert "stdbuf -oL sed" in command
+    assert mock_popen.call_args.kwargs["env"] is None
+    mock_which.assert_called_once_with("stdbuf")
+
+
+@patch("areal.infra.utils.proc.subprocess.Popen")
+@patch("areal.infra.utils.proc.shutil.which", return_value="/usr/bin/stdbuf")
+def test_run_with_streaming_logs_explicit_empty_env_uses_target_stdbuf(
+    mock_which,
+    mock_popen,
+    monkeypatch,
+):
+    """An explicit empty Popen environment does not inherit the parent's preload."""
+    mock_popen.return_value = Mock()
+    monkeypatch.setenv("LD_PRELOAD", "/opt/tms/torch_memory_saver.so")
+    child_env = {}
+
+    run_with_streaming_logs(
+        ["python", "worker.py"],
+        "/tmp/worker.log",
+        "/tmp/merged.log",
+        "actor",
+        env=child_env,
+    )
+
+    command = mock_popen.call_args.args[0]
+    assert _target_command(command) == "stdbuf -oL python worker.py"
+    assert mock_popen.call_args.kwargs["env"] is child_env
+    mock_which.assert_called_once_with("stdbuf")


### PR DESCRIPTION
## Summary

- centralize construction of local target commands so environment assignments are
  shell-quoted consistently
- skip target-side `stdbuf` when `LD_PRELOAD` is supplied as a command assignment,
  through `subprocess.Popen(env=...)`, or through `Popen`'s default inherited
  environment
- keep line buffering unchanged for ordinary targets and for the log-side `sed`
  pipeline; an explicit empty `Popen` environment remains isolated from the parent

## Root cause

GNU `stdbuf` implements buffering by appending `libstdbuf.so` to `LD_PRELOAD`.
That is normally harmless, but Torch Memory Saver (TMS) 0.0.9 reads the resulting
colon-separated value as one `ctypes.CDLL` path. A TMS target therefore receives a
value shaped like `torch_memory_saver.so:libstdbuf.so` and fails during startup.

There are two local launch paths that can expose this interaction:

1. `LocalLauncher` can put TMS's preload in command-prefixed environment variables
   or inherit it from its parent process.
2. The RPC/streaming launcher can pass TMS's preload through `Popen(env=...)` or
   inherit `os.environ` when `env=None`.

Both paths now preserve the caller's effective `LD_PRELOAD` by omitting `stdbuf`
only around that target process. Non-TMS jobs and the logging pipeline remain line
buffered. The implementation follows `Popen` semantics precisely: `env=None`
inherits `os.environ`, while `env={}` does not.

## Hardware reproduction

I reproduced the failure on Spark2 (NVIDIA GB10) while launching the trainer with
`stdbuf -oL -eL`. Before the fix, TMS 0.0.9 attempted to load
`tms.so:libstdbuf.so` as a single shared-library path and the worker failed to
start. Fixing only the command-prefixed environment exposed the second inherited
`Popen` environment layer. With both layers fixed, TMS offload completed and the
observed GPU used memory dropped from 120.84 GB to about 105.90 GB.

## Validation

- `pytest -q tests/infra/test_launcher_utils.py tests/infra/test_local_launcher.py tests/infra/test_proc.py tests/infra/rpc/test_engine_validation.py`
  (`15 passed`)
- `pre-commit run --all-files` (all hooks passed in the project virtualenv)
- GitHub Actions: pre-commit and all four package-install matrices passed

