### PR TITLE
feat(infra): support Ray-managed HTTP proxy workers

### DIFF
--- a/areal/infra/rpc/ray_http_worker_manager.py
+++ b/areal/infra/rpc/ray_http_worker_manager.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import getpass
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import ray
+import requests
+
+from areal.infra.utils.proc import kill_process_tree, run_with_streaming_logs
+from areal.utils import logging
+from areal.utils.network import format_hostport, gethostip
+
+logger = logging.getLogger("RayHTTPWorkerManager")
+
+
+class _RayHTTPWorkerManagerImpl:
+    """Ray-managed lifecycle manager for HTTP worker subprocesses.
+
+    This is the RayScheduler counterpart of the Local parent guard's
+    ``/fork`` / ``/kill_forked_worker`` path. The manager actor starts,
+    health-checks, and tears down an existing HTTP server module such as
+    ``areal.experimental.openai.proxy.proxy_rollout_server``. It is lifecycle
+    only: engine/control requests must go directly to the managed HTTP worker
+    endpoint instead of being proxied through this actor.
+    """
+
+    def __init__(self):
+        self._process: subprocess.Popen | None = None
+        self._host: str | None = None
+        self._port: int | None = None
+        self._log_file: str | None = None
+
+    def get_node_id(self) -> str:
+        return ray.get_runtime_context().get_node_id()
+
+    def _read_log_tail(self, lines: int = 80) -> str:
+        if self._log_file is None:
+            return "[No log file was created.]"
+        try:
+            with open(self._log_file) as f:
+                all_lines = f.readlines()
+                return "".join(all_lines[-lines:])
+        except Exception as e:
+            return f"[Could not read log file {self._log_file}: {e}]"
+
+    def _health_url(self) -> str:
+        if self._host is None or self._port is None:
+            raise RuntimeError("HTTP server has not been launched")
+        return f"http://{format_hostport(self._host, self._port)}/health"
+
+    def _get_advertised_host(self, bind_host: str) -> str:
+        if bind_host not in ("0.0.0.0", "::"):
+            return bind_host
+        try:
+            node_ip = ray.util.get_node_ip_address()
+            if node_ip:
+                return str(node_ip)
+        except Exception:
+            pass
+        return gethostip()
+
+    def _wait_ready(self, startup_timeout: float) -> None:
+        deadline = time.time() + startup_timeout
+        last_error = "health check did not run"
+        while time.time() < deadline:
+            if self._process is not None and self._process.poll() is not None:
+                raise RuntimeError(
+                    "HTTP server exited during startup with code "
+                    f"{self._process.returncode}.\nLog tail:\n{self._read_log_tail()}"
+                )
+
+            try:
+                response = requests.get(self._health_url(), timeout=2.0)
+                if response.status_code == 200:
+                    return
+                last_error = f"HTTP {response.status_code}: {response.text[:500]}"
+            except Exception as e:
+                last_error = str(e)
+            time.sleep(0.2)
+
+        raise TimeoutError(
+            f"HTTP server did not become ready within {startup_timeout}s: {last_error}."
+            f"\nLog tail:\n{self._read_log_tail()}"
+        )
+
+    def launch(
+        self,
+        *,
+        module: str,
+        host: str,
+        port: int,
+        experiment_name: str,
+        trial_name: str,
+        role: str,
+        worker_index: int,
+        name_resolve_type: str,
+        nfs_record_root: str,
+        etcd3_addr: str,
+        fileroot: str,
+        env: dict[str, str] | None = None,
+        startup_timeout: float = 30.0,
+    ) -> dict[str, Any]:
+        if self._process is not None and self._process.poll() is None:
+            raise RuntimeError(
+                f"HTTP server is already running at {self._host}:{self._port} "
+                f"(pid={self._process.pid})"
+            )
+
+        advertised_host = self._get_advertised_host(host)
+        self._host = advertised_host
+        self._port = int(port)
+
+        log_dir = (
+            Path(fileroot) / "logs" / getpass.getuser() / experiment_name / trial_name
+        )
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_label = f"{role}-{worker_index}"
+        log_file = log_dir / f"{role}-{worker_index}.log"
+        merged_log = log_dir / "merged.log"
+        self._log_file = str(log_file)
+
+        cmd = [
+            sys.executable,
+            "-m",
+            module,
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--experiment-name",
+            experiment_name,
+            "--trial-name",
+            trial_name,
+            "--role",
+            role,
+            "--worker-index",
+            str(worker_index),
+            "--name-resolve-type",
+            name_resolve_type,
+            "--nfs-record-root",
+            nfs_record_root,
+            "--etcd3-addr",
+            etcd3_addr,
+            "--fileroot",
+            fileroot,
+        ]
+
+        process_env = os.environ.copy()
+        if env:
+            process_env.update({str(k): str(v) for k, v in env.items()})
+
+        logger.info(
+            "Launching HTTP worker %s/%s on %s:%s with module %s",
+            role,
+            worker_index,
+            advertised_host,
+            port,
+            module,
+        )
+        try:
+            self._process = run_with_streaming_logs(
+                cmd,
+                log_file,
+                merged_log,
+                log_label,
+                env=process_env,
+            )
+            self._wait_ready(startup_timeout)
+        except Exception:
+            self.destroy(exit_actor=False)
+            raise
+
+        return {
+            "host": advertised_host,
+            "port": int(port),
+            "pid": self._process.pid,
+            "node_id": self.get_node_id(),
+            "log_file": str(log_file),
+        }
+
+    def ping(self) -> str:
+        if self._process is None:
+            raise RuntimeError("HTTP server has not been launched")
+        if self._process.poll() is not None:
+            raise RuntimeError(
+                "HTTP server process exited with code "
+                f"{self._process.returncode}.\nLog tail:\n{self._read_log_tail()}"
+            )
+        response = requests.get(self._health_url(), timeout=2.0)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"HTTP health check failed with status {response.status_code}: "
+                f"{response.text[:500]}"
+            )
+        return "ok"
+
+    def destroy(self, exit_actor: bool = True) -> None:
+        process = self._process
+        self._process = None
+        if process is not None and process.poll() is None:
+            try:
+                kill_process_tree(process.pid, timeout=5, graceful=True)
+            except Exception as e:
+                logger.warning(
+                    "Failed to gracefully stop HTTP worker process %s: %s",
+                    process.pid,
+                    e,
+                )
+                try:
+                    process.kill()
+                except Exception:
+                    pass
+        if exit_actor:
+            ray.actor.exit_actor()
+
+
+@ray.remote
+class RayHTTPWorkerManager(_RayHTTPWorkerManagerImpl):
+    pass

