### PR TITLE
fix(v2): close async clients on owner event loops

### DIFF
--- a/areal/infra/utils/http.py
+++ b/areal/infra/utils/http.py
@@ -195,7 +195,18 @@ def register_httpx_client_loop_cleanup(
     from areal.infra.utils.concurrent import register_loop_cleanup
 
     async def close_client() -> None:
-        await cleanup.close()
+        try:
+            await cleanup.close()
+        except BaseException:
+            # Event-loop shutdown must continue through the remaining cleanup
+            # callbacks and reach the real loop.close().  The cleanup object
+            # retains the exact failure so a later explicit destroy can report
+            # it; do not acknowledge closure or clear the owner's references.
+            logger.error(
+                "Failed to close async HTTP client during loop cleanup",
+                exc_info=True,
+            )
+            return
         if on_closed is not None:
             on_closed()
 

--- a/areal/infra/utils/http.py
+++ b/areal/infra/utils/http.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import concurrent.futures
 import os
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum, auto
 from http import HTTPStatus
 from typing import Any
 
@@ -51,6 +56,171 @@ def create_httpx_client(timeout: float | None = 120.0, **kwargs) -> httpx.AsyncC
         limits=get_default_httpx_limits(),
     )
     return httpx.AsyncClient(timeout=timeout, transport=transport, **kwargs)
+
+
+class HttpxAsyncClientCleanupState(Enum):
+    OPEN = auto()
+    CLOSING = auto()
+    SUCCEEDED = auto()
+    FAILED = auto()
+
+
+@dataclass
+class HttpxAsyncClientCleanup:
+    """Single-flight cleanup state for one loop-owned async client.
+
+    ``httpx.AsyncClient.is_closed`` only describes HTTPX's logical state.  It can
+    become true before the transport's ``aclose()`` has completed (or even when
+    transport cleanup subsequently fails), so it cannot acknowledge resource
+    cleanup.  This state object records the outcome of the one real close call
+    and lets concurrent callers await that same outcome.
+    """
+
+    client: httpx.AsyncClient
+    owner_loop: asyncio.AbstractEventLoop
+    _state: HttpxAsyncClientCleanupState = field(
+        default=HttpxAsyncClientCleanupState.OPEN, init=False
+    )
+    _error: BaseException | None = field(default=None, init=False)
+    _completion: concurrent.futures.Future[None] | None = field(
+        default=None, init=False
+    )
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+
+    @property
+    def succeeded(self) -> bool:
+        with self._lock:
+            return self._state is HttpxAsyncClientCleanupState.SUCCEEDED
+
+    @property
+    def error(self) -> BaseException | None:
+        with self._lock:
+            return self._error
+
+    def snapshot(
+        self,
+    ) -> tuple[HttpxAsyncClientCleanupState, BaseException | None]:
+        with self._lock:
+            return self._state, self._error
+
+    def terminal_result(self) -> bool:
+        """Return whether cleanup succeeded, or re-raise its stable failure."""
+        state, error = self.snapshot()
+        if state is HttpxAsyncClientCleanupState.FAILED:
+            assert error is not None
+            raise error
+        return state is HttpxAsyncClientCleanupState.SUCCEEDED
+
+    async def close(self) -> None:
+        current_loop = asyncio.get_running_loop()
+        with self._lock:
+            state = self._state
+            error = self._error
+            if state is HttpxAsyncClientCleanupState.SUCCEEDED:
+                return
+            if state is HttpxAsyncClientCleanupState.FAILED:
+                assert error is not None
+                raise error
+            if current_loop is not self.owner_loop:
+                raise RuntimeError(
+                    "httpx.AsyncClient cleanup must run on its owner event loop"
+                )
+            if state is HttpxAsyncClientCleanupState.OPEN:
+                completion: concurrent.futures.Future[None] = (
+                    concurrent.futures.Future()
+                )
+                # ``asyncio.wrap_future`` propagates waiter cancellation to its
+                # source future.  Mark this shared acknowledgement as running so
+                # one cancelled follower cannot cancel the leader's completion.
+                if not completion.set_running_or_notify_cancel():
+                    raise RuntimeError(
+                        "new async-client cleanup completion was unexpectedly cancelled"
+                    )
+                self._completion = completion
+                self._state = HttpxAsyncClientCleanupState.CLOSING
+                leader = True
+            else:
+                assert state is HttpxAsyncClientCleanupState.CLOSING
+                assert self._completion is not None
+                completion = self._completion
+                leader = False
+
+        if not leader:
+            await asyncio.wrap_future(completion)
+            return
+
+        try:
+            await self.client.aclose()
+        except BaseException as exc:
+            with self._lock:
+                self._error = exc
+                self._state = HttpxAsyncClientCleanupState.FAILED
+            completion.set_exception(exc)
+            raise
+        else:
+            with self._lock:
+                self._state = HttpxAsyncClientCleanupState.SUCCEEDED
+            completion.set_result(None)
+
+
+async def close_httpx_client_on_owner_loop(
+    cleanup: HttpxAsyncClientCleanup,
+) -> None:
+    """Close an async client without driving loop-bound transports elsewhere."""
+    if cleanup.terminal_result():
+        return
+
+    owner_loop = cleanup.owner_loop
+    current_loop = asyncio.get_running_loop()
+    if owner_loop is current_loop:
+        await cleanup.close()
+        return
+    if owner_loop.is_closed():
+        raise RuntimeError(
+            "httpx.AsyncClient owner event loop closed before cleanup succeeded"
+        )
+    if owner_loop.is_running():
+        close_future = asyncio.run_coroutine_threadsafe(cleanup.close(), owner_loop)
+        await asyncio.wrap_future(close_future)
+        return
+    raise RuntimeError("httpx.AsyncClient owner event loop is not running")
+
+
+def register_httpx_client_loop_cleanup(
+    cleanup: HttpxAsyncClientCleanup,
+    *,
+    on_closed: Callable[[], None] | None = None,
+) -> None:
+    """Close a client on its owner loop immediately before loop shutdown."""
+    from areal.infra.utils.concurrent import register_loop_cleanup
+
+    async def close_client() -> None:
+        await cleanup.close()
+        if on_closed is not None:
+            on_closed()
+
+    register_loop_cleanup(close_client, loop=cleanup.owner_loop)
+
+
+def close_httpx_client_from_sync(
+    cleanup: HttpxAsyncClientCleanup,
+) -> None:
+    """Synchronously close a client without deadlocking its running owner loop."""
+    if cleanup.terminal_result():
+        return
+    owner_loop = cleanup.owner_loop
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        current_loop = None
+    if current_loop is owner_loop:
+        raise RuntimeError(
+            "cannot synchronously close httpx.AsyncClient from its owner event loop"
+        )
+
+    from areal.infra.utils.concurrent import run_async_task
+
+    run_async_task(close_httpx_client_on_owner_loop, cleanup)
 
 
 def get_default_uvicorn_kwargs() -> dict[str, Any]:

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -27,7 +27,14 @@ from typing import TYPE_CHECKING, Any, cast
 import httpx
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
-from areal.infra.utils.http import async_http_retry, create_httpx_client
+from areal.infra.utils.http import (
+    HttpxAsyncClientCleanup,
+    HttpxAsyncClientCleanupState,
+    async_http_retry,
+    close_httpx_client_from_sync,
+    create_httpx_client,
+    register_httpx_client_loop_cleanup,
+)
 
 if TYPE_CHECKING:
     from areal.api.scheduler_api import Scheduler, Worker
