### PR TITLE
fix(openai): align proxy tool schemas with sglang chat-completions rendering

### DIFF
--- a/areal/experimental/openai/client.py
+++ b/areal/experimental/openai/client.py
@@ -76,6 +76,97 @@ os.environ["OPENAI_BASE_URL"] = os.environ.get("OPENAI_BASE_URL", "none")
 
 logger = logging.getLogger("OpenAIClient")
 
+
+def _align_tools_with_sglang(tools_list: list) -> list[dict]:
+    """Round-trip tools through sglang's pydantic Tool model so the dicts
+    fed to ``apply_chat_template`` byte-match what sglang's serving_chat
+    produces on its own ``/v1/chat/completions`` path.
+
+    The goal is behavioral parity with sglang's native route, so a
+    trajectory served here stays reproducible on sglang's own endpoint.
+    Without it the two paths render the ``tools`` block differently (field
+    order and default-field presence, e.g. sglang's ``Function`` dumps
+    ``strict: false`` while LiteLLM omits it). The prompt-token delta this
+    causes is a symptom of the mismatch, not the thing being optimized.
+
+    Assumptions this function cannot verify (see FIXME at the call sites):
+    - Backend is sglang. Call sites only invoke this when the engine class
+      name identifies sglang, so other backends are left unaligned.
+    - The worker venv's sglang version matches the serving version; a skew in
+      disaggregated deployments silently aligns to a stale tool format.
+
+    Behaviour:
+    - sglang not importable → log once, then still normalize shapes (dict
+      conversion and flat→nested) and skip only the pydantic round-trip, so
+      ``apply_chat_template`` always receives nested dicts.
+    - Responses ``FunctionToolParam`` is flat (top-level ``name``/``parameters``
+      and no ``function`` key); it is normalized to the nested Chat shape that
+      both sglang's ``Tool`` model and ``apply_chat_template`` expect before
+      validation.
+    - per-tool validation failure → log + keep that single tool unchanged
+      (partial alignment is still better than no alignment for the rest).
+    - BaseModel inputs are handled via ``model_dump()`` first.
+    """
+
+    def _to_chat_format(t_dict: dict) -> dict:
+        # Flat Responses FunctionToolParam → nested Chat shape. sglang's
+        # Function model drops fields it doesn't declare (e.g. defer_loading),
+        # so the dump still matches the chat-completions path. Chat tools
+        # already nest under ``function`` and pass through unchanged.
+        if (
+            t_dict.get("type") == "function"
+            and "function" not in t_dict
+            and "name" in t_dict
+        ):
+            function = {k: v for k, v in t_dict.items() if k != "type"}
+            return {"type": "function", "function": function}
+        return t_dict
+
+    _SglTool = None
+    try:
+        from sglang.srt.entrypoints.openai.protocol import Tool as _SglTool
+    except Exception as e:
+        if not getattr(_align_tools_with_sglang, "_warned_no_sglang", False):
+            logger.warning(
+                "_align_tools_with_sglang: sglang not importable (%s); tools "
+                "block will diverge from sglang chat-completions path. "
+                "Install sglang in the worker venv to fix this.",
+                e,
+            )
+            _align_tools_with_sglang._warned_no_sglang = True  # type: ignore[attr-defined]
+    aligned: list[dict] = []
+    for t in tools_list:
+        # Accept dict (TypedDict at runtime) and BaseModel.
+        if isinstance(t, BaseModel):
+            t_dict = t.model_dump()
+        elif isinstance(t, Mapping):
+            t_dict = dict(t)
+        else:
+            logger.warning(
+                "_align_tools_with_sglang: tool of type %s is neither dict "
+                "nor BaseModel; passing through unchanged.",
+                type(t).__name__,
+            )
+            aligned.append(t)
+            continue
+        t_dict = _to_chat_format(t_dict)
+        if _SglTool is None:
+            aligned.append(t_dict)
+            continue
+        try:
+            aligned.append(_SglTool(**t_dict).model_dump())
+        except Exception as e:
+            logger.warning(
+                "_align_tools_with_sglang: pydantic Tool validation failed "
+                "for tool %s (%s); passing through unchanged. This will "
+                "cause partial drift from sglang chat-completions path.",
+                t_dict.get("function", {}).get("name", "<unknown>"),
+                e,
+            )
+            aligned.append(t_dict)
+    return aligned
+
+
 _DEFAULT_MAX_TOTAL_TOKENS = 32768
 
 