--- a/areal/infra/rpc/ray_rpc_server.py
+++ b/areal/infra/rpc/ray_rpc_server.py
@@ -72,6 +72,9 @@ class RayRPCServer:
     def ping(self) -> str:
         return "ok"
 
+    def get_node_id(self) -> str:
+        return ray.get_runtime_context().get_node_id()
+
     def alloc_ports(self, count: int):
         ports = find_free_ports(count, exclude_ports=self._allocated_port)
         self._allocated_port.update(ports)

--- a/areal/infra/scheduler/ray.py
+++ b/areal/infra/scheduler/ray.py
@@ -4,16 +4,22 @@ import asyncio
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
+import aiohttp
+import orjson
 import ray
 import ray.exceptions
+import requests
 from ray.runtime_env import RuntimeEnv
 from ray.util.placement_group import (
     PlacementGroup,
     remove_placement_group,
 )
-from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+from ray.util.scheduling_strategies import (
+    NodeAffinitySchedulingStrategy,
+    PlacementGroupSchedulingStrategy,
+)
 
 from areal.api import Job, Scheduler, Worker
 from areal.api.cli_args import (
@@ -21,14 +27,22 @@ from areal.api.cli_args import (
     SchedulingSpec,
     SchedulingStrategyType,
 )
+from areal.infra.rpc.ray_http_worker_manager import RayHTTPWorkerManager
 from areal.infra.rpc.ray_rpc_server import RayRPCServer
+from areal.infra.rpc.serialization import deserialize_value, serialize_value
 from areal.infra.scheduler.exceptions import (
     EngineCallError,
+    EngineCreationError,
+    EngineImportError,
+    RPCConnectionError,
+    SchedulerError,
+    WorkerConfigurationError,
     WorkerCreationError,
     WorkerFailedError,
     WorkerNotFoundError,
     WorkerTimeoutError,
 )
+from areal.infra.utils.http import get_default_connector
 from areal.infra.utils.launcher import get_env_vars, get_thread_env_vars
 from areal.infra.utils.ray import get_placement_group_master_ip_and_port
 from areal.infra.utils.ray_placement_group import (
@@ -39,6 +53,7 @@ from areal.infra.utils.ray_placement_group import (
     ray_resource_type,
 )
 from areal.utils import logging
+from areal.utils.network import format_hostport
 from areal.utils.offload import get_tms_env_vars
 
 logger = logging.getLogger("RayScheduler")
@@ -46,6 +61,17 @@ logger = logging.getLogger("RayScheduler")
 
 @dataclass
 class RayWorkerInfo:
+    """RayScheduler worker metadata.
+
+    For ``ray_rpc`` workers, ``actor`` is the RayRPCServer that serves engine
+    control calls directly over Ray actor RPC.
+
+    For ``http_server`` workers, ``actor`` is the RayHTTPWorkerManager that
+    manages the HTTP subprocess lifecycle; ``worker.ip`` and
+    ``worker.worker_ports[0]`` are the actual ProxyRolloutServer endpoint
+    used for scheduler control calls and agent traffic.
+    """
+
     worker: Worker
     actor: ray.actor.ActorHandle
     role: str
@@ -53,6 +79,9 @@ class RayWorkerInfo:
     bundle_index: int | None
     created_at: float
     env_vars: dict[str, str] = field(default_factory=dict)
+    worker_kind: Literal["ray_rpc", "http_server"] = "ray_rpc"
+    target_worker_id: str | None = None
+    target_node_id: str | None = None
 
 
 class RayScheduler(Scheduler):
@@ -104,9 +133,15 @@ class RayScheduler(Scheduler):
     def _ping_workers(self, role: str, timeout: float | None = None):
         worker_info_list = self._workers[role]
         timeout = timeout if timeout is not None else self.startup_timeout
-        refs = [wi.actor.ping.remote() for wi in worker_info_list]
+        http_workers = [
+            wi for wi in worker_info_list if wi.worker_kind == "http_server"
+        ]
+        for wi in http_workers:
+            self._ping_http_worker(wi, timeout)
 
-        ref_to_worker = {ref: wi for wi, ref in zip(worker_info_list, refs)}
+        ray_workers = [wi for wi in worker_info_list if wi.worker_kind == "ray_rpc"]
+        refs = [wi.actor.ping.remote() for wi in ray_workers]
+        ref_to_worker = {ref: wi for wi, ref in zip(ray_workers, refs)}
 
         pending = refs
         while pending:
@@ -126,6 +161,46 @@ class RayScheduler(Scheduler):
             except ray.exceptions.RayActorError:
                 failed_worker = ref_to_worker[ref]
                 raise WorkerFailedError(failed_worker.worker.id, -1)
+
+    def _ping_http_worker(self, wi: RayWorkerInfo, timeout: float) -> None:
+        """Validate manager/target fate-sharing for managed HTTP workers."""
+        try:
+            if wi.target_worker_id is None or wi.target_node_id is None:
+                raise RuntimeError("HTTP worker is missing target worker metadata")
+            target_wi = self._worker_info_by_id.get(wi.target_worker_id)
+            if target_wi is None:
+                raise RuntimeError(f"Target worker {wi.target_worker_id} not found")
+
+            ray.get(target_wi.actor.ping.remote(), timeout=timeout)
+            target_node_id = ray.get(
+                target_wi.actor.get_node_id.remote(), timeout=timeout
+            )
+            if target_node_id != wi.target_node_id:
+                raise RuntimeError(
+                    f"Target worker moved from node {wi.target_node_id} to "
+                    f"{target_node_id}"
+                )
+
+            launcher_node_id = ray.get(wi.actor.get_node_id.remote(), timeout=timeout)
+            if launcher_node_id != wi.target_node_id:
+                raise RuntimeError(
+                    f"HTTP launcher moved from node {wi.target_node_id} to "
+                    f"{launcher_node_id}"
+                )
+            ray.get(wi.actor.ping.remote(), timeout=timeout)
+        except ray.exceptions.GetTimeoutError as e:
+            self._fail_http_worker(wi, f"health check timed out: {e}")
+        except Exception as e:
+            self._fail_http_worker(wi, str(e))
+
+    def _fail_http_worker(self, wi: RayWorkerInfo, reason: str) -> None:
+        logger.warning("HTTP worker %s failed: %s", wi.worker.id, reason)
+        self._cleanup_forked_workers([wi])
+        self._worker_info_by_id.pop(wi.worker.id, None)
+        workers = self._workers.get(wi.role)
+        if workers is not None:
+            self._workers[wi.role] = [w for w in workers if w.worker.id != wi.worker.id]
+        raise WorkerFailedError(wi.worker.id, -1, reason)
 
     def _build_env_vars(self, spec: SchedulingSpec) -> dict[str, str]:
         """Helper to build environment variables for a worker."""
@@ -344,6 +419,476 @@ class RayScheduler(Scheduler):
         )
 
         return worker_ids
+
+    def _create_managed_http_workers(
+        self,
+        role: str,
+        target_role: str,
+        target_workers: list[RayWorkerInfo],
+        command: str,
+    ) -> list[str]:
+        """Create HTTP workers managed by Ray actors colocated with targets.
+
+        This is the RayScheduler equivalent of LocalScheduler's parent guard
+        ``/fork`` path: it creates a small Ray manager actor on the target
+        Ray node, and that manager owns the HTTP worker subprocess lifecycle.
+        The manager is not a generic RayRPC worker and does not proxy engine
+        control calls; those calls go directly to the HTTP worker endpoint.
+        """
+        if self.exp_config is None:
+            raise WorkerCreationError(
+                role,
+                "Missing experiment config",
+                "Ray HTTP workers require exp_config to pass experiment/trial, "
+                "name_resolve, and fileroot settings to the launched server.",
+            )
+
+        worker_info_list: list[RayWorkerInfo] = []
+        worker_ids: list[str] = []
+        launched_manager_actor: ray.actor.ActorHandle | None = None
+
+        try:
+            name_resolve_config = self.exp_config.cluster.name_resolve
+            for idx, target_wi in enumerate(target_workers):
+                launched_manager_actor = None
+                worker_id = f"{role}/{idx}"
+                target_node_id = ray.get(
+                    target_wi.actor.get_node_id.remote(), timeout=self.startup_timeout
+                )
+                worker_ports = ray.get(
+                    target_wi.actor.alloc_ports.remote(count=1),
+                    timeout=self.startup_timeout,
+                )
+                port = int(worker_ports[0])
+
+                manager_actor = RayHTTPWorkerManager.options(
+                    num_cpus=0,
+                    max_restarts=0,
+                    max_task_retries=0,
+                    name=worker_id,
+                    runtime_env=RuntimeEnv(env_vars=target_wi.env_vars.copy()),
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(
+                        node_id=target_node_id,
+                        soft=False,
+                    ),
+                ).remote()
+                launched_manager_actor = manager_actor
+
+                manager_node_id = ray.get(
+                    manager_actor.get_node_id.remote(), timeout=self.startup_timeout
+                )
+                if manager_node_id != target_node_id:
+                    raise WorkerCreationError(
+                        role,
+                        "HTTP manager placement mismatch",
+                        f"worker={worker_id}, target_node={target_node_id}, "
+                        f"manager_node={manager_node_id}",
+                    )
+
+                launch_info = ray.get(
+                    manager_actor.launch.remote(
+                        module=command,
+                        host="0.0.0.0",
+                        port=port,
+                        experiment_name=str(self.exp_config.experiment_name),
+                        trial_name=str(self.exp_config.trial_name),
+                        role=role,
+                        worker_index=idx,
+                        name_resolve_type=name_resolve_config.type,
+                        nfs_record_root=name_resolve_config.nfs_record_root,
+                        etcd3_addr=name_resolve_config.etcd3_addr,
+                        fileroot=str(self.exp_config.cluster.fileroot),
+                        env=target_wi.env_vars.copy(),
+                        startup_timeout=self.startup_timeout,
+                    ),
+                    timeout=self.startup_timeout + 30.0,
+                )
+
+                http_worker = Worker(
+                    id=worker_id,
+                    ip=str(launch_info["host"]),
+                    worker_ports=[str(launch_info["port"])],
+                    engine_ports=[],
+                )
+                wi = RayWorkerInfo(
+                    worker=http_worker,
+                    actor=manager_actor,
+                    role=role,
+                    placement_group=target_wi.placement_group,
+                    bundle_index=target_wi.bundle_index,
+                    created_at=time.time(),
+                    env_vars=target_wi.env_vars.copy(),
+                    worker_kind="http_server",
+                    target_worker_id=target_wi.worker.id,
+                    target_node_id=target_node_id,
+                )
+                worker_info_list.append(wi)
+                worker_ids.append(worker_id)
+                launched_manager_actor = None
+
+            self._workers[role] = worker_info_list
+            for wi in worker_info_list:
+                self._worker_info_by_id[wi.worker.id] = wi
+
+            self._ping_workers(role, self.startup_timeout)
+
+            for rank, wi in enumerate(worker_info_list):
+                self._configure_http_worker(wi, rank)
+
+        except Exception as e:
+            if launched_manager_actor is not None:
+                try:
+                    ray.get(launched_manager_actor.destroy.remote(), timeout=10.0)
+                except Exception:
+                    try:
+                        ray.kill(launched_manager_actor, no_restart=True)
+                    except Exception:
+                        pass
+            self._cleanup_forked_workers(worker_info_list)
+            self._workers.pop(role, None)
+            for worker_id in worker_ids:
+                self._worker_info_by_id.pop(worker_id, None)
+            if isinstance(e, SchedulerError):
+                raise
+            raise WorkerCreationError(
+                role, "HTTP worker creation failed", str(e)
+            ) from e
+
+        logger.info(
+            f"Role '{role}' forked from '{target_role}': "
+            f"created {len(worker_ids)} HTTP workers with Ray managers"
+        )
+        return worker_ids
+
+    def _http_worker_url(self, wi: RayWorkerInfo, endpoint: str) -> str:
+        port = int(wi.worker.worker_ports[0])
+        return f"http://{format_hostport(wi.worker.ip, port)}{endpoint}"
+
+    def _extract_response_error(self, data: Any) -> str:
+        if isinstance(data, dict):
+            detail = data.get("error") or data.get("detail")
+            if detail is not None:
+                return str(detail)
+        return "Unknown error"
+
+    async def _read_aiohttp_error(self, response: aiohttp.ClientResponse) -> str:
+        try:
+            return self._extract_response_error(await response.json())
+        except Exception:
+            return await response.text()
+
+    def _read_requests_error(self, response: requests.Response) -> str:
+        try:
+            return self._extract_response_error(response.json())
+        except Exception:
+            return response.text
+
+    def _configure_http_worker(self, wi: RayWorkerInfo, worker_rank: int) -> None:
+        if self.exp_config is None:
+            return
+        worker_id = wi.worker.id
+        url = self._http_worker_url(wi, "/configure")
+        try:
+            response = requests.post(
+                url,
+                data=orjson.dumps(
+                    serialize_value(
+                        dict(
+                            config=self.exp_config,
+                            role=wi.role,
+                            rank=worker_rank,
+                        )
+                    )
+                ),
+                headers={"Content-Type": "application/json"},
+                timeout=300.0,
+            )
+            if response.status_code == 200:
+                logger.info(f"Configuration successful on worker '{worker_id}'")
+                return
+            raise WorkerConfigurationError(
+                worker_id,
+                self._read_requests_error(response),
+                str(response.status_code),
+            )
+        except requests.exceptions.ConnectionError as e:
+            port = int(wi.worker.worker_ports[0])
+            raise RPCConnectionError(worker_id, wi.worker.ip, port, str(e)) from e
+        except requests.exceptions.Timeout as e:
+            raise WorkerConfigurationError(worker_id, f"Request timed out: {e}") from e
+
+    async def _set_http_worker_env(
+        self, wi: RayWorkerInfo, env: dict[str, str]
+    ) -> None:
+        """Set environment variables on a real HTTP worker endpoint.
+
+        ``wi.actor`` is only the RayHTTPWorkerManager lifecycle owner. Scheduler
+        control requests must go directly to ``wi.worker.ip:worker_ports[0]``.
+        """
+        worker_id = wi.worker.id
+        port = int(wi.worker.worker_ports[0])
+        url = self._http_worker_url(wi, "/set_env")
+        try:
+            timeout = aiohttp.ClientTimeout(total=30.0)
+            async with aiohttp.ClientSession(
+                timeout=timeout,
+                connector=get_default_connector(),
+            ) as session:
+                async with session.post(
+                    url,
+                    data=orjson.dumps({"env": env}),
+                    headers={"Content-Type": "application/json"},
+                ) as response:
+                    if response.status == 200:
+                        wi.env_vars.update(env)
+                        return
+                    detail = await self._read_aiohttp_error(response)
+                    raise SchedulerError(
+                        f"Failed to set env on worker {worker_id}: "
+                        f"HTTP {response.status}: {detail}"
+                    )
+        except (aiohttp.ClientConnectionError, aiohttp.ClientConnectorError) as e:
+            try:
+                self._ping_http_worker(wi, 5.0)
+            except WorkerFailedError:
+                raise
+            raise RPCConnectionError(worker_id, wi.worker.ip, port, str(e)) from e
+        except TimeoutError as e:
+            raise SchedulerError(f"set_env timed out on worker {worker_id}: {e}") from e
+
+    async def _create_engine_on_http_worker(
+        self,
+        wi: RayWorkerInfo,
+        engine: str,
+        engine_name: str | None,
+        *args,
+        **kwargs,
+    ) -> Any:
+        """Create an engine inside the real HTTP worker endpoint."""
+        worker_id = wi.worker.id
+        if engine_name is None:
+            engine_name = worker_id
+        if not isinstance(engine, str):
+            raise EngineCreationError(
+                worker_id,
+                f"Engine must be a string import path, got {type(engine)}",
+            )
+
+        payload = {
+            "engine": engine,
+            "engine_name": engine_name,
+            "init_args": serialize_value(list(args)),
+            "init_kwargs": serialize_value(kwargs),
+        }
+        port = int(wi.worker.worker_ports[0])
+        url = self._http_worker_url(wi, "/create_engine")
+        try:
+            timeout = aiohttp.ClientTimeout(total=300.0)
+            async with aiohttp.ClientSession(
+                timeout=timeout,
+                read_bufsize=1024 * 1024 * 10,
+                connector=get_default_connector(),
+            ) as session:
+                async with session.post(
+                    url,
+                    data=orjson.dumps(payload),
+                    headers={"Content-Type": "application/json"},
+                ) as response:
+                    if response.status == 200:
+                        result = await response.json()
+                        return result.get("result")
+                    error_detail = await self._read_aiohttp_error(response)
+                    if response.status == 400 and "Failed to import" in error_detail:
+                        raise EngineImportError(engine, error_detail)
+                    raise EngineCreationError(worker_id, error_detail, response.status)
+        except (aiohttp.ClientConnectionError, aiohttp.ClientConnectorError) as e:
+            try:
+                self._ping_http_worker(wi, 5.0)
+            except WorkerFailedError:
+                raise
+            raise RPCConnectionError(worker_id, wi.worker.ip, port, str(e)) from e
+        except TimeoutError as e:
+            raise EngineCreationError(worker_id, f"Request timed out: {e}") from e
+
+    def _call_http_worker_engine(
+        self,
+        wi: RayWorkerInfo,
+        method: str,
+        engine_name: str | None,
+        *args,
+        rpc_meta: dict[str, Any] | None = None,
+        http_timeout: float = 7200.0,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        **kwargs,
+    ) -> Any:
+        """Call an engine method through the real HTTP worker endpoint."""
+        worker_id = wi.worker.id
+        if engine_name is None:
+            engine_name = worker_id
+        payload = {
+            "method": method,
+            "engine_name": engine_name,
+            "args": serialize_value(list(args)),
+            "kwargs": serialize_value(kwargs),
+            "rpc_meta": rpc_meta,
+        }
+        url = self._http_worker_url(wi, "/call")
+        last_error: str | None = None
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                response = requests.post(url, json=payload, timeout=http_timeout)
+                if response.status_code == 200:
+                    result = response.json()
+                    if attempt > 1:
+                        logger.info(
+                            f"Method '{method}' on '{worker_id}' "
+                            f"succeeded after {attempt} attempts"
+                        )
+                    return deserialize_value(result.get("result"))
+
+                error_detail = self._read_requests_error(response)
+                if response.status_code == 503:
+                    last_error = "Service unavailable (503)"
+                elif (
+                    response.status_code == 500
+                    and attempt < max_retries
+                    and "timeout" in error_detail.lower()
+                ):
+                    last_error = f"Engine method timeout: {error_detail}"
+                else:
+                    raise EngineCallError(
+                        worker_id,
+                        method,
+                        f"HTTP {response.status_code}: {error_detail}",
+                        attempt=attempt,
+                    )
+            except requests.exceptions.Timeout as e:
+                last_error = f"Request timeout: {e}"
+            except requests.exceptions.ConnectionError as e:
+                last_error = f"Connection error: {e}"
+                try:
+                    self._ping_http_worker(wi, min(http_timeout, 5.0))
+                except WorkerFailedError:
+                    raise
+            except EngineCallError:
+                raise
+            except Exception as e:
+                last_error = f"Unexpected error: {e}"
+
+            if attempt < max_retries:
+                delay = retry_delay * (2 ** (attempt - 1))
+                logger.warning(
+                    f"Method '{method}' failed on worker '{worker_id}' "
+                    f"(attempt {attempt}/{max_retries}): {last_error}. "
+                    f"Retrying in {delay:.1f}s..."
+                )
+                time.sleep(delay)
+
+        raise EngineCallError(
+            worker_id,
+            method,
+            last_error or "Max retries exceeded",
+            attempt=max_retries,
+        )
+
+    async def _async_call_http_worker_engine(
+        self,
+        wi: RayWorkerInfo,
+        method: str,
+        engine_name: str | None,
+        *args,
+        rpc_meta: dict[str, Any] | None = None,
+        http_timeout: float = 7200.0,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        **kwargs,
+    ) -> Any:
+        """Async-call an engine method through the real HTTP worker endpoint."""
+        worker_id = wi.worker.id
+        if engine_name is None:
+            engine_name = worker_id
+        payload = {
+            "method": method,
+            "engine_name": engine_name,
+            "args": serialize_value(list(args)),
+            "kwargs": serialize_value(kwargs),
+            "rpc_meta": rpc_meta,
+        }
+        url = self._http_worker_url(wi, "/call")
+        last_error: str | None = None
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                timeout = aiohttp.ClientTimeout(
+                    total=http_timeout,
+                    sock_connect=http_timeout,
+                    connect=http_timeout,
+                )
+                async with aiohttp.ClientSession(
+                    timeout=timeout,
+                    read_bufsize=1024 * 1024 * 10,
+                    connector=get_default_connector(),
+                ) as session:
+                    async with session.post(
+                        url,
+                        data=orjson.dumps(payload),
+                        headers={"Content-Type": "application/json"},
+                    ) as response:
+                        if response.status == 200:
+                            result = await response.json()
+                            if attempt > 1:
+                                logger.info(
+                                    f"Method '{method}' on '{worker_id}' "
+                                    f"succeeded after {attempt} attempts"
+                                )
+                            return deserialize_value(result.get("result"))
+
+                        error_detail = await self._read_aiohttp_error(response)
+                        if response.status == 503:
+                            last_error = "Service unavailable (503)"
+                        elif (
+                            response.status == 500
+                            and attempt < max_retries
+                            and "timeout" in error_detail.lower()
+                        ):
+                            last_error = f"Engine method timeout: {error_detail}"
+                        else:
+                            raise EngineCallError(
+                                worker_id,
+                                method,
+                                f"HTTP {response.status}: {error_detail}",
+                                attempt=attempt,
+                            )
+            except (aiohttp.ClientConnectionError, aiohttp.ClientConnectorError) as e:
+                last_error = f"Connection error: {e}"
+                try:
+                    self._ping_http_worker(wi, min(http_timeout, 5.0))
+                except WorkerFailedError:
+                    raise
+            except TimeoutError as e:
+                last_error = f"Request timeout: {e}"
+            except EngineCallError:
+                raise
+            except Exception as e:
+                last_error = f"Unexpected error: {e}"
+
+            if attempt < max_retries:
+                delay = retry_delay * (2 ** (attempt - 1))
+                logger.warning(
+                    f"Method '{method}' failed on worker '{worker_id}' "
+                    f"(attempt {attempt}/{max_retries}): {last_error}. "
+                    f"Retrying in {delay:.1f}s..."
+                )
+                await asyncio.sleep(delay)
+
+        raise EngineCallError(
+            worker_id,
+            method,
+            last_error or "Max retries exceeded",
+            attempt=max_retries,
+        )
 
     def _cleanup_forked_workers(self, workers: list[RayWorkerInfo]):
         """Clean up forked workers without removing placement groups.
@@ -586,6 +1131,14 @@ class RayScheduler(Scheduler):
             del self._colocated_roles[role]
             return
 
+        child_roles = [
+            child_role
+            for child_role, target in list(self._colocated_roles.items())
+            if target == role
+        ]
+        for child_role in child_roles:
+            self.delete_workers(child_role, reverse_order=reverse_order)
+
         if role not in self._workers:
             logger.warning(f"Worker role '{role}' not found, skipping deletion")
             return
@@ -607,27 +1160,37 @@ class RayScheduler(Scheduler):
         target_role: str,
         command: str | None = None,
     ) -> list[str]:
-        """Fork new worker processes from existing workers.
+        """Fork new workers from existing workers.
 
-        Creates new Ray actors colocated with existing workers of the target role.
-        The ``command`` parameter is ignored — Ray actors always run RayRPCServer.
+        Without ``command`` this creates RayRPCServer actors colocated by
+        placement group. With ``command`` this creates manager actors bound to
+        the target actor's Ray node and launches the requested HTTP module as a
+        managed subprocess.
         """
-        if command is not None:
-            logger.warning(
-                f"RayScheduler.fork_workers: 'command' parameter is ignored. "
-                f"Ray actors always use RayRPCServer. Got command='{command}'"
+        if role in self._workers or role in self._colocated_roles:
+            raise WorkerCreationError(
+                role,
+                "Worker group already exists",
+                f"Use delete_workers('{role}') first to remove existing workers.",
             )
 
         if target_role not in self._workers:
             raise WorkerNotFoundError(f"Target role '{target_role}' not found for fork")
         target_workers = self._workers[target_role]
 
+        if command is not None:
+            worker_ids = self._create_managed_http_workers(
+                role, target_role, target_workers, command
+            )
+            self._colocated_roles[role] = target_role
+            return worker_ids
+
         schedulings = []
         for target_wi in target_workers:
             # Use minimal resources for forked workers
             schedulings.append(SchedulingSpec(cpu=0, mem=0, gpu=1, port_count=1))
 
-        worker_ids = self._create_forked_workers(
+        worker_ids = self._create_forked_workers_internal(
             role, target_role, target_workers, schedulings
         )
         self._colocated_roles[role] = target_role
@@ -709,6 +1272,9 @@ class RayScheduler(Scheduler):
             if pg in self._placement_groups:
                 self._placement_groups.remove(pg)
 
+        for wi in workers:
+            self._worker_info_by_id.pop(wi.worker.id, None)
+
     def _get_worker_info_by_id(self, worker_id: str) -> RayWorkerInfo | None:
         return self._worker_info_by_id.get(worker_id, None)
 
@@ -718,6 +1284,9 @@ class RayScheduler(Scheduler):
             raise WorkerNotFoundError(worker_id)
         if not env:
             return
+
+        if wi.worker_kind == "http_server":
+            return await self._set_http_worker_env(wi, env)
 
         await wi.actor.set_env.remote(env)
         wi.env_vars.update(env)
@@ -733,6 +1302,11 @@ class RayScheduler(Scheduler):
         wi = self._get_worker_info_by_id(worker_id)
         if wi is None:
             raise WorkerNotFoundError(worker_id)
+
+        if wi.worker_kind == "http_server":
+            return await self._create_engine_on_http_worker(
+                wi, engine, engine_name, *args, **kwargs
+            )
 
         if not isinstance(engine, str):
             raise WorkerCreationError(
@@ -758,6 +1332,19 @@ class RayScheduler(Scheduler):
         wi = self._get_worker_info_by_id(worker_id)
         if wi is None:
             raise WorkerNotFoundError(worker_id)
+
+        if wi.worker_kind == "http_server":
+            return self._call_http_worker_engine(
+                wi,
+                method,
+                engine_name,
+                *args,
+                rpc_meta=rpc_meta,
+                http_timeout=http_timeout,
+                max_retries=max_retries,
+                retry_delay=retry_delay,
+                **kwargs,
+            )
 
         last_error: str | None = None
 
@@ -818,6 +1405,19 @@ class RayScheduler(Scheduler):
         wi = self._get_worker_info_by_id(worker_id)
         if wi is None:
             raise WorkerNotFoundError(worker_id)
+
+        if wi.worker_kind == "http_server":
+            return await self._async_call_http_worker_engine(
+                wi,
+                method,
+                engine_name,
+                *args,
+                rpc_meta=rpc_meta,
+                http_timeout=http_timeout,
+                max_retries=max_retries,
+                retry_delay=retry_delay,
+                **kwargs,
+            )
 
         last_error: str | None = None
 

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -1404,9 +1404,6 @@ class PPOTrainer:
         if not is_single_controller():
             raise NotImplementedError("Proxy workers not supported in SPMD mode")
 
-        if self.config.scheduler.type == "ray":
-            raise NotImplementedError("Proxy workers not supported with RayScheduler")
-
         if not isinstance(self.rollout, RolloutController):
             self._proxy_started = True
             return

--- a/areal/utils/logging.py
+++ b/areal/utils/logging.py
@@ -46,6 +46,7 @@ LOGGER_COLORS_EXACT = {
     "RayLauncher": "blue",
     "SlurmLauncher": "blue",
     "InfCli": "blue",
+    "RayHTTPWorkerManager": "blue",
     # Workflows - purple
     "RLVRWorkflow": "light_purple",
     "VisionRLVRWorkflow": "light_purple",

--- a/tests/test_ray_http_worker_manager.py
+++ b/tests/test_ray_http_worker_manager.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip("ray")
+
+from areal.infra.rpc import ray_http_worker_manager as rhwm  # noqa: E402
+
+
+class FakeProcess:
+    def __init__(self, *, pid: int = 1234, poll_result: int | None = None):
+        self.pid = pid
+        self.returncode = poll_result
+        self._poll_result = poll_result
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self._poll_result
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def test_launch_uses_worker_indexed_log_file_and_merged_log_label(
+    monkeypatch, tmp_path
+):
+    manager = rhwm._RayHTTPWorkerManagerImpl()
+    process = FakeProcess()
+    run_with_logs = Mock(return_value=process)
+
+    monkeypatch.setattr(rhwm, "run_with_streaming_logs", run_with_logs)
+    monkeypatch.setattr(
+        rhwm._RayHTTPWorkerManagerImpl,
+        "_wait_ready",
+        lambda self, timeout: None,
+    )
+    monkeypatch.setattr(
+        rhwm._RayHTTPWorkerManagerImpl,
+        "get_node_id",
+        lambda self: "node-1",
+    )
+    monkeypatch.setattr(rhwm.ray.util, "get_node_ip_address", lambda: "10.0.0.8")
+
+    launch_info = manager.launch(
+        module="example.module",
+        host="0.0.0.0",
+        port=8080,
+        experiment_name="exp",
+        trial_name="trial",
+        role="proxy",
+        worker_index=1,
+        name_resolve_type="nfs",
+        nfs_record_root="/tmp/records",
+        etcd3_addr="",
+        fileroot=str(tmp_path),
+        env={"A": "B"},
+        startup_timeout=1.0,
+    )
+
+    assert launch_info["host"] == "10.0.0.8"
+    assert launch_info["port"] == 8080
+    assert launch_info["node_id"] == "node-1"
+    assert launch_info["log_file"].endswith("proxy-1.log")
+
+    run_with_logs.assert_called_once()
+    _, log_file, merged_log, log_label = run_with_logs.call_args.args
+    assert log_file.name == "proxy-1.log"
+    assert merged_log.name == "merged.log"
+    assert log_label == "proxy-1"
+    assert run_with_logs.call_args.kwargs["env"]["A"] == "B"
+
+
+def test_get_advertised_host_prefers_ray_node_ip_for_wildcard(monkeypatch):
+    manager = rhwm._RayHTTPWorkerManagerImpl()
+    monkeypatch.setattr(rhwm.ray.util, "get_node_ip_address", lambda: "10.0.0.9")
+
+    assert manager._get_advertised_host("0.0.0.0") == "10.0.0.9"
+    assert manager._get_advertised_host("::") == "10.0.0.9"
+
+
+def test_get_advertised_host_falls_back_to_network_helper(monkeypatch):
+    manager = rhwm._RayHTTPWorkerManagerImpl()
+
+    def raise_ray_error() -> str:
+        raise RuntimeError("ray node ip unavailable")
+
+    monkeypatch.setattr(rhwm.ray.util, "get_node_ip_address", raise_ray_error)
+    monkeypatch.setattr(rhwm, "gethostip", lambda: "10.0.0.10")
+
+    assert manager._get_advertised_host("0.0.0.0") == "10.0.0.10"
+
+
+def test_get_advertised_host_keeps_explicit_host(monkeypatch):
+    manager = rhwm._RayHTTPWorkerManagerImpl()
+    get_node_ip = Mock(return_value="10.0.0.11")
+    monkeypatch.setattr(rhwm.ray.util, "get_node_ip_address", get_node_ip)
+
+    assert manager._get_advertised_host("192.0.2.10") == "192.0.2.10"
+    get_node_ip.assert_not_called()
+
+
+def test_wait_ready_raises_with_log_tail_when_process_exits(tmp_path):
+    log_file = tmp_path / "worker.log"
+    log_file.write_text("first line\nlast line\n")
+
+    manager = rhwm._RayHTTPWorkerManagerImpl()
+    manager._process = FakeProcess(poll_result=12)
+    manager._log_file = str(log_file)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        manager._wait_ready(startup_timeout=1.0)
+
+    message = str(exc_info.value)
+    assert "HTTP server exited during startup with code 12" in message
+    assert "last line" in message
+
+
+def test_wait_ready_timeout_includes_last_health_error_and_log_tail(
+    monkeypatch, tmp_path
+):
+    log_file = tmp_path / "worker.log"
+    log_file.write_text("startup details\n")
+
+    manager = rhwm._RayHTTPWorkerManagerImpl()
+    manager._process = FakeProcess()
+    manager._host = "127.0.0.1"
+    manager._port = 8080
+    manager._log_file = str(log_file)
+
+    times = iter([0.0, 0.0, 1.0])
+    monkeypatch.setattr(rhwm.time, "time", lambda: next(times))
+    monkeypatch.setattr(rhwm.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        rhwm.requests,
+        "get",
+        Mock(side_effect=RuntimeError("connection refused")),
+    )
+
+    with pytest.raises(TimeoutError) as exc_info:
+        manager._wait_ready(startup_timeout=0.1)
+
+    message = str(exc_info.value)
+    assert "connection refused" in message
+    assert "startup details" in message
+
+
+def test_destroy_without_actor_exit_kills_process_tree(monkeypatch):
+    manager = rhwm._RayHTTPWorkerManagerImpl()
+    manager._process = FakeProcess(pid=4321)
+    kill_process_tree = Mock()
+    exit_actor = Mock()
+
+    monkeypatch.setattr(rhwm, "kill_process_tree", kill_process_tree)
+    monkeypatch.setattr(rhwm.ray.actor, "exit_actor", exit_actor)
+
+    manager.destroy(exit_actor=False)
+
+    kill_process_tree.assert_called_once_with(4321, timeout=5, graceful=True)
+    exit_actor.assert_not_called()
+    assert manager._process is None

--- a/tests/test_ray_scheduler_http_proxy.py
+++ b/tests/test_ray_scheduler_http_proxy.py
@@ -1,0 +1,153 @@
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+
+pytest.importorskip("ray")
+
+from areal.api import Worker  # noqa: E402
+from areal.api.cli_args import BaseExperimentConfig  # noqa: E402
+from areal.infra.scheduler import ray as ray_scheduler_mod  # noqa: E402
+from areal.infra.scheduler.ray import RayScheduler, RayWorkerInfo  # noqa: E402
+
+
+def _worker_info(worker_id: str, role: str) -> RayWorkerInfo:
+    return RayWorkerInfo(
+        worker=Worker(id=worker_id, ip="127.0.0.1", worker_ports=["12345"]),
+        actor=Mock(),
+        role=role,
+        placement_group=Mock(),
+        bundle_index=0,
+        created_at=0.0,
+    )
+
+
+def test_fork_workers_with_command_uses_http_creator():
+    scheduler = RayScheduler(exp_config=BaseExperimentConfig())
+    target_wi = _worker_info("rollout/0", "rollout")
+    scheduler._workers["rollout"] = [target_wi]
+
+    command = "areal.experimental.openai.proxy.proxy_rollout_server"
+    with patch.object(
+        scheduler,
+        "_create_managed_http_workers",
+        return_value=["proxy-rollout/0"],
+    ) as create_managed_http:
+        worker_ids = scheduler.fork_workers(
+            role="proxy-rollout",
+            target_role="rollout",
+            command=command,
+        )
+
+    assert worker_ids == ["proxy-rollout/0"]
+    create_managed_http.assert_called_once_with(
+        "proxy-rollout", "rollout", [target_wi], command
+    )
+    assert scheduler._colocated_roles["proxy-rollout"] == "rollout"
+
+
+def test_fork_workers_without_command_keeps_ray_rpc_creator():
+    scheduler = RayScheduler(exp_config=BaseExperimentConfig())
+    target_wi = _worker_info("rollout/0", "rollout")
+    scheduler._workers["rollout"] = [target_wi]
+
+    with patch.object(
+        scheduler,
+        "_create_forked_workers_internal",
+        return_value=["ref/0"],
+    ) as create_ray_rpc:
+        worker_ids = scheduler.fork_workers(role="ref", target_role="rollout")
+
+    assert worker_ids == ["ref/0"]
+    create_ray_rpc.assert_called_once()
+    assert create_ray_rpc.call_args.args[0:3] == ("ref", "rollout", [target_wi])
+    assert scheduler._colocated_roles["ref"] == "rollout"
+
+
+def test_delete_target_role_deletes_http_child_role_first():
+    scheduler = RayScheduler(exp_config=BaseExperimentConfig())
+    target_wi = _worker_info("rollout/0", "rollout")
+    proxy_wi = _worker_info("proxy-rollout/0", "proxy-rollout")
+    proxy_wi.worker_kind = "http_server"
+    proxy_wi.target_worker_id = "rollout/0"
+    proxy_wi.target_node_id = "node-1"
+
+    scheduler._workers["rollout"] = [target_wi]
+    scheduler._workers["proxy-rollout"] = [proxy_wi]
+    scheduler._colocated_roles["proxy-rollout"] = "rollout"
+
+    with (
+        patch.object(scheduler, "_cleanup_forked_workers") as cleanup_forked,
+        patch.object(scheduler, "_cleanup_workers") as cleanup_workers,
+    ):
+        scheduler.delete_workers("rollout")
+
+    cleanup_forked.assert_called_once_with([proxy_wi])
+    cleanup_workers.assert_called_once_with([target_wi])
+    assert "proxy-rollout" not in scheduler._workers
+    assert "proxy-rollout" not in scheduler._colocated_roles
+    assert "rollout" not in scheduler._workers
+
+
+def test_create_engine_on_http_server_worker_posts_to_worker_endpoint():
+    scheduler = RayScheduler(exp_config=BaseExperimentConfig())
+    manager_actor = Mock()
+    manager_actor.create_engine.remote = Mock(
+        side_effect=AssertionError("manager must not proxy create_engine")
+    )
+    worker = RayWorkerInfo(
+        worker=Worker(id="proxy-rollout/0", ip="10.0.0.8", worker_ports=["18080"]),
+        actor=manager_actor,
+        role="proxy-rollout",
+        placement_group=Mock(),
+        bundle_index=0,
+        created_at=0.0,
+        worker_kind="http_server",
+        target_worker_id="rollout/0",
+        target_node_id="node-1",
+    )
+    scheduler._workers["proxy-rollout"] = [worker]
+    scheduler._worker_info_by_id[worker.worker.id] = worker
+
+    post_calls = []
+
+    class FakeResponse:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def json(self):
+            return {"result": "created"}
+
+    class FakeSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, url, **kwargs):
+            post_calls.append((url, kwargs))
+            return FakeResponse()
+
+    with patch.object(ray_scheduler_mod.aiohttp, "ClientSession", FakeSession):
+        result = asyncio.run(
+            scheduler.create_engine(
+                "proxy-rollout/0",
+                "tests.fake.Engine",
+                engine_name="proxy-rollout/0",
+                config={"dummy": True},
+            )
+        )
+
+    assert result == "created"
+    assert post_calls
+    assert post_calls[0][0] == "http://10.0.0.8:18080/create_engine"
+    manager_actor.create_engine.remote.assert_not_called()


### PR DESCRIPTION
## Description

  This PR adds RayScheduler support for command-based HTTP proxy workers used by agent/OpenAI-compatible rollout workflows.

  Previously, `RayScheduler.fork_workers(..., command=...)` ignored the `command` argument, so `RolloutController.start_proxy()` could not launch real proxy rollout servers under Ray. This change introduces Ray-managed HTTP worker managers that
  launch and own proxy subprocesses on the same Ray node as their target rollout workers, while scheduler control calls go directly to the proxy HTTP endpoint.

  Key changes:

  - Add `RayHTTPWorkerManager` to manage HTTP proxy subprocess lifecycle under Ray.
  - Teach `RayScheduler.fork_workers(..., command=...)` to launch managed HTTP workers.
  - Route `create_engine`, `call_engine`, `async_call_engine`, and `set_worker_env` to HTTP endpoints for HTTP workers.
  - Track HTTP worker metadata, target worker/node affinity, and cleanup child proxy roles before parent rollout roles.
  - Allow `PPOTrainer` proxy startup with `RayScheduler`.
  - Add unit coverage for HTTP manager behavior and Ray scheduler proxy contracts.

  ## Related Issue

  Fixes #<issue-number>

  ## Type of Change

  - [ ] 🐛 Bug fix
  - [x] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [ ] ⚡ Performance improvement
  - [x] ✅ Test coverage improvement

  ## Checklist

  - [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
  - [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
  - [x] Relevant tests pass; new tests added for new functionality
  - [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
  - [x] Branch is up to date with `main`
  - [x] Self-reviewed via `/review-pr` command
  - [ ] This PR was created by a coding agent via `/create-pr`
  - [ ] This PR is a breaking change

  **Breaking Change Details (if applicable):**

  Not applicable.

  ## Additional Context

  Validation performed:

  - `uv run pytest tests/test_ray_http_worker_manager.py tests/test_ray_scheduler_http_proxy.py -q`
    - `11 passed`
  - `uv run pre-commit run --files areal/infra/rpc/ray_http_worker_manager.py areal/infra/rpc/ray_rpc_server.py areal/infra/scheduler/ray.py areal/trainer/rl_trainer.py areal/utils/logging.py tests/test_ray_http_worker_manager.py tests/
  test_ray_scheduler_http_proxy.py`
    - passed

Real GPU validation was also performed on a 2-GPU Ray/SGLang setup: two rollout workers, two Ray-managed proxy workers, distinct proxy ports, one-to-one proxy mapping, real SGLang backends, and `rollout_batch()` returned trainable trajectory tensors.
Documentation was not updated because this is an internal scheduler/proxy lifecycle change and does not add or change user-facing configuration.