@@ -173,6 +180,8 @@ class RolloutControllerV2:
         self._sync_client = httpx.Client(timeout=30.0)
         self._async_client: httpx.AsyncClient | None = None
         self._async_client_loop: asyncio.AbstractEventLoop | None = None
+        self._async_client_cleanup: HttpxAsyncClientCleanup | None = None
+        self._async_client_lock = Lock()
         self._destroyed = False
 
         # Proxy compatibility (no-ops — gateway IS the proxy)
@@ -968,15 +977,33 @@ class RolloutControllerV2:
 
         # Close shared HTTP clients after all kill requests have been sent
         self._sync_client.close()
-        if self._async_client is not None:
+        async_client_cleanup_error: BaseException | None = None
+        with self._async_client_lock:
+            async_client = self._async_client
+            async_client_loop = self._async_client_loop
+            async_client_cleanup = self._async_client_cleanup
+        if async_client is not None and async_client_cleanup is None:
+            async_client_cleanup_error = RuntimeError(
+                "async HTTP client cleanup state is missing"
+            )
+        elif async_client is None and (
+            async_client_loop is not None or async_client_cleanup is not None
+        ):
+            async_client_cleanup_error = RuntimeError(
+                "async HTTP client cleanup state is inconsistent"
+            )
+        elif async_client_cleanup is not None:
             try:
-                from areal.infra.utils.concurrent import run_async_task
-
-                run_async_task(self._async_client.aclose)
-            except Exception:
-                pass
-            self._async_client = None
-            self._async_client_loop = None
+                close_httpx_client_from_sync(async_client_cleanup)
+            except BaseException as exc:
+                logger.error("Failed to close async HTTP client", exc_info=True)
+                async_client_cleanup_error = exc
+            else:
+                with self._async_client_lock:
+                    if self._async_client_cleanup is async_client_cleanup:
+                        self._async_client = None
+                        self._async_client_loop = None
+                        self._async_client_cleanup = None
 
         # RPCGuard's shutdown `finally` block automatically kills all
         # forked children, so explicit teardown above is best-effort.
@@ -1007,6 +1034,12 @@ class RolloutControllerV2:
         self._router_addr = ""
         self._gateway_addr = ""
         self._staleness_manager = None
+
+        if async_client_cleanup_error is not None:
+            # Keep the client and its explicit cleanup outcome for diagnosis and
+            # allow a caller to retry teardown instead of reporting false success.
+            self._destroyed = False
+            raise async_client_cleanup_error
 
     # -- Version management ------------------------------------------------
 