@@ -655,6 +746,15 @@ class AsyncCompletionsWithReward(BaseAsyncCompletions):
             if not isinstance(tools, Iterable):
                 raise TypeError("tools must be an iterable of ChatCompletionToolParam")
             tools_list = list(tools)
+            # FIXME: alignment targets sglang's rendering, so it is only
+            # correct for an sglang backend. Apply it only when the engine is
+            # positively identified as sglang (by class name); any other
+            # backend is left unaligned to avoid aligning to the wrong format
+            # or a misleading "install sglang" hint. A proper fix gates on a
+            # backend identifier exposed by the engine.
+            # See docs/en/tutorial/online_proxy.md.
+            if "sglang" in type(self.engine).__name__.lower():
+                tools_list = _align_tools_with_sglang(tools_list)
 
         image_data, messages_for_tokenizer, vision_messages_for_vllm = (
             _extract_images_from_messages(messages_list)
@@ -1101,6 +1201,15 @@ class AsyncResponsesWithReward(BaseAsyncResponses):
             if not isinstance(tools, Iterable):
                 raise TypeError("tools must be an iterable of ChatCompletionToolParam")
             tools_list = list(tools)
+            # FIXME: alignment targets sglang's rendering, so it is only
+            # correct for an sglang backend. Apply it only when the engine is
+            # positively identified as sglang (by class name); any other
+            # backend is left unaligned to avoid aligning to the wrong format
+            # or a misleading "install sglang" hint. A proper fix gates on a
+            # backend identifier exposed by the engine.
+            # See docs/en/tutorial/online_proxy.md.
+            if "sglang" in type(self.engine).__name__.lower():
+                tools_list = _align_tools_with_sglang(tools_list)
 
         image_data, messages_for_tokenizer, vision_messages_for_vllm = (
             _extract_images_from_messages(messages_list)

--- a/docs/en/tutorial/online_proxy.md
+++ b/docs/en/tutorial/online_proxy.md
@@ -389,6 +389,14 @@ live rollout is unchanged.
   schedulers. The proxy gateway has not yet been validated end-to-end under `ray`.
 - **Single-controller mode**: Online mode only works in single-controller mode (i.e.
   when `AREAL_SPMD_MODE` is not set).
+- **Tool-schema alignment assumes sglang**: For behavioral parity with sglang's native
+  route, the proxy round-trips request `tools` through sglang's `Tool` model so they
+  byte-match sglang's own `/v1/chat/completions` rendering (keeping trajectories
+  reproducible on that endpoint). This is only correct for an **sglang** backend whose
+  version matches the worker venv's installed sglang. The alignment therefore runs only
+  when the engine class name identifies sglang; any other backend (e.g. vLLM) is left
+  unaligned. Robust backend-aware gating is tracked as a FIXME in
+  `areal/experimental/openai/client.py`.
 
 ## See Also
 

--- a/tests/experimental/openai/test_align_tools_with_sglang.py
+++ b/tests/experimental/openai/test_align_tools_with_sglang.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import pytest
+from pydantic import BaseModel
+
+from areal.experimental.openai.client import _align_tools_with_sglang
+
+pytest.importorskip(
+    "sglang.srt.entrypoints.openai.protocol",
+    reason="alignment target is sglang's own Tool model",
+)
+
+CHAT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    },
+}
+
+FLAT_RESPONSES_TOOL = {
+    "type": "function",
+    "name": "get_weather",
+    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+}
+
+
+def _sglang_rendering(tool: dict) -> dict:
+    from sglang.srt.entrypoints.openai.protocol import Tool
+
+    return Tool(**tool).model_dump()
+
+
+def test_chat_tool_matches_sglang_native_rendering():
+    assert _align_tools_with_sglang([CHAT_TOOL]) == [_sglang_rendering(CHAT_TOOL)]
+
+
+def test_alignment_adds_the_defaults_that_caused_the_drift():
+    function = _align_tools_with_sglang([CHAT_TOOL])[0]["function"]
+
+    assert function["strict"] is False
+    assert function["description"] is None
+    assert "strict" not in CHAT_TOOL["function"]
+
+
+def test_flat_responses_tool_is_normalized_to_the_chat_shape():
+    assert _align_tools_with_sglang([FLAT_RESPONSES_TOOL]) == _align_tools_with_sglang(
+        [CHAT_TOOL]
+    )
+
+
+def test_pydantic_tool_input_is_accepted():
+    class Function(BaseModel):
+        name: str
+        parameters: dict
+
+    class Tool(BaseModel):
+        type: str
+        function: Function
+
+    aligned = _align_tools_with_sglang(
+        [Tool(type="function", function=Function(name="get_weather", parameters={}))]
+    )
+
+    assert aligned[0]["function"]["name"] == "get_weather"
+
+
+def test_alignment_is_idempotent():
+    once = _align_tools_with_sglang([CHAT_TOOL])
+
+    assert _align_tools_with_sglang(once) == once
+
+
+def test_invalid_tool_is_passed_through_without_failing_the_batch():
+    aligned = _align_tools_with_sglang([CHAT_TOOL, {"type": "function"}])
+
+    assert aligned[0] == _sglang_rendering(CHAT_TOOL)
+    assert aligned[1] == {"type": "function"}
+
+
+def test_unsupported_tool_type_is_passed_through():
+    assert _align_tools_with_sglang(["not-a-tool"]) == ["not-a-tool"]
+
+
+def test_empty_list_is_unchanged():
+    assert _align_tools_with_sglang([]) == []
+
+
+@pytest.fixture
+def sglang_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "sglang.srt.entrypoints.openai.protocol", None)
+    monkeypatch.delattr(_align_tools_with_sglang, "_warned_no_sglang", raising=False)
+
+
+def test_flat_responses_tool_is_still_nested_without_sglang(sglang_missing):
+    assert _align_tools_with_sglang([FLAT_RESPONSES_TOOL]) == [CHAT_TOOL]
+
+
+def test_pydantic_tool_becomes_a_dict_without_sglang(sglang_missing):
+    class Function(BaseModel):
+        name: str
+        parameters: dict
+
+    class Tool(BaseModel):
+        type: str
+        function: Function
+
+    tool = Tool(type="function", function=Function(**CHAT_TOOL["function"]))
+
+    assert _align_tools_with_sglang([tool]) == [CHAT_TOOL]
+
+
+def test_chat_tool_keeps_its_fields_without_sglang(sglang_missing):
+    aligned = _align_tools_with_sglang([CHAT_TOOL])
+
+    assert aligned == [CHAT_TOOL]
+    assert "strict" not in aligned[0]["function"]


