### PR TITLE
fix: align CP metrics and TP grad norm metadata

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -496,6 +496,7 @@ class MegatronEngine(TrainEngine):
             if len(self.model) == 1:
                 model_config.param_sync_func = model_config.param_sync_func[0]
         model_config.finalize_model_grads_func = finalize_model_grads
+        self._mark_duplicated_params()
         self._create_optimizer(ft_spec)
         self._initialized = True
 
@@ -1152,9 +1153,13 @@ class MegatronEngine(TrainEngine):
         return split_batch(res, meta)
 
     def export_stats(self) -> dict[str, float]:
+        key_sync_group = None
+        if self.parallel_strategy.context_parallel_size > 1:
+            key_sync_group = mpu.get_data_parallel_group(with_context_parallel=True)
         with self._offload_aware_context():
             data = stats_tracker.export_all(
                 reduce_group=self.data_parallel_group,
+                key_sync_group=key_sync_group,
             )
         if mpu.get_pipeline_model_parallel_world_size() > 1:
             # Some log info only exist in last pipeline rank
@@ -1563,6 +1568,39 @@ class MegatronEngine(TrainEngine):
                                 duplicated.add(full)
             self._cached_duplicated_param_names = duplicated
         return self._cached_duplicated_param_names
+
+    def _mark_duplicated_params(self) -> None:
+        """Fix TP metadata for params whose parent module is duplicated.
+
+        These params are replicated (not TP-sharded), but TE can mark them with
+        ``tensor_model_parallel=True``. Megatron's optimizer uses that attribute
+        to decide which TP ranks contribute to grad norm/clipping, so leaving it
+        true double-counts duplicated params when TP > 1. We also keep
+        ``_is_duplicated`` for weight collection code that needs the same signal.
+
+        Detection uses module.tp_size == 1 instead of module.parallel_mode ==
+        'duplicated', because Megatron's TELinear converts 'duplicated' to
+        te_parallel_mode=None before calling the TE base class, so
+        module.parallel_mode ends up as None.  tp_size=1 is reliably set for
+        duplicated mode while TP-sharded modules have tp_size > 1.
+
+        Expert modules with explicit TP communication also have tp_size=1
+        (Megatron pre-divides sizes), but their weights ARE TP-sharded.
+        These are excluded by checking the module name for "expert".
+        """
+        if getattr(self, "_duplicated_params_marked", False):
+            return
+        if self.model is not None:
+            for model in self.model:
+                for mod_name, module in model.named_modules():
+                    if getattr(module, "tp_size", None) == 1:
+                        if "expert" in mod_name:
+                            continue
+                        for _, param in module.named_parameters(recurse=False):
+                            if getattr(param, "tensor_model_parallel", False):
+                                param._is_duplicated = True
+                                param.tensor_model_parallel = False
+        self._duplicated_params_marked = True
 
     def _collect_param(
         self,

--- a/areal/utils/stats_tracker.py
+++ b/areal/utils/stats_tracker.py
@@ -216,14 +216,22 @@ class DistributedStatsTracker:
             pass
         return "cpu"
 
-    def _zero_scalar_tensor(self, like: torch.Tensor | None = None, group=None):
+    def _placeholder_scalar(
+        self,
+        fill: float = 0.0,
+        like: torch.Tensor | None = None,
+        group=None,
+    ):
+        """Scalar identity tensor for reductions (0.0 for SUM/AVG, +/-inf for
+        MIN/MAX). Placed on ``like``'s device if given, else on the device
+        matching ``group``."""
         device = (
             like.device
             if like is not None
             else self._device_for_placeholder_tensor(group)
         )
         return torch.tensor(
-            0.0,
+            fill,
             dtype=torch.float32,
             device=device,
         )
@@ -374,21 +382,19 @@ class DistributedStatsTracker:
             effective_group = self._effective_reduce_group(
                 key, reduce_group, sync_metadata, key_sync_group
             )
-            device = self._device_for_placeholder_tensor(effective_group)
-            value = torch.tensor(
-                sum(self.stats[key]),
-                dtype=torch.float32,
-                device=device,
+            # `.get`: a rank may learn about this key via key/metadata sync
+            # without holding any local values for it.
+            stats = self.stats.get(key, [])
+            value = self._placeholder_scalar(
+                fill=float(sum(stats)), group=effective_group
             )
-            cnt = torch.tensor(
-                len(self.stats[key]),
-                dtype=torch.float32,
-                device=device,
+            cnt = self._placeholder_scalar(
+                fill=float(len(stats)), group=effective_group
             )
             if effective_group is not None:
                 dist.all_reduce(value, group=effective_group)
                 dist.all_reduce(cnt, group=effective_group)
-            result[key] = float(value / cnt)
+            result[key] = float(value / cnt) if float(cnt) > 0 else 0.0
             result[key + "__count"] = int(cnt)
         else:
             raise ValueError(f"Unknown reduce type: {reduce_type}")
@@ -410,7 +416,7 @@ class DistributedStatsTracker:
             key, reduce_group, sync_metadata, key_sync_group
         )
         if not values:
-            x = self._zero_scalar_tensor(group=effective_group)
+            x = self._placeholder_scalar(group=effective_group)
             if effective_group is not None:
                 dist.all_reduce(x, group=effective_group)
             return float(x)
@@ -421,7 +427,7 @@ class DistributedStatsTracker:
             metadata.denominator if metadata is not None else None,
         )
         if denominator is None:
-            x = sum([x.sum() for x in values], self._zero_scalar_tensor(values[0]))
+            x = sum([x.sum() for x in values], self._placeholder_scalar(like=values[0]))
             if effective_group is not None:
                 dist.all_reduce(x, group=effective_group)
         else:
@@ -432,7 +438,7 @@ class DistributedStatsTracker:
             xs = []
             for v, d in zip(values, self.stats[denominator]):
                 xs.append(torch.where(d, v, 0.0).sum())
-            x = sum(xs, self._zero_scalar_tensor(values[0]))
+            x = sum(xs, self._placeholder_scalar(like=values[0]))
             if effective_group is not None:
                 dist.all_reduce(x, group=effective_group)
         return float(x)
@@ -461,8 +467,8 @@ class DistributedStatsTracker:
             effective_group = self._effective_reduce_group(
                 key, reduce_group, sync_metadata, key_sync_group
             )
-            x = self._zero_scalar_tensor(group=effective_group)
-            d = self._zero_scalar_tensor(group=effective_group)
+            x = self._placeholder_scalar(group=effective_group)
+            d = self._placeholder_scalar(group=effective_group)
             if effective_group is not None:
                 dist.all_reduce(x, group=effective_group)
                 dist.all_reduce(d, group=effective_group)
@@ -478,8 +484,8 @@ class DistributedStatsTracker:
         for v, d in zip(values, self.stats[denominator]):
             xs.append(torch.where(d, v, 0.0).sum())
             ds.append(d.sum())
-        x = sum(xs, self._zero_scalar_tensor(values[0]))
-        d = sum(ds, self._zero_scalar_tensor(values[0]))
+        x = sum(xs, self._placeholder_scalar(like=values[0]))
+        d = sum(ds, self._placeholder_scalar(like=values[0]))
         effective_group = self._effective_reduce_group(
             key, reduce_group, sync_metadata, key_sync_group
         )
@@ -502,11 +508,7 @@ class DistributedStatsTracker:
             effective_group = self._effective_reduce_group(
                 key, reduce_group, sync_metadata, key_sync_group
             )
-            x = torch.tensor(
-                float("inf"),
-                dtype=torch.float32,
-                device=self._device_for_placeholder_tensor(effective_group),
-            )
+            x = self._placeholder_scalar(fill=float("inf"), group=effective_group)
             if effective_group is not None:
                 dist.all_reduce(x, group=effective_group, op=dist.ReduceOp.MIN)
             if torch.isinf(x):
@@ -519,7 +521,7 @@ class DistributedStatsTracker:
         xs = []
         for v, d in zip(values, self.stats[denominator]):
             xs.append(torch.where(d, v, float("inf")).min())
-        x = min(xs)
+        x = torch.stack(xs).min()
         effective_group = self._effective_reduce_group(
             key, reduce_group, sync_metadata, key_sync_group
         )
@@ -541,11 +543,7 @@ class DistributedStatsTracker:
             effective_group = self._effective_reduce_group(
                 key, reduce_group, sync_metadata, key_sync_group
             )
-            x = torch.tensor(
-                -float("inf"),
-                dtype=torch.float32,
-                device=self._device_for_placeholder_tensor(effective_group),
-            )
+            x = self._placeholder_scalar(fill=-float("inf"), group=effective_group)
             if effective_group is not None:
                 dist.all_reduce(x, group=effective_group, op=dist.ReduceOp.MAX)
             if torch.isinf(x):
@@ -558,7 +556,7 @@ class DistributedStatsTracker:
         xs = []
         for v, d in zip(values, self.stats[denominator]):
             xs.append(torch.where(d, v, -float("inf")).max())
-        x = max(xs)
+        x = torch.stack(xs).max()
         effective_group = self._effective_reduce_group(
             key, reduce_group, sync_metadata, key_sync_group
         )

--- a/areal/utils/stats_tracker.py
+++ b/areal/utils/stats_tracker.py
@@ -3,6 +3,7 @@
 import time
 from collections import defaultdict
 from contextlib import contextmanager
+from dataclasses import dataclass
 from enum import Enum, auto
 from threading import Lock
 
@@ -23,6 +24,13 @@ class ReduceType(Enum):
     MIN = auto()
     MAX = auto()
     SCALAR = auto()
+
+
+@dataclass(frozen=True)
+class _StatMetadata:
+    reduce_type: ReduceType
+    denominator: str | None
+    has_reduce_group: bool
 
 
 MOE_AUX_LOSSES = {}
@@ -169,11 +177,90 @@ class DistributedStatsTracker:
             raise ValueError("reduce_type must be a ReduceType enum")
         self.reduce_types[key] = reduce_type
 
-    def _effective_reduce_group(self, key, default_reduce_group):
+    def _effective_reduce_group(
+        self,
+        key,
+        default_reduce_group,
+        sync_metadata: dict[str, _StatMetadata] | None = None,
+        key_sync_group=None,
+    ):
         """Return the per-key reduce_group override if any, else the default."""
-        return self.reduce_groups.get(key, default_reduce_group)
+        if sync_metadata is not None:
+            metadata = sync_metadata.get(key)
+            if metadata is not None and metadata.has_reduce_group:
+                if key_sync_group is not None:
+                    return key_sync_group
+                if key in self.reduce_groups:
+                    return self.reduce_groups[key]
+                raise RuntimeError(
+                    f"Key `{key}` has a per-key reduce_group on another rank, "
+                    "but no key_sync_group was provided for this rank."
+                )
+        if key in self.reduce_groups:
+            return self.reduce_groups[key]
+        return default_reduce_group
 
-    def export(self, key=None, reduce_group=None, reset=True) -> dict[str, float]:
+    def _device_for_placeholder_tensor(self, group=None):
+        if group is not None:
+            try:
+                backend = str(dist.get_backend(group)).lower()
+                platform_backend = current_platform.communication_backend
+                if backend == platform_backend:
+                    return current_platform.device_type
+            except (AttributeError, RuntimeError, ValueError):
+                pass
+        try:
+            if current_platform.is_initialized():
+                return current_platform.device_type
+        except AttributeError:
+            pass
+        return "cpu"
+
+    def _zero_scalar_tensor(self, like: torch.Tensor | None = None, group=None):
+        device = (
+            like.device
+            if like is not None
+            else self._device_for_placeholder_tensor(group)
+        )
+        return torch.tensor(
+            0.0,
+            dtype=torch.float32,
+            device=device,
+        )
+
+    def _local_metadata(self, keys: list[str]) -> dict[str, _StatMetadata]:
+        return {
+            key: _StatMetadata(
+                reduce_type=self.reduce_types.get(key, ReduceType.SCALAR),
+                denominator=self.denominators.get(key),
+                has_reduce_group=key in self.reduce_groups,
+            )
+            for key in keys
+        }
+
+    @staticmethod
+    def _merge_metadata(
+        all_metadata: list[dict[str, _StatMetadata]],
+    ) -> dict[str, _StatMetadata]:
+        metadata: dict[str, _StatMetadata] = {}
+        for rank_metadata in all_metadata:
+            for key, key_metadata in rank_metadata.items():
+                if key not in metadata:
+                    metadata[key] = key_metadata
+                elif metadata[key] != key_metadata:
+                    raise ValueError(
+                        f"Inconsistent stats metadata for key `{key}`: "
+                        f"{metadata[key]} vs {key_metadata}"
+                    )
+        return metadata
+
+    def export(
+        self,
+        key=None,
+        reduce_group=None,
+        key_sync_group=None,
+        reset=True,
+    ) -> dict[str, float]:
         """Get aggregated statistics"""
         with self.lock:
             if key is not None:
@@ -191,14 +278,55 @@ class DistributedStatsTracker:
 
             # synchronize keys across ranks
             keys = list(self.stats.keys())
+            sync_metadata = self._local_metadata(keys)
             if reduce_group is not None:
-                all_keys = [None for _ in range(dist.get_world_size(reduce_group))]
-                dist.all_gather_object(all_keys, keys, group=reduce_group)
+                all_metadata = [None for _ in range(dist.get_world_size(reduce_group))]
+                dist.all_gather_object(
+                    all_metadata,
+                    self._local_metadata(keys),
+                    group=reduce_group,
+                )
+                sync_metadata = self._merge_metadata(all_metadata)
+
+            # Per-key reduce groups may be wider than the default export group
+            # (for example DP+CP vs DP). Only those override keys need the
+            # wider key/metadata sync; default keys keep the original
+            # reduce_group alignment.
+            if key_sync_group is not None:
+                override_keys = list(self.reduce_groups.keys())
+                all_override_metadata = [
+                    None for _ in range(dist.get_world_size(key_sync_group))
+                ]
+                dist.all_gather_object(
+                    all_override_metadata,
+                    self._local_metadata(override_keys),
+                    group=key_sync_group,
+                )
+                override_metadata = self._merge_metadata(all_override_metadata)
+                for override_key, override_value in override_metadata.items():
+                    if (
+                        override_key in sync_metadata
+                        and sync_metadata[override_key] != override_value
+                    ):
+                        raise ValueError(
+                            f"Inconsistent stats metadata for key `{override_key}`: "
+                            f"{sync_metadata[override_key]} vs {override_value}"
+                        )
+                    sync_metadata[override_key] = override_value
+
+            if reduce_group is not None or key_sync_group is not None:
                 # Should ensure that the orders are the same
-                keys = sorted(list(set(flat2d(all_keys))))
+                keys = sorted(sync_metadata)
             results = {}
             for key in keys:
-                results.update(self._aggregate(key, reduce_group))
+                results.update(
+                    self._aggregate(
+                        key,
+                        reduce_group,
+                        sync_metadata=sync_metadata,
+                        key_sync_group=key_sync_group,
+                    )
+                )
             if reset:
                 self.denominators = {}
                 self.reduce_types = {}
@@ -210,32 +338,53 @@ class DistributedStatsTracker:
             }
             return results
 