@@ -1777,18 +1810,60 @@ class RolloutControllerV2:
         calls) share one client and its connection pool.
         """
         current_loop = asyncio.get_running_loop()
-        if self._async_client is None or self._async_client_loop is not current_loop:
-            old = self._async_client
-            self._async_client = create_httpx_client(
-                timeout=self.config.request_timeout
-            )
+        with self._async_client_lock:
+            client = self._async_client
+            cleanup = self._async_client_cleanup
+            owner_loop = self._async_client_loop
+            if client is not None:
+                if cleanup is None or owner_loop is not cleanup.owner_loop:
+                    raise RuntimeError(
+                        "async HTTP client cleanup state is inconsistent"
+                    )
+                state, error = cleanup.snapshot()
+                if state is HttpxAsyncClientCleanupState.FAILED:
+                    assert error is not None
+                    raise error
+                if state is HttpxAsyncClientCleanupState.SUCCEEDED:
+                    self._async_client = None
+                    self._async_client_loop = None
+                    self._async_client_cleanup = None
+                elif cleanup.owner_loop is current_loop:
+                    if state is HttpxAsyncClientCleanupState.CLOSING:
+                        raise RuntimeError(
+                            "async HTTP client cleanup is already in progress"
+                        )
+                    return client
+                elif cleanup.owner_loop.is_running():
+                    raise RuntimeError(
+                        "async HTTP client is active on another event loop"
+                    )
+                elif cleanup.owner_loop.is_closed():
+                    raise RuntimeError(
+                        "async HTTP client owner event loop closed before cleanup "
+                        "succeeded"
+                    )
+                else:
+                    raise RuntimeError(
+                        "async HTTP client owner event loop is not running"
+                    )
+            elif cleanup is not None or owner_loop is not None:
+                raise RuntimeError("async HTTP client cleanup state is inconsistent")
+
+            client = create_httpx_client(timeout=self.config.request_timeout)
+            cleanup = HttpxAsyncClientCleanup(client, current_loop)
+
+            def clear_client() -> None:
+                with self._async_client_lock:
+                    if self._async_client_cleanup is cleanup:
+                        self._async_client = None
+                        self._async_client_loop = None
+                        self._async_client_cleanup = None
+
+            register_httpx_client_loop_cleanup(cleanup, on_closed=clear_client)
+            self._async_client = client
             self._async_client_loop = current_loop
-            if old is not None:
-                try:
-                    await old.aclose()
-                except Exception:
-                    pass
-        return self._async_client
+            self._async_client_cleanup = cleanup
+            return client
 
     @async_http_retry
     async def _async_data_proxy_post(

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -1811,6 +1811,8 @@ class RolloutControllerV2:
         """
         current_loop = asyncio.get_running_loop()
         with self._async_client_lock:
+            if self._destroyed:
+                raise RuntimeError("RolloutControllerV2 has been destroyed")
             client = self._async_client
             cleanup = self._async_client_cleanup
             owner_loop = self._async_client_loop

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -147,6 +147,8 @@ class GatewayTrainController:
     async def _get_async_client(self):
         current_loop = asyncio.get_running_loop()
         with self._async_client_lock:
+            if self._shutdown_requested.is_set():
+                raise RuntimeError("GatewayTrainController is shutting down")
             client = self._async_client
             cleanup = self._async_client_cleanup
             owner_loop = self._async_client_loop

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -15,7 +15,13 @@ from uuid import uuid4
 import aiohttp
 
 from areal.infra.utils.concurrent import get_executor, run_async_task
-from areal.infra.utils.http import create_httpx_client
+from areal.infra.utils.http import (
+    HttpxAsyncClientCleanup,
+    HttpxAsyncClientCleanupState,
+    close_httpx_client_from_sync,
+    create_httpx_client,
+    register_httpx_client_loop_cleanup,
+)
 from areal.utils import logging
 from areal.utils.network import format_hostport, gethostip
 
@@ -64,6 +70,8 @@ class GatewayTrainController:
         # Shared HTTP client (lazy, per-event-loop)
         self._async_client: Any | None = None
         self._async_client_loop: asyncio.AbstractEventLoop | None = None
+        self._async_client_cleanup: HttpxAsyncClientCleanup | None = None
+        self._async_client_lock = Lock()
 
         # Pipelined initialization state
         self._init_future: concurrent.futures.Future | None = None
@@ -138,16 +146,60 @@ class GatewayTrainController:
 
     async def _get_async_client(self):
         current_loop = asyncio.get_running_loop()
-        if self._async_client is None or self._async_client_loop is not current_loop:
-            old = self._async_client
-            self._async_client = create_httpx_client(timeout=self.config.setup_timeout)
+        with self._async_client_lock:
+            client = self._async_client
+            cleanup = self._async_client_cleanup
+            owner_loop = self._async_client_loop
+            if client is not None:
+                if cleanup is None or owner_loop is not cleanup.owner_loop:
+                    raise RuntimeError(
+                        "async HTTP client cleanup state is inconsistent"
+                    )
+                state, error = cleanup.snapshot()
+                if state is HttpxAsyncClientCleanupState.FAILED:
+                    assert error is not None
+                    raise error
+                if state is HttpxAsyncClientCleanupState.SUCCEEDED:
+                    self._async_client = None
+                    self._async_client_loop = None
+                    self._async_client_cleanup = None
+                elif cleanup.owner_loop is current_loop:
+                    if state is HttpxAsyncClientCleanupState.CLOSING:
+                        raise RuntimeError(
+                            "async HTTP client cleanup is already in progress"
+                        )
+                    return client
+                elif cleanup.owner_loop.is_running():
+                    raise RuntimeError(
+                        "async HTTP client is active on another event loop"
+                    )
+                elif cleanup.owner_loop.is_closed():
+                    raise RuntimeError(
+                        "async HTTP client owner event loop closed before cleanup "
+                        "succeeded"
+                    )
+                else:
+                    raise RuntimeError(
+                        "async HTTP client owner event loop is not running"
+                    )
+            elif cleanup is not None or owner_loop is not None:
+                raise RuntimeError("async HTTP client cleanup state is inconsistent")
+
+            client = create_httpx_client(timeout=self.config.setup_timeout)
+            cleanup = HttpxAsyncClientCleanup(client, current_loop)
+
+            def clear_client() -> None:
+                with self._async_client_lock:
+                    if self._async_client_cleanup is cleanup:
+                        self._async_client = None
+                        self._async_client_loop = None
+                        self._async_client_cleanup = None
+
+            register_httpx_client_loop_cleanup(cleanup, on_closed=clear_client)
+            self._async_client = client
             self._async_client_loop = current_loop
-            if old is not None:
-                try:
-                    await old.aclose()
-                except Exception:
-                    pass
-        return self._async_client
+            self._async_client_cleanup = cleanup
+            return client
 
     async def _async_initialize(
         self,
@@ -404,12 +456,33 @@ class GatewayTrainController:
                 self._router_addr, self._model_addr, self.api_key
             )
             logger.info("Model registered with api_key=%s", self.api_key)
