### PR TITLE
feat(workflow): add stage-1 stepwise reward plumbing

### DIFF
--- a/areal/api/__init__.py
+++ b/areal/api/__init__.py
@@ -3,6 +3,8 @@
 __all__ = [
     "RolloutWorkflow",
     "AsyncRewardWrapper",
+    "RewardResult",
+    "normalize_reward_result",
     "TrainEngine",
     "InferenceEngine",
     "Scheduler",
@@ -49,6 +51,8 @@ _LAZY_IMPORTS = {
     "WorkflowLike": "areal.api.workflow_api",
     "AgentWorkflow": "areal.api.workflow_api",
     "AsyncRewardWrapper": "areal.api.reward_api",
+    "RewardResult": "areal.api.reward_api",
+    "normalize_reward_result": "areal.api.reward_api",
     "RolloutWorkflow": "areal.api.workflow_api",
 }
 

--- a/areal/api/reward_api.py
+++ b/areal/api/reward_api.py
@@ -9,7 +9,7 @@ from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any
+from typing import Any, TypeAlias
 
 from areal.utils import logging
 
@@ -74,8 +74,8 @@ class RewardResult:
         Optional reward value for each process step.
     step_ends:
         Optional 1-based completion-token end offsets for each step. Each entry
-        points to the completion token position where the corresponding
-        ``step_rewards`` value should be injected.
+        points to the completion token whose prediction timestep should receive
+        the corresponding ``step_rewards`` value.
     metadata:
         Optional debug-only payload for logging or inspection. This field is
         not consumed by the trainer in Stage 1.
@@ -87,7 +87,10 @@ class RewardResult:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
-def normalize_reward_result(value: float | RewardResult) -> RewardResult:
+RewardValue: TypeAlias = float | RewardResult
+
+
+def normalize_reward_result(value: RewardValue) -> RewardResult:
     """Normalize legacy scalar rewards into ``RewardResult``.
 
     This keeps existing reward functions working unchanged while allowing new
@@ -178,7 +181,7 @@ class AsyncRewardWrapper:
             logger.info(f"Recreated ProcessPoolExecutor with {max_workers} workers")
             return new_executor
 
-    async def __call__(self, *args, **kwargs) -> float:
+    async def __call__(self, *args, **kwargs) -> RewardValue:
         for attempt in range(self.max_retries + 1):
             executor = self._executors.get(self._executor_key)
             if executor is None:

--- a/areal/api/reward_api.py
+++ b/areal/api/reward_api.py
@@ -7,7 +7,9 @@ import threading
 from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
+from dataclasses import dataclass, field
 from functools import partial
+from typing import Any
 
 from areal.utils import logging
 
@@ -57,6 +59,44 @@ def reward_fn(
         Any other attributes in the dataset will be passed as keyword arguments to this function.
     :rtype: float
     """
+
+
+@dataclass
+class RewardResult:
+    """Structured reward payload for workflows that expose process rewards.
+
+    Parameters
+    ----------
+    final_reward:
+        Sequence-level terminal reward. This is the compatibility anchor used
+        by existing workflows and PPO code paths.
+    step_rewards:
+        Optional reward value for each process step.
+    step_ends:
+        Optional 1-based completion-token end offsets for each step. Each entry
+        points to the completion token position where the corresponding
+        ``step_rewards`` value should be injected.
+    metadata:
+        Optional debug-only payload for logging or inspection. This field is
+        not consumed by the trainer in Stage 1.
+    """
+
+    final_reward: float
+    step_rewards: list[float] | None = None
+    step_ends: list[int] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def normalize_reward_result(value: float | RewardResult) -> RewardResult:
+    """Normalize legacy scalar rewards into ``RewardResult``.
+
+    This keeps existing reward functions working unchanged while allowing new
+    implementations to return a structured process-reward payload.
+    """
+
+    if isinstance(value, RewardResult):
+        return value
+    return RewardResult(final_reward=float(value))
 
 
 class AsyncRewardWrapper:

--- a/areal/api/reward_api.py
+++ b/areal/api/reward_api.py
@@ -71,7 +71,11 @@ class RewardResult:
         Sequence-level terminal reward. This is the compatibility anchor used
         by existing workflows and PPO code paths.
     step_rewards:
-        Optional reward value for each process step.
+        Optional additive reward increment for each process step, expressed in
+        the same raw units as ``final_reward``. Increments with the same
+        ``step_end`` are summed at their aligned reward timestep before PPO
+        applies ``reward_scaling`` and ``reward_clip``. Sequence-level reward
+        bias and ``reward_norm`` do not apply to process increments.
     step_ends:
         Optional 1-based completion-token end offsets for each step. Each entry
         points to the completion token whose prediction timestep should receive

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -210,6 +210,16 @@ class PPOActor:
         seq_no_eos_mask = seqlens == attn_mask.shape[1]
         rewards = -self.kl_ctl * self.kl_estimator(old_logp, ref_logp)
         kl_rewards = rewards.clone()
+        step_rewards = data.get("step_rewards")
+        step_reward_mask = data.get("step_reward_mask")
+        if step_rewards is not None:
+            if step_reward_mask is None:
+                raise ValueError(
+                    "step_reward_mask is required when step_rewards is provided"
+                )
+            rewards = rewards + step_rewards.to(rewards.dtype) * step_reward_mask.to(
+                rewards.dtype
+            )
         # KL rewards at the next token after eos is zero.
         rewards[batch_indices, seqlens - 1] = 0
         indices = torch.clip(seqlens - 2, min=0)
@@ -306,6 +316,15 @@ class PPOActor:
             final_reward=data["tot_rewards"],
         )
         stats_tracker.stat(**stats, denominator="n_valid_tokens")
