### PR TITLE
[codex] add immutable Memory Service evidence ledger

### DIFF
--- a/areal/v2/memory_service/__init__.py
+++ b/areal/v2/memory_service/__init__.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public contracts for immutable Memory Service evidence."""
+
+from areal.v2.memory_service.errors import (
+    EvidenceConflictError,
+    EvidenceNotFoundError,
+    MemoryServiceError,
+)
+from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+__all__ = [
+    "EvidenceConflictError",
+    "EvidenceEvent",
+    "EvidenceKind",
+    "EvidenceNotFoundError",
+    "EvidenceRecord",
+    "EvidenceStore",
+    "InMemoryEvidenceStore",
+    "MemoryScope",
+    "MemoryServiceError",
+]

--- a/areal/v2/memory_service/_atomic.py
+++ b/areal/v2/memory_service/_atomic.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small rollback helper for process-local multi-index publication."""
+
+from __future__ import annotations
+
+_MISSING = object()
+
+
+def _atomic_publish(
+    *,
+    mapping_writes: tuple[tuple[dict, object, object], ...],
+    sequence_appends: tuple[tuple[dict, object, object], ...] = (),
+) -> None:
+    """Publish mapping writes and indexed list appends as one local unit.
+
+    The helper deliberately catches ``BaseException`` because cancellation,
+    ``KeyboardInterrupt``, and allocation failures must not leave only some
+    indexes visible.  Rollback is best-effort for hostile test doubles; normal
+    built-in dictionaries and lists restore their exact prior state.
+    """
+
+    undo: list[tuple[str, object, object, object]] = []
+    try:
+        for mapping, key, value in mapping_writes:
+            previous = mapping.get(key, _MISSING)
+            undo.append(("mapping", mapping, key, previous))
+            mapping[key] = value
+        for mapping, key, value in sequence_appends:
+            sequence = mapping.get(key, _MISSING)
+            if sequence is _MISSING:
+                undo.append(("mapping", mapping, key, _MISSING))
+                mapping[key] = [value]
+                continue
+            if type(sequence) is not list:
+                raise TypeError("indexed publication sequence must be a list")
+            undo.append(("sequence", sequence, len(sequence), _MISSING))
+            sequence.append(value)
+    except BaseException:
+        for kind, target, key_or_length, previous in reversed(undo):
+            try:
+                if kind == "sequence":
+                    del target[key_or_length:]
+                elif previous is _MISSING:
+                    target.pop(key_or_length, None)
+                else:
+                    target[key_or_length] = previous
+            except BaseException:
+                pass
+        raise

--- a/areal/v2/memory_service/_atomic.py
+++ b/areal/v2/memory_service/_atomic.py
@@ -16,8 +16,9 @@ def _atomic_publish(
 
     The helper deliberately catches ``BaseException`` because cancellation,
     ``KeyboardInterrupt``, and allocation failures must not leave only some
-    indexes visible.  Rollback is best-effort for hostile test doubles; normal
-    built-in dictionaries and lists restore their exact prior state.
+    indexes visible.  Store indexes are private built-in dictionaries and
+    lists.  Rollback calls the built-in mutation methods directly so a fault-
+    injection subclass cannot interrupt both publication and its own undo.
     """
 
     undo: list[tuple[str, object, object, object]] = []
@@ -40,11 +41,14 @@ def _atomic_publish(
         for kind, target, key_or_length, previous in reversed(undo):
             try:
                 if kind == "sequence":
-                    del target[key_or_length:]
+                    list.__delitem__(target, slice(key_or_length, None))
                 elif previous is _MISSING:
-                    target.pop(key_or_length, None)
+                    dict.pop(target, key_or_length, None)
                 else:
-                    target[key_or_length] = previous
+                    dict.__setitem__(target, key_or_length, previous)
             except BaseException:
+                # A second process-level interruption can still make rollback
+                # impossible.  Continue undoing the other independent indexes
+                # and preserve the original publication exception.
                 pass
         raise

--- a/areal/v2/memory_service/errors.py
+++ b/areal/v2/memory_service/errors.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Errors raised by the Memory Service."""
+
+
+class MemoryServiceError(Exception):
+    """Base class for Memory Service failures."""
+
+
+class EvidenceNotFoundError(MemoryServiceError):
+    """Raised when requested evidence is unavailable in the requested scope."""
+
+
+class EvidenceConflictError(MemoryServiceError):
+    """Raised when evidence conflicts with an existing immutable record."""

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -46,10 +46,8 @@ class InMemoryEvidenceStore:
 
     def __init__(self) -> None:
         self._lock = RLock()
-        self._by_evidence_id: dict[str, tuple[EvidenceRecord, bytes]] = {}
-        self._by_idempotency_key: dict[
-            tuple[MemoryScope, str], tuple[EvidenceRecord, bytes]
-        ] = {}
+        self._by_evidence_id: dict[str, EvidenceRecord] = {}
+        self._by_idempotency_key: dict[tuple[MemoryScope, str], EvidenceRecord] = {}
         self._by_scope: dict[MemoryScope, list[EvidenceRecord]] = {}
 
     def append(self, event: EvidenceEvent) -> EvidenceRecord:
@@ -61,19 +59,17 @@ class InMemoryEvidenceStore:
         idempotency_index = (event.scope, event.idempotency_key)
 
         with self._lock:
-            existing_idempotency = self._by_idempotency_key.get(idempotency_index)
-            if existing_idempotency is not None:
-                existing_record, existing_bytes = existing_idempotency
-                if existing_bytes == canonical_bytes:
+            existing_record = self._by_idempotency_key.get(idempotency_index)
+            if existing_record is not None:
+                if existing_record.event.canonical_bytes() == canonical_bytes:
                     return existing_record
                 raise EvidenceConflictError(
                     "scoped idempotency key already refers to different evidence"
                 )
 
-            existing_id = self._by_evidence_id.get(evidence_id)
-            if existing_id is not None:
-                existing_record, existing_bytes = existing_id
-                if existing_bytes == canonical_bytes:
+            existing_record = self._by_evidence_id.get(evidence_id)
+            if existing_record is not None:
+                if existing_record.event.canonical_bytes() == canonical_bytes:
                     return existing_record
                 raise EvidenceConflictError(
                     f"evidence ID collision for {evidence_id!r}"
@@ -85,9 +81,8 @@ class InMemoryEvidenceStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            indexed_record = (record, canonical_bytes)
-            self._by_evidence_id[evidence_id] = indexed_record
-            self._by_idempotency_key[idempotency_index] = indexed_record
+            self._by_evidence_id[evidence_id] = record
+            self._by_idempotency_key[idempotency_index] = record
             self._by_scope.setdefault(event.scope, []).append(record)
             return record
 
@@ -95,10 +90,10 @@ class InMemoryEvidenceStore:
         """Return evidence only when it belongs to the requested scope."""
 
         with self._lock:
-            indexed_record = self._by_evidence_id.get(evidence_id)
-            if indexed_record is None or indexed_record[0].event.scope != scope:
+            record = self._by_evidence_id.get(evidence_id)
+            if record is None or record.event.scope != scope:
                 raise EvidenceNotFoundError(f"evidence {evidence_id!r} was not found")
-            return indexed_record[0]
+            return record
 
     def list(
         self,

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -46,7 +46,7 @@ class InMemoryEvidenceStore:
 
     def __init__(self) -> None:
         self._lock = RLock()
-        self._by_evidence_id: dict[str, EvidenceRecord] = {}
+        self._by_evidence_id: dict[tuple[MemoryScope, str], EvidenceRecord] = {}
         self._by_idempotency_key: dict[tuple[MemoryScope, str], EvidenceRecord] = {}
         self._by_scope: dict[MemoryScope, list[EvidenceRecord]] = {}
 
@@ -56,6 +56,7 @@ class InMemoryEvidenceStore:
         canonical_bytes = event.canonical_bytes()
         content_hash = hashlib.sha256(canonical_bytes).hexdigest()
         evidence_id = f"evd_{content_hash[:24]}"
+        evidence_index = (event.scope, evidence_id)
         idempotency_index = (event.scope, event.idempotency_key)
 
         with self._lock:
@@ -67,7 +68,7 @@ class InMemoryEvidenceStore:
                     "scoped idempotency key already refers to different evidence"
                 )
 
-            existing_record = self._by_evidence_id.get(evidence_id)
+            existing_record = self._by_evidence_id.get(evidence_index)
             if existing_record is not None:
                 if existing_record.event.canonical_bytes() == canonical_bytes:
                     return existing_record
@@ -81,7 +82,7 @@ class InMemoryEvidenceStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._by_evidence_id[evidence_id] = record
+            self._by_evidence_id[evidence_index] = record
             self._by_idempotency_key[idempotency_index] = record
             self._by_scope.setdefault(event.scope, []).append(record)
             return record
@@ -90,8 +91,8 @@ class InMemoryEvidenceStore:
         """Return evidence only when it belongs to the requested scope."""
 
         with self._lock:
-            record = self._by_evidence_id.get(evidence_id)
-            if record is None or record.event.scope != scope:
+            record = self._by_evidence_id.get((scope, evidence_id))
+            if record is None:
                 raise EvidenceNotFoundError(f"evidence {evidence_id!r} was not found")
             return record
 

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -53,6 +53,8 @@ class InMemoryEvidenceStore:
     def append(self, event: EvidenceEvent) -> EvidenceRecord:
         """Persist an event, enforcing scoped idempotency and collision safety."""
 
+        if type(event) is not EvidenceEvent:
+            raise TypeError("event must be an EvidenceEvent")
         canonical_bytes = event.canonical_bytes()
         content_hash = hashlib.sha256(canonical_bytes).hexdigest()
         evidence_id = f"evd_{content_hash[:24]}"
@@ -90,6 +92,8 @@ class InMemoryEvidenceStore:
     def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:
         """Return evidence only when it belongs to the requested scope."""
 
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
         with self._lock:
             record = self._by_evidence_id.get((scope, evidence_id))
             if record is None:
@@ -105,6 +109,8 @@ class InMemoryEvidenceStore:
     ) -> tuple[EvidenceRecord, ...]:
         """Return a stable snapshot of records belonging to the requested scope."""
 
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
         with self._lock:
             matches = (
                 record

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -120,6 +120,6 @@ def _record_sort_key(record: EvidenceRecord) -> tuple[str, str, int, datetime, s
         event.session_id,
         event.run_id,
         event.sequence_no,
-        event.observed_at.astimezone(UTC),
+        event.observed_at,
         record.evidence_id,
     )

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -13,7 +13,12 @@ from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
 )
-from areal.v2.memory_service.types import EvidenceEvent, EvidenceRecord, MemoryScope
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceRecord,
+    MemoryScope,
+    _validate_string,
+)
 
 
 class EvidenceStore(Protocol):