-        except Exception:
+        except Exception as exc:
             logger.error(
                 "GatewayTrainController initialization failed, rolling back",
                 exc_info=True,
             )
-            self._cleanup_runtime_state()
+            # Initialization and its HTTP client share this running event loop.
+            # Close the client here before entering the synchronous cleanup path,
+            # which deliberately rejects owner-loop reentrancy to avoid deadlock.
+            with self._async_client_lock:
+                async_client_cleanup = self._async_client_cleanup
+            if (
+                async_client_cleanup is not None
+                and async_client_cleanup.owner_loop is asyncio.get_running_loop()
+            ):
+                try:
+                    await async_client_cleanup.close()
+                except BaseException:
+                    # The cleanup token retains the stable failure.  The complete
+                    # runtime cleanup below will re-raise it as secondary context.
+                    pass
+            try:
+                self._cleanup_runtime_state()
+            except BaseException as cleanup_error:
+                exc.add_note(
+                    "Local startup rollback failed: "
+                    f"{type(cleanup_error).__name__}: {cleanup_error}"
+                )
             raise
 
     # -- Engine creation ---------------------------------------------------
@@ -1178,13 +1251,33 @@ class GatewayTrainController:
         self._model_addr = ""
         self.api_key = None
 
-        if self._async_client is not None:
+        async_client_cleanup_error: BaseException | None = None
+        with self._async_client_lock:
+            async_client = self._async_client
+            async_client_loop = self._async_client_loop
+            async_client_cleanup = self._async_client_cleanup
+        if async_client is not None and async_client_cleanup is None:
+            async_client_cleanup_error = RuntimeError(
+                "async HTTP client cleanup state is missing"
+            )
+        elif async_client is None and (
+            async_client_loop is not None or async_client_cleanup is not None
+        ):
+            async_client_cleanup_error = RuntimeError(
+                "async HTTP client cleanup state is inconsistent"
+            )
+        elif async_client_cleanup is not None:
             try:
-                run_async_task(self._async_client.aclose)
-            except Exception:
-                pass
-            self._async_client = None
-            self._async_client_loop = None
+                close_httpx_client_from_sync(async_client_cleanup)
+            except BaseException as exc:
+                logger.error("Failed to close async HTTP client", exc_info=True)
+                async_client_cleanup_error = exc
+            else:
+                with self._async_client_lock:
+                    if self._async_client_cleanup is async_client_cleanup:
+                        self._async_client = None
+                        self._async_client_loop = None
+                        self._async_client_cleanup = None
 
         import torch.distributed as dist
 
@@ -1198,6 +1291,9 @@ class GatewayTrainController:
                 )
             finally:
                 self._own_process_group = False
+
+        if async_client_cleanup_error is not None:
+            raise async_client_cleanup_error
 
     def destroy(self) -> None:
         self._shutdown_requested.set()