### PR DESCRIPTION
## Description

The OpenAI-compatible proxy renders the request `tools` block as plain dicts, while sglang's native `/v1/chat/completions` route round-trips tools through its pydantic `Tool` model before applying the chat template. The two renderings differ in field order and default-field presence (e.g. sglang's `Function` dumps `strict: false` while the proxy omits it). Since the tools block is serialized into the prompt by the chat template, the same trajectory produces different prompt token ids on the two paths, so training rewards drift from evaluation results served by sglang directly.

This PR round-trips tools through sglang's `Tool` model on the proxy path so the dicts fed to `apply_chat_template` byte-match sglang's own rendering:

- Flat Responses `FunctionToolParam` entries (top-level `name`/`parameters`, no `function` key) are normalized to the nested Chat shape before validation.
- The alignment runs only when the engine class name identifies an sglang backend; other backends (e.g. vLLM) are left unaligned to avoid aligning to the wrong format. Robust backend-aware gating is left as a FIXME.
- sglang not importable: warn once and pass tools through unchanged; per-tool validation failure: keep that single tool unchanged.

The sglang-only assumption is documented in `docs/en/tutorial/online_proxy.md`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tests/experimental/openai/test_parse_tool_call_arguments.py` and `test_tool_call_parser.py`: 9 passed, 2 skipped in the dev image; `test_client*.py` collection requires HuggingFace model downloads, unavailable on the offline test node)
- [x] Any dependent changes have been merged and published

## Additional Context

Ported from a verified internal fix. Smoke-tested in the dev image against the installed sglang: chat-format tools pass through re-serialized, flat Responses tools are normalized to the nested shape, and sglang's default fields (e.g. `strict`) are materialized exactly as on its native route.
