### PR TITLE
fix(v2): expose primary online rollout gateway

### DIFF
--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -1407,6 +1407,19 @@ class PPOTrainer:
         if self.config.scheduler.type == "ray":
             raise NotImplementedError("Proxy workers not supported with RayScheduler")
 
+        agent_cfg = self.config.rollout.agent
+        if isinstance(self.rollout, RolloutControllerV2):
+            # The V2 gateway is also the proxy and is started during controller
+            # initialization. Publish the primary rollout address here so online
+            # clients do not have to infer it from rollout/eval startup order.
+            if agent_cfg is not None and agent_cfg.mode == "online":
+                logger.info(
+                    "Proxy gateway available at %s (role=rollout)",
+                    self.rollout.proxy_gateway_addr,
+                )
+            self._proxy_started = True
+            return
+
         if not isinstance(self.rollout, RolloutController):
             self._proxy_started = True
             return
@@ -1418,7 +1431,6 @@ class PPOTrainer:
             self.eval_rollout.start_proxy()
 
         # Start proxy gateway for online mode.
-        agent_cfg = self.config.rollout.agent
         if agent_cfg is not None and agent_cfg.mode == "online":
             self.rollout.start_proxy_gateway()
             logger.info(

--- a/tests/test_online_gateway_discovery.py
+++ b/tests/test_online_gateway_discovery.py
@@ -1,16 +1,36 @@
 """Tests for discovering the primary online rollout gateway."""
 
+from concurrent.futures import Future, ThreadPoolExecutor
+from threading import Event
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
+
+import pytest
 
 from areal.api.cli_args import InferenceEngineConfig
+from areal.infra import RolloutController
 from areal.trainer.rl_trainer import PPOTrainer
 from areal.v2.inference_service.controller.controller import (
     RolloutControllerV2,
 )
 
 
-def _make_v2_controller(gateway_addr: str) -> RolloutControllerV2:
+class _ObservedFuture(Future):
+    """Future that signals when a caller starts waiting for its result."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.result_entered = Event()
+
+    def result(self, timeout: float | None = None):
+        self.result_entered.set()
+        return super().result(timeout=timeout)
+
+
+def _make_v2_controller(
+    gateway_addr: str,
+    init_future: Future | None = None,
+) -> RolloutControllerV2:
     controller = RolloutControllerV2(
         config=InferenceEngineConfig(
             backend="sglang:d1",
@@ -19,19 +39,95 @@ def _make_v2_controller(gateway_addr: str) -> RolloutControllerV2:
         scheduler=MagicMock(n_gpus_per_node=8),
     )
     controller._gateway_addr = gateway_addr
+    controller._init_future = init_future
     return controller
 
 
-def test_v2_online_proxy_logs_primary_rollout_gateway_with_role():
-    primary_gateway = "http://127.0.0.1:18080"
-    eval_gateway = "http://127.0.0.1:18081"
+def _make_trainer(rollout, eval_rollout=None) -> PPOTrainer:
     trainer = object.__new__(PPOTrainer)
     trainer._proxy_started = False
-    trainer.rollout = _make_v2_controller(primary_gateway)
-    trainer.eval_rollout = _make_v2_controller(eval_gateway)
+    trainer.rollout = rollout
+    trainer.eval_rollout = eval_rollout
     trainer.config = SimpleNamespace(
         scheduler=SimpleNamespace(type="local"),
         rollout=SimpleNamespace(agent=SimpleNamespace(mode="online")),
+    )
+    return trainer
+
+
+def test_v2_online_proxy_waits_for_initialization_before_logging():
+    primary_gateway = "http://127.0.0.1:18080"
+    init_future = _ObservedFuture()
+    trainer = _make_trainer(
+        _make_v2_controller(primary_gateway, init_future=init_future)
+    )
+    executor = ThreadPoolExecutor(max_workers=1)
+
+    try:
+        with (
+            patch("areal.trainer.rl_trainer.is_single_controller", return_value=True),
+            patch("areal.trainer.rl_trainer.logger") as mock_logger,
+        ):
+            start = executor.submit(trainer._ensure_proxy_started)
+
+            assert init_future.result_entered.wait(timeout=5)
+            assert start.done() is False
+            assert trainer._proxy_started is False
+            mock_logger.info.assert_not_called()
+
+            init_future.set_result(None)
+            start.result(timeout=5)
+    finally:
+        if not init_future.done():
+            init_future.set_result(None)
+        executor.shutdown(wait=True)
+
+    mock_logger.info.assert_called_once_with(
+        "Proxy gateway available at %s (role=rollout)",
+        primary_gateway,
+    )
+    assert trainer._proxy_started is True
+
+
+def test_v2_online_proxy_propagates_initialization_failure_and_can_retry():
+    initialization_error = RuntimeError("gateway initialization failed")
+    failed_future = Future()
+    failed_future.set_exception(initialization_error)
+    trainer = _make_trainer(
+        _make_v2_controller(
+            "http://127.0.0.1:18080",
+            init_future=failed_future,
+        )
+    )
+
+    with (
+        patch("areal.trainer.rl_trainer.is_single_controller", return_value=True),
+        patch("areal.trainer.rl_trainer.logger") as mock_logger,
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            trainer._ensure_proxy_started()
+
+        assert exc_info.value is initialization_error
+        assert trainer._proxy_started is False
+        mock_logger.info.assert_not_called()
+
+        healthy_gateway = "http://127.0.0.1:18081"
+        trainer.rollout = _make_v2_controller(healthy_gateway)
+        trainer._ensure_proxy_started()
+
+    mock_logger.info.assert_called_once_with(
+        "Proxy gateway available at %s (role=rollout)",
+        healthy_gateway,
+    )
+    assert trainer._proxy_started is True
+
+
+def test_v2_online_proxy_logs_primary_rollout_gateway_only_once():
+    primary_gateway = "http://127.0.0.1:18080"
+    eval_gateway = "http://127.0.0.1:18081"
+    trainer = _make_trainer(
+        _make_v2_controller(primary_gateway),
+        eval_rollout=_make_v2_controller(eval_gateway),
     )
 
     with (
@@ -39,9 +135,34 @@ def test_v2_online_proxy_logs_primary_rollout_gateway_with_role():
         patch("areal.trainer.rl_trainer.logger") as mock_logger,
     ):
         trainer._ensure_proxy_started()
+        trainer._ensure_proxy_started()
 
     mock_logger.info.assert_called_once_with(
         "Proxy gateway available at %s (role=rollout)",
         primary_gateway,
     )
+    assert trainer._proxy_started is True
+
+
+def test_v1_online_proxy_start_behavior_is_unchanged():
+    primary_gateway = "http://127.0.0.1:18080"
+    rollout = MagicMock(spec=RolloutController)
+    rollout.proxy_gateway_addr = primary_gateway
+    eval_rollout = MagicMock(spec=RolloutController)
+    trainer = _make_trainer(rollout, eval_rollout=eval_rollout)
+
+    with (
+        patch("areal.trainer.rl_trainer.is_single_controller", return_value=True),
+        patch("areal.trainer.rl_trainer.logger") as mock_logger,
+    ):
+        trainer._ensure_proxy_started()
+
+    rollout.start_proxy.assert_called_once_with()
+    eval_rollout.start_proxy.assert_called_once_with()
+    rollout.start_proxy_gateway.assert_called_once_with()
+    eval_rollout.start_proxy_gateway.assert_not_called()
+    assert mock_logger.info.call_args_list == [
+        call("Initializing proxy workers for AgentWorkflow support"),
+        call("Proxy gateway available at %s", primary_gateway),
+    ]
     assert trainer._proxy_started is True

--- a/tests/test_online_gateway_discovery.py
+++ b/tests/test_online_gateway_discovery.py
@@ -1,0 +1,47 @@
+"""Tests for discovering the primary online rollout gateway."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from areal.api.cli_args import InferenceEngineConfig
+from areal.trainer.rl_trainer import PPOTrainer
+from areal.v2.inference_service.controller.controller import (
+    RolloutControllerV2,
+)
+
+
+def _make_v2_controller(gateway_addr: str) -> RolloutControllerV2:
+    controller = RolloutControllerV2(
+        config=InferenceEngineConfig(
+            backend="sglang:d1",
+            admin_api_key="test-admin-key",
+        ),
+        scheduler=MagicMock(n_gpus_per_node=8),
+    )
+    controller._gateway_addr = gateway_addr
+    return controller
+
+
+def test_v2_online_proxy_logs_primary_rollout_gateway_with_role():
+    primary_gateway = "http://127.0.0.1:18080"
+    eval_gateway = "http://127.0.0.1:18081"
+    trainer = object.__new__(PPOTrainer)
+    trainer._proxy_started = False
+    trainer.rollout = _make_v2_controller(primary_gateway)
+    trainer.eval_rollout = _make_v2_controller(eval_gateway)
+    trainer.config = SimpleNamespace(
+        scheduler=SimpleNamespace(type="local"),
+        rollout=SimpleNamespace(agent=SimpleNamespace(mode="online")),
+    )
+
+    with (
+        patch("areal.trainer.rl_trainer.is_single_controller", return_value=True),
+        patch("areal.trainer.rl_trainer.logger") as mock_logger,
+    ):
+        trainer._ensure_proxy_started()
+
+    mock_logger.info.assert_called_once_with(
+        "Proxy gateway available at %s (role=rollout)",
+        primary_gateway,
+    )
+    assert trainer._proxy_started is True


### PR DESCRIPTION
## Summary

- publish one explicit primary rollout gateway address for V2 online workflows
- wait for rollout-controller initialization before announcing readiness
- preserve retry semantics after initialization failure and leave V1 behavior unchanged
- cover rollout versus eval selection, idempotency, failure, retry, and V1 compatibility

## Motivation

A V2 trainer can initialize both rollout and evaluation gateways. Generic gateway startup logs do not identify which address an online producer should use, so consumers that infer the endpoint from log order can connect to the evaluation gateway. This change exposes a stable, role-tagged readiness line from the trainer after the primary rollout controller is ready.

## Validation

- `.venv/bin/python -m pytest -q tests/test_online_gateway_discovery.py` — 4 passed
- broader non-GPU trainer/controller suite — 49 passed, 1 skipped, 4 deselected
- `pre-commit run --all-files` — passed