--- a/tests/v2/inference_service/test_startup_failure_lifecycle.py
+++ b/tests/v2/inference_service/test_startup_failure_lifecycle.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from areal.api.cli_args import InferenceEngineConfig
+from areal.infra.utils.concurrent import run_async_task
+from areal.infra.utils.http import (
+    HttpxAsyncClientCleanup,
+    close_httpx_client_from_sync,
+    close_httpx_client_on_owner_loop,
+)
+from areal.v2.inference_service.controller.controller import RolloutControllerV2
+
+
+def _controller() -> RolloutControllerV2:
+    return RolloutControllerV2(
+        config=InferenceEngineConfig(
+            backend="sglang:d1",
+            admin_api_key="test-key",
+            setup_timeout=1.0,
+            workers_ready_timeout=1.0,
+        ),
+        scheduler=MagicMock(n_gpus_per_node=8),
+    )
+
+
+def test_destroy_rejects_open_async_client_after_owner_loop_closed() -> None:
+    controller = _controller()
+    owner_loop = MagicMock()
+    owner_loop.is_closed.return_value = True
+    client = MagicMock()
+    client.is_closed = False
+    client.aclose = AsyncMock()
+    cleanup = HttpxAsyncClientCleanup(client, owner_loop)
+    controller._async_client = client
+    controller._async_client_loop = owner_loop
+    controller._async_client_cleanup = cleanup
+
+    with pytest.raises(RuntimeError, match="owner event loop closed"):
+        controller.destroy()
+
+    client.aclose.assert_not_awaited()
+    assert controller._async_client is client
+    assert controller._async_client_loop is owner_loop
+    assert controller._async_client_cleanup is cleanup
+    assert controller._destroyed is False
+
+
+def test_async_client_closes_on_owner_loop_shutdown_before_destroy() -> None:
+    controller = _controller()
+    client = MagicMock()
+    client.is_closed = False
+    close_loops: list[asyncio.AbstractEventLoop] = []
+
+    async def close_client() -> None:
+        close_loops.append(asyncio.get_running_loop())
+        client.is_closed = True
+
+    client.aclose = AsyncMock(side_effect=close_client)
+    loop = asyncio.new_event_loop()
+    try:
+        with patch(
+            "areal.v2.inference_service.controller.controller.create_httpx_client",
+            return_value=client,
+        ):
+            assert loop.run_until_complete(controller._get_async_client()) is client
+    finally:
+        loop.close()
+
+    client.aclose.assert_awaited_once_with()
+    assert close_loops == [loop]
+    assert client.is_closed is True
+    assert controller._async_client is None
+    assert controller._async_client_loop is None
+    assert controller._async_client_cleanup is None
+
+    controller.destroy()
+
+    client.aclose.assert_awaited_once_with()
+    assert controller._destroyed is True
+
+
+def test_sequential_run_async_task_clients_close_on_their_own_loops() -> None:
+    controller = _controller()
+    clients: list[MagicMock] = []
+    close_loops: list[asyncio.AbstractEventLoop] = []
+
+    for _ in range(2):
+        client = MagicMock()
+        client.is_closed = False
+
+        async def close_client(client=client) -> None:
+            close_loops.append(asyncio.get_running_loop())
+            client.is_closed = True
+
+        client.aclose = AsyncMock(side_effect=close_client)
+        clients.append(client)
+
+    with patch(
+        "areal.v2.inference_service.controller.controller.create_httpx_client",
+        side_effect=clients,
+    ):
+        assert run_async_task(controller._get_async_client) is clients[0]
+        assert controller._async_client is None
+        assert run_async_task(controller._get_async_client) is clients[1]
+
+    assert controller._async_client is None
+    assert controller._async_client_loop is None
+    assert controller._async_client_cleanup is None
+    assert close_loops[0] is not close_loops[1]
+    for client in clients:
+        client.aclose.assert_awaited_once_with()
+
+
+def test_run_async_task_closes_real_keepalive_transport_before_loop_exit() -> None:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    listener.settimeout(2.0)
+    peer_saw_eof = threading.Event()
+    server_done = threading.Event()
+    server_errors: list[BaseException] = []
+
+    def serve_one_keepalive_response() -> None:
+        try:
+            conn, _ = listener.accept()
+            with conn:
+                conn.settimeout(2.0)
+                request = bytearray()
+                while b"\r\n\r\n" not in request:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        raise AssertionError("client closed before request headers")
+                    request.extend(chunk)
+                conn.sendall(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Length: 2\r\n"
+                    b"Connection: keep-alive\r\n\r\nok"
+                )
+                if conn.recv(1) == b"":
+                    peer_saw_eof.set()
+        except BaseException as exc:
+            server_errors.append(exc)
+        finally:
+            server_done.set()
+
+    thread = threading.Thread(target=serve_one_keepalive_response, daemon=True)
+    thread.start()
+    controller = _controller()
+    old_policy = asyncio.get_event_loop_policy()
+    asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
+    try:
+
+        async def make_request() -> None:
+            client = await controller._get_async_client()
+            response = await client.get(f"http://127.0.0.1:{listener.getsockname()[1]}")
+            assert response.status_code == 200
+            assert response.content == b"ok"
+
+        run_async_task(make_request)
+        assert peer_saw_eof.wait(timeout=2.0)
+        assert server_done.wait(timeout=2.0)
+        assert server_errors == []
+        assert controller._async_client is None
+        assert controller._async_client_loop is None
+        assert controller._async_client_cleanup is None
+    finally:
+        asyncio.set_event_loop_policy(old_policy)
+        listener.close()
+        thread.join(timeout=2.0)
+        controller.destroy()
+
+
+def test_destroy_retains_async_client_when_live_loop_close_fails() -> None:
+    controller = _controller()
+    owner_loop = MagicMock()
+    primary = RuntimeError("async transport close failed")
+    client = MagicMock()
+    client.is_closed = False
+    client.aclose = AsyncMock(side_effect=primary)
+    cleanup = HttpxAsyncClientCleanup(client, owner_loop)
+    controller._async_client = client
+    controller._async_client_loop = owner_loop
+    controller._async_client_cleanup = cleanup
+
+    with (
+        patch(
+            "areal.v2.inference_service.controller.controller."
+            "close_httpx_client_from_sync",
+            side_effect=primary,
+        ),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        controller.destroy()
+
+    assert exc_info.value is primary
+    assert controller._async_client is client
+    assert controller._async_client_loop is owner_loop
+    assert controller._async_client_cleanup is cleanup
+    assert controller._destroyed is False
+
+
+def test_transport_close_failure_is_never_mistaken_for_httpx_closed() -> None:
+    primary = RuntimeError("transport resource is still open")
+
+    class FailingCloseTransport(httpx.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.resource_open = True
+            self.close_calls = 0
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, request=request)
+
+        async def aclose(self) -> None:
+            self.close_calls += 1
+            raise primary
+
+    controller = _controller()
+    transport = FailingCloseTransport()
+    client = httpx.AsyncClient(transport=transport)
+    loop = asyncio.new_event_loop()
+    try:
+        with patch(
+            "areal.v2.inference_service.controller.controller.create_httpx_client",
+            return_value=client,
+        ):
+            assert loop.run_until_complete(controller._get_async_client()) is client
+            cleanup = controller._async_client_cleanup
+            assert cleanup is not None
+    finally:
+        loop.close()
+
+    assert client.is_closed is True
+    assert transport.resource_open is True
+    assert transport.close_calls == 1
+    assert cleanup.succeeded is False
+    assert cleanup.error is primary
+    assert controller._async_client is client
+    assert controller._async_client_cleanup is cleanup
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError) as exc_info:
+            controller.destroy()
+        assert exc_info.value is primary
+        assert controller._async_client is client
+        assert controller._async_client_cleanup is cleanup
+        assert transport.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_client_close_propagates_failure_on_owner_loop() -> None:
+    owner_loop = asyncio.get_running_loop()
+    primary = RuntimeError("async transport close failed")
+    client = MagicMock()
+    client.is_closed = False
+    client.aclose = AsyncMock(side_effect=primary)
+    cleanup = HttpxAsyncClientCleanup(client, owner_loop)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await close_httpx_client_on_owner_loop(cleanup)
+
+    assert exc_info.value is primary
+    client.aclose.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_async_client_close_is_single_flight() -> None:
+    owner_loop = asyncio.get_running_loop()
+    primary = RuntimeError("single transport close failed")
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    client = MagicMock()
+
+    async def close_client() -> None:
+        close_started.set()
+        await release_close.wait()
+        raise primary
+
+    client.aclose = AsyncMock(side_effect=close_client)
+    cleanup = HttpxAsyncClientCleanup(client, owner_loop)
+    first = asyncio.create_task(cleanup.close())
+    second: asyncio.Task[None] | None = None
+    try:
+        await asyncio.wait_for(close_started.wait(), timeout=1.0)
+        second = asyncio.create_task(cleanup.close())
+        await asyncio.sleep(0)
+        release_close.set()
+        results = await asyncio.wait_for(
+            asyncio.gather(first, second, return_exceptions=True), timeout=1.0
+        )
+    finally:
+        release_close.set()
+        pending = [
+            task for task in (first, second) if task is not None and not task.done()
+        ]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    assert results == [primary, primary]
+    client.aclose.assert_awaited_once_with()
+    assert cleanup.succeeded is False
+    assert cleanup.error is primary
+
+
+@pytest.mark.asyncio
+async def test_cancelled_close_follower_does_not_cancel_shared_completion() -> None:
+    owner_loop = asyncio.get_running_loop()
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    client = MagicMock()
+
+    async def close_client() -> None:
+        close_started.set()
+        await release_close.wait()
+
+    client.aclose = AsyncMock(side_effect=close_client)
+    cleanup = HttpxAsyncClientCleanup(client, owner_loop)
+    leader = asyncio.create_task(cleanup.close())
+    follower: asyncio.Task[None] | None = None
+    try:
+        await asyncio.wait_for(close_started.wait(), timeout=1.0)
+        follower = asyncio.create_task(cleanup.close())
+        await asyncio.sleep(0)
+
+        follower.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await follower
+        release_close.set()
+        await asyncio.wait_for(leader, timeout=1.0)
+    finally:
+        release_close.set()
+        pending = [
+            task for task in (leader, follower) if task is not None and not task.done()
+        ]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    client.aclose.assert_awaited_once_with()
+    assert cleanup.succeeded is True
+    assert cleanup.error is None
+
+
+def test_sync_async_client_close_runs_on_live_owner_loop() -> None:
+    owner_loop = asyncio.new_event_loop()
+    owner_started = threading.Event()
+    close_loops: list[asyncio.AbstractEventLoop] = []
+    thread_errors: list[BaseException] = []
+
+    def run_owner_loop() -> None:
+        try:
+            asyncio.set_event_loop(owner_loop)
+            owner_loop.call_soon(owner_started.set)
+            owner_loop.run_forever()
+        except BaseException as exc:
+            thread_errors.append(exc)
+        finally:
+            owner_loop.close()
+
+    owner_thread = threading.Thread(target=run_owner_loop, daemon=True)
+    owner_thread.start()
+    try:
+        assert owner_started.wait(timeout=1.0)
+        client = MagicMock()
+        client.is_closed = False
+
+        async def close_client() -> None:
+            close_loops.append(asyncio.get_running_loop())
+            client.is_closed = True
+
+        client.aclose = AsyncMock(side_effect=close_client)
+        cleanup = HttpxAsyncClientCleanup(client, owner_loop)
+        close_httpx_client_from_sync(cleanup)
+    finally:
+        if not owner_loop.is_closed():
+            owner_loop.call_soon_threadsafe(owner_loop.stop)
+        owner_thread.join(timeout=1.0)
+
+    assert not owner_thread.is_alive()
+    assert thread_errors == []
+    assert close_loops == [owner_loop]
+    client.aclose.assert_awaited_once_with()
+
+
+def test_get_async_client_rejects_concurrent_foreign_event_loop() -> None:
+    controller = _controller()
+    owner_loop = asyncio.new_event_loop()
+    owner_started = threading.Event()
+    owner_errors: list[BaseException] = []
+    close_loops: list[asyncio.AbstractEventLoop] = []
+    client = MagicMock()
+
+    async def close_client() -> None:
+        close_loops.append(asyncio.get_running_loop())
+
+    client.aclose = AsyncMock(side_effect=close_client)
+
+    def run_owner_loop() -> None:
+        try:
+            asyncio.set_event_loop(owner_loop)
+            owner_loop.call_soon(owner_started.set)
+            owner_loop.run_forever()
+        except BaseException as exc:
+            owner_errors.append(exc)
+        finally:
+            owner_loop.close()
+
+    owner_thread = threading.Thread(target=run_owner_loop, daemon=True)
+    owner_thread.start()
+    try:
+        assert owner_started.wait(timeout=1.0)
+        with patch(
+            "areal.v2.inference_service.controller.controller.create_httpx_client",
+            return_value=client,
+        ):
+            owner_client = asyncio.run_coroutine_threadsafe(
+                controller._get_async_client(), owner_loop
+            ).result(timeout=1.0)
+            assert owner_client is client
+
+            with pytest.raises(RuntimeError, match="active on another event loop"):
+                asyncio.run(controller._get_async_client())
+
+            client.aclose.assert_not_awaited()
+    finally:
+        if not owner_loop.is_closed():
+            owner_loop.call_soon_threadsafe(owner_loop.stop)
+        owner_thread.join(timeout=1.0)
+
+    assert not owner_thread.is_alive()
+    assert owner_errors == []
+    assert close_loops == [owner_loop]
+    client.aclose.assert_awaited_once_with()
+    assert controller._async_client is None
+    assert controller._async_client_loop is None
+    assert controller._async_client_cleanup is None
+
+
+@pytest.mark.asyncio
+async def test_sync_async_client_close_rejects_owner_loop_reentrancy() -> None:
+    owner_loop = asyncio.get_running_loop()
+    client = MagicMock()
+    client.is_closed = False
+    client.aclose = AsyncMock()
+    cleanup = HttpxAsyncClientCleanup(client, owner_loop)
+
+    with pytest.raises(RuntimeError, match="from its owner event loop"):
+        close_httpx_client_from_sync(cleanup)
+
+    client.aclose.assert_not_awaited()