+        if step_rewards is not None and step_reward_mask is not None:
+            step_reward_values = step_rewards.float() * step_reward_mask.float()
+            stats_tracker.stat(
+                step_reward=step_reward_values,
+                denominator="n_valid_tokens",
+            )
+            stats_tracker.scalar(
+                step_reward_events=float(step_reward_mask.sum().item()),
+            )
 
         prompt_lens = data["attention_mask"].sum(-1) - data["loss_mask"].sum(-1)
         seq_stats = dict(

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -217,8 +217,12 @@ class PPOActor:
                 raise ValueError(
                     "step_reward_mask is required when step_rewards is provided"
                 )
-            rewards = rewards + step_rewards.to(rewards.dtype) * step_reward_mask.to(
-                rewards.dtype
+            rewards = rewards + step_rewards.to(
+                device=rewards.device,
+                dtype=rewards.dtype,
+            ) * step_reward_mask.to(
+                device=rewards.device,
+                dtype=rewards.dtype,
             )
         # KL rewards at the next token after eos is zero.
         rewards[batch_indices, seqlens - 1] = 0
@@ -316,6 +320,8 @@ class PPOActor:
             final_reward=data["tot_rewards"],
         )
         stats_tracker.stat(**stats, denominator="n_valid_tokens")
+        step_rewards = data.get("step_rewards")
+        step_reward_mask = data.get("step_reward_mask")
         if step_rewards is not None and step_reward_mask is not None:
             step_reward_values = step_rewards.float() * step_reward_mask.float()
             stats_tracker.stat(

--- a/areal/trainer/ppo/actor.py
+++ b/areal/trainer/ppo/actor.py
@@ -152,7 +152,13 @@ class PPOActor:
         batch_indices = torch.arange(
             bs, device=data["input_ids"].device, dtype=torch.long
         )
-
+        step_rewards = data.get("step_rewards")
+        step_reward_mask = data.get("step_reward_mask")
+        if (step_rewards is None) != (step_reward_mask is None):
+            raise ValueError(
+                "step_rewards and step_reward_mask must either both be provided "
+                "or both be absent"
+            )
         # Reward Penalty on length
         if self.config.overlong_reward_penalty:
             overlong_tokens = self.config.overlong_tokens
@@ -210,20 +216,35 @@ class PPOActor:
         seq_no_eos_mask = seqlens == attn_mask.shape[1]
         rewards = -self.kl_ctl * self.kl_estimator(old_logp, ref_logp)
         kl_rewards = rewards.clone()
-        step_rewards = data.get("step_rewards")
-        step_reward_mask = data.get("step_reward_mask")
         if step_rewards is not None:
-            if step_reward_mask is None:
-                raise ValueError(
-                    "step_reward_mask is required when step_rewards is provided"
-                )
-            rewards = rewards + step_rewards.to(
+            assert step_reward_mask is not None
+            step_reward_mask = step_reward_mask.to(
                 device=rewards.device,
-                dtype=rewards.dtype,
-            ) * step_reward_mask.to(
+                dtype=torch.bool,
+            )
+            step_rewards = step_rewards.to(
                 device=rewards.device,
                 dtype=rewards.dtype,
             )
+            data["step_rewards"] = step_rewards
+            data["step_reward_mask"] = step_reward_mask
+            processed_step_rewards = torch.where(
+                step_reward_mask,
+                step_rewards,
+                0.0,
+            )
+            # Process rewards are additive deltas, so sequence-level reward_bias
+            # and group normalization do not apply to each individual event.
+            processed_step_rewards = torch.clip(
+                processed_step_rewards * self.reward_scaling,
+                max=self.reward_clip,
+                min=-self.reward_clip,
+            )
+            if self.mask_no_eos_with_zero:
+                processed_step_rewards = torch.where(
+                    seq_no_eos_mask.unsqueeze(-1), 0.0, processed_step_rewards
+                )
+            rewards = rewards + processed_step_rewards
         # KL rewards at the next token after eos is zero.
         rewards[batch_indices, seqlens - 1] = 0
         indices = torch.clip(seqlens - 2, min=0)
@@ -282,6 +303,23 @@ class PPOActor:
         attn_mask = data["attention_mask"]
         loss_mask = data["loss_mask"]
         reward_score = data["rewards"]
+        step_rewards = data.pop("step_rewards", None)
+        step_reward_mask = data.pop("step_reward_mask", None)
+        if (step_rewards is None) != (step_reward_mask is None):
+            raise ValueError(
+                "step_rewards and step_reward_mask must either both be provided "
+                "or both be absent"
+            )
+        if step_rewards is not None:
+            assert step_reward_mask is not None
+            step_rewards = step_rewards.to(
+                device=loss_mask.device,
+                dtype=torch.float32,
+            )
+            step_reward_mask = step_reward_mask.to(
+                device=loss_mask.device,
+                dtype=torch.bool,
+            )
         seqlens = attn_mask.sum(-1)
 
         ########## Logging code starts ##########
@@ -289,6 +327,8 @@ class PPOActor:
             "correct_n_seqs": (reward_score > 0).bool(),
             "incorrect_n_seqs": (reward_score <= 0).bool(),
         }
+        if step_reward_mask is not None:
+            result_denominators["step_reward_events"] = step_reward_mask
         if self.config.log_agent_stats:
             if "begin_of_trajectory" not in data:
                 raise RuntimeError(
@@ -320,16 +360,12 @@ class PPOActor:
             final_reward=data["tot_rewards"],
         )
         stats_tracker.stat(**stats, denominator="n_valid_tokens")
-        step_rewards = data.get("step_rewards")
-        step_reward_mask = data.get("step_reward_mask")
-        if step_rewards is not None and step_reward_mask is not None:
-            step_reward_values = step_rewards.float() * step_reward_mask.float()
+        if step_rewards is not None:
+            assert step_reward_mask is not None
+            step_reward_values = torch.where(step_reward_mask, step_rewards, 0.0)
             stats_tracker.stat(
                 step_reward=step_reward_values,
-                denominator="n_valid_tokens",
-            )
-            stats_tracker.scalar(
-                step_reward_events=float(step_reward_mask.sum().item()),
+                denominator="step_reward_events",
             )
 
         prompt_lens = data["attention_mask"].sum(-1) - data["loss_mask"].sum(-1)

--- a/areal/workflow/rlvr.py
+++ b/areal/workflow/rlvr.py
@@ -116,11 +116,11 @@ class RLVRWorkflow(RolloutWorkflow):
     @session_context()
     async def _collect_samples(
         self,
-        engine: "InferenceEngine",
+        engine: InferenceEngine,
         req: ModelRequest,
         prompt_str: str,
         task_data: dict[str, Any],
-    ) -> tuple["ModelResponse", RewardResult]:
+    ) -> tuple[ModelResponse, RewardResult]:
         """Generate one sample and compute its reward.
 
         Registers a new session for this sample, calls engine.agenerate,
@@ -153,7 +153,7 @@ class RLVRWorkflow(RolloutWorkflow):
     def _build_stepwise_reward_tensors(
         self,
         reward: RewardResult,
-        resp: "ModelResponse",
+        resp: ModelResponse,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Convert stepwise rewards into completion-aligned tensors.
 
@@ -197,7 +197,7 @@ class RLVRWorkflow(RolloutWorkflow):
         return step_rewards, step_reward_mask
 
     async def arun_episode(
-        self, engine: "InferenceEngine", data: dict[str, Any]
+        self, engine: InferenceEngine, data: dict[str, Any]
     ) -> dict[str, torch.Tensor]:
         # NOTE: load reward function dynamically if given as string
         if isinstance(self.reward_fn, str):
@@ -229,7 +229,6 @@ class RLVRWorkflow(RolloutWorkflow):
         step_rewards, step_reward_mask = self._build_stepwise_reward_tensors(
             reward, resp
         )
-
         res = {
             "input_ids": torch.tensor(seq, dtype=torch.int32),
             "loss_mask": torch.tensor(loss_mask, dtype=torch.int32),

--- a/areal/workflow/rlvr.py
+++ b/areal/workflow/rlvr.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Callable
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -12,10 +11,12 @@ from transformers import PreTrainedTokenizerFast
 
 from areal.api import (
     AsyncRewardWrapper,
+    ModelRequest,
     RewardResult,
     RolloutWorkflow,
     normalize_reward_result,
 )
+from areal.api.cli_args import GenerationHyperparameters
 from areal.utils import logging
 from areal.utils.dynamic_import import import_from_string
 from areal.utils.hf_utils import apply_chat_template
@@ -30,15 +31,6 @@ if TYPE_CHECKING:
     from areal.api.io_struct import ModelResponse
 
 logger = logging.getLogger("RLVRWorkflow")
-
-
-@dataclass
-class _WorkflowModelRequest:
-    rid: str
-    input_ids: list[int]
-    gconfig: Any
-    tokenizer: PreTrainedTokenizerFast | None = None
-    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 def default_get_input_ids_fn(
@@ -65,7 +57,7 @@ class RLVRWorkflow(RolloutWorkflow):
     def __init__(
         self,
         reward_fn: Callable[..., Any] | str,
-        gconfig: Any,
+        gconfig: GenerationHyperparameters,
         tokenizer: PreTrainedTokenizerFast | str,
         enable_thinking: bool = False,
         get_input_ids_fn: Callable[[Any, PreTrainedTokenizerFast, bool], list[int]]
@@ -125,7 +117,7 @@ class RLVRWorkflow(RolloutWorkflow):
     async def _collect_samples(
         self,
         engine: "InferenceEngine",
-        req: _WorkflowModelRequest,
+        req: ModelRequest,
         prompt_str: str,
         task_data: dict[str, Any],
     ) -> tuple["ModelResponse", RewardResult]:
@@ -166,8 +158,9 @@ class RLVRWorkflow(RolloutWorkflow):
         """Convert stepwise rewards into completion-aligned tensors.
 
         Returns tensors of shape ``[seqlen]`` aligned to the full prompt +
-        completion sequence. Reward values are injected at the completion token
-        positions indicated by ``reward.step_ends``.
+        completion sequence. Reward values are injected at the PPO reward
+        timesteps that correspond to predicting the completion token indicated
+        by ``reward.step_ends``.
         """
 
         seq_len = resp.input_len + resp.output_len
@@ -192,7 +185,12 @@ class RLVRWorkflow(RolloutWorkflow):
                 raise ValueError(
                     f"Invalid step_end={step_end}; expected 1 <= step_end <= {completion_len}"
                 )
-            seq_index = resp.input_len + step_end - 1
+            seq_index = resp.input_len + step_end - 2
+            if seq_index < 0:
+                raise ValueError(
+                    f"Invalid aligned step index for step_end={step_end}; "
+                    "reward injection requires at least one conditioning token"
+                )
             step_rewards[seq_index] += float(step_reward)
             step_reward_mask[seq_index] = True
 
@@ -211,7 +209,7 @@ class RLVRWorkflow(RolloutWorkflow):
             self.tokenizer,
             self.enable_thinking,
         )
-        req = _WorkflowModelRequest(
+        req = ModelRequest(
             rid=uuid.uuid4().hex,
             input_ids=input_ids,
             gconfig=self.gconfig.new(n_samples=1),

--- a/areal/workflow/rlvr.py
+++ b/areal/workflow/rlvr.py
@@ -1,22 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import uuid
 from collections.abc import Callable
-from typing import Any
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
 
 import torch
 from transformers import PreTrainedTokenizerFast
 
-from areal import workflow_context
 from areal.api import (
     AsyncRewardWrapper,
-    InferenceEngine,
-    ModelRequest,
-    ModelResponse,
+    RewardResult,
     RolloutWorkflow,
+    normalize_reward_result,
 )
-from areal.api.cli_args import GenerationHyperparameters
-from areal.utils import logging, stats_tracker
+from areal.utils import logging
 from areal.utils.dynamic_import import import_from_string
 from areal.utils.hf_utils import apply_chat_template
 from areal.utils.perf_tracer import (
@@ -25,7 +25,20 @@ from areal.utils.perf_tracer import (
     trace_session,
 )
 
+if TYPE_CHECKING:
+    from areal.api.engine_api import InferenceEngine
+    from areal.api.io_struct import ModelResponse
+
 logger = logging.getLogger("RLVRWorkflow")
+
+
+@dataclass
+class _WorkflowModelRequest:
+    rid: str
+    input_ids: list[int]
+    gconfig: Any
+    tokenizer: PreTrainedTokenizerFast | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 def default_get_input_ids_fn(
@@ -52,7 +65,7 @@ class RLVRWorkflow(RolloutWorkflow):
     def __init__(
         self,
         reward_fn: Callable[..., Any] | str,
-        gconfig: GenerationHyperparameters,
+        gconfig: Any,
         tokenizer: PreTrainedTokenizerFast | str,
         enable_thinking: bool = False,
         get_input_ids_fn: Callable[[Any, PreTrainedTokenizerFast, bool], list[int]]
@@ -86,7 +99,7 @@ class RLVRWorkflow(RolloutWorkflow):
         resp: ModelResponse,
         prompt_str: str,
         task_data: dict[str, Any],
-    ) -> float:
+    ) -> RewardResult:
         """Decode completion and compute reward.
 
         Traces reward phase execution for SessionTracer. Decodes output tokens
@@ -94,8 +107,8 @@ class RLVRWorkflow(RolloutWorkflow):
 
         Returns
         -------
-        float
-            Reward value.
+        RewardResult
+            Reward payload.
         """
         completions_str = self.tokenizer.decode(resp.output_tokens)
         reward = await self.async_reward_fn(
@@ -106,16 +119,16 @@ class RLVRWorkflow(RolloutWorkflow):
             **task_data,
         )
 
-        return reward
+        return normalize_reward_result(reward)
 
     @session_context()
     async def _collect_samples(
         self,
-        engine: InferenceEngine,
-        req: ModelRequest,
+        engine: "InferenceEngine",
+        req: _WorkflowModelRequest,
         prompt_str: str,
         task_data: dict[str, Any],
-    ) -> tuple[ModelResponse, float]:
+    ) -> tuple["ModelResponse", RewardResult]:
         """Generate one sample and compute its reward.
 
         Registers a new session for this sample, calls engine.agenerate,
@@ -124,20 +137,69 @@ class RLVRWorkflow(RolloutWorkflow):
 
         Returns
         -------
-        tuple[ModelResponse, float]
-            Model response and reward value.
+        tuple[ModelResponse, RewardResult]
+            Model response and reward payload.
         """
         async with atrace_session_phase("generate"):
             resp = await engine.agenerate(req)
 
         reward = await self._compute_rewards(resp, prompt_str, task_data)
 
-        stats_tracker.get(workflow_context.stat_scope()).scalar(reward=reward)
+        from areal.infra import workflow_context
+        from areal.utils import stats_tracker
+
+        tracker = stats_tracker.get(workflow_context.stat_scope())
+        tracker.scalar(reward=reward.final_reward)
+        if reward.step_rewards is not None:
+            tracker.scalar(
+                step_reward_count=len(reward.step_rewards),
+                step_reward_sum=float(sum(reward.step_rewards)),
+            )
 
         return resp, reward
 
+    def _build_stepwise_reward_tensors(
+        self,
+        reward: RewardResult,
+        resp: "ModelResponse",
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Convert stepwise rewards into completion-aligned tensors.
+
+        Returns tensors of shape ``[seqlen]`` aligned to the full prompt +
+        completion sequence. Reward values are injected at the completion token
+        positions indicated by ``reward.step_ends``.
+        """
+
+        seq_len = resp.input_len + resp.output_len
+        step_rewards = torch.zeros(seq_len, dtype=torch.float32)
+        step_reward_mask = torch.zeros(seq_len, dtype=torch.bool)
+
+        if reward.step_rewards is None and reward.step_ends is None:
+            return step_rewards, step_reward_mask
+        if reward.step_rewards is None or reward.step_ends is None:
+            raise ValueError(
+                "step_rewards and step_ends must either both be provided or both be None"
+            )
+        if len(reward.step_rewards) != len(reward.step_ends):
+            raise ValueError(
+                "step_rewards and step_ends must have the same length, got "
+                f"{len(reward.step_rewards)} and {len(reward.step_ends)}"
+            )
+
+        completion_len = resp.output_len
+        for step_reward, step_end in zip(reward.step_rewards, reward.step_ends):
+            if step_end <= 0 or step_end > completion_len:
+                raise ValueError(
+                    f"Invalid step_end={step_end}; expected 1 <= step_end <= {completion_len}"
+                )
+            seq_index = resp.input_len + step_end - 1
+            step_rewards[seq_index] += float(step_reward)
+            step_reward_mask[seq_index] = True
+
+        return step_rewards, step_reward_mask
+
     async def arun_episode(
-        self, engine: InferenceEngine, data: dict[str, Any]
+        self, engine: "InferenceEngine", data: dict[str, Any]
     ) -> dict[str, torch.Tensor]:
         # NOTE: load reward function dynamically if given as string
         if isinstance(self.reward_fn, str):
@@ -149,7 +211,7 @@ class RLVRWorkflow(RolloutWorkflow):
             self.tokenizer,
             self.enable_thinking,
         )