-    def _aggregate(self, key, reduce_group):
-        reduce_type = self.reduce_types.get(key, ReduceType.SCALAR)
+    def _aggregate(
+        self,
+        key,
+        reduce_group,
+        sync_metadata: dict[str, _StatMetadata] | None = None,
+        key_sync_group=None,
+    ):
+        metadata = sync_metadata.get(key) if sync_metadata is not None else None
+        reduce_type = self.reduce_types.get(
+            key,
+            metadata.reduce_type if metadata is not None else ReduceType.SCALAR,
+        )
 
         result = {}
         if reduce_type == ReduceType.AVG_MIN_MAX:
-            result["/".join([key, "avg"])] = self._avg_of(key, reduce_group)
-            result["/".join([key, "min"])] = self._min_of(key, reduce_group)
-            result["/".join([key, "max"])] = self._max_of(key, reduce_group)
-        elif reduce_type == ReduceType.AVG:
-            result[key] = self._avg_of(key, reduce_group)
-        elif reduce_type == ReduceType.SUM:
-            result[key] = self._sum_of(key, reduce_group)
-        elif reduce_type == ReduceType.MIN:
-            result[key] = self._min_of(key, reduce_group)
-        elif reduce_type == ReduceType.MAX:
-            result[key] = self._max_of(key, reduce_group)
-        elif reduce_type == ReduceType.SCALAR:
-            if current_platform.is_initialized():
-                device = current_platform.device_type
-            else:
-                device = "cpu"
-            value = torch.tensor(
-                sum(self.stats[key]), dtype=torch.float32, device=device
+            result["/".join([key, "avg"])] = self._avg_of(
+                key, reduce_group, sync_metadata, key_sync_group
             )
-            cnt = torch.tensor(len(self.stats[key]), dtype=torch.float32, device=device)
-            effective_group = self._effective_reduce_group(key, reduce_group)
+            result["/".join([key, "min"])] = self._min_of(
+                key, reduce_group, sync_metadata, key_sync_group
+            )
+            result["/".join([key, "max"])] = self._max_of(
+                key, reduce_group, sync_metadata, key_sync_group
+            )
+        elif reduce_type == ReduceType.AVG:
+            result[key] = self._avg_of(key, reduce_group, sync_metadata, key_sync_group)
+        elif reduce_type == ReduceType.SUM:
+            result[key] = self._sum_of(key, reduce_group, sync_metadata, key_sync_group)
+        elif reduce_type == ReduceType.MIN:
+            result[key] = self._min_of(key, reduce_group, sync_metadata, key_sync_group)
+        elif reduce_type == ReduceType.MAX:
+            result[key] = self._max_of(key, reduce_group, sync_metadata, key_sync_group)
+        elif reduce_type == ReduceType.SCALAR:
+            effective_group = self._effective_reduce_group(
+                key, reduce_group, sync_metadata, key_sync_group
+            )
+            device = self._device_for_placeholder_tensor(effective_group)
+            value = torch.tensor(
+                sum(self.stats[key]),
+                dtype=torch.float32,
+                device=device,
+            )
+            cnt = torch.tensor(
+                len(self.stats[key]),
+                dtype=torch.float32,
+                device=device,
+            )
             if effective_group is not None:
                 dist.all_reduce(value, group=effective_group)
                 dist.all_reduce(cnt, group=effective_group)
@@ -249,15 +398,33 @@ class DistributedStatsTracker:
             result.pop(k)
         return result
 
-    def _sum_of(self, key, reduce_group):
-        values = self.stats[key]
-        effective_group = self._effective_reduce_group(key, reduce_group)
-        if key not in self.denominators:
-            x = sum([x.sum() for x in values])
+    def _sum_of(
+        self,
+        key,
+        reduce_group,
+        sync_metadata: dict[str, _StatMetadata] | None = None,
+        key_sync_group=None,
+    ):
+        values = self.stats.get(key, [])
+        effective_group = self._effective_reduce_group(
+            key, reduce_group, sync_metadata, key_sync_group
+        )
+        if not values:
+            x = self._zero_scalar_tensor(group=effective_group)
+            if effective_group is not None:
+                dist.all_reduce(x, group=effective_group)
+            return float(x)
+
+        metadata = sync_metadata.get(key) if sync_metadata is not None else None
+        denominator = self.denominators.get(
+            key,
+            metadata.denominator if metadata is not None else None,
+        )
+        if denominator is None:
+            x = sum([x.sum() for x in values], self._zero_scalar_tensor(values[0]))
             if effective_group is not None:
                 dist.all_reduce(x, group=effective_group)
         else:
-            denominator = self.denominators[key]
             if denominator not in self.stats:
                 raise ValueError(
                     f"Denominator `{denominator}` not set for key `{key}`."
@@ -265,14 +432,45 @@ class DistributedStatsTracker:
             xs = []
             for v, d in zip(values, self.stats[denominator]):
                 xs.append(torch.where(d, v, 0.0).sum())
-            x = sum(xs)
+            x = sum(xs, self._zero_scalar_tensor(values[0]))
             if effective_group is not None:
                 dist.all_reduce(x, group=effective_group)
         return float(x)
 
-    def _avg_of(self, key, reduce_group):
-        values = self.stats[key]
-        denominator = self.denominators[key]
+    def _denominator_of(
+        self,
+        key,
+        sync_metadata: dict[str, _StatMetadata] | None = None,
+    ):
+        if key in self.denominators:
+            return self.denominators[key]
+        metadata = sync_metadata.get(key) if sync_metadata is not None else None
+        if metadata is not None and metadata.denominator is not None:
+            return metadata.denominator
+        raise ValueError(f"Denominator not set for key `{key}`.")
+
+    def _avg_of(
+        self,
+        key,
+        reduce_group,
+        sync_metadata: dict[str, _StatMetadata] | None = None,
+        key_sync_group=None,
+    ):
+        values = self.stats.get(key, [])
+        if not values:
+            effective_group = self._effective_reduce_group(
+                key, reduce_group, sync_metadata, key_sync_group
+            )
+            x = self._zero_scalar_tensor(group=effective_group)
+            d = self._zero_scalar_tensor(group=effective_group)
+            if effective_group is not None:
+                dist.all_reduce(x, group=effective_group)
+                dist.all_reduce(d, group=effective_group)
+            if d == 0:
+                return None
+            return x / d
+
+        denominator = self._denominator_of(key, sync_metadata)
         if denominator not in self.stats:
             raise ValueError(f"Denominator `{denominator}` not set for key `{key}`.")
         xs = []
@@ -280,9 +478,11 @@ class DistributedStatsTracker:
         for v, d in zip(values, self.stats[denominator]):
             xs.append(torch.where(d, v, 0.0).sum())
             ds.append(d.sum())
-        x = sum(xs)
-        d = sum(ds)
-        effective_group = self._effective_reduce_group(key, reduce_group)
+        x = sum(xs, self._zero_scalar_tensor(values[0]))
+        d = sum(ds, self._zero_scalar_tensor(values[0]))
+        effective_group = self._effective_reduce_group(
+            key, reduce_group, sync_metadata, key_sync_group
+        )
         if effective_group is not None:
             dist.all_reduce(x, group=effective_group)
             dist.all_reduce(d, group=effective_group)
@@ -290,32 +490,78 @@ class DistributedStatsTracker:
             return None
         return x / d
 
-    def _min_of(self, key, reduce_group):
-        values = self.stats[key]
-        denominator = self.denominators[key]
+    def _min_of(
+        self,
+        key,
+        reduce_group,
+        sync_metadata: dict[str, _StatMetadata] | None = None,
+        key_sync_group=None,
+    ):
+        values = self.stats.get(key, [])
+        if not values:
+            effective_group = self._effective_reduce_group(
+                key, reduce_group, sync_metadata, key_sync_group
+            )
+            x = torch.tensor(
+                float("inf"),
+                dtype=torch.float32,
+                device=self._device_for_placeholder_tensor(effective_group),
+            )
+            if effective_group is not None:
+                dist.all_reduce(x, group=effective_group, op=dist.ReduceOp.MIN)
+            if torch.isinf(x):
+                return None
+            return float(x)
+
+        denominator = self._denominator_of(key, sync_metadata)
         if denominator not in self.stats:
             raise ValueError(f"Denominator `{denominator}` not set for key `{key}`.")
         xs = []
         for v, d in zip(values, self.stats[denominator]):
             xs.append(torch.where(d, v, float("inf")).min())
         x = min(xs)
-        effective_group = self._effective_reduce_group(key, reduce_group)
+        effective_group = self._effective_reduce_group(
+            key, reduce_group, sync_metadata, key_sync_group
+        )
         if effective_group is not None:
             dist.all_reduce(x, group=effective_group, op=dist.ReduceOp.MIN)
         if torch.isinf(x):
             return None
         return float(x)
 
-    def _max_of(self, key, reduce_group):
-        values = self.stats[key]
-        denominator = self.denominators[key]
+    def _max_of(
+        self,
+        key,
+        reduce_group,
+        sync_metadata: dict[str, _StatMetadata] | None = None,
+        key_sync_group=None,
+    ):
+        values = self.stats.get(key, [])
+        if not values:
+            effective_group = self._effective_reduce_group(
+                key, reduce_group, sync_metadata, key_sync_group
+            )
+            x = torch.tensor(
+                -float("inf"),
+                dtype=torch.float32,
+                device=self._device_for_placeholder_tensor(effective_group),
+            )
+            if effective_group is not None:
+                dist.all_reduce(x, group=effective_group, op=dist.ReduceOp.MAX)
+            if torch.isinf(x):
+                return None
+            return float(x)
+
+        denominator = self._denominator_of(key, sync_metadata)
         if denominator not in self.stats:
             raise ValueError(f"Denominator `{denominator}` not set for key `{key}`.")
         xs = []
         for v, d in zip(values, self.stats[denominator]):
             xs.append(torch.where(d, v, -float("inf")).max())
         x = max(xs)
-        effective_group = self._effective_reduce_group(key, reduce_group)
+        effective_group = self._effective_reduce_group(
+            key, reduce_group, sync_metadata, key_sync_group
+        )
         if effective_group is not None:
             dist.all_reduce(x, group=effective_group, op=dist.ReduceOp.MAX)
         if torch.isinf(x):
@@ -344,17 +590,22 @@ def get(name: str = ""):
         return TRACKERS[name]
 
 
-def export_all(reduce_group=None, reset=True) -> dict[str, float]:
+def export_all(reduce_group=None, key_sync_group=None, reset=True) -> dict[str, float]:
     stat = {}
     duplicate_keys = set()
     tracker_keys = list(TRACKERS.keys())
-    if reduce_group is not None:
-        all_trackers = [None for _ in range(dist.get_world_size(reduce_group))]
-        dist.all_gather_object(all_trackers, list(TRACKERS.keys()), group=reduce_group)
+    sync_group = key_sync_group if key_sync_group is not None else reduce_group
+    if sync_group is not None:
+        all_trackers = [None for _ in range(dist.get_world_size(sync_group))]
+        dist.all_gather_object(all_trackers, list(TRACKERS.keys()), group=sync_group)
         tracker_keys = sorted(list(set(flat2d(all_trackers))))
     for tracker_key in tracker_keys:
         tracker = get(tracker_key)
-        x = tracker.export(reduce_group=reduce_group, reset=reset)
+        x = tracker.export(
+            reduce_group=reduce_group,
+            key_sync_group=key_sync_group,
+            reset=reset,
+        )
         for k in x.keys():
             if k in stat:
                 duplicate_keys.add(k)

--- a/tests/megatron/test_grad_norm_tp_invariance.py
+++ b/tests/megatron/test_grad_norm_tp_invariance.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end check that duplicated params do not inflate the TP grad norm.
+
+The global grad norm is a property of the full model + data and must be
+invariant to the tensor-parallel degree. If replicated params are left marked
+``tensor_model_parallel=True`` (the TE default that
+``MegatronEngine._mark_duplicated_params`` fixes), they get counted on every TP
+rank and SUM-reduced, so the reported grad norm grows with TP.
+
+This launches the real MegatronEngine via torchrun at TP=1 and TP=2 on the same
+deterministic input and asserts the two grad norms agree. It also asserts that
+the fix actually demoted at least one real duplicated param at TP=2.
+
+Requires >= 2 GPUs; skipped otherwise.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+
+from areal.infra.platforms import current_platform
+from areal.infra.utils.proc import kill_process_tree
+from areal.utils.network import find_free_ports
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA not available"
+)
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_WORKER = "tests/megatron/torchrun/run_grad_norm_tp.py"
+
+
+def _run_tp(tp: int, output: str) -> dict:
+    port = find_free_ports(1)[0]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = _PROJECT_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.Popen(
+        [
+            "torchrun",
+            f"--nproc_per_node={tp}",
+            "--nnodes=1",
+            "--master-addr=localhost",
+            f"--master_port={port}",
+            _WORKER,
+            f"--tp={tp}",
+            f"--output={output}",
+        ],
+        text=True,
+        stderr=sys.stdout,
+        stdout=sys.stdout,
+        env=env,
+    )
+    try:
+        proc.wait()
+    except BaseException:
+        kill_process_tree(proc.pid)
+        raise
+    if proc.returncode != 0:
+        pytest.fail(f"torchrun (tp={tp}) exited with code {proc.returncode}")
+
+    with open(output) as f:
+        return json.load(f)
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.slow
+def test_grad_norm_is_tp_invariant(tmp_path_factory):
+    if current_platform.device_count() < 2:
+        pytest.skip("This test requires 2 GPUs")
+
+    out_dir = tmp_path_factory.mktemp("grad_norm_tp")
+    res1 = _run_tp(1, str(out_dir / "tp1.json"))
+    res2 = _run_tp(2, str(out_dir / "tp2.json"))
+
+    # The fix must have demoted at least one real duplicated param at TP=2.
+    assert res2["structural_ok"], "a duplicated param kept tensor_model_parallel=True"
+    assert res2["num_duplicated"] > 0, "no duplicated params detected in the model"
+
+    gn1, gn2 = res1["grad_norm"], res2["grad_norm"]
+    assert gn1 == pytest.approx(gn2, rel=0.02), (
+        f"grad norm not TP-invariant: tp1={gn1}, tp2={gn2} "
+        "(duplicated params likely double-counted)"
+    )

--- a/tests/megatron/torchrun/run_grad_norm_tp.py
+++ b/tests/megatron/torchrun/run_grad_norm_tp.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""torchrun worker: run one train step under a given TP degree and report the
+global grad norm plus whether duplicated params were correctly demoted.
+
+Launched by tests/megatron/test_grad_norm_tp_invariance.py with nproc == tp.
+The parent compares grad norms across TP degrees: a correct implementation
+keeps the global grad norm TP-invariant, while double-counting replicated
+params (tensor_model_parallel left True) inflates it as TP grows.
+"""
+
+import argparse
+import json
+import os
+
+import torch
+import torch.distributed as dist
+
+from areal.api import FinetuneSpec
+from areal.api.alloc_mode import ModelAllocation
+from areal.api.cli_args import (
+    MegatronEngineConfig,
+    OptimizerConfig,
+    TrainEngineConfig,
+)
+from areal.engine import MegatronEngine
+from areal.infra.platforms import current_platform
+
+VOCAB_SIZE = 100
+BATCH_SIZE = 4
+SEQLEN = 16
+
+
+def _local_model_path() -> str:
+    local = "/storage/openpsi/models/Qwen__Qwen3-0.6B/"
+    return local if os.path.isdir(local) else "Qwen/Qwen3-0.6B"
+
+
+def _deterministic_input() -> dict:
+    # Fully deterministic and identical regardless of TP degree (dp == 1).
+    device = current_platform.device_type
+    ids = (torch.arange(BATCH_SIZE * SEQLEN, dtype=torch.long) % VOCAB_SIZE).reshape(
+        BATCH_SIZE, SEQLEN
+    )
+    return dict(
+        input_ids=ids.to(device),
+        attention_mask=torch.ones(BATCH_SIZE, SEQLEN, dtype=torch.bool, device=device),
+    )
+
+
+def _loss_fn(logprobs, entropy, input_data, **kwargs):
+    return torch.mean(logprobs)
+
+
+def _check_duplicated_params_demoted(engine) -> tuple[bool, int]:
+    """On a real model, every param marked _is_duplicated must have had its
+    tensor_model_parallel flag cleared. Returns (ok, num_duplicated)."""
+    n_dup = 0
+    for model in engine.model:
+        for _, param in model.named_parameters():
+            if getattr(param, "_is_duplicated", False):
+                n_dup += 1
+                if getattr(param, "tensor_model_parallel", False):
+                    return False, n_dup
+    return True, n_dup
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tp", type=int, required=True)
+    parser.add_argument("--output", type=str, required=True)
+    args = parser.parse_args()
+
+    model_path = _local_model_path()
+    config = TrainEngineConfig(
+        backend="fsdp:d1",
+        experiment_name="test",
+        trial_name="test",
+        path=model_path,
+        optimizer=OptimizerConfig(gradient_clipping=1e9),  # clip off; keep raw norm
+        megatron=MegatronEngineConfig(),
+    )
+    alloc_mode = ModelAllocation.from_str(f"fsdp:d1p1t{args.tp}")
+    ft_spec = FinetuneSpec(
+        total_train_epochs=1, dataset_size=128, train_batch_size=BATCH_SIZE
+    )
+
+    engine = MegatronEngine(config)
+    engine.create_process_group(alloc_mode.parallel)
+    engine.initialize(addr=None, ft_spec=ft_spec)
+    try:
+        structural_ok, n_dup = _check_duplicated_params_demoted(engine)
+
+        engine.train()
+        stats = engine.train_batch(
+            _deterministic_input(),
+            loss_fn=_loss_fn,
+            loss_weight_fn=lambda x: torch.tensor(1.0, device=engine.device),
+        )
+        grad_norm = float(stats["grad_norm"])
+
+        if dist.get_rank() == 0:
+            with open(args.output, "w") as f:
+                json.dump(
+                    {
+                        "tp": args.tp,
+                        "grad_norm": grad_norm,
+                        "structural_ok": structural_ok,
+                        "num_duplicated": n_dup,
+                    },
+                    f,
+                )
+    finally:
+        engine.destroy()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_all_gather_param.py
+++ b/tests/test_all_gather_param.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Routing tests for ``all_gather_param``.
+
+These verify that a parameter is treated as *replicated* (returned as-is,
+no TP all-gather) exactly when it should be:
+- ``tensor_model_parallel`` is False (what ``_mark_duplicated_params`` sets on
+  duplicated params), or
+- its name is listed in ``duplicated_param_names``.
+
+and is actually all-gathered only when it is a genuine TP-sharded param.
+
+The module imports ``megatron.core`` at import time, so this test runs in the
+GPU/megatron CI env (like tests/test_megatron_engine.py). The gather branch is
+stubbed, so no process group is required.
+"""
+
+import pytest
+import torch
+
+megatron = pytest.importorskip("areal.engine.megatron_utils.megatron")
+
+
+def _make_param(tensor_model_parallel):
+    """A plain Linear weight with the attributes all_gather_param reads."""
+    weight = torch.nn.Linear(4, 4, bias=False).weight
+    if tensor_model_parallel is not None:
+        weight.tensor_model_parallel = tensor_model_parallel
+    # Only read on the gather path, but harmless to always set.
+    weight.partition_dim = 0
+    weight.partition_stride = 1
+    return weight
+
+
+def test_returns_param_data_when_tensor_model_parallel_false(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        megatron,
+        "_all_gather_and_concat",
+        lambda *a, **k: calls.append(a) or torch.empty(0),
+    )
+    param = _make_param(tensor_model_parallel=False)
+
+    out = megatron.all_gather_param("decoder.layers.0.mlp.dense.weight", param)
+
+    assert out is param.data
+    assert calls == []  # never entered the all-gather path
+
+
+def test_returns_param_data_when_name_in_duplicated_set(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        megatron,
+        "_all_gather_and_concat",
+        lambda *a, **k: calls.append(a) or torch.empty(0),
+    )
+    # Even mis-marked as TP (TE default), the name set forces replicated handling.
+    param = _make_param(tensor_model_parallel=True)
+    name = "decoder.layers.0.self_attention.linear_qkv.layer_norm_weight"
+
+    out = megatron.all_gather_param(name, param, duplicated_param_names={name})
+
+    assert out is param.data
+    assert calls == []
+
+
+def test_all_gathers_genuine_tp_sharded_param(monkeypatch):
+    sentinel = torch.arange(8)
+    calls = []
+
+    def fake_gather(*args, **kwargs):
+        calls.append((args, kwargs))
+        return sentinel
+
+    monkeypatch.setattr(megatron, "_all_gather_and_concat", fake_gather)
+    monkeypatch.setattr(megatron.mpu, "get_tensor_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(
+        megatron.mpu, "get_tensor_model_parallel_group", lambda: "tp_group"
+    )
+    param = _make_param(tensor_model_parallel=True)
+
+    out = megatron.all_gather_param("decoder.layers.0.mlp.dense.weight", param)
+
+    assert out is sentinel
+    assert len(calls) == 1
+    # (data, tp_size, tp_group, partition_dim, partition_stride, name)
+    args = calls[0][0]
+    assert args[1] == 2
+    assert args[2] == "tp_group"

--- a/tests/test_grad_norm_duplicated.py
+++ b/tests/test_grad_norm_duplicated.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify that duplicated (replicated) params are not double-counted in the
+TP-reduced global grad norm.
+
+This is the numerical consequence that ``MegatronEngine._mark_duplicated_params``
+relies on when it clears ``tensor_model_parallel`` on replicated params. It
+mirrors Megatron's ``param_is_not_tensor_parallel_duplicate`` selection:
+a parameter is included in *this* rank's local grad-norm sum iff it is
+tensor-parallel-sharded (each rank holds a unique shard) OR this is tp_rank 0.
+The local sum-of-squares is then all-reduced (SUM) over the tensor-parallel
+group.
+
+The test runs on CPU via gloo (no GPU / megatron required); the full optimizer
+path is exercised separately by the GPU integration test.
+"""
+
+import contextlib
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def _find_free_port() -> int:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
+
+
+def _param_included_on_rank(param: torch.nn.Parameter, tp_rank: int) -> bool:
+    """Mirror Megatron's param_is_not_tensor_parallel_duplicate."""
+    return bool(getattr(param, "tensor_model_parallel", False)) or tp_rank == 0
+
+
+def _tp_global_grad_norm(params, group, tp_rank: int) -> float:
+    local_sq = torch.zeros((), dtype=torch.float64)
+    for p in params:
+        if _param_included_on_rank(p, tp_rank):
+            local_sq += (p.grad.double() ** 2).sum()
+    dist.all_reduce(local_sq, op=dist.ReduceOp.SUM, group=group)
+    return local_sq.sqrt().item()
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"tcp://localhost:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        group = dist.group.WORLD
+
+        # A replicated Linear weight: every TP rank holds an identical copy,
+        # so its grad is identical on every rank.
+        weight = torch.nn.Linear(4, 4, bias=False).weight
+        weight.grad = torch.ones_like(weight)
+        single_copy_norm = weight.grad.norm().double().item()
+
+        # Correct: marked duplicated -> counted once (only on tp_rank 0).
+        weight.tensor_model_parallel = False
+        norm_fixed = _tp_global_grad_norm([weight], group, rank)
+
+        # Buggy (TE default): mis-marked as TP-sharded -> counted on every rank
+        # and SUM-reduced, inflating the norm by sqrt(world_size).
+        weight.tensor_model_parallel = True
+        norm_inflated = _tp_global_grad_norm([weight], group, rank)
+
+        torch.testing.assert_close(norm_fixed, single_copy_norm, rtol=1e-9, atol=1e-9)
+        torch.testing.assert_close(
+            norm_inflated,
+            single_copy_norm * (world_size**0.5),
+            rtol=1e-9,
+            atol=1e-9,
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_duplicated_param_not_double_counted_in_tp_grad_norm(world_size: int):
+    """A replicated param counts once when tensor_model_parallel is False, and
+    is inflated by sqrt(tp) when it is (incorrectly) left True."""
+    port = _find_free_port()
+    mp.spawn(
+        _worker,
+        args=(world_size, port),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/test_megatron_engine.py
+++ b/tests/test_megatron_engine.py
@@ -70,6 +70,39 @@ def mock_loss_fn(
     return torch.mean(logprobs)
 
 
+def test_mark_duplicated_params_clears_tp_metadata_for_replicated_params():
+    model = torch.nn.Module()
+
+    duplicated_linear = torch.nn.Linear(2, 2, bias=False)
+    duplicated_linear.tp_size = 1
+    duplicated_linear.weight.tensor_model_parallel = True
+
+    expert_linear = torch.nn.Linear(2, 2, bias=False)
+    expert_linear.tp_size = 1
+    expert_linear.weight.tensor_model_parallel = True
+
+    sharded_linear = torch.nn.Linear(2, 2, bias=False)
+    sharded_linear.tp_size = 4
+    sharded_linear.weight.tensor_model_parallel = True
+
+    model.add_module("duplicated_linear", duplicated_linear)
+    model.add_module("moe_expert_linear", expert_linear)
+    model.add_module("sharded_linear", sharded_linear)
+
+    engine = type("DummyEngine", (), {"model": [model]})()
+
+    MegatronEngine._mark_duplicated_params(engine)
+
+    assert duplicated_linear.weight._is_duplicated
+    assert not duplicated_linear.weight.tensor_model_parallel
+
+    assert not hasattr(expert_linear.weight, "_is_duplicated")
+    assert expert_linear.weight.tensor_model_parallel
+
+    assert not hasattr(sharded_linear.weight, "_is_duplicated")
+    assert sharded_linear.weight.tensor_model_parallel
+
+
 # Cannot use a "module" scope since process groups can only be initialized once.
 @pytest.fixture
 def engine():

--- a/tests/test_stats_tracker.py
+++ b/tests/test_stats_tracker.py
@@ -1,0 +1,114 @@
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+
+from areal.utils.stats_tracker import (
+    DistributedStatsTracker,
+    ReduceType,
+    _StatMetadata,
+)
+
+
+def test_export_uses_key_sync_group_for_missing_per_key_stat():
+    tracker = DistributedStatsTracker()
+    dp_group = object()
+    cp_dp_group = object()
+    remote_metadata = {
+        "n_tokens": _StatMetadata(ReduceType.SUM, None, True),
+        "vocab_min_logits": _StatMetadata(
+            ReduceType.AVG_MIN_MAX,
+            "n_tokens",
+            True,
+        ),
+    }
+    all_reduce_calls = []
+
+    def fake_get_world_size(group):
+        return 2 if group is cp_dp_group else 1
+
+    def fake_all_gather_object(output, local_metadata, group):
+        if group is dp_group:
+            assert local_metadata == {}
+            output[:] = [local_metadata]
+        else:
+            assert group is cp_dp_group
+            assert local_metadata == {}
+            output[:] = [local_metadata, remote_metadata]
+
+    def fake_all_reduce(tensor, group=None, op=None):
+        all_reduce_calls.append((group, op))
+
+    with (
+        patch(
+            "areal.utils.stats_tracker.dist.get_world_size",
+            side_effect=fake_get_world_size,
+        ),
+        patch(
+            "areal.utils.stats_tracker.dist.all_gather_object",
+            side_effect=fake_all_gather_object,
+        ),
+        patch(
+            "areal.utils.stats_tracker.dist.all_reduce",
+            side_effect=fake_all_reduce,
+        ),
+    ):
+        tracker.export(
+            reduce_group=dp_group,
+            key_sync_group=cp_dp_group,
+            reset=False,
+        )
+
+    assert [group for group, _ in all_reduce_calls] == [cp_dp_group] * 5
+    assert [op for _, op in all_reduce_calls] == [
+        None,
+        None,
+        None,
+        dist.ReduceOp.MIN,
+        dist.ReduceOp.MAX,
+    ]
+
+
+def test_export_keeps_default_reduce_group_when_key_sync_group_is_larger():
+    tracker = DistributedStatsTracker()
+    dp_group = object()
+    cp_dp_group = object()
+    tracker.denominator(n_seqs=torch.ones(2, dtype=torch.bool))
+    all_reduce_groups = []
+
+    def fake_get_world_size(group):
+        return 1
+
+    def fake_all_gather_object(output, local_metadata, group):
+        if group is dp_group:
+            assert set(local_metadata) == {"n_seqs"}
+            output[:] = [local_metadata]
+        else:
+            assert group is cp_dp_group
+            assert local_metadata == {}
+            output[:] = [local_metadata]
+
+    def fake_all_reduce(tensor, group=None, op=None):
+        all_reduce_groups.append(group)
+
+    with (
+        patch(
+            "areal.utils.stats_tracker.dist.get_world_size",
+            side_effect=fake_get_world_size,
+        ),
+        patch(
+            "areal.utils.stats_tracker.dist.all_gather_object",
+            side_effect=fake_all_gather_object,
+        ),
+        patch(
+            "areal.utils.stats_tracker.dist.all_reduce",
+            side_effect=fake_all_reduce,
+        ),
+    ):
+        tracker.export(
+            reduce_group=dp_group,
+            key_sync_group=cp_dp_group,
+            reset=False,
+        )
+
+    assert all_reduce_groups == [dp_group]

--- a/tests/test_stats_tracker.py
+++ b/tests/test_stats_tracker.py
@@ -112,3 +112,45 @@ def test_export_keeps_default_reduce_group_when_key_sync_group_is_larger():
         )
 
     assert all_reduce_groups == [dp_group]
+
+
+def test_export_scalar_key_missing_on_this_rank_does_not_crash():
+    """A SCALAR key known only via metadata sync must still take part in the
+    collective (aggregating over empty local values) and return 0.0 rather
+    than NaN from a 0/0 division."""
+    tracker = DistributedStatsTracker()
+    dp_group = object()
+    remote_metadata = {"loss_scalar": _StatMetadata(ReduceType.SCALAR, None, False)}
+    all_reduce_groups = []
+
+    def fake_get_world_size(group):
+        return 2
+
+    def fake_all_gather_object(output, local_metadata, group):
+        assert group is dp_group
+        assert local_metadata == {}  # this rank never recorded the scalar
+        output[:] = [local_metadata, remote_metadata]
+
+    def fake_all_reduce(tensor, group=None, op=None):
+        all_reduce_groups.append(group)
+
+    with (
+        patch(
+            "areal.utils.stats_tracker.dist.get_world_size",
+            side_effect=fake_get_world_size,
+        ),
+        patch(
+            "areal.utils.stats_tracker.dist.all_gather_object",
+            side_effect=fake_all_gather_object,
+        ),
+        patch(
+            "areal.utils.stats_tracker.dist.all_reduce",
+            side_effect=fake_all_reduce,
+        ),
+    ):
+        result = tracker.export(reduce_group=dp_group, reset=False)
+
+    # value + cnt are both reduced over the default group.
+    assert all_reduce_groups == [dp_group, dp_group]
+    assert result["loss_scalar"] == 0.0  # guarded 0/0, not NaN
+    assert result["loss_scalar__count"] == 0


### PR DESCRIPTION
## What

Two independent correctness fixes for the Megatron engine.

### 1. CP metrics alignment (`stats_tracker`)
Per-key `reduce_group` overrides can be wider than the default DP export group (e.g. DP+CP for token-level metrics). Adds a `key_sync_group` argument so override keys sync their key set / metadata and reduce over DP+CP, while default keys keep DP alignment. Aggregation helpers now emit identity placeholder tensors (`0` / `+inf` / `-inf`) for keys absent on a rank, so every rank still participates in the collective — avoiding hangs / mismatched reductions when CP > 1.

### 2. TP grad norm metadata (`megatron_engine`)
`_mark_duplicated_params` now also clears `param.tensor_model_parallel` on replicated (`tp_size == 1`, non-expert) params. Megatron's optimizer uses that attribute to decide which TP ranks contribute to grad norm/clipping, so leaving it `True` double-counts duplicated params when TP > 1. Clearing it is consistent with `all_gather_param` and `hf_save`, which already treat non-TP params as replicated.

Preserves the name-based `_duplicated_param_names` property used by `all_gather_param`; the new attribute-based marking coexists with it and converges to the same result.

## Tests
- `tests/test_stats_tracker.py`: `key_sync_group` behavior for missing per-key stats and default-group alignment.
- `tests/test_megatron_engine.py`: `_mark_duplicated_params` clears TP metadata only for replicated non-expert params.
- `tests/test_all_gather_param.py`: `all_gather_param` routing — replicated params returned as-is, genuine TP-sharded params all-gathered.
- `tests/test_grad_norm_duplicated.py`: a replicated param is counted once under the TP grad-norm reduction, and inflated by sqrt(tp) if left marked TP.
- `tests/megatron/test_grad_norm_tp_invariance.py`: end-to-end grad-norm TP-invariance on the real MegatronEngine (2 GPUs, `multi_gpu`/`slow`).