--- a/tests/v2/inference_service/test_startup_failure_lifecycle.py
+++ b/tests/v2/inference_service/test_startup_failure_lifecycle.py
@@ -9,11 +9,12 @@ import httpx
 import pytest
 
 from areal.api.cli_args import InferenceEngineConfig
-from areal.infra.utils.concurrent import run_async_task
+from areal.infra.utils.concurrent import register_loop_cleanup, run_async_task
 from areal.infra.utils.http import (
     HttpxAsyncClientCleanup,
     close_httpx_client_from_sync,
     close_httpx_client_on_owner_loop,
+    register_httpx_client_loop_cleanup,
 )
 from areal.v2.inference_service.controller.controller import RolloutControllerV2
 
@@ -52,6 +53,31 @@ def test_destroy_rejects_open_async_client_after_owner_loop_closed() -> None:
     assert controller._destroyed is False
 
 
+def test_get_async_client_rejects_access_after_destroy() -> None:
+    controller = _controller()
+    controller.destroy()
+    client = MagicMock()
+    client.aclose = AsyncMock()
+    loop = asyncio.new_event_loop()
+    try:
+        with (
+            patch(
+                "areal.v2.inference_service.controller.controller.create_httpx_client",
+                return_value=client,
+            ) as create_client,
+            pytest.raises(RuntimeError, match="has been destroyed"),
+        ):
+            loop.run_until_complete(controller._get_async_client())
+    finally:
+        loop.close()
+
+    create_client.assert_not_called()
+    client.aclose.assert_not_awaited()
+    assert controller._async_client is None
+    assert controller._async_client_loop is None
+    assert controller._async_client_cleanup is None
+
+
 def test_async_client_closes_on_owner_loop_shutdown_before_destroy() -> None:
     controller = _controller()
     client = MagicMock()