@@ -94,6 +99,7 @@ class InMemoryEvidenceStore:
 
         if type(scope) is not MemoryScope:
             raise TypeError("scope must be a MemoryScope")
+        evidence_id = _validate_string(evidence_id, "evidence_id", allow_blank=True)
         with self._lock:
             record = self._by_evidence_id.get((scope, evidence_id))
             if record is None:
@@ -111,6 +117,10 @@ class InMemoryEvidenceStore:
 
         if type(scope) is not MemoryScope:
             raise TypeError("scope must be a MemoryScope")
+        if session_id is not None:
+            session_id = _validate_string(session_id, "session_id", allow_blank=True)
+        if run_id is not None:
+            run_id = _validate_string(run_id, "run_id", allow_blank=True)
         with self._lock:
             matches = (
                 record

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from threading import RLock
 from typing import Protocol
 
+from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
@@ -89,9 +90,13 @@ class InMemoryEvidenceStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._by_evidence_id[evidence_index] = record
-            self._by_idempotency_key[idempotency_index] = record
-            self._by_scope.setdefault(event.scope, []).append(record)
+            _atomic_publish(
+                mapping_writes=(
+                    (self._by_evidence_id, evidence_index, record),
+                    (self._by_idempotency_key, idempotency_index, record),
+                ),
+                sequence_appends=((self._by_scope, event.scope, record),),
+            )
             return record
 
     def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evidence store contracts and an in-memory implementation."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from threading import RLock
+from typing import Protocol
+
+from areal.v2.memory_service.errors import (
+    EvidenceConflictError,
+    EvidenceNotFoundError,
+)
+from areal.v2.memory_service.types import EvidenceEvent, EvidenceRecord, MemoryScope
+
+
+class EvidenceStore(Protocol):
+    """Storage contract for immutable evidence records."""
+
+    def append(self, event: EvidenceEvent) -> EvidenceRecord:
+        """Persist an event or return its existing idempotent record."""
+
+        ...
+
+    def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:
+        """Return evidence from a scope or raise ``EvidenceNotFoundError``."""
+
+        ...
+
+    def list(
+        self,
+        scope: MemoryScope,
+        *,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ...]:
+        """Return deterministically ordered evidence matching the filters."""
+
+        ...
+
+
+class InMemoryEvidenceStore:
+    """Lock-protected process-local storage for immutable evidence records."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._by_evidence_id: dict[str, tuple[EvidenceRecord, bytes]] = {}
+        self._by_idempotency_key: dict[
+            tuple[MemoryScope, str], tuple[EvidenceRecord, bytes]
+        ] = {}
+        self._by_scope: dict[MemoryScope, list[EvidenceRecord]] = {}
+
+    def append(self, event: EvidenceEvent) -> EvidenceRecord:
+        """Persist an event, enforcing scoped idempotency and collision safety."""
+
+        canonical_bytes = event.canonical_bytes()
+        content_hash = hashlib.sha256(canonical_bytes).hexdigest()
+        evidence_id = f"evd_{content_hash[:24]}"
+        idempotency_index = (event.scope, event.idempotency_key)
+
+        with self._lock:
+            existing_idempotency = self._by_idempotency_key.get(idempotency_index)
+            if existing_idempotency is not None:
+                existing_record, existing_bytes = existing_idempotency
+                if existing_bytes == canonical_bytes:
+                    return existing_record
+                raise EvidenceConflictError(
+                    "scoped idempotency key already refers to different evidence"
+                )
+
+            existing_id = self._by_evidence_id.get(evidence_id)
+            if existing_id is not None:
+                existing_record, existing_bytes = existing_id
+                if existing_bytes == canonical_bytes:
+                    return existing_record
+                raise EvidenceConflictError(
+                    f"evidence ID collision for {evidence_id!r}"
+                )
+
+            record = EvidenceRecord(
+                evidence_id=evidence_id,
+                event=event,
+                content_hash=content_hash,
+                created_at=datetime.now(UTC),
+            )
+            indexed_record = (record, canonical_bytes)
+            self._by_evidence_id[evidence_id] = indexed_record
+            self._by_idempotency_key[idempotency_index] = indexed_record
+            self._by_scope.setdefault(event.scope, []).append(record)
+            return record
+
+    def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:
+        """Return evidence only when it belongs to the requested scope."""
+
+        with self._lock:
+            indexed_record = self._by_evidence_id.get(evidence_id)
+            if indexed_record is None or indexed_record[0].event.scope != scope:
+                raise EvidenceNotFoundError(f"evidence {evidence_id!r} was not found")
+            return indexed_record[0]
+
+    def list(
+        self,
+        scope: MemoryScope,
+        *,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ...]:
+        """Return a stable snapshot of records belonging to the requested scope."""
+
+        with self._lock:
+            matches = (
+                record
+                for record in self._by_scope.get(scope, ())
+                if (session_id is None or record.event.session_id == session_id)
+                and (run_id is None or record.event.run_id == run_id)
+            )
+            return tuple(sorted(matches, key=_record_sort_key))
+
+
+def _record_sort_key(record: EvidenceRecord) -> tuple[str, str, int, datetime, str]:
+    event = record.event
+    return (
+        event.session_id,
+        event.run_id,
+        event.sequence_no,
+        event.observed_at.astimezone(UTC),
+        record.evidence_id,
+    )

--- a/areal/v2/memory_service/types.py
+++ b/areal/v2/memory_service/types.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable evidence value objects for the Memory Service."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+
+_MAX_SEQUENCE_NO = 2**63 - 1
+
+
+def _validate_string(
+    value: object, field_name: str, *, allow_blank: bool = False
+) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not allow_blank and not value.strip():
+        raise ValueError(f"{field_name} must not be blank")
+    try:
+        value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{field_name} must be valid UTF-8") from exc
+
+
+def _validate_aware_datetime(value: object, field_name: str) -> None:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field_name} must be a datetime")
+    if value.tzinfo is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    try:
+        offset = value.utcoffset()
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be normalizable to UTC") from exc
+    if offset is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    try:
+        value.astimezone(UTC)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be normalizable to UTC") from exc
+
+
+class EvidenceKind(StrEnum):
+    """The source or role represented by an evidence event."""
+
+    USER_MESSAGE = "user_message"
+    AGENT_MESSAGE = "agent_message"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    ENVIRONMENT = "environment"
+    FEEDBACK = "feedback"
+    OUTCOME = "outcome"
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryScope:
+    """The tenant, namespace, and subject that own a memory."""
+
+    tenant_id: str
+    namespace: str
+    subject_id: str
+
+    def __post_init__(self) -> None:
+        _validate_string(self.tenant_id, "tenant_id")
+        _validate_string(self.namespace, "namespace")
+        _validate_string(self.subject_id, "subject_id")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceEvent:
+    """An immutable observation submitted to the Memory Service."""
+
+    scope: MemoryScope
+    session_id: str
+    run_id: str
+    sequence_no: int
+    kind: EvidenceKind
+    payload: str
+    observed_at: datetime
+    idempotency_key: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope, MemoryScope):
+            raise TypeError("scope must be a MemoryScope")
+        _validate_string(self.session_id, "session_id")
+        _validate_string(self.run_id, "run_id")
+        _validate_string(self.idempotency_key, "idempotency_key")
+        if isinstance(self.sequence_no, bool) or not isinstance(self.sequence_no, int):
+            raise TypeError("sequence_no must be an integer")
+        if self.sequence_no < 0:
+            raise ValueError("sequence_no must be non-negative")
+        if self.sequence_no > _MAX_SEQUENCE_NO:
+            raise ValueError("sequence_no must fit in a signed 64-bit integer")
+        if not isinstance(self.kind, EvidenceKind):
+            raise TypeError("kind must be an EvidenceKind")
+        _validate_string(self.payload, "payload", allow_blank=True)
+        _validate_aware_datetime(self.observed_at, "observed_at")
+
+    def canonical_bytes(self) -> bytes:
+        """Serialize the event as deterministic, compact UTF-8 JSON."""
+
+        value = {
+            "scope": {
+                "tenant_id": self.scope.tenant_id,
+                "namespace": self.scope.namespace,
+                "subject_id": self.scope.subject_id,
+            },
+            "session_id": self.session_id,
+            "run_id": self.run_id,
+            "sequence_no": self.sequence_no,
+            "kind": self.kind.value,
+            "payload": self.payload,
+            "observed_at": self.observed_at.astimezone(UTC).isoformat(),
+            "idempotency_key": self.idempotency_key,
+        }
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRecord:
+    """A persisted evidence event and its storage metadata."""
+
+    evidence_id: str
+    event: EvidenceEvent
+    content_hash: str
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.event, EvidenceEvent):
+            raise TypeError("event must be an EvidenceEvent")
+        _validate_string(self.evidence_id, "evidence_id")
+        _validate_string(self.content_hash, "content_hash")
+        _validate_aware_datetime(self.created_at, "created_at")

--- a/areal/v2/memory_service/types.py
+++ b/areal/v2/memory_service/types.py
@@ -14,15 +14,17 @@ _MAX_SEQUENCE_NO = 2**63 - 1
 
 def _validate_string(
     value: object, field_name: str, *, allow_blank: bool = False
-) -> None:
+) -> str:
     if not isinstance(value, str):
         raise TypeError(f"{field_name} must be a string")
-    if not allow_blank and not value.strip():
+    snapshot = str.__str__(value)
+    if not allow_blank and not str.strip(snapshot):
         raise ValueError(f"{field_name} must not be blank")
     try:
-        value.encode("utf-8", errors="strict")
+        str.encode(snapshot, "utf-8", "strict")
     except UnicodeEncodeError as exc:
         raise ValueError(f"{field_name} must be valid UTF-8") from exc
+    return snapshot
 
 
 def _validate_aware_datetime(value: object, field_name: str) -> datetime:
@@ -73,9 +75,12 @@ class MemoryScope:
     subject_id: str
 
     def __post_init__(self) -> None:
-        _validate_string(self.tenant_id, "tenant_id")
-        _validate_string(self.namespace, "namespace")
-        _validate_string(self.subject_id, "subject_id")
+        tenant_id = _validate_string(self.tenant_id, "tenant_id")
+        namespace = _validate_string(self.namespace, "namespace")
+        subject_id = _validate_string(self.subject_id, "subject_id")
+        object.__setattr__(self, "tenant_id", tenant_id)
+        object.__setattr__(self, "namespace", namespace)
+        object.__setattr__(self, "subject_id", subject_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,12 +97,12 @@ class EvidenceEvent:
     idempotency_key: str
 
     def __post_init__(self) -> None:
-        if not isinstance(self.scope, MemoryScope):
+        if type(self.scope) is not MemoryScope:
             raise TypeError("scope must be a MemoryScope")
-        _validate_string(self.session_id, "session_id")
-        _validate_string(self.run_id, "run_id")
-        _validate_string(self.idempotency_key, "idempotency_key")
-        if isinstance(self.sequence_no, bool) or not isinstance(self.sequence_no, int):
+        session_id = _validate_string(self.session_id, "session_id")
+        run_id = _validate_string(self.run_id, "run_id")
+        idempotency_key = _validate_string(self.idempotency_key, "idempotency_key")
+        if type(self.sequence_no) is not int:
             raise TypeError("sequence_no must be an integer")
         if self.sequence_no < 0:
             raise ValueError("sequence_no must be non-negative")
@@ -105,8 +110,12 @@ class EvidenceEvent:
             raise ValueError("sequence_no must fit in a signed 64-bit integer")
         if not isinstance(self.kind, EvidenceKind):
             raise TypeError("kind must be an EvidenceKind")
-        _validate_string(self.payload, "payload", allow_blank=True)
+        payload = _validate_string(self.payload, "payload", allow_blank=True)
         observed_at = _validate_aware_datetime(self.observed_at, "observed_at")
+        object.__setattr__(self, "session_id", session_id)
+        object.__setattr__(self, "run_id", run_id)
+        object.__setattr__(self, "payload", payload)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
         object.__setattr__(self, "observed_at", observed_at)
 
     def canonical_bytes(self) -> bytes:
@@ -144,9 +153,11 @@ class EvidenceRecord:
     created_at: datetime
 
     def __post_init__(self) -> None:
-        if not isinstance(self.event, EvidenceEvent):
+        if type(self.event) is not EvidenceEvent:
             raise TypeError("event must be an EvidenceEvent")
-        _validate_string(self.evidence_id, "evidence_id")
-        _validate_string(self.content_hash, "content_hash")
+        evidence_id = _validate_string(self.evidence_id, "evidence_id")
+        content_hash = _validate_string(self.content_hash, "content_hash")
         created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "evidence_id", evidence_id)
+        object.__setattr__(self, "content_hash", content_hash)
         object.__setattr__(self, "created_at", created_at)

--- a/areal/v2/memory_service/types.py
+++ b/areal/v2/memory_service/types.py
@@ -25,7 +25,7 @@ def _validate_string(
         raise ValueError(f"{field_name} must be valid UTF-8") from exc
 
 
-def _validate_aware_datetime(value: object, field_name: str) -> None:
+def _validate_aware_datetime(value: object, field_name: str) -> datetime:
     if not isinstance(value, datetime):
         raise TypeError(f"{field_name} must be a datetime")
     if value.tzinfo is None:
@@ -37,9 +37,19 @@ def _validate_aware_datetime(value: object, field_name: str) -> None:
     if offset is None:
         raise ValueError(f"{field_name} must be timezone-aware")
     try:
-        value.astimezone(UTC)
+        normalized = datetime.astimezone(value, UTC)
     except (OverflowError, ValueError) as exc:
         raise ValueError(f"{field_name} must be normalizable to UTC") from exc
+    return datetime(
+        normalized.year,
+        normalized.month,
+        normalized.day,
+        normalized.hour,
+        normalized.minute,
+        normalized.second,
+        normalized.microsecond,
+        tzinfo=UTC,
+    )
 
 
 class EvidenceKind(StrEnum):
@@ -96,7 +106,8 @@ class EvidenceEvent:
         if not isinstance(self.kind, EvidenceKind):
             raise TypeError("kind must be an EvidenceKind")
         _validate_string(self.payload, "payload", allow_blank=True)
-        _validate_aware_datetime(self.observed_at, "observed_at")
+        observed_at = _validate_aware_datetime(self.observed_at, "observed_at")
+        object.__setattr__(self, "observed_at", observed_at)
 
     def canonical_bytes(self) -> bytes:
         """Serialize the event as deterministic, compact UTF-8 JSON."""
@@ -137,4 +148,5 @@ class EvidenceRecord:
             raise TypeError("event must be an EvidenceEvent")
         _validate_string(self.evidence_id, "evidence_id")
         _validate_string(self.content_hash, "content_hash")
-        _validate_aware_datetime(self.created_at, "created_at")
+        created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "created_at", created_at)

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -176,6 +176,20 @@ class AlwaysEqualStr(str):
     __hash__ = str.__hash__
 
 
+class SetThenInterruptDict(dict[object, object]):
+    """Expose rollback bugs where a mapping mutates before interruption."""
+
+    def __init__(self, values: dict[object, object] | None = None) -> None:
+        super().__init__({} if values is None else values)
+        self.should_interrupt = True
+
+    def __setitem__(self, key: object, value: object) -> None:
+        super().__setitem__(key, value)
+        if self.should_interrupt:
+            self.should_interrupt = False
+            raise KeyboardInterrupt("injected publication interruption")
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -199,6 +213,28 @@ def make_event(**overrides: object) -> EvidenceEvent:
     }
     values.update(overrides)
     return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("failing_index", ("idempotency", "scope"))
+def test_append_rolls_back_every_index_after_base_exception(
+    failing_index: str,
+) -> None:
+    store = InMemoryEvidenceStore()
+    if failing_index == "idempotency":
+        store._by_idempotency_key = SetThenInterruptDict()
+    else:
+        store._by_scope = SetThenInterruptDict()
+    event = make_event()
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        store.append(event)
+
+    assert store._by_evidence_id == {}
+    assert store._by_idempotency_key == {}
+    assert store._by_scope == {}
+    record = store.append(event)
+    assert store.get(event.scope, record.evidence_id) == record
+    assert store.list(event.scope) == (record,)
 
 
 def test_error_types_share_memory_service_base_error() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -55,6 +55,16 @@ class FoldAwareTimezone(tzinfo):
         return "FOLD-DST" if value is not None and value.fold == 0 else "FOLD-STD"
 
 
+class MemoryScopeSubclass(MemoryScope):
+    def __hash__(self) -> int:
+        return 0
+
+
+class EvidenceEventSubclass(EvidenceEvent):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -145,6 +155,37 @@ def test_evidence_store_contract_exposes_no_update_or_delete() -> None:
     assert not hasattr(EvidenceStore, "delete")
     assert not hasattr(store, "update")
     assert not hasattr(store, "delete")
+
+
+def test_append_rejects_evidence_event_subclass() -> None:
+    event = make_event()
+    event_subclass = EvidenceEventSubclass(
+        scope=event.scope,
+        session_id=event.session_id,
+        run_id=event.run_id,
+        sequence_no=event.sequence_no,
+        kind=event.kind,
+        payload=event.payload,
+        observed_at=event.observed_at,
+        idempotency_key=event.idempotency_key,
+    )
+
+    with pytest.raises(TypeError, match="event must be an EvidenceEvent"):
+        InMemoryEvidenceStore().append(event_subclass)
+
+
+def test_get_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        InMemoryEvidenceStore().get(scope, "evd_missing")
+
+
+def test_list_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        InMemoryEvidenceStore().list(scope)
 
 
 def test_append_and_get_round_trip_returns_persisted_record() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -18,6 +18,7 @@ import pytest
 
 import areal.v2.memory_service as memory_service
 from areal.v2.memory_service import store as store_module
+from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
@@ -190,6 +191,13 @@ class SetThenInterruptDict(dict[object, object]):
             raise KeyboardInterrupt("injected publication interruption")
 
 
+class InterruptingRollbackDict(SetThenInterruptDict):
+    """Try to interrupt rollback through an overridden mapping method."""
+
+    def pop(self, key: object, default: object = None) -> object:
+        raise KeyboardInterrupt("rollback override must be bypassed")
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -235,6 +243,40 @@ def test_append_rolls_back_every_index_after_base_exception(
     record = store.append(event)
     assert store.get(event.scope, record.evidence_id) == record
     assert store.list(event.scope) == (record,)
+
+
+def test_rollback_bypasses_fault_injection_mapping_overrides() -> None:
+    store = InMemoryEvidenceStore()
+    store._by_idempotency_key = InterruptingRollbackDict()
+    event = make_event()
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        store.append(event)
+
+    assert store._by_evidence_id == {}
+    assert store._by_idempotency_key == {}
+    assert store._by_scope == {}
+    record = store.append(event)
+    assert store.get(event.scope, record.evidence_id) == record
+
+
+def test_atomic_publish_restores_an_existing_scope_list() -> None:
+    old_record = object()
+    new_record = object()
+    scope_index: dict[object, list[object]] = {"scope": [old_record]}
+    failing_index = SetThenInterruptDict()
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        _atomic_publish(
+            mapping_writes=(),
+            sequence_appends=(
+                (scope_index, "scope", new_record),
+                (failing_index, "later-scope", new_record),
+            ),
+        )
+
+    assert scope_index == {"scope": [old_record]}
+    assert failing_index == {}
 
 
 def test_error_types_share_memory_service_base_error() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -546,3 +546,56 @@ def test_hash_prefix_collision_fails_without_overwriting(
     assert original.evidence_id == f"evd_{shared_prefix}"
     assert store.get(original.event.scope, original.evidence_id) is original
     assert store.list(original.event.scope) == (original,)
+
+
+def test_hash_prefix_collision_is_isolated_across_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared_prefix = "a" * 24
+    first_digest = shared_prefix + "b" * 40
+    second_digest = shared_prefix + "c" * 40
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    missing_scope = make_scope(subject_id="user-3")
+    first_event = make_event(
+        scope=first_scope,
+        payload="first",
+        idempotency_key="shared-key",
+    )
+    second_event = make_event(
+        scope=second_scope,
+        payload="second",
+        idempotency_key="shared-key",
+    )
+    digest_by_canonical_bytes = {
+        first_event.canonical_bytes(): first_digest,
+        second_event.canonical_bytes(): second_digest,
+    }
+
+    class StubHash:
+        def __init__(self, digest: str) -> None:
+            self._digest = digest
+
+        def hexdigest(self) -> str:
+            return self._digest
+
+    def prefix_colliding_sha256(canonical_bytes: bytes) -> StubHash:
+        return StubHash(digest_by_canonical_bytes[canonical_bytes])
+
+    monkeypatch.setattr(store_module.hashlib, "sha256", prefix_colliding_sha256)
+    store = InMemoryEvidenceStore()
+
+    first = store.append(first_event)
+    second = store.append(second_event)
+
+    assert first is not second
+    assert first.evidence_id == second.evidence_id == f"evd_{shared_prefix}"
+    assert first.content_hash == first_digest
+    assert second.content_hash == second_digest
+    assert store.get(first_scope, first.evidence_id) is first
+    assert store.get(second_scope, second.evidence_id) is second
+    with pytest.raises(EvidenceNotFoundError):
+        store.get(missing_scope, first.evidence_id)
+    assert store.list(first_scope) == (first,)
+    assert store.list(second_scope) == (second,)
+    assert store.list(missing_scope) == ()

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import re
 from concurrent.futures import ThreadPoolExecutor
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
 from hashlib import sha256 as calculate_sha256
 from threading import Barrier
 from time import sleep
@@ -40,6 +40,19 @@ class YieldingMissingDict(dict[object, object]):
         if value is default:
             sleep(0.05)
         return value
+
+
+class FoldAwareTimezone(tzinfo):
+    """Minimal repeated-hour timezone independent of the system tz database."""
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        return timedelta(hours=-4 if value is not None and value.fold == 0 else -5)
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(hours=1 if value is not None and value.fold == 0 else 0)
+
+    def tzname(self, value: datetime | None) -> str:
+        return "FOLD-DST" if value is not None and value.fold == 0 else "FOLD-STD"
 
 
 def make_scope(**overrides: str) -> MemoryScope:
@@ -406,6 +419,39 @@ def test_list_returns_deterministic_order_using_normalized_instants() -> None:
         later_run,
         later_session,
     )
+
+
+def test_list_orders_folded_datetimes_by_absolute_instant() -> None:
+    """Normalize before sorting when one repeated wall-clock hour folds backward."""
+    store = InMemoryEvidenceStore()
+    scope = make_scope()
+    fold_timezone = FoldAwareTimezone()
+    earlier_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(2026, 11, 1, 1, 45, tzinfo=fold_timezone, fold=0),
+            idempotency_key="earlier-fold-instant",
+        )
+    )
+    later_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(2026, 11, 1, 1, 15, tzinfo=fold_timezone, fold=1),
+            idempotency_key="later-fold-instant",
+        )
+    )
+
+    assert later_instant.event.observed_at < earlier_instant.event.observed_at
+    assert earlier_instant.event.observed_at.astimezone(
+        UTC
+    ) < later_instant.event.observed_at.astimezone(UTC)
+    assert store.list(scope) == (earlier_instant, later_instant)
 
 
 def test_append_sets_aware_utc_created_at() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -65,6 +65,36 @@ class EvidenceEventSubclass(EvidenceEvent):
         return b"overridden"
 
 
+class MutableHashStr(str):
+    hash_calls: int
+    hash_salt: int
+
+    def __new__(cls, value: str) -> MutableHashStr:
+        instance = str.__new__(cls, value)
+        instance.hash_calls = 0
+        instance.hash_salt = 0
+        return instance
+
+    def __hash__(self) -> int:
+        self.hash_calls += 1
+        return str.__hash__(self) + self.hash_salt
+
+
+class AlwaysEqualStr(str):
+    equality_calls: int
+
+    def __new__(cls, value: str) -> AlwaysEqualStr:
+        instance = str.__new__(cls, value)
+        instance.equality_calls = 0
+        return instance
+
+    def __eq__(self, other: object) -> bool:
+        self.equality_calls += 1
+        return True
+
+    __hash__ = str.__hash__
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -305,6 +335,26 @@ def test_get_missing_evidence_raises_not_found() -> None:
     assert type(error.value) is EvidenceNotFoundError
 
 
+def test_get_snapshots_evidence_id_before_lookup() -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+    query_id = MutableHashStr(record.evidence_id)
+    query_id.hash_salt = 1_000_003
+
+    assert store.get(record.event.scope, query_id) is record
+    assert query_id.hash_calls == 0
+
+
+def test_blank_query_values_remain_no_match() -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+
+    with pytest.raises(EvidenceNotFoundError):
+        store.get(record.event.scope, "")
+    assert store.list(record.event.scope, session_id="") == ()
+    assert store.list(record.event.scope, run_id="") == ()
+
+
 def test_get_hides_record_that_belongs_to_another_scope() -> None:
     store = InMemoryEvidenceStore()
     record = store.append(make_event())
@@ -375,6 +425,16 @@ def test_list_filters_by_scope_session_and_run() -> None:
         session_one_run_two,
     )
     assert store.list(scope, session_id="missing") == ()
+
+
+@pytest.mark.parametrize("field", ["session_id", "run_id"])
+def test_list_snapshots_filter_before_comparison(field: str) -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+    query = AlwaysEqualStr(f"missing-{field}")
+
+    assert store.list(record.event.scope, **{field: query}) == ()
+    assert query.equality_calls == 0
 
 
 def test_list_returns_deterministic_order_using_normalized_instants() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the in-memory Memory Service evidence store."""
+
+from __future__ import annotations
+
+import re
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta, timezone
+from hashlib import sha256 as calculate_sha256
+from threading import Barrier
+from time import sleep
+
+import pytest
+
+import areal.v2.memory_service as memory_service
+from areal.v2.memory_service import store as store_module
+from areal.v2.memory_service.errors import (
+    EvidenceConflictError,
+    EvidenceNotFoundError,
+    MemoryServiceError,
+)
+from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
+CONCURRENCY_TIMEOUT_SECONDS = 10.0
+
+
+class YieldingMissingDict(dict[object, object]):
+    """Yield after a missing lookup to expose an unprotected check/write race."""
+
+    def get(self, key: object, default: object = None) -> object:
+        value = super().get(key, default)
+        if value is default:
+            sleep(0.05)
+        return value
+
+
+def make_scope(**overrides: str) -> MemoryScope:
+    values = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)
+
+
+def make_event(**overrides: object) -> EvidenceEvent:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "sequence_no": 0,
+        "kind": EvidenceKind.USER_MESSAGE,
+        "payload": "hello",
+        "observed_at": UTC_INSTANT,
+        "idempotency_key": "idempotency-1",
+    }
+    values.update(overrides)
+    return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+def test_error_types_share_memory_service_base_error() -> None:
+    assert issubclass(EvidenceNotFoundError, MemoryServiceError)
+    assert issubclass(EvidenceConflictError, MemoryServiceError)
+
+
+def test_public_module_exports_only_stable_evidence_contract() -> None:
+    """Expose only the intended immutable evidence API at package level."""
+    from areal.v2.memory_service import (
+        EvidenceConflictError as PublicEvidenceConflictError,
+    )
+    from areal.v2.memory_service import EvidenceEvent as PublicEvidenceEvent
+    from areal.v2.memory_service import EvidenceKind as PublicEvidenceKind
+    from areal.v2.memory_service import (
+        EvidenceNotFoundError as PublicEvidenceNotFoundError,
+    )
+    from areal.v2.memory_service import EvidenceRecord as PublicEvidenceRecord
+    from areal.v2.memory_service import EvidenceStore as PublicEvidenceStore
+    from areal.v2.memory_service import (
+        InMemoryEvidenceStore as PublicInMemoryEvidenceStore,
+    )
+    from areal.v2.memory_service import MemoryScope as PublicMemoryScope
+    from areal.v2.memory_service import MemoryServiceError as PublicMemoryServiceError
+
+    assert memory_service.__all__ == [
+        "EvidenceConflictError",
+        "EvidenceEvent",
+        "EvidenceKind",
+        "EvidenceNotFoundError",
+        "EvidenceRecord",
+        "EvidenceStore",
+        "InMemoryEvidenceStore",
+        "MemoryScope",
+        "MemoryServiceError",
+    ]
+    assert (
+        PublicEvidenceConflictError,
+        PublicEvidenceEvent,
+        PublicEvidenceKind,
+        PublicEvidenceNotFoundError,
+        PublicEvidenceRecord,
+        PublicEvidenceStore,
+        PublicInMemoryEvidenceStore,
+        PublicMemoryScope,
+        PublicMemoryServiceError,
+    ) == (
+        EvidenceConflictError,
+        EvidenceEvent,
+        EvidenceKind,
+        EvidenceNotFoundError,
+        EvidenceRecord,
+        EvidenceStore,
+        InMemoryEvidenceStore,
+        MemoryScope,
+        MemoryServiceError,
+    )
+
+
+def test_evidence_store_contract_exposes_no_update_or_delete() -> None:
+    """Keep both the protocol and implementation append-only."""
+    store = InMemoryEvidenceStore()
+
+    assert not hasattr(EvidenceStore, "update")
+    assert not hasattr(EvidenceStore, "delete")
+    assert not hasattr(store, "update")
+    assert not hasattr(store, "delete")
+
+
+def test_append_and_get_round_trip_returns_persisted_record() -> None:
+    store = InMemoryEvidenceStore()
+    event = make_event()
+
+    record = store.append(event)
+
+    assert record.event is event
+    assert store.get(event.scope, record.evidence_id) is record
+
+
+def test_append_identical_retry_returns_exact_original_record() -> None:
+    store = InMemoryEvidenceStore()
+    original_event = make_event()
+    equivalent_retry = make_event()
+    assert equivalent_retry is not original_event
+    assert equivalent_retry.canonical_bytes() == original_event.canonical_bytes()
+
+    original_record = store.append(original_event)
+    retry_record = store.append(equivalent_retry)
+
+    assert retry_record is original_record
+    assert retry_record.event is original_event
+    assert store.list(original_event.scope) == (original_record,)
+
+
+def test_concurrent_identical_appends_return_exact_original_record() -> None:
+    """Serialize same-event races into one record without duplicate writes."""
+    store = InMemoryEvidenceStore()
+    store._by_evidence_id = YieldingMissingDict()
+    store._by_idempotency_key = YieldingMissingDict()
+    event = make_event()
+    caller_count = 32
+    start = Barrier(caller_count, timeout=CONCURRENCY_TIMEOUT_SECONDS)
+
+    def append_after_start() -> EvidenceRecord:
+        start.wait()
+        return store.append(event)
+
+    with ThreadPoolExecutor(max_workers=caller_count) as executor:
+        futures = [executor.submit(append_after_start) for _ in range(caller_count)]
+        records = tuple(
+            future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS) for future in futures
+        )
+
+    original = records[0]
+    assert all(record is original for record in records)
+    assert {record.evidence_id for record in records} == {original.evidence_id}
+    assert store.list(event.scope) == (original,)
+
+
+def test_append_rejects_changed_event_with_same_scoped_idempotency_key() -> None:
+    store = InMemoryEvidenceStore()
+    original = store.append(make_event(payload="first"))
+
+    with pytest.raises(EvidenceConflictError, match="idempotency"):
+        store.append(make_event(payload="changed"))
+
+    assert store.get(original.event.scope, original.evidence_id) is original
+    assert store.list(original.event.scope) == (original,)
+
+
+def test_concurrent_scoped_idempotency_conflicts_leave_only_winner_indexed() -> None:
+    """Commit one racing event atomically and reject every conflicting writer."""
+    store = InMemoryEvidenceStore()
+    store._by_evidence_id = YieldingMissingDict()
+    store._by_idempotency_key = YieldingMissingDict()
+    scope = make_scope()
+    events = tuple(
+        make_event(scope=scope, sequence_no=index, payload=f"payload-{index}")
+        for index in range(32)
+    )
+    start = Barrier(len(events), timeout=CONCURRENCY_TIMEOUT_SECONDS)
+
+    def append_after_start(event: EvidenceEvent) -> EvidenceRecord:
+        start.wait()
+        return store.append(event)
+
+    with ThreadPoolExecutor(max_workers=len(events)) as executor:
+        futures = [executor.submit(append_after_start, event) for event in events]
+        winners: list[EvidenceRecord] = []
+        conflicts: list[EvidenceConflictError] = []
+        for future in futures:
+            try:
+                winners.append(future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS))
+            except EvidenceConflictError as error:
+                conflicts.append(error)
+
+    assert len(winners) == 1
+    assert len(conflicts) == len(events) - 1
+    assert {type(error) for error in conflicts} == {EvidenceConflictError}
+
+    winner = winners[0]
+    losers = tuple(event for event in events if event is not winner.event)
+    assert len(losers) == len(events) - 1
+    assert store.list(scope) == (winner,)
+    assert store.get(scope, winner.evidence_id) is winner
+    assert store.append(winner.event) is winner
+
+    for loser in losers:
+        with pytest.raises(EvidenceConflictError, match="idempotency"):
+            store.append(loser)
+        loser_hash = calculate_sha256(loser.canonical_bytes()).hexdigest()
+        with pytest.raises(EvidenceNotFoundError):
+            store.get(scope, f"evd_{loser_hash[:24]}")
+
+    assert store.list(scope) == (winner,)
+
+
+def test_get_missing_evidence_raises_not_found() -> None:
+    store = InMemoryEvidenceStore()
+
+    with pytest.raises(EvidenceNotFoundError) as error:
+        store.get(make_scope(), "evd_missing")
+
+    assert type(error.value) is EvidenceNotFoundError
+
+
+def test_get_hides_record_that_belongs_to_another_scope() -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+    other_scope = make_scope(subject_id="user-2")
+
+    with pytest.raises(EvidenceNotFoundError) as missing_error:
+        store.get(record.event.scope, "evd_missing")
+    with pytest.raises(EvidenceNotFoundError) as wrong_scope_error:
+        store.get(other_scope, record.evidence_id)
+
+    assert type(wrong_scope_error.value) is EvidenceNotFoundError
+    assert str(wrong_scope_error.value) == str(missing_error.value).replace(
+        "evd_missing", record.evidence_id
+    )
+
+
+def test_list_filters_by_scope_session_and_run() -> None:
+    store = InMemoryEvidenceStore()
+    scope = make_scope()
+    other_scope = make_scope(subject_id="user-2")
+    session_one_run_one = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-1",
+            run_id="run-1",
+            idempotency_key="one-one",
+        )
+    )
+    session_one_run_two = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-1",
+            run_id="run-2",
+            idempotency_key="one-two",
+        )
+    )
+    session_two_run_one = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-2",
+            run_id="run-1",
+            idempotency_key="two-one",
+        )
+    )
+    store.append(
+        make_event(
+            scope=other_scope,
+            session_id="session-1",
+            run_id="run-1",
+            idempotency_key="one-one",
+        )
+    )
+
+    assert store.list(scope) == (
+        session_one_run_one,
+        session_one_run_two,
+        session_two_run_one,
+    )
+    assert store.list(scope, session_id="session-1") == (
+        session_one_run_one,
+        session_one_run_two,
+    )
+    assert store.list(scope, run_id="run-1") == (
+        session_one_run_one,
+        session_two_run_one,
+    )
+    assert store.list(scope, session_id="session-1", run_id="run-2") == (
+        session_one_run_two,
+    )
+    assert store.list(scope, session_id="missing") == ()
+
+
+def test_list_returns_deterministic_order_using_normalized_instants() -> None:
+    store = InMemoryEvidenceStore()
+    scope = make_scope()
+    earlier_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(
+                2026, 7, 7, 12, 0, tzinfo=timezone(timedelta(hours=8))
+            ),
+            idempotency_key="earlier-instant",
+        )
+    )
+    later_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(2026, 7, 7, 4, 30, tzinfo=UTC),
+            idempotency_key="later-instant",
+        )
+    )
+    tied_a = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=2,
+            payload="tie-a",
+            idempotency_key="tie-a",
+        )
+    )
+    tied_b = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=2,
+            payload="tie-b",
+            idempotency_key="tie-b",
+        )
+    )
+    later_sequence = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=3,
+            observed_at=datetime(2020, 1, 1, tzinfo=UTC),
+            idempotency_key="later-sequence",
+        )
+    )
+    later_run = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-b",
+            sequence_no=0,
+            idempotency_key="later-run",
+        )
+    )
+    later_session = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-b",
+            run_id="run-a",
+            sequence_no=0,
+            idempotency_key="later-session",
+        )
+    )
+    tied_by_id = tuple(sorted((tied_a, tied_b), key=lambda item: item.evidence_id))
+
+    assert store.list(scope) == (
+        earlier_instant,
+        later_instant,
+        *tied_by_id,
+        later_sequence,
+        later_run,
+        later_session,
+    )
+
+
+def test_append_sets_aware_utc_created_at() -> None:
+    record = InMemoryEvidenceStore().append(make_event())
+
+    assert record.created_at.tzinfo is UTC
+    assert record.created_at.utcoffset() == timedelta(0)
+
+
+def test_append_uses_sha256_content_hash_and_derived_evidence_id() -> None:
+    event = make_event()
+    expected_hash = calculate_sha256(event.canonical_bytes()).hexdigest()
+
+    record = InMemoryEvidenceStore().append(event)
+
+    assert record.content_hash == expected_hash
+    assert re.fullmatch(r"[0-9a-f]{64}", record.content_hash)
+    assert record.evidence_id == f"evd_{expected_hash[:24]}"
+    assert re.fullmatch(r"evd_[0-9a-f]{24}", record.evidence_id)
+
+
+def test_same_idempotency_key_is_independent_across_scopes() -> None:
+    store = InMemoryEvidenceStore()
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+
+    first = store.append(make_event(scope=first_scope, payload="first"))
+    second = store.append(make_event(scope=second_scope, payload="second"))
+
+    assert first is not second
+    assert first.evidence_id != second.evidence_id
+    assert store.list(first_scope) == (first,)
+    assert store.list(second_scope) == (second,)
+
+
+def test_full_hash_collision_fails_without_overwriting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ConstantHash:
+        def hexdigest(self) -> str:
+            return "a" * 64
+
+    def constant_sha256(_: bytes) -> ConstantHash:
+        return ConstantHash()
+
+    monkeypatch.setattr(store_module.hashlib, "sha256", constant_sha256)
+    store = InMemoryEvidenceStore()
+    original = store.append(make_event(idempotency_key="first"))
+    colliding_event = make_event(payload="different", idempotency_key="second")
+
+    with pytest.raises(EvidenceConflictError, match="collision"):
+        store.append(colliding_event)
+
+    assert store.get(original.event.scope, original.evidence_id) is original
+    assert store.list(original.event.scope) == (original,)
+
+
+def test_hash_prefix_collision_fails_without_overwriting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject distinct full hashes that derive the same truncated evidence ID."""
+    shared_prefix = "a" * 24
+    original_digest = shared_prefix + "b" * 40
+    colliding_digest = shared_prefix + "c" * 40
+    original_event = make_event(idempotency_key="first")
+    colliding_event = make_event(payload="different", idempotency_key="second")
+    digest_by_canonical_bytes = {
+        original_event.canonical_bytes(): original_digest,
+        colliding_event.canonical_bytes(): colliding_digest,
+    }
+
+    class StubHash:
+        def __init__(self, digest: str) -> None:
+            self._digest = digest
+
+        def hexdigest(self) -> str:
+            return self._digest
+
+    def prefix_colliding_sha256(canonical_bytes: bytes) -> StubHash:
+        return StubHash(digest_by_canonical_bytes[canonical_bytes])
+
+    monkeypatch.setattr(store_module.hashlib, "sha256", prefix_colliding_sha256)
+    store = InMemoryEvidenceStore()
+    original = store.append(original_event)
+
+    with pytest.raises(EvidenceConflictError, match="collision"):
+        store.append(colliding_event)
+
+    assert original.content_hash == original_digest
+    assert original.evidence_id == f"evd_{shared_prefix}"
+    assert store.get(original.event.scope, original.evidence_id) is original
+    assert store.list(original.event.scope) == (original,)

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -4,11 +4,14 @@
 
 from __future__ import annotations
 
+import faulthandler
 import re
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta, timezone, tzinfo
 from hashlib import sha256 as calculate_sha256
-from threading import Barrier
+from threading import Barrier, Event
 from time import sleep
 
 import pytest
@@ -30,6 +33,84 @@ from areal.v2.memory_service.types import (
 
 UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
 CONCURRENCY_TIMEOUT_SECONDS = 10.0
+HARD_CONCURRENCY_TIMEOUT_SECONDS = CONCURRENCY_TIMEOUT_SECONDS + 5.0
+
+
+@contextmanager
+def _hard_bounded_executor(*, max_workers: int) -> Iterator[ThreadPoolExecutor]:
+    faulthandler.dump_traceback_later(
+        HARD_CONCURRENCY_TIMEOUT_SECONDS,
+        exit=True,
+    )
+    try:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            yield executor
+    finally:
+        faulthandler.cancel_dump_traceback_later()
+
+
+def test_hard_bounded_executor_waits_for_workers_before_cancel_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bounded_executor = _hard_bounded_executor
+    watchdog_events: list[object] = []
+    worker_started = Event()
+    shutdown_started = Event()
+    shutdown_finished = Event()
+    worker_finished = Event()
+    shutdown_wait_values: list[bool] = []
+    original_shutdown = ThreadPoolExecutor.shutdown
+    original_error = RuntimeError("body failed")
+
+    def arm_watchdog(timeout: float, *, exit: bool) -> None:
+        watchdog_events.append(("arm", timeout, exit))
+
+    def cancel_watchdog() -> None:
+        watchdog_events.append(
+            (
+                "cancel",
+                worker_finished.is_set(),
+                shutdown_finished.is_set(),
+            )
+        )
+
+    def observe_shutdown(
+        executor: ThreadPoolExecutor,
+        wait: bool = True,
+        *,
+        cancel_futures: bool = False,
+    ) -> None:
+        shutdown_wait_values.append(wait)
+        shutdown_started.set()
+        original_shutdown(
+            executor,
+            wait=wait,
+            cancel_futures=cancel_futures,
+        )
+        shutdown_finished.set()
+
+    def slow_worker() -> None:
+        worker_started.set()
+        assert shutdown_started.wait(timeout=CONCURRENCY_TIMEOUT_SECONDS)
+        worker_finished.set()
+
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", arm_watchdog)
+    monkeypatch.setattr(faulthandler, "cancel_dump_traceback_later", cancel_watchdog)
+    monkeypatch.setattr(ThreadPoolExecutor, "shutdown", observe_shutdown)
+
+    with pytest.raises(RuntimeError) as raised:
+        with bounded_executor(max_workers=1) as executor:
+            future = executor.submit(slow_worker)
+            assert worker_started.wait(timeout=CONCURRENCY_TIMEOUT_SECONDS)
+            raise original_error
+
+    assert raised.value is original_error
+    assert future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS) is None
+    assert watchdog_events == [
+        ("arm", CONCURRENCY_TIMEOUT_SECONDS + 5.0, True),
+        ("cancel", True, True),
+    ]
+    assert shutdown_wait_values == [True]
 
 
 class YieldingMissingDict(dict[object, object]):
@@ -256,7 +337,7 @@ def test_concurrent_identical_appends_return_exact_original_record() -> None:
         start.wait()
         return store.append(event)
 
-    with ThreadPoolExecutor(max_workers=caller_count) as executor:
+    with _hard_bounded_executor(max_workers=caller_count) as executor:
         futures = [executor.submit(append_after_start) for _ in range(caller_count)]
         records = tuple(
             future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS) for future in futures
@@ -295,7 +376,7 @@ def test_concurrent_scoped_idempotency_conflicts_leave_only_winner_indexed() -> 
         start.wait()
         return store.append(event)
 
-    with ThreadPoolExecutor(max_workers=len(events)) as executor:
+    with _hard_bounded_executor(max_workers=len(events)) as executor:
         futures = [executor.submit(append_after_start, event) for event in events]
         winners: list[EvidenceRecord] = []
         conflicts: list[EvidenceConflictError] = []

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -422,17 +422,19 @@ def test_list_returns_deterministic_order_using_normalized_instants() -> None:
 
 
 def test_list_orders_folded_datetimes_by_absolute_instant() -> None:
-    """Normalize before sorting when one repeated wall-clock hour folds backward."""
+    """Snapshot and sort absolute instants when a wall-clock hour folds backward."""
     store = InMemoryEvidenceStore()
     scope = make_scope()
     fold_timezone = FoldAwareTimezone()
+    earlier_source = datetime(2026, 11, 1, 1, 45, tzinfo=fold_timezone, fold=0)
+    later_source = datetime(2026, 11, 1, 1, 15, tzinfo=fold_timezone, fold=1)
     earlier_instant = store.append(
         make_event(
             scope=scope,
             session_id="session-a",
             run_id="run-a",
             sequence_no=1,
-            observed_at=datetime(2026, 11, 1, 1, 45, tzinfo=fold_timezone, fold=0),
+            observed_at=earlier_source,
             idempotency_key="earlier-fold-instant",
         )
     )
@@ -442,15 +444,15 @@ def test_list_orders_folded_datetimes_by_absolute_instant() -> None:
             session_id="session-a",
             run_id="run-a",
             sequence_no=1,
-            observed_at=datetime(2026, 11, 1, 1, 15, tzinfo=fold_timezone, fold=1),
+            observed_at=later_source,
             idempotency_key="later-fold-instant",
         )
     )
 
-    assert later_instant.event.observed_at < earlier_instant.event.observed_at
-    assert earlier_instant.event.observed_at.astimezone(
-        UTC
-    ) < later_instant.event.observed_at.astimezone(UTC)
+    assert earlier_instant.event.observed_at == datetime(2026, 11, 1, 5, 45, tzinfo=UTC)
+    assert later_instant.event.observed_at == datetime(2026, 11, 1, 6, 15, tzinfo=UTC)
+    assert earlier_instant.event.observed_at.tzinfo is UTC
+    assert later_instant.event.observed_at.tzinfo is UTC
     assert store.list(scope) == (earlier_instant, later_instant)
 
 

--- a/tests/v2/memory_service/test_types.py
+++ b/tests/v2/memory_service/test_types.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for immutable Memory Service evidence value objects."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
+LONE_SURROGATE = "\ud800"
+PLUS_ONE_HOUR = timezone(timedelta(hours=1))
+MINUS_ONE_HOUR = timezone(-timedelta(hours=1))
+UTC_OVERFLOWING_DATETIMES = (
+    datetime.min.replace(tzinfo=PLUS_ONE_HOUR),
+    datetime.max.replace(tzinfo=MINUS_ONE_HOUR),
+)
+VALID_UTC_BOUNDARIES = (
+    (
+        (datetime.min + timedelta(hours=1)).replace(tzinfo=PLUS_ONE_HOUR),
+        datetime.min.replace(tzinfo=UTC),
+    ),
+    (
+        (datetime.max - timedelta(hours=1)).replace(tzinfo=MINUS_ONE_HOUR),
+        datetime.max.replace(tzinfo=UTC),
+    ),
+)
+
+
+def make_scope(**overrides: object) -> MemoryScope:
+    values: dict[str, object] = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)  # type: ignore[arg-type]
+
+
+def make_event(**overrides: object) -> EvidenceEvent:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "sequence_no": 0,
+        "kind": EvidenceKind.USER_MESSAGE,
+        "payload": "hello",
+        "observed_at": UTC_INSTANT,
+        "idempotency_key": "idempotency-1",
+    }
+    values.update(overrides)
+    return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+def make_record(**overrides: object) -> EvidenceRecord:
+    values: dict[str, object] = {
+        "evidence_id": "evidence-1",
+        "event": make_event(),
+        "content_hash": "sha256:abc123",
+        "created_at": UTC_INSTANT,
+    }
+    values.update(overrides)
+    return EvidenceRecord(**values)  # type: ignore[arg-type]
+
+
+def test_evidence_kind_values_are_lowercase_snake_case() -> None:
+    assert {kind.name: kind.value for kind in EvidenceKind} == {
+        "USER_MESSAGE": "user_message",
+        "AGENT_MESSAGE": "agent_message",
+        "TOOL_CALL": "tool_call",
+        "TOOL_RESULT": "tool_result",
+        "ENVIRONMENT": "environment",
+        "FEEDBACK": "feedback",
+        "OUTCOME": "outcome",
+    }
+
+
+@pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
+@pytest.mark.parametrize("value", ["", " \t\n"])
+def test_memory_scope_rejects_blank_identifiers(field: str, value: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_scope(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
+@pytest.mark.parametrize("value", [None, 7])
+def test_memory_scope_rejects_non_string_identifiers(field: str, value: object) -> None:
+    with pytest.raises(TypeError, match=field):
+        make_scope(**{field: value})
+
+
+def test_memory_scope_preserves_identifier_whitespace() -> None:
+    scope = MemoryScope(
+        tenant_id=" tenant-1 ",
+        namespace=" assistant-memory ",
+        subject_id=" user-1 ",
+    )
+
+    assert scope.tenant_id == " tenant-1 "
+    assert scope.namespace == " assistant-memory "
+    assert scope.subject_id == " user-1 "
+
+
+@pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
+def test_memory_scope_rejects_invalid_unicode_identifier(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_scope(**{field: LONE_SURROGATE})
+
+
+@pytest.mark.parametrize("field", ["session_id", "run_id", "idempotency_key"])
+@pytest.mark.parametrize("value", ["", " \t\n"])
+def test_evidence_event_rejects_blank_identifiers(field: str, value: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_event(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["session_id", "run_id", "idempotency_key"])
+@pytest.mark.parametrize("value", [None, 7])
+def test_evidence_event_rejects_non_string_identifiers(
+    field: str, value: object
+) -> None:
+    with pytest.raises(TypeError, match=field):
+        make_event(**{field: value})
+
+
+def test_evidence_event_preserves_identifier_whitespace() -> None:
+    event = make_event(
+        session_id=" session-1 ",
+        run_id=" run-1 ",
+        idempotency_key=" idempotency-1 ",
+    )
+
+    assert event.session_id == " session-1 "
+    assert event.run_id == " run-1 "
+    assert event.idempotency_key == " idempotency-1 "
+
+
+@pytest.mark.parametrize(
+    "field", ["session_id", "run_id", "idempotency_key", "payload"]
+)
+def test_evidence_event_rejects_invalid_unicode_string(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_event(**{field: LONE_SURROGATE})
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        {
+            "tenant_id": "tenant-1",
+            "namespace": "assistant-memory",
+            "subject_id": "user-1",
+        },
+        object(),
+    ],
+    ids=["dict", "object"],
+)
+def test_evidence_event_requires_memory_scope(scope: object) -> None:
+    with pytest.raises(TypeError, match="scope"):
+        make_event(scope=scope)
+
+
+def test_evidence_event_accepts_empty_string_payload() -> None:
+    assert make_event(payload="").payload == ""
+
+
+@pytest.mark.parametrize("payload", [None, b"hello", 7])
+def test_evidence_event_rejects_non_string_payload(payload: object) -> None:
+    with pytest.raises(TypeError, match="payload"):
+        make_event(payload=payload)
+
+
+@pytest.mark.parametrize("sequence_no", [True, False, 1.0, "1", None])
+def test_evidence_event_rejects_non_integer_sequence_numbers(
+    sequence_no: object,
+) -> None:
+    with pytest.raises(TypeError, match="sequence_no"):
+        make_event(sequence_no=sequence_no)
+
+
+def test_evidence_event_rejects_negative_sequence_number() -> None:
+    with pytest.raises(ValueError, match="sequence_no"):
+        make_event(sequence_no=-1)
+
+
+def test_evidence_event_accepts_zero_sequence_number() -> None:
+    assert make_event(sequence_no=0).sequence_no == 0
+
+
+def test_evidence_event_accepts_maximum_protocol_sequence_number() -> None:
+    sequence_no = 2**63 - 1
+    event = make_event(sequence_no=sequence_no)
+
+    assert event.sequence_no == sequence_no
+    assert json.loads(event.canonical_bytes())["sequence_no"] == sequence_no
+
+
+@pytest.mark.parametrize(
+    "sequence_no",
+    [2**63, 10**4300],
+    ids=["past-int64", "past-python-json-digit-limit"],
+)
+def test_evidence_event_rejects_sequence_number_above_protocol_maximum(
+    sequence_no: int,
+) -> None:
+    with pytest.raises(ValueError, match="sequence_no"):
+        make_event(sequence_no=sequence_no)
+
+
+@pytest.mark.parametrize("kind", ["user_message", None, 7])
+def test_evidence_event_requires_evidence_kind(kind: object) -> None:
+    with pytest.raises(TypeError, match="kind"):
+        make_event(kind=kind)
+
+
+@pytest.mark.parametrize("observed_at", [None, "2026-07-07T04:05:06Z"])
+def test_evidence_event_rejects_non_datetime_observed_at(
+    observed_at: object,
+) -> None:
+    with pytest.raises(TypeError, match="observed_at"):
+        make_event(observed_at=observed_at)
+
+
+def test_evidence_event_rejects_naive_observed_at() -> None:
+    with pytest.raises(ValueError, match="observed_at"):
+        make_event(observed_at=datetime(2026, 7, 7, 4, 5, 6))
+
+
+@pytest.mark.parametrize(
+    "observed_at",
+    UTC_OVERFLOWING_DATETIMES,
+    ids=["minimum-at-plus-one", "maximum-at-minus-one"],
+)
+def test_evidence_event_rejects_datetime_that_cannot_normalize_to_utc(
+    observed_at: datetime,
+) -> None:
+    with pytest.raises(ValueError, match="observed_at"):
+        make_event(observed_at=observed_at)
+
+
+def test_canonical_bytes_are_sorted_compact_and_deterministic() -> None:
+    event = make_event()
+
+    expected = (
+        b'{"idempotency_key":"idempotency-1","kind":"user_message",'
+        b'"observed_at":"2026-07-07T04:05:06.789000+00:00",'
+        b'"payload":"hello","run_id":"run-1",'
+        b'"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        b'"tenant_id":"tenant-1"},"sequence_no":0,"session_id":"session-1"}'
+    )
+
+    assert event.canonical_bytes() == expected
+    assert event.canonical_bytes() == make_event().canonical_bytes()
+
+
+def test_canonical_bytes_preserve_valid_non_ascii_payload() -> None:
+    payload = "你好，世界 🌍"
+    canonical = make_event(payload=payload).canonical_bytes()
+
+    assert payload.encode("utf-8") in canonical
+    assert json.loads(canonical)["payload"] == payload
+
+
+@pytest.mark.parametrize(
+    ("observed_at", "expected_utc"),
+    VALID_UTC_BOUNDARIES,
+    ids=["minimum", "maximum"],
+)
+def test_canonical_bytes_support_valid_utc_datetime_boundaries(
+    observed_at: datetime, expected_utc: datetime
+) -> None:
+    event = make_event(observed_at=observed_at)
+
+    assert event.observed_at is observed_at
+    assert (
+        json.loads(event.canonical_bytes())["observed_at"] == expected_utc.isoformat()
+    )
+
+
+def test_canonical_bytes_normalize_semantically_equal_instants_to_utc() -> None:
+    utc_event = make_event(observed_at=UTC_INSTANT)
+    utc_plus_eight_event = make_event(
+        observed_at=UTC_INSTANT.astimezone(timezone(timedelta(hours=8)))
+    )
+
+    assert utc_event.observed_at != utc_plus_eight_event.observed_at or (
+        utc_event.observed_at.tzinfo != utc_plus_eight_event.observed_at.tzinfo
+    )
+    assert utc_event.canonical_bytes() == utc_plus_eight_event.canonical_bytes()
+
+
+@pytest.mark.parametrize(
+    "event",
+    ["not-an-event", {"payload": "hello"}, object()],
+    ids=["string", "dict", "object"],
+)
+def test_evidence_record_requires_evidence_event(event: object) -> None:
+    with pytest.raises(TypeError, match="event"):
+        make_record(event=event)
+
+
+@pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
+@pytest.mark.parametrize("value", ["", " \t\n"])
+def test_evidence_record_rejects_blank_identifiers_and_hash(
+    field: str, value: str
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_record(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
+@pytest.mark.parametrize("value", [None, 7])
+def test_evidence_record_rejects_non_string_identifiers_and_hash(
+    field: str, value: object
+) -> None:
+    with pytest.raises(TypeError, match=field):
+        make_record(**{field: value})
+
+
+def test_evidence_record_preserves_identifier_and_hash_whitespace() -> None:
+    record = make_record(evidence_id=" evidence-1 ", content_hash=" sha256:abc123 ")
+
+    assert record.evidence_id == " evidence-1 "
+    assert record.content_hash == " sha256:abc123 "
+
+
+@pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
+def test_evidence_record_rejects_invalid_unicode_string(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_record(**{field: LONE_SURROGATE})
+
+
+@pytest.mark.parametrize("created_at", [None, "2026-07-07T04:05:06Z"])
+def test_evidence_record_rejects_non_datetime_created_at(created_at: object) -> None:
+    with pytest.raises(TypeError, match="created_at"):
+        make_record(created_at=created_at)
+
+
+def test_evidence_record_rejects_naive_created_at() -> None:
+    with pytest.raises(ValueError, match="created_at"):
+        make_record(created_at=datetime(2026, 7, 7, 4, 5, 6))
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    UTC_OVERFLOWING_DATETIMES,
+    ids=["minimum-at-plus-one", "maximum-at-minus-one"],
+)
+def test_evidence_record_rejects_datetime_that_cannot_normalize_to_utc(
+    created_at: datetime,
+) -> None:
+    with pytest.raises(ValueError, match="created_at"):
+        make_record(created_at=created_at)
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    [value for value, _ in VALID_UTC_BOUNDARIES],
+    ids=["minimum", "maximum"],
+)
+def test_evidence_record_accepts_valid_utc_datetime_boundaries(
+    created_at: datetime,
+) -> None:
+    assert make_record(created_at=created_at).created_at is created_at
+
+
+@pytest.mark.parametrize(
+    ("instance", "field", "new_value"),
+    [
+        (make_scope(), "tenant_id", "other-tenant"),
+        (make_event(), "payload", "other payload"),
+        (make_record(), "content_hash", "sha256:other"),
+    ],
+    ids=["memory-scope", "evidence-event", "evidence-record"],
+)
+def test_value_objects_are_frozen_and_slotted(
+    instance: object, field: str, new_value: str
+) -> None:
+    assert not hasattr(instance, "__dict__")
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(instance, field, new_value)

--- a/tests/v2/memory_service/test_types.py
+++ b/tests/v2/memory_service/test_types.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta, timezone, tzinfo
 
 import pytest
 
+from areal.v2.memory_service.store import InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
     EvidenceEvent,
     EvidenceKind,
@@ -63,6 +64,51 @@ class StatefulDatetime(datetime):
 
     def isoformat(self, sep: str = "T", timespec: str = "auto") -> str:
         return f"{datetime.isoformat(self, sep, timespec)}{self.suffix}"
+
+
+class MutableHashStr(str):
+    """String subclass whose hash can change after construction."""
+
+    hash_salt: int
+
+    def __new__(cls, value: str) -> MutableHashStr:
+        instance = str.__new__(cls, value)
+        instance.hash_salt = 0
+        return instance
+
+    def __hash__(self) -> int:
+        return str.__hash__(self) + self.hash_salt
+
+    def __str__(self) -> str:
+        return "overridden"
+
+
+class AdversarialStr(str):
+    """String subclass overriding validation and conversion operations."""
+
+    def __str__(self) -> str:
+        return "overridden"
+
+    def strip(self, chars: str | None = None) -> str:
+        return "overridden"
+
+    def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
+        return b"overridden"
+
+
+class MemoryScopeSubclass(MemoryScope):
+    def __hash__(self) -> int:
+        return 0
+
+
+class EvidenceEventSubclass(EvidenceEvent):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
+class OverriddenInt(int):
+    def __int__(self) -> int:
+        return 999
 
 
 def make_scope(**overrides: object) -> MemoryScope:
@@ -139,10 +185,52 @@ def test_memory_scope_preserves_identifier_whitespace() -> None:
     assert scope.subject_id == " user-1 "
 
 
+def test_memory_scope_snapshots_mutable_hash_strings_for_store_indexes() -> None:
+    tenant_id = MutableHashStr("tenant-1")
+    namespace = MutableHashStr("assistant-memory")
+    subject_id = MutableHashStr("user-1")
+    scope = MemoryScope(
+        tenant_id=tenant_id,
+        namespace=namespace,
+        subject_id=subject_id,
+    )
+    event = make_event(scope=scope)
+    store = InMemoryEvidenceStore()
+    scope_hash = hash(scope)
+    original = store.append(event)
+
+    tenant_id.hash_salt = 1_000_003
+    namespace.hash_salt = 1_000_003
+    subject_id.hash_salt = 1_000_003
+    retry = store.append(event)
+
+    assert retry is original
+    assert hash(scope) == scope_hash
+    assert type(scope.tenant_id) is str
+    assert type(scope.namespace) is str
+    assert type(scope.subject_id) is str
+    assert scope == make_scope()
+    assert store.get(scope, original.evidence_id) is original
+    assert store.list(scope) == (original,)
+    assert len(store._by_evidence_id) == 1
+    assert len(store._by_idempotency_key) == 1
+    assert len(store._by_scope) == 1
+
+
 @pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
 def test_memory_scope_rejects_invalid_unicode_identifier(field: str) -> None:
     with pytest.raises(ValueError, match=field):
         make_scope(**{field: LONE_SURROGATE})
+
+
+def test_string_snapshot_uses_base_blank_validation() -> None:
+    with pytest.raises(ValueError, match="session_id"):
+        make_event(session_id=AdversarialStr(" \t\n"))
+
+
+def test_string_snapshot_uses_base_utf8_validation() -> None:
+    with pytest.raises(ValueError, match="payload"):
+        make_event(payload=AdversarialStr(LONE_SURROGATE))
 
 
 @pytest.mark.parametrize("field", ["session_id", "run_id", "idempotency_key"])
@@ -198,8 +286,32 @@ def test_evidence_event_requires_memory_scope(scope: object) -> None:
         make_event(scope=scope)
 
 
+def test_evidence_event_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        make_event(scope=scope)
+
+
 def test_evidence_event_accepts_empty_string_payload() -> None:
     assert make_event(payload="").payload == ""
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("session_id", " session-1 "),
+        ("run_id", " run-1 "),
+        ("payload", " payload "),
+        ("idempotency_key", " idempotency-1 "),
+    ],
+)
+def test_evidence_event_snapshots_string_subclasses(field: str, value: str) -> None:
+    event = make_event(**{field: AdversarialStr(value)})
+    stored = getattr(event, field)
+
+    assert type(stored) is str
+    assert stored == value
 
 
 @pytest.mark.parametrize("payload", [None, b"hello", 7])
@@ -208,7 +320,7 @@ def test_evidence_event_rejects_non_string_payload(payload: object) -> None:
         make_event(payload=payload)
 
 
-@pytest.mark.parametrize("sequence_no", [True, False, 1.0, "1", None])
+@pytest.mark.parametrize("sequence_no", [True, False, OverriddenInt(1), 1.0, "1", None])
 def test_evidence_event_rejects_non_integer_sequence_numbers(
     sequence_no: object,
 ) -> None:
@@ -374,6 +486,23 @@ def test_evidence_record_requires_evidence_event(event: object) -> None:
         make_record(event=event)
 
 
+def test_evidence_record_rejects_evidence_event_subclass() -> None:
+    event = make_event()
+    event_subclass = EvidenceEventSubclass(
+        scope=event.scope,
+        session_id=event.session_id,
+        run_id=event.run_id,
+        sequence_no=event.sequence_no,
+        kind=event.kind,
+        payload=event.payload,
+        observed_at=event.observed_at,
+        idempotency_key=event.idempotency_key,
+    )
+
+    with pytest.raises(TypeError, match="event must be an EvidenceEvent"):
+        make_record(event=event_subclass)
+
+
 @pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
 @pytest.mark.parametrize("value", ["", " \t\n"])
 def test_evidence_record_rejects_blank_identifiers_and_hash(
@@ -397,6 +526,21 @@ def test_evidence_record_preserves_identifier_and_hash_whitespace() -> None:
 
     assert record.evidence_id == " evidence-1 "
     assert record.content_hash == " sha256:abc123 "
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("evidence_id", " evidence-1 "),
+        ("content_hash", " sha256:abc123 "),
+    ],
+)
+def test_evidence_record_snapshots_string_subclasses(field: str, value: str) -> None:
+    record = make_record(**{field: AdversarialStr(value)})
+    stored = getattr(record, field)
+
+    assert type(stored) is str
+    assert stored == value
 
 
 @pytest.mark.parametrize("field", ["evidence_id", "content_hash"])

--- a/tests/v2/memory_service/test_types.py
+++ b/tests/v2/memory_service/test_types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import FrozenInstanceError
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
 
 import pytest
 
@@ -35,6 +35,34 @@ VALID_UTC_BOUNDARIES = (
         datetime.max.replace(tzinfo=UTC),
     ),
 )
+
+
+class MutableTimezone(tzinfo):
+    """Timezone whose offset can change after a datetime is constructed."""
+
+    def __init__(self, offset: timedelta) -> None:
+        self.offset = offset
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        return self.offset
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(0)
+
+    def tzname(self, value: datetime | None) -> str:
+        return "MUTABLE"
+
+
+class StatefulDatetime(datetime):
+    """Datetime subclass with unsafe conversion and serialization overrides."""
+
+    suffix: str = ""
+
+    def astimezone(self, timezone: tzinfo | None = None) -> StatefulDatetime:
+        return self
+
+    def isoformat(self, sep: str = "T", timespec: str = "auto") -> str:
+        return f"{datetime.isoformat(self, sep, timespec)}{self.suffix}"
 
 
 def make_scope(**overrides: object) -> MemoryScope:
@@ -248,6 +276,42 @@ def test_evidence_event_rejects_datetime_that_cannot_normalize_to_utc(
         make_event(observed_at=observed_at)
 
 
+def test_evidence_event_snapshots_mutable_observed_at_as_utc() -> None:
+    source_timezone = MutableTimezone(timedelta(hours=1))
+    source = datetime(2026, 7, 7, 5, 5, 6, 789000, tzinfo=source_timezone)
+    event = make_event(observed_at=source)
+    canonical_bytes = event.canonical_bytes()
+
+    source_timezone.offset = timedelta(hours=2)
+
+    assert event.canonical_bytes() == canonical_bytes
+    assert event.observed_at == UTC_INSTANT
+    assert event.observed_at.tzinfo is UTC
+
+
+def test_evidence_event_snapshots_datetime_subclass_as_plain_utc() -> None:
+    source = StatefulDatetime(
+        2026,
+        7,
+        7,
+        5,
+        5,
+        6,
+        789000,
+        tzinfo=timezone(timedelta(hours=1)),
+    )
+    source.suffix = "-before"
+    event = make_event(observed_at=source)
+    canonical_bytes = event.canonical_bytes()
+
+    source.suffix = "-after"
+
+    assert type(event.observed_at) is datetime
+    assert event.observed_at == UTC_INSTANT
+    assert event.canonical_bytes() == canonical_bytes
+    assert b"-before" not in canonical_bytes
+
+
 def test_canonical_bytes_are_sorted_compact_and_deterministic() -> None:
     event = make_event()
 
@@ -281,7 +345,8 @@ def test_canonical_bytes_support_valid_utc_datetime_boundaries(
 ) -> None:
     event = make_event(observed_at=observed_at)
 
-    assert event.observed_at is observed_at
+    assert event.observed_at == expected_utc
+    assert event.observed_at.tzinfo is UTC
     assert (
         json.loads(event.canonical_bytes())["observed_at"] == expected_utc.isoformat()
     )
@@ -293,9 +358,9 @@ def test_canonical_bytes_normalize_semantically_equal_instants_to_utc() -> None:
         observed_at=UTC_INSTANT.astimezone(timezone(timedelta(hours=8)))
     )
 
-    assert utc_event.observed_at != utc_plus_eight_event.observed_at or (
-        utc_event.observed_at.tzinfo != utc_plus_eight_event.observed_at.tzinfo
-    )
+    assert utc_event.observed_at == utc_plus_eight_event.observed_at == UTC_INSTANT
+    assert utc_event.observed_at.tzinfo is UTC
+    assert utc_plus_eight_event.observed_at.tzinfo is UTC
     assert utc_event.canonical_bytes() == utc_plus_eight_event.canonical_bytes()
 
 
@@ -363,15 +428,29 @@ def test_evidence_record_rejects_datetime_that_cannot_normalize_to_utc(
         make_record(created_at=created_at)
 
 
+def test_evidence_record_snapshots_mutable_created_at_as_utc() -> None:
+    source_timezone = MutableTimezone(timedelta(hours=1))
+    source = datetime(2026, 7, 7, 5, 5, 6, 789000, tzinfo=source_timezone)
+    record = make_record(created_at=source)
+
+    source_timezone.offset = timedelta(hours=2)
+
+    assert record.created_at == UTC_INSTANT
+    assert record.created_at.tzinfo is UTC
+
+
 @pytest.mark.parametrize(
-    "created_at",
-    [value for value, _ in VALID_UTC_BOUNDARIES],
+    ("created_at", "expected_utc"),
+    VALID_UTC_BOUNDARIES,
     ids=["minimum", "maximum"],
 )
 def test_evidence_record_accepts_valid_utc_datetime_boundaries(
-    created_at: datetime,
+    created_at: datetime, expected_utc: datetime
 ) -> None:
-    assert make_record(created_at=created_at).created_at is created_at
+    record = make_record(created_at=created_at)
+
+    assert record.created_at == expected_utc
+    assert record.created_at.tzinfo is UTC
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Add the first, deliberately narrow Memory Service primitive proposed in #1490:
immutable evidence value objects and a deterministic in-memory reference store.

The goal is to establish the provenance boundary before adding candidates, releases,
retrieval, Agent Service integration, or RL. Every future derived memory can refer to
an immutable evidence record, and repeated writes are either exactly idempotent or
fail explicitly instead of silently overwriting history.

## Related Issue

Refs #1490

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## What Changed

- add frozen `MemoryScope`, `EvidenceEvent`, and `EvidenceRecord` value objects;
- add explicit evidence kinds for user, agent, tool, environment, feedback, and
  outcome events;
- define deterministic compact canonical JSON for content hashing;
- reject values at construction when they cannot be canonically serialized, including
  invalid Unicode, non-UTC-normalizable timestamps, and sequence numbers outside the
  non-negative signed-64 range;
- snapshot accepted strings and timestamps as exact built-in immutable values so
  caller-owned subclasses or mutable timezone state cannot change stored identity;
- add `EvidenceStore` as a structural backend protocol;
- add a lock-protected `InMemoryEvidenceStore` with scoped idempotency, collision
  protection, deterministic filtering/order, and cross-scope not-found behavior;
- expose only the nine evidence-ledger contracts from `areal.v2.memory_service`.

## Core Invariants

- Evidence is append-only; no update or delete API exists.
- The same `(MemoryScope, idempotency_key)` and canonical content returns the exact
  original record.
- Reusing that key for different content raises `EvidenceConflictError` without a
  partial write.
- Evidence IDs are derived from SHA-256 content hashes and are scope-relative: the
  complete identity is `(MemoryScope, evidence_id)`.
- Full-hash and truncated-prefix collisions fail without overwrite inside one scope;
  forced collisions across scopes coexist without revealing the other scope.
- Looking up another scope's record is indistinguishable from a missing record.
- Query IDs and filters are snapshotted before locking, so caller-defined hashing or
  equality code never executes in the critical section.
- Concurrent identical writers converge on one record; concurrent conflicting writers
  produce one winner and explicit conflicts.

## Explicit Non-goals

- no HTTP service or persistent backend;
- no vector database, embeddings, or retrieval policy;
- no candidate, revision, or release lifecycle yet;
- no Agent Service/DataProxy changes;
- no LLM extraction, consolidation, prompt mutation, or Memory Manager training;
- no existing AReaL behavior or configuration change.

## Compatibility

The change is additive, modifies no existing source file, adds no dependency, and is
inactive unless imported explicitly. Existing agent, rollout, and training paths are
unchanged.

## Validation

- `uv run pytest tests/v2/memory_service tests/v2/agent_service/test_protocol.py -ra`
  — **159 passed**;
- `uv run pre-commit run --all-files` — **all hooks passed**;
- `.venv/bin/python -m compileall -q areal/v2/memory_service` — **passed**;
- `git diff --check origin/main...HEAD` — **passed**;
- independent spec, code-quality, concurrency/scope, and final PR reviews found no
  remaining Critical or Important issue.

## Follow-up

After the service boundary in #1490 is confirmed, the next separate PR will introduce
evidence-grounded candidates and immutable revision transitions. It will not add LLM
extraction or runtime promotion in the same change.

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated (not applicable: the public design remains in #1490)
- [x] Branch is up to date with `main`
- [x] Self-reviewed and independently reviewed
- [x] This PR was created by a coding agent
- [ ] This PR is a breaking change

**Breaking Change Details:** None.