-        req = ModelRequest(
+        req = _WorkflowModelRequest(
             rid=uuid.uuid4().hex,
             input_ids=input_ids,
             gconfig=self.gconfig.new(n_samples=1),
@@ -166,6 +228,9 @@ class RLVRWorkflow(RolloutWorkflow):
         logprobs = [0.0] * resp.input_len + resp.output_logprobs
         loss_mask = [0] * resp.input_len + [1] * resp.output_len
         versions = [-1] * resp.input_len + resp.output_versions
+        step_rewards, step_reward_mask = self._build_stepwise_reward_tensors(
+            reward, resp
+        )
 
         res = {
             "input_ids": torch.tensor(seq, dtype=torch.int32),
@@ -173,6 +238,8 @@ class RLVRWorkflow(RolloutWorkflow):
             "logprobs": torch.tensor(logprobs, dtype=torch.float32),
             "versions": torch.tensor(versions, dtype=torch.int32),
             "attention_mask": torch.ones(len(seq), dtype=torch.bool),
-            "rewards": torch.tensor(reward, dtype=torch.float32),
+            "rewards": torch.tensor(reward.final_reward, dtype=torch.float32),
+            "step_rewards": step_rewards,
+            "step_reward_mask": step_reward_mask,
         }
         return {k: v.unsqueeze(0) for k, v in res.items()}

--- a/tests/test_stepwise_reward_stage1.py
+++ b/tests/test_stepwise_reward_stage1.py
@@ -11,6 +11,8 @@ import torch
 
 from areal.api.reward_api import normalize_reward_result
 from areal.api.reward_api import RewardResult
+from areal.api.io_struct import ModelRequest
+from areal.trainer.ppo.actor import PPOActor
 
 
 @contextlib.asynccontextmanager
@@ -110,13 +112,15 @@ class _DummyModelResponse:
 
 class _DummyEngine:
     async def agenerate(self, req):
+        assert isinstance(req, ModelRequest)
+        copied_req = req.copy()
         return _DummyModelResponse(
-            input_tokens=req.input_ids,
+            input_tokens=copied_req.input_ids,
             output_tokens=[11, 12, 13, 14],
             output_logprobs=[-0.1, -0.2, -0.3, -0.4],
             output_versions=[1, 1, 1, 1],
             stop_reason="stop",
-            tokenizer=req.tokenizer,
+            tokenizer=copied_req.tokenizer,
         )
 
 
@@ -193,10 +197,10 @@ class TestRLVRWorkflowStepwiseReward:
 
         assert torch.equal(result["rewards"], torch.tensor([0.5], dtype=torch.float32))
         expected_step_rewards = torch.tensor(
-            [[0.0, 0.0, 0.0, 0.2, 0.0, -0.1]], dtype=torch.float32
+            [[0.0, 0.0, 0.2, 0.0, -0.1, 0.0]], dtype=torch.float32
         )
         expected_mask = torch.tensor(
-            [[False, False, False, True, False, True]], dtype=torch.bool
+            [[False, False, True, False, True, False]], dtype=torch.bool
         )
         assert torch.equal(result["step_rewards"], expected_step_rewards)
         assert torch.equal(result["step_reward_mask"], expected_mask)
@@ -213,3 +217,137 @@ class TestRLVRWorkflowStepwiseReward:
 
         with pytest.raises(ValueError, match="Invalid step_end"):
             await workflow.arun_episode(_DummyEngine(), {"messages": []})
+
+
+class _DummyStatsTracker:
+    def __init__(self):
+        self.denominators = []
+        self.stats = []
+        self.scalars = []
+
+    def denominator(self, **kwargs):
+        self.denominators.append(kwargs)
+
+    def stat(self, **kwargs):
+        self.stats.append(kwargs)
+
+    def scalar(self, **kwargs):
+        self.scalars.append(kwargs)
+
+    @contextlib.contextmanager
+    def scope(self, _name):
+        yield
+
+
+class _DummyEngineForPPO:
+    def train(self):
+        return None
+
+    def get_version(self):
+        return 0
+
+    def train_batch(self, *args, **kwargs):
+        return {}
+
+
+class _DummyRewardNorm:
+    def __call__(self, x, group_sizes=None):
+        del group_sizes
+        return x
+
+
+class _DummyKL:
+    def __call__(self, old_logp, ref_logp):
+        del old_logp, ref_logp
+        return torch.zeros_like(old_logp)
+
+
+def _build_actor_for_test():
+    actor = PPOActor.__new__(PPOActor)
+    actor.reward_bias = 0.0
+    actor.reward_scaling = 1.0
+    actor.reward_clip = 10.0
+    actor.reward_norm = _DummyRewardNorm()
+    actor.adv_norm = None
+    actor.kl_ctl = 0.0
+    actor.kl_estimator = _DummyKL()
+    actor.discount = 1.0
+    actor.gae_lambda = 1.0
+    actor.mask_no_eos_with_zero = False
+    actor.engine = _DummyEngineForPPO()
+    actor.config = types.SimpleNamespace(
+        overlong_reward_penalty=False,
+        overlong_tokens=None,
+        overlong_penalty_factor=None,
+        use_decoupled_loss=False,
+        recompute_logprob=False,
+        log_agent_stats=False,
+        ppo_n_minibatches=1,
+        eps_clip=0.2,
+        c_clip=None,
+        rejection_sampling=None,
+        importance_sampling_level="token",
+        prox_logp_method="recompute",
+        use_sapo_loss=False,
+        sapo_tau_pos=1.0,
+        sapo_tau_neg=1.05,
+        use_cispo_loss=False,
+    )
+    return actor
+
+
+class TestPPOActorStepwiseReward:
+    def test_compute_advantages_keeps_final_step_reward(self, monkeypatch):
+        actor = _build_actor_for_test()
+        data = {
+            "input_ids": torch.tensor([[101, 102, 11, 12, 13, 14]], dtype=torch.int32),
+            "attention_mask": torch.ones((1, 6), dtype=torch.bool),
+            "loss_mask": torch.tensor([[0, 0, 1, 1, 1, 1]], dtype=torch.int32),
+            "logprobs": torch.zeros((1, 6), dtype=torch.float32),
+            "rewards": torch.tensor([0.5], dtype=torch.float32),
+            "step_rewards": torch.tensor(
+                [[0.0, 0.0, 0.2, 0.0, -0.1, 0.0]], dtype=torch.float32
+            ),
+            "step_reward_mask": torch.tensor(
+                [[False, False, True, False, True, False]], dtype=torch.bool
+            ),
+        }
+
+        result = actor._compute_advantages(data)
+
+        expected_tot_rewards = torch.tensor(
+            [[0.0, 0.0, 0.2, 0.0, 0.4, 0.0]], dtype=torch.float32
+        )
+        assert torch.equal(result["tot_rewards"], expected_tot_rewards)
+
+    def test_ppo_update_reads_stepwise_rewards_from_batch(self, monkeypatch):
+        actor = _build_actor_for_test()
+        tracker = _DummyStatsTracker()
+        monkeypatch.setattr("areal.trainer.ppo.actor.stats_tracker", tracker)
+        monkeypatch.setattr(
+            "areal.trainer.ppo.actor.split_padded_tensor_dict_into_mb_list",
+            lambda data, mb_spec: types.SimpleNamespace(mbs=[data]),
+        )
+
+        data = {
+            "input_ids": torch.tensor([[101, 102, 11, 12]], dtype=torch.int32),
+            "attention_mask": torch.ones((1, 4), dtype=torch.bool),
+            "loss_mask": torch.tensor([[0.0, 0.0, 1.0, 1.0]], dtype=torch.float32),
+            "rewards": torch.tensor([0.5], dtype=torch.float32),
+            "advantages": torch.zeros((1, 4), dtype=torch.float32),
+            "kl_rewards": torch.zeros((1, 4), dtype=torch.float32),
+            "tot_rewards": torch.zeros((1, 4), dtype=torch.float32),
+            "step_rewards": torch.tensor([[0.0, 0.2, 0.0, 0.0]], dtype=torch.float32),
+            "step_reward_mask": torch.tensor(
+                [[False, True, False, False]], dtype=torch.bool
+            ),
+            "logprobs": torch.zeros((1, 4), dtype=torch.float32),
+            "versions": torch.zeros((1, 4), dtype=torch.int32),
+        }
+
+        actor._ppo_update(data)
+
+        assert any("step_reward" in stat for stat in tracker.stats)
+        assert any(
+            scalar.get("step_reward_events") == 1.0 for scalar in tracker.scalars
+        )

--- a/tests/test_stepwise_reward_stage1.py
+++ b/tests/test_stepwise_reward_stage1.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextlib
+import sys
+import types
+
+import pytest
+import torch
+
+from areal.api.reward_api import normalize_reward_result
+from areal.api.reward_api import RewardResult
+
+
+@contextlib.asynccontextmanager
+async def _dummy_atrace_session_phase(_name):
+    yield
+
+
+def _dummy_trace_session(_name):
+    def decorator(fn):
+        return fn
+
+    return decorator
+
+
+def _dummy_session_context():
+    def decorator(fn):
+        return fn
+
+    return decorator
+
+
+_perf_tracer_stub = types.ModuleType("areal.utils.perf_tracer")
+_perf_tracer_stub.atrace_session_phase = _dummy_atrace_session_phase
+_perf_tracer_stub.trace_session = _dummy_trace_session
+_perf_tracer_stub.session_context = _dummy_session_context
+sys.modules.setdefault("areal.utils.perf_tracer", _perf_tracer_stub)
+
+
+class _DummyTracker:
+    def scalar(self, **kwargs):
+        return None
+
+
+_stats_tracker_stub = types.ModuleType("areal.utils.stats_tracker")
+_stats_tracker_stub.get = lambda _scope: _DummyTracker()
+sys.modules.setdefault("areal.utils.stats_tracker", _stats_tracker_stub)
+
+_workflow_context_stub = types.ModuleType("areal.infra.workflow_context")
+_workflow_context_stub.stat_scope = lambda: "rollout"
+sys.modules.setdefault("areal.infra.workflow_context", _workflow_context_stub)
+
+_infra_stub = types.ModuleType("areal.infra")
+_infra_stub.workflow_context = _workflow_context_stub
+sys.modules.setdefault("areal.infra", _infra_stub)
+
+from areal.workflow.rlvr import RLVRWorkflow
+
+
+class _DummyTokenizer:
+    eos_token_id = 0
+    pad_token_id = 0
+
+    def decode(self, token_ids):
+        return "|".join(str(x) for x in token_ids)
+
+
+class _DummyGConfig:
+    def __init__(self, max_new_tokens=8, n_samples=1):
+        self.max_new_tokens = max_new_tokens
+        self.n_samples = n_samples
+
+    def new_with_stop_and_pad_token_ids(self, _tokenizer):
+        return self
+
+    def new(self, n_samples=1):
+        return _DummyGConfig(
+            max_new_tokens=self.max_new_tokens,
+            n_samples=n_samples,
+        )
+
+
+class _DummyModelResponse:
+    def __init__(
+        self,
+        input_tokens,
+        output_tokens,
+        output_logprobs,
+        output_versions,
+        stop_reason="stop",
+        tokenizer=None,
+    ):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.output_logprobs = output_logprobs
+        self.output_versions = output_versions
+        self.stop_reason = stop_reason
+        self.tokenizer = tokenizer
+
+    @property
+    def input_len(self):
+        return len(self.input_tokens)
+
+    @property
+    def output_len(self):
+        return len(self.output_tokens)
+
+
+class _DummyEngine:
+    async def agenerate(self, req):
+        return _DummyModelResponse(
+            input_tokens=req.input_ids,
+            output_tokens=[11, 12, 13, 14],
+            output_logprobs=[-0.1, -0.2, -0.3, -0.4],
+            output_versions=[1, 1, 1, 1],
+            stop_reason="stop",
+            tokenizer=req.tokenizer,
+        )
+
+
+def _dummy_get_input_ids_fn(_data, _tokenizer, _enable_thinking):
+    return [101, 102]
+
+
+def _scalar_reward_fn(prompt, completions, prompt_ids, completion_ids, **kwargs):
+    del prompt, completions, prompt_ids, completion_ids, kwargs
+    return 1.25
+
+
+def _stepwise_reward_fn(prompt, completions, prompt_ids, completion_ids, **kwargs):
+    del prompt, completions, prompt_ids, completion_ids, kwargs
+    return RewardResult(
+        final_reward=0.5,
+        step_rewards=[0.2, -0.1],
+        step_ends=[2, 4],
+        metadata={"num_steps": 2},
+    )
+
+
+def _bad_reward_fn(prompt, completions, prompt_ids, completion_ids, **kwargs):
+    del prompt, completions, prompt_ids, completion_ids, kwargs
+    return RewardResult(
+        final_reward=0.0,
+        step_rewards=[1.0],
+        step_ends=[5],
+    )
+
+
+class TestRewardResultNormalization:
+    def test_normalize_scalar_reward(self):
+        reward = normalize_reward_result(1.5)
+        assert reward == RewardResult(final_reward=1.5)
+
+    def test_normalize_reward_result_passthrough(self):
+        reward = RewardResult(final_reward=2.0, step_rewards=[0.1], step_ends=[1])
+        assert normalize_reward_result(reward) is reward
+
+
+class TestRLVRWorkflowStepwiseReward:
+    @pytest.mark.asyncio
+    async def test_scalar_reward_keeps_zero_stepwise_tensors(self):
+        workflow = RLVRWorkflow(
+            reward_fn=_scalar_reward_fn,
+            gconfig=_DummyGConfig(max_new_tokens=8),
+            tokenizer=_DummyTokenizer(),
+            enable_thinking=False,
+            get_input_ids_fn=_dummy_get_input_ids_fn,
+        )
+
+        result = await workflow.arun_episode(_DummyEngine(), {"messages": []})
+
+        assert torch.equal(result["rewards"], torch.tensor([1.25], dtype=torch.float32))
+        assert torch.equal(
+            result["step_rewards"], torch.zeros((1, 6), dtype=torch.float32)
+        )
+        assert torch.equal(
+            result["step_reward_mask"], torch.zeros((1, 6), dtype=torch.bool)
+        )
+
+    @pytest.mark.asyncio
+    async def test_stepwise_reward_aligns_to_completion_end_positions(self):
+        workflow = RLVRWorkflow(
+            reward_fn=_stepwise_reward_fn,
+            gconfig=_DummyGConfig(max_new_tokens=8),
+            tokenizer=_DummyTokenizer(),
+            enable_thinking=False,
+            get_input_ids_fn=_dummy_get_input_ids_fn,
+        )
+
+        result = await workflow.arun_episode(_DummyEngine(), {"messages": []})
+
+        assert torch.equal(result["rewards"], torch.tensor([0.5], dtype=torch.float32))
+        expected_step_rewards = torch.tensor(
+            [[0.0, 0.0, 0.0, 0.2, 0.0, -0.1]], dtype=torch.float32
+        )
+        expected_mask = torch.tensor(
+            [[False, False, False, True, False, True]], dtype=torch.bool
+        )
+        assert torch.equal(result["step_rewards"], expected_step_rewards)
+        assert torch.equal(result["step_reward_mask"], expected_mask)
+
+    @pytest.mark.asyncio
+    async def test_invalid_stepwise_reward_raises(self):
+        workflow = RLVRWorkflow(
+            reward_fn=_bad_reward_fn,
+            gconfig=_DummyGConfig(max_new_tokens=8),
+            tokenizer=_DummyTokenizer(),
+            enable_thinking=False,
+            get_input_ids_fn=_dummy_get_input_ids_fn,
+        )
+
+        with pytest.raises(ValueError, match="Invalid step_end"):
+            await workflow.arun_episode(_DummyEngine(), {"messages": []})

--- a/tests/test_stepwise_reward_stage1.py
+++ b/tests/test_stepwise_reward_stage1.py
@@ -3,62 +3,18 @@
 from __future__ import annotations
 
 import contextlib
-import sys
 import types
 
 import pytest
 import torch
 
-from areal.api.reward_api import normalize_reward_result
-from areal.api.reward_api import RewardResult
 from areal.api.io_struct import ModelRequest
+from areal.api.reward_api import RewardResult, normalize_reward_result
 from areal.trainer.ppo.actor import PPOActor
-
-
-@contextlib.asynccontextmanager
-async def _dummy_atrace_session_phase(_name):
-    yield
-
-
-def _dummy_trace_session(_name):
-    def decorator(fn):
-        return fn
-
-    return decorator
-
-
-def _dummy_session_context():
-    def decorator(fn):
-        return fn
-
-    return decorator
-
-
-_perf_tracer_stub = types.ModuleType("areal.utils.perf_tracer")
-_perf_tracer_stub.atrace_session_phase = _dummy_atrace_session_phase
-_perf_tracer_stub.trace_session = _dummy_trace_session
-_perf_tracer_stub.session_context = _dummy_session_context
-sys.modules.setdefault("areal.utils.perf_tracer", _perf_tracer_stub)
-
-
-class _DummyTracker:
-    def scalar(self, **kwargs):
-        return None
-
-
-_stats_tracker_stub = types.ModuleType("areal.utils.stats_tracker")
-_stats_tracker_stub.get = lambda _scope: _DummyTracker()
-sys.modules.setdefault("areal.utils.stats_tracker", _stats_tracker_stub)
-
-_workflow_context_stub = types.ModuleType("areal.infra.workflow_context")
-_workflow_context_stub.stat_scope = lambda: "rollout"
-sys.modules.setdefault("areal.infra.workflow_context", _workflow_context_stub)
-
-_infra_stub = types.ModuleType("areal.infra")
-_infra_stub.workflow_context = _workflow_context_stub
-sys.modules.setdefault("areal.infra", _infra_stub)
-
+from areal.utils.data import concat_batch
 from areal.workflow.rlvr import RLVRWorkflow
+
+CUDA_AVAILABLE = torch.cuda.is_available()
 
 
 class _DummyTokenizer:
@@ -143,6 +99,22 @@ def _stepwise_reward_fn(prompt, completions, prompt_ids, completion_ids, **kwarg
     )
 
 
+def _duplicate_step_reward_fn(
+    prompt, completions, prompt_ids, completion_ids, **kwargs
+):
+    del prompt, completions, prompt_ids, completion_ids, kwargs
+    return RewardResult(
+        final_reward=0.0,
+        step_rewards=[0.8, 0.8],
+        step_ends=[1, 1],
+    )
+
+
+def _empty_step_reward_fn(prompt, completions, prompt_ids, completion_ids, **kwargs):
+    del prompt, completions, prompt_ids, completion_ids, kwargs
+    return RewardResult(final_reward=0.25, step_rewards=[], step_ends=[])
+
+
 def _bad_reward_fn(prompt, completions, prompt_ids, completion_ids, **kwargs):
     del prompt, completions, prompt_ids, completion_ids, kwargs
     return RewardResult(
@@ -175,12 +147,23 @@ class TestRLVRWorkflowStepwiseReward:
 
         result = await workflow.arun_episode(_DummyEngine(), {"messages": []})
 
-        assert torch.equal(result["rewards"], torch.tensor([1.25], dtype=torch.float32))
-        assert torch.equal(
-            result["step_rewards"], torch.zeros((1, 6), dtype=torch.float32)
+        torch.testing.assert_close(
+            result["rewards"],
+            torch.tensor([1.25], dtype=torch.float32),
+            rtol=0,
+            atol=0,
         )
-        assert torch.equal(
-            result["step_reward_mask"], torch.zeros((1, 6), dtype=torch.bool)
+        torch.testing.assert_close(
+            result["step_rewards"],
+            torch.zeros((1, 6), dtype=torch.float32),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            result["step_reward_mask"],
+            torch.zeros((1, 6), dtype=torch.bool),
+            rtol=0,
+            atol=0,
         )
 
     @pytest.mark.asyncio
@@ -195,15 +178,24 @@ class TestRLVRWorkflowStepwiseReward:
 
         result = await workflow.arun_episode(_DummyEngine(), {"messages": []})
 
-        assert torch.equal(result["rewards"], torch.tensor([0.5], dtype=torch.float32))
+        torch.testing.assert_close(
+            result["rewards"],
+            torch.tensor([0.5], dtype=torch.float32),
+            rtol=0,
+            atol=0,
+        )
         expected_step_rewards = torch.tensor(
             [[0.0, 0.0, 0.2, 0.0, -0.1, 0.0]], dtype=torch.float32
         )
         expected_mask = torch.tensor(
             [[False, False, True, False, True, False]], dtype=torch.bool
         )
-        assert torch.equal(result["step_rewards"], expected_step_rewards)
-        assert torch.equal(result["step_reward_mask"], expected_mask)
+        torch.testing.assert_close(
+            result["step_rewards"], expected_step_rewards, rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            result["step_reward_mask"], expected_mask, rtol=0, atol=0
+        )
 
     @pytest.mark.asyncio
     async def test_invalid_stepwise_reward_raises(self):
@@ -217,6 +209,66 @@ class TestRLVRWorkflowStepwiseReward:
 
         with pytest.raises(ValueError, match="Invalid step_end"):
             await workflow.arun_episode(_DummyEngine(), {"messages": []})
+
+    @pytest.mark.asyncio
+    async def test_duplicate_first_step_rewards_aggregate_before_actor_clip(self):
+        """Duplicate boundaries aggregate before per-timestep clipping."""
+        workflow = RLVRWorkflow(
+            reward_fn=_duplicate_step_reward_fn,
+            gconfig=_DummyGConfig(max_new_tokens=8),
+            tokenizer=_DummyTokenizer(),
+            enable_thinking=False,
+            get_input_ids_fn=_dummy_get_input_ids_fn,
+        )
+        result = await workflow.arun_episode(_DummyEngine(), {"messages": []})
+        actor = _build_actor_for_test(reward_clip=1.0)
+
+        result = actor._compute_advantages(result)
+
+        expected_tot_rewards = torch.tensor(
+            [[0.0, 1.0, 0.0, 0.0, 0.0, 0.0]], dtype=torch.float32
+        )
+        torch.testing.assert_close(
+            result["tot_rewards"], expected_tot_rewards, rtol=0, atol=0
+        )
+
+    @pytest.mark.parametrize(
+        "non_stepwise_reward_fn",
+        [_scalar_reward_fn, _empty_step_reward_fn],
+        ids=["scalar", "empty-step-list"],
+    )
+    @pytest.mark.asyncio
+    async def test_non_stepwise_and_stepwise_samples_batch_together(
+        self, non_stepwise_reward_fn
+    ):
+        """Optional process rewards retain a batch-compatible tensor schema."""
+        non_stepwise_workflow = RLVRWorkflow(
+            reward_fn=non_stepwise_reward_fn,
+            gconfig=_DummyGConfig(max_new_tokens=8),
+            tokenizer=_DummyTokenizer(),
+            enable_thinking=False,
+            get_input_ids_fn=_dummy_get_input_ids_fn,
+        )
+        stepwise_workflow = RLVRWorkflow(
+            reward_fn=_stepwise_reward_fn,
+            gconfig=_DummyGConfig(max_new_tokens=8),
+            tokenizer=_DummyTokenizer(),
+            enable_thinking=False,
+            get_input_ids_fn=_dummy_get_input_ids_fn,
+        )
+        non_stepwise_result = await non_stepwise_workflow.arun_episode(
+            _DummyEngine(), {"messages": []}
+        )
+        stepwise_result = await stepwise_workflow.arun_episode(
+            _DummyEngine(), {"messages": []}
+        )
+
+        batched, _ = concat_batch([non_stepwise_result, stepwise_result])
+
+        assert batched["step_rewards"].shape == (2, 6)
+        assert batched["step_reward_mask"].shape == (2, 6)
+        assert not batched["step_reward_mask"][0].any()
+        assert batched["step_reward_mask"][1].sum() == 2
 
 
 class _DummyStatsTracker:
@@ -256,24 +308,38 @@ class _DummyRewardNorm:
         return x
 
 
+class _ShiftRewardNorm:
+    def __call__(self, x, group_sizes=None):
+        del group_sizes
+        return x + 1.0
+
+
 class _DummyKL:
     def __call__(self, old_logp, ref_logp):
-        del old_logp, ref_logp
+        del ref_logp
         return torch.zeros_like(old_logp)
 
 
-def _build_actor_for_test():
+def _build_actor_for_test(
+    *,
+    reward_bias: float = 0.0,
+    reward_scaling: float = 1.0,
+    reward_clip: float = 10.0,
+    reward_norm: _DummyRewardNorm | _ShiftRewardNorm | None = None,
+    mask_no_eos_with_zero: bool = False,
+) -> PPOActor:
     actor = PPOActor.__new__(PPOActor)
-    actor.reward_bias = 0.0
-    actor.reward_scaling = 1.0
-    actor.reward_clip = 10.0
-    actor.reward_norm = _DummyRewardNorm()
+    actor.reward_bias = reward_bias
+    actor.reward_scaling = reward_scaling
+    actor.reward_clip = reward_clip
+    actor.reward_norm = reward_norm
     actor.adv_norm = None
     actor.kl_ctl = 0.0
     actor.kl_estimator = _DummyKL()
     actor.discount = 1.0
     actor.gae_lambda = 1.0
-    actor.mask_no_eos_with_zero = False
+    actor.mask_no_eos_with_zero = mask_no_eos_with_zero
+    actor.m2_threshold = None
     actor.engine = _DummyEngineForPPO()
     actor.config = types.SimpleNamespace(
         overlong_reward_penalty=False,
@@ -282,8 +348,10 @@ def _build_actor_for_test():
         use_decoupled_loss=False,
         recompute_logprob=False,
         log_agent_stats=False,
+        mask_no_eos_with_zero=mask_no_eos_with_zero,
         ppo_n_minibatches=1,
         eps_clip=0.2,
+        eps_clip_higher=None,
         c_clip=None,
         rejection_sampling=None,
         importance_sampling_level="token",
@@ -297,7 +365,7 @@ def _build_actor_for_test():
 
 
 class TestPPOActorStepwiseReward:
-    def test_compute_advantages_keeps_final_step_reward(self, monkeypatch):
+    def test_compute_advantages_keeps_final_step_reward(self):
         actor = _build_actor_for_test()
         data = {
             "input_ids": torch.tensor([[101, 102, 11, 12, 13, 14]], dtype=torch.int32),
@@ -318,7 +386,143 @@ class TestPPOActorStepwiseReward:
         expected_tot_rewards = torch.tensor(
             [[0.0, 0.0, 0.2, 0.0, 0.4, 0.0]], dtype=torch.float32
         )
-        assert torch.equal(result["tot_rewards"], expected_tot_rewards)
+        torch.testing.assert_close(
+            result["tot_rewards"], expected_tot_rewards, rtol=0, atol=0
+        )
+
+    def test_compute_advantages_scales_and_clips_step_rewards(self):
+        """Step deltas share scaling and clipping, but not terminal bias."""
+        actor = _build_actor_for_test(
+            reward_bias=-0.5,
+            reward_scaling=10.0,
+            reward_clip=1.0,
+        )
+        data = {
+            "input_ids": torch.tensor([[101, 102, 11, 12, 13, 14]], dtype=torch.int32),
+            "attention_mask": torch.ones((1, 6), dtype=torch.bool),
+            "loss_mask": torch.tensor([[0, 0, 1, 1, 1, 1]], dtype=torch.int32),
+            "logprobs": torch.zeros((1, 6), dtype=torch.float32),
+            "rewards": torch.tensor([0.5], dtype=torch.float32),
+            "step_rewards": torch.tensor(
+                [[0.0, 0.0, 0.2, float("nan"), -0.2, 0.0]], dtype=torch.float32
+            ),
+            "step_reward_mask": torch.tensor(
+                [[False, False, True, False, True, False]], dtype=torch.bool
+            ),
+        }
+
+        result = actor._compute_advantages(data)
+
+        expected_tot_rewards = torch.tensor(
+            [[0.0, 0.0, 1.0, 0.0, -1.0, 0.0]], dtype=torch.float32
+        )
+        torch.testing.assert_close(
+            result["tot_rewards"], expected_tot_rewards, rtol=0, atol=0
+        )
+
+    @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA is not available")
+    def test_compute_advantages_moves_step_rewards_to_actor_device(self):
+        """CPU process rewards are moved to the actor's CUDA device."""
+        actor = _build_actor_for_test()
+        data = {
+            "input_ids": torch.tensor(
+                [[101, 102, 11, 12]], dtype=torch.int32, device="cuda"
+            ),
+            "attention_mask": torch.ones((1, 4), dtype=torch.bool, device="cuda"),
+            "loss_mask": torch.tensor([[0, 0, 1, 1]], dtype=torch.int32, device="cuda"),
+            "logprobs": torch.zeros((1, 4), dtype=torch.float32, device="cuda"),
+            "rewards": torch.tensor([0.5], dtype=torch.float32, device="cuda"),
+            "step_rewards": torch.tensor([[0.0, 0.2, -0.1, 0.0]], dtype=torch.float32),
+            "step_reward_mask": torch.tensor(
+                [[False, True, True, False]], dtype=torch.bool
+            ),
+        }
+
+        result = actor._compute_advantages(data)
+
+        expected_tot_rewards = torch.tensor(
+            [[0.0, 0.2, 0.4, 0.0]], dtype=torch.float32, device="cuda"
+        )
+        torch.testing.assert_close(
+            result["tot_rewards"], expected_tot_rewards, rtol=0, atol=0
+        )
+        assert result["step_rewards"].device.type == "cuda"
+        assert result["step_reward_mask"].device.type == "cuda"
+
+    def test_compute_advantages_applies_reward_norm_only_to_terminal_reward(self):
+        """Sequence normalization does not alter sparse process increments."""
+        actor = _build_actor_for_test(reward_norm=_ShiftRewardNorm())
+        data = {
+            "input_ids": torch.tensor([[101, 102, 11, 12]], dtype=torch.int32),
+            "attention_mask": torch.ones((1, 4), dtype=torch.bool),
+            "loss_mask": torch.tensor([[0, 0, 1, 1]], dtype=torch.int32),
+            "logprobs": torch.zeros((1, 4), dtype=torch.float32),
+            "rewards": torch.tensor([0.5], dtype=torch.float32),
+            "step_rewards": torch.tensor([[0.0, 0.2, -0.1, 0.0]], dtype=torch.float32),
+            "step_reward_mask": torch.tensor(
+                [[False, True, True, False]], dtype=torch.bool
+            ),
+        }
+
+        result = actor._compute_advantages(data)
+
+        expected_tot_rewards = torch.tensor([[0.0, 0.2, 1.4, 0.0]], dtype=torch.float32)
+        torch.testing.assert_close(
+            result["tot_rewards"], expected_tot_rewards, rtol=0, atol=0
+        )
+
+    def test_compute_advantages_keeps_scalar_reward_norm_path(self):
+        """Scalar rewards retain the existing bias, scale, clip, and norm path."""
+        actor = _build_actor_for_test(
+            reward_bias=-0.5,
+            reward_scaling=10.0,
+            reward_clip=2.0,
+            reward_norm=_DummyRewardNorm(),
+        )
+        data = {
+            "input_ids": torch.tensor([[101, 102, 11, 12]], dtype=torch.int32),
+            "attention_mask": torch.ones((1, 4), dtype=torch.bool),
+            "loss_mask": torch.tensor([[0, 0, 1, 1]], dtype=torch.int32),
+            "logprobs": torch.zeros((1, 4), dtype=torch.float32),
+            "rewards": torch.tensor([0.6], dtype=torch.float32),
+        }
+
+        result = actor._compute_advantages(data)
+
+        expected_tot_rewards = torch.tensor([[0.0, 0.0, 1.0, 0.0]], dtype=torch.float32)
+        torch.testing.assert_close(
+            result["tot_rewards"], expected_tot_rewards, rtol=1e-6, atol=1e-6
+        )
+
+    def test_compute_advantages_masks_step_rewards_for_truncated_sequence(self):
+        """No-EOS masking removes terminal and process task rewards."""
+        actor = _build_actor_for_test(mask_no_eos_with_zero=True)
+        actor.kl_ctl = 0.1
+        actor.kl_estimator = lambda old_logp, ref_logp: old_logp - ref_logp
+        actor.config.overlong_reward_penalty = True
+        actor.config.overlong_tokens = 1
+        actor.config.overlong_penalty_factor = 1.0
+        actor.config.max_new_tokens = 2
+        data = {
+            "input_ids": torch.tensor([[101, 102, 11, 12]], dtype=torch.int32),
+            "attention_mask": torch.ones((1, 4), dtype=torch.bool),
+            "loss_mask": torch.tensor([[0, 0, 1, 1]], dtype=torch.int32),
+            "logprobs": torch.tensor([[0.0, 0.0, 0.5, 0.5]], dtype=torch.float32),
+            "rewards": torch.tensor([0.5], dtype=torch.float32),
+            "step_rewards": torch.tensor([[0.0, 0.2, -0.1, 0.0]], dtype=torch.float32),
+            "step_reward_mask": torch.tensor(
+                [[False, True, True, False]], dtype=torch.bool
+            ),
+        }
+
+        result = actor._compute_advantages(data)
+
+        expected_tot_rewards = torch.tensor(
+            [[0.0, -0.05, -0.05, 0.0]], dtype=torch.float32
+        )
+        torch.testing.assert_close(
+            result["tot_rewards"], expected_tot_rewards, rtol=0, atol=0
+        )
 
     def test_ppo_update_reads_stepwise_rewards_from_batch(self, monkeypatch):
         actor = _build_actor_for_test()
@@ -337,7 +541,9 @@ class TestPPOActorStepwiseReward:
             "advantages": torch.zeros((1, 4), dtype=torch.float32),
             "kl_rewards": torch.zeros((1, 4), dtype=torch.float32),
             "tot_rewards": torch.zeros((1, 4), dtype=torch.float32),
-            "step_rewards": torch.tensor([[0.0, 0.2, 0.0, 0.0]], dtype=torch.float32),
+            "step_rewards": torch.tensor(
+                [[float("nan"), 0.2, 0.0, 0.0]], dtype=torch.float32
+            ),
             "step_reward_mask": torch.tensor(
                 [[False, True, False, False]], dtype=torch.bool
             ),
@@ -347,7 +553,14 @@ class TestPPOActorStepwiseReward:
 
         actor._ppo_update(data)
 
-        assert any("step_reward" in stat for stat in tracker.stats)
-        assert any(
-            scalar.get("step_reward_events") == 1.0 for scalar in tracker.scalars
+        step_reward_stat = next(stat for stat in tracker.stats if "step_reward" in stat)
+        assert step_reward_stat["denominator"] == "step_reward_events"
+        torch.testing.assert_close(
+            step_reward_stat["step_reward"],
+            torch.tensor([[0.0, 0.2, 0.0, 0.0]], dtype=torch.float32),
+            rtol=0,
+            atol=0,
         )
+        assert tracker.denominators[0]["step_reward_events"].sum() == 1
+        assert "step_rewards" not in data
+        assert "step_reward_mask" not in data


### PR DESCRIPTION
## Description

This PR implements a scoped Stage-1 landing for stepwise / process-level reward plumbing.

It does **not** change the default scalar-reward behavior. Existing reward functions that return a single `float` continue to work unchanged.

This first landing adds:

- a structured `RewardResult` payload that can carry `final_reward` plus optional per-step rewards;
- normalization from legacy scalar rewards into the structured format;
- workflow-side alignment from step-level rewards to completion-token positions in `RLVRWorkflow`;
- PPO-side consumption of `step_rewards` / `step_reward_mask` by injecting them into token-level total rewards;
- focused tests for reward normalization, stepwise alignment, and backward compatibility.

The intent is to make process supervision a first-class path in AReaL while keeping the current default behavior intact.

## Related Issue

Fixes #1381

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

Tested on the Aliyun Linux environment with:

- `tests/test_stepwise_reward_stage1.py`
- `tests/test_async_reward_wrapper.py`

I did not run the full local Windows test flow because the repository lockfile targets Linux/macOS environments.

This PR intentionally stops at Stage 1 plumbing. It does not yet introduce a broader process-reward API across all workflows, and it does not attempt the algorithmic `IcePop Plus` integration.