@@ -84,6 +110,35 @@ def test_async_client_closes_on_owner_loop_shutdown_before_destroy() -> None:
 
     client.aclose.assert_awaited_once_with()
     assert controller._destroyed is True
+
+
+def test_cancelled_loop_cleanup_preserves_failure_and_runs_later_callbacks() -> None:
+    loop = asyncio.new_event_loop()
+    cancelled = asyncio.CancelledError("transport close cancelled")
+    client = MagicMock()
+    client.aclose = AsyncMock(side_effect=cancelled)
+    cleanup = HttpxAsyncClientCleanup(client, loop)
+    later_callbacks: list[str] = []
+    cleared: list[bool] = []
+
+    # Callbacks run LIFO, so register the observer first and the failing HTTP
+    # cleanup second.  The observer proves that cancellation did not abort the
+    # rest of loop teardown.
+    register_loop_cleanup(lambda: later_callbacks.append("ran"), loop=loop)
+    register_httpx_client_loop_cleanup(cleanup, on_closed=lambda: cleared.append(True))
+    try:
+        loop.close()
+    finally:
+        # Keep the test from leaking an open loop if teardown raises.
+        if not loop.is_closed():
+            loop._cleanup_orig_close()
+
+    assert loop.is_closed()
+    assert later_callbacks == ["ran"]
+    assert cleared == []
+    assert cleanup.succeeded is False
+    assert cleanup.error is cancelled
+    client.aclose.assert_awaited_once_with()
 
 
 def test_sequential_run_async_task_clients_close_on_their_own_loops() -> None:

--- a/tests/v2/training_service/test_controller_unit.py
+++ b/tests/v2/training_service/test_controller_unit.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from areal.api.cli_args import SchedulingSpec, TrainEngineConfig
+from areal.infra.utils.http import HttpxAsyncClientCleanup
 from areal.v2.training_service.controller.controller import (
     GatewayTrainController,
 )
@@ -72,6 +74,80 @@ class _FakeAsyncClient:
 
 
 class TestGatewayTrainControllerInitialization:
