### PR TITLE
feat(sglang): add abort-all and tagged offload protocol primitives

### DIFF
--- a/areal/engine/sglang_remote.py
+++ b/areal/engine/sglang_remote.py
@@ -330,13 +330,18 @@ class SGLangBackend:
         """Get SGLang resume request."""
         return HttpRequest(endpoint="/continue_generation", payload={})
 
+    def get_abort_all_request(self) -> HttpRequest:
+        """Get SGLang abort-all request."""
+        return HttpRequest(endpoint="/abort_request", payload={"abort_all": True})
+
     def get_health_check_request(self) -> HttpRequest:
         """Get SGLang health check request."""
         return HttpRequest(endpoint="/health", payload={}, method="GET")
 
-    def get_offload_request(self) -> HttpRequest:
+    def get_offload_request(self, tags: list[str] | None = None) -> HttpRequest:
         """Get SGLang offload request."""
-        return HttpRequest(endpoint="/release_memory_occupation", payload={})
+        payload = {"tags": tags} if tags is not None else {}
+        return HttpRequest(endpoint="/release_memory_occupation", payload=payload)
 
     def get_onload_request(self, tags: list[str] | None = None) -> HttpRequest:
         """Get SGLang onload request.
@@ -575,8 +580,11 @@ class RemoteSGLangEngine(InferenceEngine):
     def teardown_server(self):
         return self._engine.teardown_server()
 
-    def offload(self):
-        return self._engine.offload()
+    def offload(self, tags: list[str] | None = None):
+        return self._engine.offload(tags=tags)
+
+    def abort_all_requests(self):
+        return self._engine.abort_all_requests()
 
     def onload(self, tags: list[str] | None = None):
         return self._engine.onload(tags=tags)

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -1289,10 +1289,18 @@ class RemoteInfEngine(InferenceEngine):
         """Resume request submission for async rollout."""
         return self.workflow_executor.resume()
 
-    def offload(self) -> None:
+    def offload(self, tags: list[str] | None = None) -> None:
         """Offload model memory on all servers."""
-        offload_req = self.backend.get_offload_request()
+        if tags is None:
+            offload_req = self.backend.get_offload_request()
+        else:
+            offload_req = self.backend.get_offload_request(tags=tags)
         self._run_request_on_all_servers(offload_req)
+
+    def abort_all_requests(self) -> None:
+        """Abort all in-flight requests on all servers (SGLang backend only)."""
+        abort_req = self.backend.get_abort_all_request()
+        self._run_request_on_all_servers(abort_req)
 
     def onload(self, tags: list[str] | None = None) -> None:
         """Onload model memory on all servers."""


### PR DESCRIPTION
## Description

Colocated actor/rollout training needs the inference server to fully yield the
GPU around weight updates. This PR adds the SGLang protocol primitives that a
colocated-training controller drives:

- **Abort-all**: add `SGLangBackend.get_abort_all_request()` (`/abort_request` with `abort_all: true`) and `RemoteInfEngine.abort_all_requests()` to drop all in-flight requests on all servers before the trainer takes over the GPUs.
- **Tagged offload**: `get_offload_request(tags=...)` / `RemoteInfEngine.offload(tags=...)`, mirroring the existing tagged onload, so weights and KV cache can be released selectively (`/release_memory_occupation` with `tags`).

This is purely additive — no existing behavior changes:

- `RemoteInfEngine.offload` forwards `tags` only when provided, so the vLLM backend keeps its existing no-argument call path and is entirely unaffected; `abort_all_requests` is documented as SGLang-only.
- Pause/resume semantics are untouched.

## Related Issue

N/A — extracted from ongoing colocated (shared-GPU) RL training work.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

`abort_all_requests` has no in-tree caller yet: it is a primitive for the upcoming colocated-training controller, which needs to drain in-flight work without toggling the server's pause state (`/pause_generation` stops the scheduler loop until `/continue_generation`, while `/abort_request` with `abort_all` only clears the waiting queue and running batch and keeps the server serving). Tagged offload mirrors the existing tagged onload and changes nothing when `tags` is not passed.

Verified via an import smoke test in the project image: abort-all and tagged / untagged offload request payloads, `RemoteInfEngine` signatures, and that the vLLM backend signature is unchanged.