### PR TITLE
docs: update NPU installation guide for ascend-v1.0.4

### DIFF
--- a/docs/en/tutorial/installation_npu.md
+++ b/docs/en/tutorial/installation_npu.md
@@ -1,5 +1,10 @@
 # Installation (Ascend NPU)
 
+**Note**: Ascend NPU support is maintained on the
+[`ascend-v1.0.4`](https://github.com/areal-project/AReaL/tree/ascend-v1.0.4) branch
+rather than `main`. All code, configurations, and examples referenced in this document
+refer to that branch — make sure to check it out as described below.
+
 ## Prerequisites
 
 ### Hardware Requirements
@@ -20,11 +25,11 @@ The following hardware configuration has been extensively tested:
 | ---------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | Operating System |                                                                      Ubuntu, EulerOS or any system meeting the requirements below                                                                      |
 | Ascend HDK       |                                                                                                 25.2.1                                                                                                 |
-| CANN             |                                                                                                 8.5.0                                                                                                  |
+| CANN             |                                                                                                 9.0.0                                                                                                  |
 | Git LFS          | Required for downloading models, datasets, and AReaL code. See [installation guide](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) |
 | Docker           |                                                                                                 27.2.0                                                                                                 |
-| AReaL Image (A2) |                                                            `swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a2` (see details below)                                                            |
-| AReaL Image (A3) |                                                            `swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a3` (see details below)                                                            |
+| AReaL Image (A2) |                                                                       `ghcr.io/hwvanici/areal_npu:v1.0.4-a2` (see details below)                                                                       |
+| AReaL Image (A3) |                                                                       `ghcr.io/hwvanici/areal_npu:v1.0.4-a3` (see details below)                                                                       |
 
 **Note**: This tutorial does not cover the installation of CANN, or shared storage
 mounting, as these depend on your specific node configuration and system version. Please
@@ -34,8 +39,26 @@ vLLM-Ascend community at
 
 ## Runtime Environment
 
-We recommend using Docker with our provided image for NPU, which contains CANN and
-pre-built vLLM and vLLM-Ascend.
+We recommend using Docker with our provided image for NPU. The A2 image targets Atlas A2
+and the A3 image targets Atlas A3; both are built from the same recipe (see
+[`Dockerfile.a2`](https://github.com/areal-project/AReaL/blob/ascend-v1.0.4/Dockerfile.a2)
+/
+[`Dockerfile.a3`](https://github.com/areal-project/AReaL/blob/ascend-v1.0.4/Dockerfile.a3)
+on the `ascend-v1.0.4` branch) and ship the following pre-built stack:
+
+| Component       |                         Version                         |
+| --------------- | :-----------------------------------------------------: |
+| Base image      | `quay.io/ascend/cann:9.0.0` (Ubuntu 22.04, Python 3.11) |
+| torch_npu       |                       2.9.0.post2                       |
+| vLLM-Ascend     |                         v0.18.0                         |
+| triton-ascend   |                          3.2.1                          |
+| Megatron-Core   |                         v0.16.1                         |
+| MindSpeed       |              core_r0.16.0 (pinned commit)               |
+| Megatron-Bridge |   pinned commit compatible with Megatron-Core 0.16.x    |
+
+All other AReaL Python dependencies are pre-installed from `pyproject.npu.toml`.
+Megatron-LM, MindSpeed, and Megatron-Bridge sources live under `/areal-workspace` and
+are made importable via `PYTHONPATH`.
 
 ### Create Container
 
@@ -44,8 +67,8 @@ WORK_DIR=<your_workspace>
 CONTAINER_WORK_DIR=<your_container_workspace>
 
 # Use A2/A3 image depending on your hardware type
-# IMAGE=swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a2
-IMAGE=swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a3
+# IMAGE=ghcr.io/hwvanici/areal_npu:v1.0.4-a2
+IMAGE=ghcr.io/hwvanici/areal_npu:v1.0.4-a3
 CONTAINER_NAME=areal_npu
 
 cd ${WORK_DIR}
@@ -93,7 +116,9 @@ checkpoints and logs.
 ### Custom Environment Installation
 
 The image includes a built-in copy of the AReaL source code under `/AReaL`, but it may
-be out of date. We recommend removing it and installing AReaL from source.
+be out of date. We recommend removing it and installing AReaL from the latest source.
+This only replaces the AReaL package itself — all dependencies (including MindSpeed and
+Megatron-Bridge under `/areal-workspace`) stay untouched.
 
 ```bash
 rm -rf /AReaL
@@ -102,10 +127,11 @@ git clone https://github.com/areal-project/AReaL
 cd AReaL
 
 # Checkout to ascend branch
-git checkout ascend-v1.0.1
+git checkout ascend-v1.0.4
 
-# Install AReaL
-pip install -e . --no-deps
+# Install AReaL. All Python dependencies (from pyproject.npu.toml) are already
+# installed in the image, so only the AReaL package itself needs to be installed.
+uv pip install --no-deps -e . --system
 ```
 
 ## (Optional) Launch Ray Cluster for Distributed Training
@@ -131,16 +157,28 @@ script will automatically detect the resources and allocate workers to the clust
 
 ## Next Steps
 
-Check the [quickstart section](quickstart.md) to launch your first AReaL job. To run on
-NPU, make the following changes:
+Check the [quickstart section](quickstart.md) to get familiar with launching AReaL jobs.
+On NPU, we recommend starting from the vision-language model (VLM) GRPO examples in
+[`examples/vlm_npu/`](https://github.com/areal-project/AReaL/tree/ascend-v1.0.4/examples/vlm_npu)
+on the `ascend-v1.0.4` branch, which train on the Geometry3K dataset. For example, to
+train Qwen2.5-VL-3B on a single node (16 NPUs, vLLM rollout + Megatron training):
 
-- **Training script:** use `examples/math/gsm8k_rl.py`
-- **Configuration file:** use the provided NPU configuration file
-  `examples/math/gsm8k_grpo_npu.yaml`
+```bash
+# Some models are optimized by vllm-ascend, but the optimized variants
+# may be unsuitable for RLHF training. Disable them before launching.
+export USE_OPTIMIZED_MODEL=0
 
-Follow the instructions there. If you want to run multi-node training with Ray, make
-sure your Ray cluster is started as described above before launching the job.
+python examples/vlm/geometry3k_grpo.py \
+    --config examples/vlm_npu/qwen2_5_vl_3b_geometry3k_grpo.yaml
+```
 
-**Note**: Currently, only the `fsdp` training engine and the `vllm` rollout engine
-(through the vLLM-Ascend plugin) are supported on Ascend NPU. The `megatron` engine
-(through [MindSpeed](https://gitcode.com/Ascend/MindSpeed)) is currently experimental.
+See the
+[`examples/vlm_npu/README.md`](https://github.com/areal-project/AReaL/blob/ascend-v1.0.4/examples/vlm_npu/README.md)
+on the `ascend-v1.0.4` branch for the full list of configurations (Qwen2.5-VL, Qwen3-VL,
+Qwen3.5, Qwen3.6 dense and MoE), dataset preparation, and multi-node training with Ray.
+If you want to run multi-node training, make sure your Ray cluster is started as
+described above before launching the job.
+
+**Note**: On Ascend NPU, rollout is supported through the `vllm` engine (via the
+vLLM-Ascend plugin); SGLang is not available. Both the `fsdp` and `megatron` (through
+[MindSpeed](https://gitcode.com/Ascend/MindSpeed)) training engines are supported.

--- a/docs/zh/tutorial/installation_npu.md
+++ b/docs/zh/tutorial/installation_npu.md
@@ -1,5 +1,9 @@
 # 安装指南（昇腾 NPU）
 
+**注意**：昇腾 NPU 支持在
+[`ascend-v1.0.4`](https://github.com/areal-project/AReaL/tree/ascend-v1.0.4) 分支维护而非
+`main` 分支。本文档中引用的所有代码、配置和示例均指该分支——请按照下文说明检出该分支。
+
 ## 前置要求
 
 ### 硬件要求
@@ -20,18 +24,35 @@
 | --------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | 操作系统        |                                                                Ubuntu、EulerOS 或满足以下要求的任何系统                                                                |
 | 昇腾 HDK        |                                                                                 25.2.1                                                                                 |
-| CANN            |                                                                                 8.5.0                                                                                  |
+| CANN            |                                                                                 9.0.0                                                                                  |
 | Git LFS         | 下载模型、数据集和 AReaL 代码所需。请参阅[安装指南](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) |
 | Docker          |                                                                                 27.2.0                                                                                 |
-| AReaL 镜像 (A2) |                                                `swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a2`（详见下文）                                                |
-| AReaL 镜像 (A3) |                                                `swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a3`（详见下文）                                                |
+| AReaL 镜像 (A2) |                                                           `ghcr.io/hwvanici/areal_npu:v1.0.4-a2`（详见下文）                                                           |
+| AReaL 镜像 (A3) |                                                           `ghcr.io/hwvanici/areal_npu:v1.0.4-a3`（详见下文）                                                           |
 
 **注意**：本教程不涵盖 CANN 的安装或共享存储挂载，因为这些取决于您特定的节点配置和系统版本。请独立完成这些安装。您可以从 vLLM-Ascend
 社区查看更多详情[此页面](https://docs.vllm.ai/projects/ascend/en/latest/installation.html)。
 
 ## 运行环境
 
-我们建议使用 Docker 和我们提供的 NPU 镜像，其中包含 CANN 以及预构建的 vLLM 和 vLLM-Ascend。
+我们建议使用 Docker 和我们提供的 NPU 镜像。A2 镜像面向 Atlas A2，A3 镜像面向 Atlas A3；两者基于相同的方法构建（参见
+`ascend-v1.0.4` 分支上的
+[`Dockerfile.a2`](https://github.com/areal-project/AReaL/blob/ascend-v1.0.4/Dockerfile.a2)
+/
+[`Dockerfile.a3`](https://github.com/areal-project/AReaL/blob/ascend-v1.0.4/Dockerfile.a3)），并预装以下依赖栈：
+
+| 组件            |                           版本                           |
+| --------------- | :------------------------------------------------------: |
+| 基础镜像        | `quay.io/ascend/cann:9.0.0`（Ubuntu 22.04、Python 3.11） |
+| torch_npu       |                       2.9.0.post2                        |
+| vLLM-Ascend     |                         v0.18.0                          |
+| triton-ascend   |                          3.2.1                           |
+| Megatron-Core   |                         v0.16.1                          |
+| MindSpeed       |               core_r0.16.0（固定 commit）                |
+| Megatron-Bridge |        固定 commit，与 Megatron-Core 0.16.x 兼容         |
+
+其余 AReaL Python 依赖均已根据 `pyproject.npu.toml` 预装。Megatron-LM、MindSpeed 和 Megatron-Bridge
+的源码位于 `/areal-workspace` 目录下，并通过 `PYTHONPATH` 使其可导入。
 
 ### 创建容器
 
@@ -40,8 +61,8 @@ WORK_DIR=<your_workspace>
 CONTAINER_WORK_DIR=<your_container_workspace>
 
 # 根据您的硬件类型使用 A2/A3 镜像
-# IMAGE=swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a2
-IMAGE=swr.cn-north-9.myhuaweicloud.com/areal/areal_npu:v1.0.1-a3
+# IMAGE=ghcr.io/hwvanici/areal_npu:v1.0.4-a2
+IMAGE=ghcr.io/hwvanici/areal_npu:v1.0.4-a3
 CONTAINER_NAME=areal_npu
 
 cd ${WORK_DIR}
@@ -86,7 +107,8 @@ ${IMAGE}  \
 
 ### 自定义环境安装
 
-该镜像在 `/AReaL` 目录下包含一份内置的 AReaL 源代码副本，但该副本可能已过时。建议删除该目录，并从源码重新安装 AReaL。
+该镜像在 `/AReaL` 目录下包含一份内置的 AReaL 源代码副本，但该副本可能已过时。建议删除该目录，并使用最新源码重新安装 AReaL。此操作只会替换 AReaL
+包本身——所有依赖（包括位于 `/areal-workspace` 下的 MindSpeed 和 Megatron-Bridge）都不会受到影响。
 
 ```bash
 rm -rf /AReaL
@@ -95,10 +117,11 @@ git clone https://github.com/areal-project/AReaL
 cd AReaL
 
 # 切换到 ascend 分支
-git checkout ascend-v1.0.1
+git checkout ascend-v1.0.4
 
-# 安装 AReaL
-pip install -e . --no-deps
+# 安装 AReaL。所有 Python 依赖（来自 pyproject.npu.toml）已预装在镜像中，
+# 因此只需安装 AReaL 包本身。
+uv pip install --no-deps -e . --system
 ```
 
 ## （可选）启动 Ray 集群用于分布式训练
@@ -123,12 +146,24 @@ ray start --address $RAY_HEAD_IP
 
 ## 下一步
 
-查看[快速入门部分](quickstart.md)来启动您的第一个 AReaL 任务。要在 NPU 上运行，请进行以下更改：
+查看[快速入门部分](quickstart.md)来熟悉 AReaL 任务的启动方式。在 NPU 上，我们建议从 `ascend-v1.0.4`
+分支上的视觉语言模型（VLM）GRPO 示例
+[`examples/vlm_npu/`](https://github.com/areal-project/AReaL/tree/ascend-v1.0.4/examples/vlm_npu)
+开始，这些示例在 Geometry3K 数据集上进行训练。例如，在单节点上（16 个 NPU，vLLM 推理 + Megatron 训练）训练 Qwen2.5-VL-3B：
 
-- **训练脚本：** 使用 `examples/math/gsm8k_rl.py`
-- **配置文件：** 使用提供的 NPU 配置文件 `examples/math/gsm8k_grpo_npu.yaml`
+```bash
+# 部分模型会被 vllm-ascend 优化，但优化后的变体可能不适用于 RLHF 训练。
+# 启动前请先禁用。
+export USE_OPTIMIZED_MODEL=0
 
-按照那里的说明进行操作。如果要使用 Ray 运行多节点训练，请在启动任务之前确保您的 Ray 集群已按上述说明启动。
+python examples/vlm/geometry3k_grpo.py \
+    --config examples/vlm_npu/qwen2_5_vl_3b_geometry3k_grpo.yaml
+```
 
-**注意**：目前，昇腾 NPU 上仅支持 `fsdp` 训练引擎和 `vllm` 推理引擎（通过 vLLM-Ascend 插件）。`megatron` 引擎（通过
-[MindSpeed](https://gitcode.com/Ascend/MindSpeed)）目前仍处于实验阶段。
+完整的配置列表（Qwen2.5-VL、Qwen3-VL、Qwen3.5、Qwen3.6 稠密与 MoE 模型）、数据集准备以及基于 Ray 的多节点训练，请参阅
+`ascend-v1.0.4` 分支上的
+[`examples/vlm_npu/README.md`](https://github.com/areal-project/AReaL/blob/ascend-v1.0.4/examples/vlm_npu/README.md)。如果要运行多节点训练，请在启动任务之前确保您的
+Ray 集群已按上述说明启动。
+
+**注意**：在昇腾 NPU 上，推理（rollout）通过 `vllm` 引擎（vLLM-Ascend 插件）支持；SGLang 不可用。`fsdp` 和
+`megatron`（通过 [MindSpeed](https://gitcode.com/Ascend/MindSpeed)）训练引擎均已支持。


### PR DESCRIPTION
## Description

Update the Ascend NPU installation guide (EN + ZH) to match the current `ascend-v1.0.4` release branch. The doc previously described the v1.0.1 release (CANN 8.5.0, SWR-hosted images, GSM8K quickstart) and claimed the `megatron` engine was experimental, all of which are stale.

Key updates:

- Add a top-of-page note directing Ascend users to the `ascend-v1.0.4` branch, since NPU support is maintained there rather than on `main`.
- Refresh the software requirements to CANN 9.0.0 and the `ghcr.io/hwvanici/areal_npu:v1.0.4-a2/a3` images.
- Describe the image stack from `Dockerfile.a2`/`Dockerfile.a3` — torch_npu 2.9.0.post2, vLLM-Ascend v0.18.0, triton-ascend 3.2.1, Megatron-Core v0.16.1 + MindSpeed core_r0.16.0, Megatron-Bridge pinned commit — with links pinned to the branch.
- Update the source-install steps to `git checkout ascend-v1.0.4` + `uv pip install --no-deps -e . --system`, clarifying that reinstalling only replaces the AReaL package.
- Replace the GSM8K quickstart pointers with a runnable Geometry3K VLM example (`USE_OPTIMIZED_MODEL=0` + `examples/vlm/geometry3k_grpo.py --config examples/vlm_npu/qwen2_5_vl_3b_geometry3k_grpo.yaml`) and link the branch's `examples/vlm_npu/README.md` for the full config list.
- Update the engine-support note: both `fsdp` and `megatron` (via MindSpeed) are supported; SGLang is unavailable.

## Related Issue

N/A — documentation refresh for the ascend-v1.0.4 release.

## Type of Change

- [x] 📝 Documentation update

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Relevant tests pass; new tests added for new functionality (N/A — docs only)
- [x] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