+    def test_async_client_closes_on_owner_loop_shutdown(self):
+        controller = _make_controller()
+        client = MagicMock()
+        client.is_closed = False
+        close_loops: list[asyncio.AbstractEventLoop] = []
+
+        async def close_client() -> None:
+            close_loops.append(asyncio.get_running_loop())
+            client.is_closed = True
+
+        client.aclose = AsyncMock(side_effect=close_client)
+        loop = asyncio.new_event_loop()
+        try:
+            with patch(f"{MODULE}.create_httpx_client", return_value=client):
+                assert loop.run_until_complete(controller._get_async_client()) is client
+        finally:
+            loop.close()
+
+        client.aclose.assert_awaited_once_with()
+        assert close_loops == [loop]
+        assert controller._async_client is None
+        assert controller._async_client_loop is None
+        assert controller._async_client_cleanup is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("close_fails", [False, True])
+    async def test_async_startup_rollback_preserves_primary_on_owner_loop(
+        self, close_fails: bool
+    ):
+        worker0 = MagicMock(ip="127.0.0.1", worker_ports=[18000], id="guard-0")
+        worker1 = MagicMock(ip="127.0.0.1", worker_ports=[18001], id="guard-1")
+        scheduler = MagicMock()
+        scheduler.create_workers.return_value = ["guard-0", "guard-1"]
+        scheduler.get_workers.return_value = [worker0, worker1]
+        controller = _make_controller(scheduler)
+        primary = RuntimeError("guard setup failed")
+        cleanup_error = RuntimeError("transport close failed")
+        close_loops: list[asyncio.AbstractEventLoop] = []
+        client = MagicMock()
+
+        async def close_client() -> None:
+            close_loops.append(asyncio.get_running_loop())
+            if close_fails:
+                raise cleanup_error
+
+        client.aclose = AsyncMock(side_effect=close_client)
+        client.post = AsyncMock(side_effect=primary)
+
+        async def _run_in_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with (
+            patch(f"{MODULE}.asyncio.to_thread", side_effect=_run_in_thread),
+            patch(f"{MODULE}.create_httpx_client", return_value=client),
+            patch(f"{MODULE}.register_httpx_client_loop_cleanup"),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            await controller._async_initialize(role="train-role")
+
+        assert exc_info.value is primary
+        client.aclose.assert_awaited_once_with()
+        assert close_loops == [asyncio.get_running_loop()]
+        if close_fails:
+            assert controller._async_client is client
+            assert controller._async_client_cleanup is not None
+            assert any(
+                "transport close failed" in note
+                for note in getattr(primary, "__notes__", [])
+            )
+        else:
+            assert controller._async_client is None
+            assert controller._async_client_loop is None
+            assert controller._async_client_cleanup is None
+
     @pytest.mark.asyncio
     async def test_async_initialize_offloads_scheduler_and_uses_async_helpers(self):
         worker0 = MagicMock(ip="127.0.0.1", worker_ports=[18000], id="guard-0")
@@ -162,3 +238,34 @@ class TestGatewayTrainControllerInitialization:
         assert controller._gateway_addr == "http://127.0.0.1:18080"
         assert controller.api_key is not None
         assert controller.api_key.startswith("ak-train-role-")
+
+
+class TestGatewayTrainControllerLifecycle:
+    def test_destroy_retains_async_client_when_close_fails(self):
+        controller = _make_controller()
+        client = MagicMock()
+        owner_loop = MagicMock()
+        primary = RuntimeError("async transport close failed")
+        cleanup = HttpxAsyncClientCleanup(client, owner_loop)
+        controller._async_client = client
+        controller._async_client_loop = owner_loop
+        controller._async_client_cleanup = cleanup
+
+        with (
+            patch(f"{MODULE}.close_httpx_client_from_sync", side_effect=primary),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            controller.destroy()
+
+        assert exc_info.value is primary
+        assert controller._async_client is client
+        assert controller._async_client_loop is owner_loop
+        assert controller._async_client_cleanup is cleanup
+
+        with patch(f"{MODULE}.close_httpx_client_from_sync") as close_client:
+            controller.destroy()
+
+        close_client.assert_called_once_with(cleanup)
+        assert controller._async_client is None
+        assert controller._async_client_loop is None
+        assert controller._async_client_cleanup is None

--- a/tests/v2/training_service/test_controller_unit.py
+++ b/tests/v2/training_service/test_controller_unit.py
@@ -241,6 +241,27 @@ class TestGatewayTrainControllerInitialization:
 
 
 class TestGatewayTrainControllerLifecycle:
+    @pytest.mark.asyncio
+    async def test_get_async_client_rejects_access_during_shutdown(self):
+        controller = _make_controller()
+        controller.destroy()
+        client = MagicMock()
+        client.aclose = AsyncMock()
+
+        with (
+            patch(
+                f"{MODULE}.create_httpx_client", return_value=client
+            ) as create_client,
+            pytest.raises(RuntimeError, match="is shutting down"),
+        ):
+            await controller._get_async_client()
+
+        create_client.assert_not_called()
+        client.aclose.assert_not_awaited()
+        assert controller._async_client is None
+        assert controller._async_client_loop is None
+        assert controller._async_client_cleanup is None
+
     def test_destroy_retains_async_client_when_close_fails(self):
         controller = _make_controller()
         client = MagicMock()


### PR DESCRIPTION
## Description

V2 rollout and training controllers cache an `httpx.AsyncClient`, while synchronous call sites use `run_async_task`, which creates a fresh event loop through `asyncio.run`. A client could therefore open keep-alive transports on one loop and later be closed on another, making an otherwise successful online-RL run exit non-zero during teardown.

This PR:

- registers client cleanup on the event loop that created the client;
- adds an explicit single-flight `OPEN -> CLOSING -> SUCCEEDED/FAILED` cleanup acknowledgement instead of trusting `AsyncClient.is_closed`;
- makes concurrent close callers share one transport close outcome, including when a follower is cancelled;
- rejects access from a second live event loop instead of closing a client that may still be in use;
- clears controller ownership only after confirmed cleanup and retains stable failures for teardown reporting;
- preserves the primary training-startup error when rollback occurs inside the client owner loop.

Both `RolloutControllerV2` and `GatewayTrainController` use the same owner-loop cleanup contract.

## Related Issue

Fixes #1484

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (not applicable; no user-facing API change)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via an independent code-review pass
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

None.

## Additional Context

Regression coverage includes:

- real HTTP/1.1 keep-alive EOF before a temporary loop exits;
- transport-close failure after HTTPX has already set `client.is_closed=True`;
- single-flight concurrent close and cancelled-follower behavior;
- live foreign-loop rejection and synchronous live-owner-loop close;
- controller failure retention and primary startup-exception preservation.

Validation:

- focused owner-loop regression suite: 17 passed;
- extended controller/infra regression suite: 255 passed, 6 skipped;
- Ruff lint and format checks: passed;
- full pre-commit: passed;
- pinned-image Spark2 online PPO: F2 and F1 trainer, producer, and checkpoint watcher all exited 0; before this fix the completed F2 run exited 1 from `TCPTransport ... handler is closed` during teardown.
