### PR TITLE
feat(v2): add auditable InfBridge client traces

### DIFF
--- a/areal/v2/inference_service/backend.py
+++ b/areal/v2/inference_service/backend.py
@@ -92,3 +92,25 @@ class InfBridgeBackend(Protocol):
     ) -> None:
         """Mutate ``http_req`` for an abort/resubmit iteration."""
         ...
+
+
+@runtime_checkable
+class TraceableInfBridgeBackend(Protocol):
+    """Optional backend capability for observing submitted token IDs.
+
+    The snapshot is taken after :meth:`InfBridgeBackend.patch_generation_request`
+    and immediately before the HTTP request is sent.  Backends should return a
+    newly allocated tuple so later payload mutations cannot rewrite history.
+
+    ``None`` means that the physical payload does not expose a flat token-ID
+    sequence (for example, a multimodal chat request).  This protocol is kept
+    separate from :class:`InfBridgeBackend` so third-party backends remain
+    compatible without implementing tracing.
+    """
+
+    def snapshot_generation_input_ids(
+        self,
+        http_req: HttpRequest,
+    ) -> tuple[int, ...] | None:
+        """Return an immutable snapshot of token IDs in the patched payload."""
+        ...

--- a/areal/v2/inference_service/client_trace.py
+++ b/areal/v2/inference_service/client_trace.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from areal.api.io_struct import ModelResponse
@@ -18,14 +18,24 @@ from areal.api.io_struct import ModelResponse
 __all__ = [
     "GenerationAttemptTrace",
     "GenerationPhysicalTrace",
+    "GenerationResponseEvidence",
+    "ParsedResponseJSONEvidence",
+    "canonical_parsed_response_json_bytes",
+    "generation_physical_trace_from_bytes",
     "generation_physical_trace_bytes",
     "generation_physical_trace_sha256",
+    "generation_response_evidence_bytes",
+    "generation_response_evidence_from_bytes",
+    "generation_response_evidence_sha256",
+    "generation_response_evidence_values",
     "parsed_response_json_sha256",
     "prepared_request_json_sha256",
+    "validate_generation_response_evidence",
     "validate_generation_physical_trace_response",
 ]
 
-_TRACE_KIND = "areal-generation-physical-trace-v1"
+_TRACE_KIND = "areal-generation-physical-trace-v2"
+_RESPONSE_EVIDENCE_KIND = "areal-generation-response-evidence-v1"
 _PREPARED_REQUEST_JSON_DOMAIN = b"areal-infbridge-prepared-request-json-v1\0"
 _PARSED_RESPONSE_JSON_DOMAIN = b"areal-infbridge-parsed-response-json-v1\0"
 _SHA256_HEX_CHARS = frozenset("0123456789abcdef")
@@ -82,6 +92,97 @@ def parsed_response_json_sha256(value: object) -> str:
     return _canonical_json_sha256(value, domain=_PARSED_RESPONSE_JSON_DOMAIN)
 
 
+def canonical_parsed_response_json_bytes(value: object) -> bytes:
+    """Return the exact canonical JSON preimage used by response evidence."""
+
+    if type(value) is not dict:
+        raise TypeError("parsed response JSON must be a dict")
+    return _canonical_json_bytes(value)
+
+
+def _reject_json_constant(value: str) -> object:
+    raise ValueError(f"non-finite JSON number is forbidden: {value}")
+
+
+def _reject_duplicate_json_keys(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON key is forbidden: {key}")
+        value[key] = item
+    return value
+
+
+def _parse_canonical_json_object(value: object) -> dict[str, Any]:
+    if type(value) is not bytes or not value:
+        raise ValueError("canonical_json_bytes must be non-empty exact bytes")
+    try:
+        text = value.decode("ascii")
+    except UnicodeDecodeError as error:
+        raise ValueError("canonical_json_bytes must be ASCII") from error
+    try:
+        parsed = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        raise ValueError("canonical_json_bytes must contain strict JSON") from error
+    if type(parsed) is not dict:
+        raise ValueError("canonical JSON must decode to an object")
+    if _canonical_json_bytes(parsed) != value:
+        raise ValueError("canonical_json_bytes are not canonical JSON")
+    return parsed
+
+
+def _require_exact_keys(
+    value: dict[str, Any],
+    expected: frozenset[str],
+    name: str,
+) -> None:
+    if frozenset(value) != expected:
+        raise ValueError(f"{name} has missing or unknown fields")
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedResponseJSONEvidence:
+    """A content-addressed, replayable parsed-response JSON preimage."""
+
+    attempt_index: int
+    parsed_response_json_sha256: str
+    canonical_json_bytes: bytes = field(repr=False)
+
+    def __post_init__(self) -> None:
+        _require_exact_int("attempt_index", self.attempt_index)
+        if self.attempt_index < 0:
+            raise ValueError("attempt_index must be non-negative")
+        _require_sha256("parsed_response_json_sha256", self.parsed_response_json_sha256)
+        parsed = _parse_canonical_json_object(self.canonical_json_bytes)
+        if parsed_response_json_sha256(parsed) != self.parsed_response_json_sha256:
+            raise ValueError(
+                "canonical response JSON does not match parsed_response_json_sha256"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationResponseEvidence:
+    """Optional response preimages kept outside the compact physical trace.
+
+    Response JSON can contain generated text and other sensitive server data.
+    Callers should apply the same access, encryption, and retention controls as
+    for prompts and generated token IDs.
+    """
+
+    schema_version: int
+    generation_trace_sha256: str
+    attempts: tuple[ParsedResponseJSONEvidence, ...]
+
+    def __post_init__(self) -> None:
+        _validate_generation_response_evidence(self)
+
+
 @dataclass(frozen=True, slots=True)
 class GenerationAttemptTrace:
     """Immutable client-side observations for one physical HTTP attempt.
@@ -96,6 +197,9 @@ class GenerationAttemptTrace:
     client_version_before_send: int
     client_version_after_receive: int
     output_version_label: int
+    client_version_epoch_before_send: int
+    client_version_epoch_after_receive: int
+    output_version_epoch: int
     remaining_new_tokens: int
     endpoint: str
     method: str
@@ -117,6 +221,22 @@ class GenerationAttemptTrace:
             "client_version_after_receive", self.client_version_after_receive
         )
         _require_exact_int("output_version_label", self.output_version_label)
+        _require_exact_int(
+            "client_version_epoch_before_send",
+            self.client_version_epoch_before_send,
+        )
+        _require_exact_int(
+            "client_version_epoch_after_receive",
+            self.client_version_epoch_after_receive,
+        )
+        _require_exact_int("output_version_epoch", self.output_version_epoch)
+        if (
+            self.client_version_epoch_before_send < 0
+            or self.client_version_epoch_after_receive
+            < self.client_version_epoch_before_send
+            or self.output_version_epoch < self.client_version_epoch_after_receive
+        ):
+            raise ValueError("client version epochs must be non-negative and monotonic")
         _require_exact_int("remaining_new_tokens", self.remaining_new_tokens)
         if self.remaining_new_tokens <= 0:
             raise ValueError("remaining_new_tokens must be positive")
@@ -155,7 +275,9 @@ class GenerationPhysicalTrace:
     prepared and parsed, including abort/resubmit attempts.  It does not
     establish that the request ID was transmitted to or echoed by the server,
     and it does *not* authenticate the remote server, deployed model, or model
-    weights.
+    weights.  Version epochs expose calls to ``InfBridge.set_version`` between
+    observations, including an A→B→A label change; they do not observe direct
+    state mutation or prove which weights a remote server used.
     """
 
     schema_version: int
@@ -167,6 +289,8 @@ class GenerationPhysicalTrace:
     configured_attempt_limit: int
     initial_client_version: int
     final_client_version: int
+    initial_client_version_epoch: int
+    final_client_version_epoch: int
     attempts: tuple[GenerationAttemptTrace, ...]
     final_output_token_ids: tuple[int, ...]
     final_stop_reason: str
@@ -178,8 +302,8 @@ class GenerationPhysicalTrace:
 
 def _validate_generation_physical_trace(trace: GenerationPhysicalTrace) -> None:
     _require_exact_int("schema_version", trace.schema_version)
-    if trace.schema_version != 1:
-        raise ValueError("schema_version must be 1")
+    if trace.schema_version != 2:
+        raise ValueError("schema_version must be 2")
     _require_nonempty_str("request_id", trace.request_id)
     _require_nonempty_str("backend_kind", trace.backend_kind)
     _require_sha256("backend_addr_sha256", trace.backend_addr_sha256)
@@ -192,6 +316,17 @@ def _validate_generation_physical_trace(trace: GenerationPhysicalTrace) -> None:
         raise ValueError("configured_attempt_limit must be non-negative")
     _require_exact_int("initial_client_version", trace.initial_client_version)
     _require_exact_int("final_client_version", trace.final_client_version)
+    _require_exact_int(
+        "initial_client_version_epoch", trace.initial_client_version_epoch
+    )
+    _require_exact_int("final_client_version_epoch", trace.final_client_version_epoch)
+    if (
+        trace.initial_client_version_epoch < 0
+        or trace.final_client_version_epoch < trace.initial_client_version_epoch
+    ):
+        raise ValueError(
+            "trace client version epochs must be non-negative and monotonic"
+        )
     if type(trace.attempts) is not tuple or any(
         type(attempt) is not GenerationAttemptTrace for attempt in trace.attempts
     ):
@@ -201,12 +336,15 @@ def _validate_generation_physical_trace(trace: GenerationPhysicalTrace) -> None:
     _require_token_ids("final_output_token_ids", trace.final_output_token_ids)
 
     output_count_before_attempt = 0
+    previous_version_epoch = trace.initial_client_version_epoch
     for expected_index, attempt in enumerate(trace.attempts):
         # Revalidate nested frozen values in case callers bypassed dataclass
         # construction with object.__setattr__.
         attempt.__post_init__()
         if attempt.attempt_index != expected_index:
             raise ValueError("attempt indexes must be contiguous and start at zero")
+        if attempt.client_version_epoch_before_send < previous_version_epoch:
+            raise ValueError("attempt client version epochs must be monotonic")
         expected_remaining = (
             trace.effective_max_new_tokens - output_count_before_attempt
         )
@@ -215,10 +353,45 @@ def _validate_generation_physical_trace(trace: GenerationPhysicalTrace) -> None:
                 "remaining_new_tokens must equal effective_max_new_tokens minus "
                 "previously observed output tokens"
             )
+        if len(attempt.output_token_ids) > expected_remaining:
+            raise ValueError(
+                "attempt output_token_ids cannot exceed remaining_new_tokens"
+            )
         output_count_before_attempt += len(attempt.output_token_ids)
         if expected_index < len(trace.attempts) - 1:
             if attempt.raw_stop_reason != "abort":
                 raise ValueError("only an abort may precede another physical attempt")
+        previous_version_epoch = attempt.output_version_epoch
+
+    if trace.final_client_version_epoch < previous_version_epoch:
+        raise ValueError("final client version epoch precedes attempt evidence")
+
+    version_by_epoch: dict[int, int] = {}
+    version_observations = [
+        (trace.initial_client_version_epoch, trace.initial_client_version),
+        *(
+            observation
+            for attempt in trace.attempts
+            for observation in (
+                (
+                    attempt.client_version_epoch_before_send,
+                    attempt.client_version_before_send,
+                ),
+                (
+                    attempt.client_version_epoch_after_receive,
+                    attempt.client_version_after_receive,
+                ),
+                (attempt.output_version_epoch, attempt.output_version_label),
+            )
+        ),
+        (trace.final_client_version_epoch, trace.final_client_version),
+    ]
+    for version_epoch, version_label in version_observations:
+        observed_label = version_by_epoch.setdefault(version_epoch, version_label)
+        if observed_label != version_label:
+            raise ValueError(
+                "one client version epoch cannot carry different version labels"
+            )
 
     observed_output = tuple(
         token_id for attempt in trace.attempts for token_id in attempt.output_token_ids
@@ -287,12 +460,21 @@ def _generation_physical_trace_value(trace: GenerationPhysicalTrace) -> dict[str
         "configured_attempt_limit": trace.configured_attempt_limit,
         "initial_client_version": trace.initial_client_version,
         "final_client_version": trace.final_client_version,
+        "initial_client_version_epoch": trace.initial_client_version_epoch,
+        "final_client_version_epoch": trace.final_client_version_epoch,
         "attempts": [
             {
                 "attempt_index": attempt.attempt_index,
                 "client_version_before_send": attempt.client_version_before_send,
                 "client_version_after_receive": attempt.client_version_after_receive,
                 "output_version_label": attempt.output_version_label,
+                "client_version_epoch_before_send": (
+                    attempt.client_version_epoch_before_send
+                ),
+                "client_version_epoch_after_receive": (
+                    attempt.client_version_epoch_after_receive
+                ),
+                "output_version_epoch": attempt.output_version_epoch,
                 "remaining_new_tokens": attempt.remaining_new_tokens,
                 "endpoint": attempt.endpoint,
                 "method": attempt.method,
@@ -323,9 +505,294 @@ def generation_physical_trace_bytes(trace: GenerationPhysicalTrace) -> bytes:
     return _canonical_json_bytes(_generation_physical_trace_value(trace))
 
 
+def generation_physical_trace_from_bytes(value: bytes) -> GenerationPhysicalTrace:
+    """Strictly decode one canonical v2 physical-trace artifact."""
+
+    decoded = _parse_canonical_json_object(value)
+    _require_exact_keys(
+        decoded,
+        frozenset(
+            {
+                "kind",
+                "schema_version",
+                "request_id",
+                "backend_kind",
+                "backend_addr_sha256",
+                "request_input_token_ids",
+                "effective_max_new_tokens",
+                "configured_attempt_limit",
+                "initial_client_version",
+                "final_client_version",
+                "initial_client_version_epoch",
+                "final_client_version_epoch",
+                "attempts",
+                "final_output_token_ids",
+                "final_stop_reason",
+                "terminal_reason",
+            }
+        ),
+        "physical trace",
+    )
+    if decoded["kind"] != _TRACE_KIND:
+        raise ValueError("physical trace kind does not match schema v2")
+    request_input = decoded["request_input_token_ids"]
+    attempts_value = decoded["attempts"]
+    final_output = decoded["final_output_token_ids"]
+    if (
+        type(request_input) is not list
+        or type(attempts_value) is not list
+        or type(final_output) is not list
+    ):
+        raise ValueError("physical trace token IDs and attempts must be JSON arrays")
+    attempts: list[GenerationAttemptTrace] = []
+    attempt_keys = frozenset(
+        {
+            "attempt_index",
+            "client_version_before_send",
+            "client_version_after_receive",
+            "output_version_label",
+            "client_version_epoch_before_send",
+            "client_version_epoch_after_receive",
+            "output_version_epoch",
+            "remaining_new_tokens",
+            "endpoint",
+            "method",
+            "prepared_request_json_sha256",
+            "parsed_response_json_sha256",
+            "submitted_input_token_ids",
+            "raw_stop_reason",
+            "output_token_ids",
+            "output_logprob_count",
+        }
+    )
+    for attempt_value in attempts_value:
+        if type(attempt_value) is not dict:
+            raise ValueError("physical trace attempts must contain JSON objects")
+        _require_exact_keys(attempt_value, attempt_keys, "physical trace attempt")
+        submitted = attempt_value["submitted_input_token_ids"]
+        output = attempt_value["output_token_ids"]
+        if submitted is not None and type(submitted) is not list:
+            raise ValueError("submitted_input_token_ids must be null or a JSON array")
+        if type(output) is not list:
+            raise ValueError("output_token_ids must be a JSON array")
+        attempts.append(
+            GenerationAttemptTrace(
+                attempt_index=attempt_value["attempt_index"],
+                client_version_before_send=attempt_value["client_version_before_send"],
+                client_version_after_receive=attempt_value[
+                    "client_version_after_receive"
+                ],
+                output_version_label=attempt_value["output_version_label"],
+                client_version_epoch_before_send=attempt_value[
+                    "client_version_epoch_before_send"
+                ],
+                client_version_epoch_after_receive=attempt_value[
+                    "client_version_epoch_after_receive"
+                ],
+                output_version_epoch=attempt_value["output_version_epoch"],
+                remaining_new_tokens=attempt_value["remaining_new_tokens"],
+                endpoint=attempt_value["endpoint"],
+                method=attempt_value["method"],
+                prepared_request_json_sha256=attempt_value[
+                    "prepared_request_json_sha256"
+                ],
+                parsed_response_json_sha256=attempt_value[
+                    "parsed_response_json_sha256"
+                ],
+                submitted_input_token_ids=(
+                    None if submitted is None else tuple(submitted)
+                ),
+                raw_stop_reason=attempt_value["raw_stop_reason"],
+                output_token_ids=tuple(output),
+                output_logprob_count=attempt_value["output_logprob_count"],
+            )
+        )
+    trace = GenerationPhysicalTrace(
+        schema_version=decoded["schema_version"],
+        request_id=decoded["request_id"],
+        backend_kind=decoded["backend_kind"],
+        backend_addr_sha256=decoded["backend_addr_sha256"],
+        request_input_token_ids=tuple(request_input),
+        effective_max_new_tokens=decoded["effective_max_new_tokens"],
+        configured_attempt_limit=decoded["configured_attempt_limit"],
+        initial_client_version=decoded["initial_client_version"],
+        final_client_version=decoded["final_client_version"],
+        initial_client_version_epoch=decoded["initial_client_version_epoch"],
+        final_client_version_epoch=decoded["final_client_version_epoch"],
+        attempts=tuple(attempts),
+        final_output_token_ids=tuple(final_output),
+        final_stop_reason=decoded["final_stop_reason"],
+        terminal_reason=decoded["terminal_reason"],
+    )
+    if generation_physical_trace_bytes(trace) != value:
+        raise ValueError("physical trace does not round-trip canonically")
+    return trace
+
+
 def generation_physical_trace_sha256(trace: GenerationPhysicalTrace) -> str:
     """Hash :func:`generation_physical_trace_bytes` with SHA-256."""
     return hashlib.sha256(generation_physical_trace_bytes(trace)).hexdigest()
+
+
+def _validate_generation_response_evidence(
+    evidence: GenerationResponseEvidence,
+) -> None:
+    _require_exact_int("schema_version", evidence.schema_version)
+    if evidence.schema_version != 1:
+        raise ValueError("response evidence schema_version must be 1")
+    _require_sha256("generation_trace_sha256", evidence.generation_trace_sha256)
+    if type(evidence.attempts) is not tuple or any(
+        type(attempt) is not ParsedResponseJSONEvidence for attempt in evidence.attempts
+    ):
+        raise ValueError(
+            "response evidence attempts must be a tuple of "
+            "ParsedResponseJSONEvidence values"
+        )
+    for expected_index, attempt in enumerate(evidence.attempts):
+        attempt.__post_init__()
+        if attempt.attempt_index != expected_index:
+            raise ValueError(
+                "response evidence attempt indexes must be contiguous and start at zero"
+            )
+
+
+def _generation_response_evidence_value(
+    evidence: GenerationResponseEvidence,
+) -> dict[str, Any]:
+    return {
+        "kind": _RESPONSE_EVIDENCE_KIND,
+        "schema_version": evidence.schema_version,
+        "generation_trace_sha256": evidence.generation_trace_sha256,
+        "attempts": [
+            {
+                "attempt_index": attempt.attempt_index,
+                "parsed_response_json_sha256": (attempt.parsed_response_json_sha256),
+                "canonical_json_ascii": attempt.canonical_json_bytes.decode("ascii"),
+            }
+            for attempt in evidence.attempts
+        ],
+    }
+
+
+def generation_response_evidence_bytes(
+    evidence: GenerationResponseEvidence,
+) -> bytes:
+    """Return canonical JSON for the optional replayable response sidecar."""
+
+    if type(evidence) is not GenerationResponseEvidence:
+        raise TypeError("evidence must be GenerationResponseEvidence")
+    _validate_generation_response_evidence(evidence)
+    return _canonical_json_bytes(_generation_response_evidence_value(evidence))
+
+
+def generation_response_evidence_from_bytes(
+    value: bytes,
+) -> GenerationResponseEvidence:
+    """Strictly decode one canonical response-evidence sidecar."""
+
+    decoded = _parse_canonical_json_object(value)
+    _require_exact_keys(
+        decoded,
+        frozenset(
+            {
+                "kind",
+                "schema_version",
+                "generation_trace_sha256",
+                "attempts",
+            }
+        ),
+        "response evidence",
+    )
+    if decoded["kind"] != _RESPONSE_EVIDENCE_KIND:
+        raise ValueError("response evidence kind does not match schema v1")
+    attempts_value = decoded["attempts"]
+    if type(attempts_value) is not list:
+        raise ValueError("response evidence attempts must be a JSON array")
+    attempts: list[ParsedResponseJSONEvidence] = []
+    expected_attempt_keys = frozenset(
+        {
+            "attempt_index",
+            "parsed_response_json_sha256",
+            "canonical_json_ascii",
+        }
+    )
+    for attempt_value in attempts_value:
+        if type(attempt_value) is not dict:
+            raise ValueError("response evidence attempts must contain JSON objects")
+        _require_exact_keys(
+            attempt_value,
+            expected_attempt_keys,
+            "response evidence attempt",
+        )
+        canonical_json_ascii = attempt_value["canonical_json_ascii"]
+        if type(canonical_json_ascii) is not str:
+            raise ValueError("canonical_json_ascii must be an exact str")
+        try:
+            canonical_json = canonical_json_ascii.encode("ascii")
+        except UnicodeEncodeError as error:
+            raise ValueError("canonical_json_ascii must contain only ASCII") from error
+        attempts.append(
+            ParsedResponseJSONEvidence(
+                attempt_index=attempt_value["attempt_index"],
+                parsed_response_json_sha256=attempt_value[
+                    "parsed_response_json_sha256"
+                ],
+                canonical_json_bytes=canonical_json,
+            )
+        )
+    evidence = GenerationResponseEvidence(
+        schema_version=decoded["schema_version"],
+        generation_trace_sha256=decoded["generation_trace_sha256"],
+        attempts=tuple(attempts),
+    )
+    if generation_response_evidence_bytes(evidence) != value:
+        raise ValueError("response evidence does not round-trip canonically")
+    return evidence
+
+
+def generation_response_evidence_sha256(
+    evidence: GenerationResponseEvidence,
+) -> str:
+    return hashlib.sha256(generation_response_evidence_bytes(evidence)).hexdigest()
+
+
+def generation_response_evidence_values(
+    trace: GenerationPhysicalTrace,
+    evidence: GenerationResponseEvidence,
+) -> tuple[dict[str, Any], ...]:
+    """Validate and decode response preimages bound to a physical trace."""
+
+    generation_physical_trace_bytes(trace)
+    generation_response_evidence_bytes(evidence)
+    if evidence.generation_trace_sha256 != generation_physical_trace_sha256(trace):
+        raise ValueError("response evidence does not bind this generation trace")
+    if len(evidence.attempts) != len(trace.attempts):
+        raise ValueError("response evidence must cover every physical attempt")
+    values: list[dict[str, Any]] = []
+    for traced_attempt, response_attempt in zip(
+        trace.attempts,
+        evidence.attempts,
+        strict=True,
+    ):
+        if (
+            response_attempt.attempt_index != traced_attempt.attempt_index
+            or response_attempt.parsed_response_json_sha256
+            != traced_attempt.parsed_response_json_sha256
+        ):
+            raise ValueError("response evidence attempt does not match trace")
+        values.append(
+            _parse_canonical_json_object(response_attempt.canonical_json_bytes)
+        )
+    return tuple(values)
+
+
+def validate_generation_response_evidence(
+    trace: GenerationPhysicalTrace,
+    evidence: GenerationResponseEvidence,
+) -> None:
+    """Validate complete response-preimage coverage for one traced generation."""
+
+    generation_response_evidence_values(trace, evidence)
 
 
 def validate_generation_physical_trace_response(

--- a/areal/v2/inference_service/client_trace.py
+++ b/areal/v2/inference_service/client_trace.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical client-local observations for InfBridge generation calls.
+
+These values commit to JSON prepared and parsed by the client.  They are not
+remote-server, model-identity, or model-weight attestations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from areal.api.io_struct import ModelResponse
+
+__all__ = [
+    "GenerationAttemptTrace",
+    "GenerationPhysicalTrace",
+    "generation_physical_trace_bytes",
+    "generation_physical_trace_sha256",
+    "parsed_response_json_sha256",
+    "prepared_request_json_sha256",
+    "validate_generation_physical_trace_response",
+]
+
+_TRACE_KIND = "areal-generation-physical-trace-v1"
+_PREPARED_REQUEST_JSON_DOMAIN = b"areal-infbridge-prepared-request-json-v1\0"
+_PARSED_RESPONSE_JSON_DOMAIN = b"areal-infbridge-parsed-response-json-v1\0"
+_SHA256_HEX_CHARS = frozenset("0123456789abcdef")
+
+
+def _require_exact_int(name: str, value: object) -> None:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be an int")
+
+
+def _require_nonempty_str(name: str, value: object) -> None:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty str")
+
+
+def _require_sha256(name: str, value: object) -> None:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(char not in _SHA256_HEX_CHARS for char in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 hex digest")
+
+
+def _require_token_ids(name: str, value: object) -> None:
+    if type(value) is not tuple or any(
+        type(token_id) is not int or token_id < 0 for token_id in value
+    ):
+        raise ValueError(f"{name} must be a tuple of non-negative ints")
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    """Encode a deterministic Python-v1 JSON semantic view."""
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("ascii")
+
+
+def _canonical_json_sha256(value: object, *, domain: bytes) -> str:
+    return hashlib.sha256(domain + _canonical_json_bytes(value)).hexdigest()
+
+
+def prepared_request_json_sha256(value: object) -> str:
+    """Hash the locally prepared request JSON with an explicit domain."""
+    return _canonical_json_sha256(value, domain=_PREPARED_REQUEST_JSON_DOMAIN)
+
+
+def parsed_response_json_sha256(value: object) -> str:
+    """Hash the locally parsed response JSON with an explicit domain."""
+    return _canonical_json_sha256(value, domain=_PARSED_RESPONSE_JSON_DOMAIN)
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationAttemptTrace:
+    """Immutable client-side observations for one physical HTTP attempt.
+
+    The hashes commit to JSON prepared and parsed inside this client; they are
+    not hashes of raw HTTP bytes, and complete JSON bodies are not copied into
+    the trace.  Submitted token IDs may still encode sensitive prompt content
+    and require the same access and retention controls as the source request.
+    """
+
+    attempt_index: int
+    client_version_before_send: int
+    client_version_after_receive: int
+    output_version_label: int
+    remaining_new_tokens: int
+    endpoint: str
+    method: str
+    prepared_request_json_sha256: str
+    parsed_response_json_sha256: str
+    submitted_input_token_ids: tuple[int, ...] | None
+    raw_stop_reason: str
+    output_token_ids: tuple[int, ...]
+    output_logprob_count: int
+
+    def __post_init__(self) -> None:
+        _require_exact_int("attempt_index", self.attempt_index)
+        if self.attempt_index < 0:
+            raise ValueError("attempt_index must be non-negative")
+        _require_exact_int(
+            "client_version_before_send", self.client_version_before_send
+        )
+        _require_exact_int(
+            "client_version_after_receive", self.client_version_after_receive
+        )
+        _require_exact_int("output_version_label", self.output_version_label)
+        _require_exact_int("remaining_new_tokens", self.remaining_new_tokens)
+        if self.remaining_new_tokens <= 0:
+            raise ValueError("remaining_new_tokens must be positive")
+        _require_nonempty_str("endpoint", self.endpoint)
+        _require_nonempty_str("method", self.method)
+        if self.method not in ("GET", "POST"):
+            raise ValueError(
+                "method must be the effective GET or POST transport method"
+            )
+        _require_sha256(
+            "prepared_request_json_sha256", self.prepared_request_json_sha256
+        )
+        _require_sha256("parsed_response_json_sha256", self.parsed_response_json_sha256)
+        if self.submitted_input_token_ids is not None:
+            _require_token_ids(
+                "submitted_input_token_ids", self.submitted_input_token_ids
+            )
+        _require_nonempty_str("raw_stop_reason", self.raw_stop_reason)
+        if self.raw_stop_reason not in ("length", "stop", "tool_calls", "abort"):
+            raise ValueError(
+                "raw_stop_reason must be length, stop, tool_calls, or abort"
+            )
+        _require_token_ids("output_token_ids", self.output_token_ids)
+        _require_exact_int("output_logprob_count", self.output_logprob_count)
+        if self.output_logprob_count != len(self.output_token_ids):
+            raise ValueError(
+                "output_logprob_count must equal the number of output token IDs"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationPhysicalTrace:
+    """Immutable client-local trace for one logical generation.
+
+    This commits to the pre/post-transport JSON views that InfBridge locally
+    prepared and parsed, including abort/resubmit attempts.  It does not
+    establish that the request ID was transmitted to or echoed by the server,
+    and it does *not* authenticate the remote server, deployed model, or model
+    weights.
+    """
+
+    schema_version: int
+    request_id: str
+    backend_kind: str
+    backend_addr_sha256: str
+    request_input_token_ids: tuple[int, ...]
+    effective_max_new_tokens: int
+    configured_attempt_limit: int
+    initial_client_version: int
+    final_client_version: int
+    attempts: tuple[GenerationAttemptTrace, ...]
+    final_output_token_ids: tuple[int, ...]
+    final_stop_reason: str
+    terminal_reason: str
+
+    def __post_init__(self) -> None:
+        _validate_generation_physical_trace(self)
+
+
+def _validate_generation_physical_trace(trace: GenerationPhysicalTrace) -> None:
+    _require_exact_int("schema_version", trace.schema_version)
+    if trace.schema_version != 1:
+        raise ValueError("schema_version must be 1")
+    _require_nonempty_str("request_id", trace.request_id)
+    _require_nonempty_str("backend_kind", trace.backend_kind)
+    _require_sha256("backend_addr_sha256", trace.backend_addr_sha256)
+    _require_token_ids("request_input_token_ids", trace.request_input_token_ids)
+    _require_exact_int("effective_max_new_tokens", trace.effective_max_new_tokens)
+    if trace.effective_max_new_tokens <= 0:
+        raise ValueError("effective_max_new_tokens must be positive")
+    _require_exact_int("configured_attempt_limit", trace.configured_attempt_limit)
+    if trace.configured_attempt_limit < 0:
+        raise ValueError("configured_attempt_limit must be non-negative")
+    _require_exact_int("initial_client_version", trace.initial_client_version)
+    _require_exact_int("final_client_version", trace.final_client_version)
+    if type(trace.attempts) is not tuple or any(
+        type(attempt) is not GenerationAttemptTrace for attempt in trace.attempts
+    ):
+        raise ValueError("attempts must be a tuple of GenerationAttemptTrace values")
+    if len(trace.attempts) > trace.configured_attempt_limit:
+        raise ValueError("attempts cannot exceed configured_attempt_limit")
+    _require_token_ids("final_output_token_ids", trace.final_output_token_ids)
+
+    output_count_before_attempt = 0
+    for expected_index, attempt in enumerate(trace.attempts):
+        # Revalidate nested frozen values in case callers bypassed dataclass
+        # construction with object.__setattr__.
+        attempt.__post_init__()
+        if attempt.attempt_index != expected_index:
+            raise ValueError("attempt indexes must be contiguous and start at zero")
+        expected_remaining = (
+            trace.effective_max_new_tokens - output_count_before_attempt
+        )
+        if attempt.remaining_new_tokens != expected_remaining:
+            raise ValueError(
+                "remaining_new_tokens must equal effective_max_new_tokens minus "
+                "previously observed output tokens"
+            )
+        output_count_before_attempt += len(attempt.output_token_ids)
+        if expected_index < len(trace.attempts) - 1:
+            if attempt.raw_stop_reason != "abort":
+                raise ValueError("only an abort may precede another physical attempt")
+
+    observed_output = tuple(
+        token_id for attempt in trace.attempts for token_id in attempt.output_token_ids
+    )
+    if trace.final_output_token_ids != observed_output:
+        raise ValueError(
+            "final_output_token_ids must equal concatenated attempt output_token_ids"
+        )
+
+    _require_nonempty_str("final_stop_reason", trace.final_stop_reason)
+    if trace.final_stop_reason not in ("length", "stop", "tool_calls"):
+        raise ValueError("final_stop_reason must be length, stop, or tool_calls")
+    _require_nonempty_str("terminal_reason", trace.terminal_reason)
+    if trace.terminal_reason not in (
+        "backend_stop",
+        "backend_tool_calls",
+        "backend_length",
+        "budget_exhausted",
+        "attempt_limit",
+    ):
+        raise ValueError("invalid terminal_reason")
+
+    expected_terminal: tuple[str, str | None]
+    if trace.terminal_reason == "backend_stop":
+        expected_terminal = ("stop", "stop")
+    elif trace.terminal_reason == "backend_tool_calls":
+        expected_terminal = ("tool_calls", "tool_calls")
+    elif trace.terminal_reason == "backend_length":
+        expected_terminal = ("length", "length")
+    elif trace.terminal_reason == "budget_exhausted":
+        expected_terminal = ("length", "abort")
+    else:
+        expected_terminal = ("length", "abort" if trace.attempts else None)
+
+    expected_stop, expected_raw_stop = expected_terminal
+    actual_raw_stop = trace.attempts[-1].raw_stop_reason if trace.attempts else None
+    if trace.final_stop_reason != expected_stop or actual_raw_stop != expected_raw_stop:
+        raise ValueError(
+            "terminal_reason is inconsistent with the observed stop reasons"
+        )
+    if trace.terminal_reason == "budget_exhausted":
+        if len(trace.final_output_token_ids) < trace.effective_max_new_tokens:
+            raise ValueError(
+                "budget_exhausted requires at least effective_max_new_tokens outputs"
+            )
+    if trace.terminal_reason == "attempt_limit":
+        if len(trace.attempts) != trace.configured_attempt_limit:
+            raise ValueError(
+                "attempt_limit requires exactly configured_attempt_limit attempts"
+            )
+        if len(trace.final_output_token_ids) >= trace.effective_max_new_tokens:
+            raise ValueError(
+                "attempt_limit cannot claim an already exhausted generation budget"
+            )
+
+
+def _generation_physical_trace_value(trace: GenerationPhysicalTrace) -> dict[str, Any]:
+    return {
+        "kind": _TRACE_KIND,
+        "schema_version": trace.schema_version,
+        "request_id": trace.request_id,
+        "backend_kind": trace.backend_kind,
+        "backend_addr_sha256": trace.backend_addr_sha256,
+        "request_input_token_ids": list(trace.request_input_token_ids),
+        "effective_max_new_tokens": trace.effective_max_new_tokens,
+        "configured_attempt_limit": trace.configured_attempt_limit,
+        "initial_client_version": trace.initial_client_version,
+        "final_client_version": trace.final_client_version,
+        "attempts": [
+            {
+                "attempt_index": attempt.attempt_index,
+                "client_version_before_send": attempt.client_version_before_send,
+                "client_version_after_receive": attempt.client_version_after_receive,
+                "output_version_label": attempt.output_version_label,
+                "remaining_new_tokens": attempt.remaining_new_tokens,
+                "endpoint": attempt.endpoint,
+                "method": attempt.method,
+                "prepared_request_json_sha256": attempt.prepared_request_json_sha256,
+                "parsed_response_json_sha256": attempt.parsed_response_json_sha256,
+                "submitted_input_token_ids": (
+                    list(attempt.submitted_input_token_ids)
+                    if attempt.submitted_input_token_ids is not None
+                    else None
+                ),
+                "raw_stop_reason": attempt.raw_stop_reason,
+                "output_token_ids": list(attempt.output_token_ids),
+                "output_logprob_count": attempt.output_logprob_count,
+            }
+            for attempt in trace.attempts
+        ],
+        "final_output_token_ids": list(trace.final_output_token_ids),
+        "final_stop_reason": trace.final_stop_reason,
+        "terminal_reason": trace.terminal_reason,
+    }
+
+
+def generation_physical_trace_bytes(trace: GenerationPhysicalTrace) -> bytes:
+    """Return the canonical, content-addressable JSON representation."""
+    if type(trace) is not GenerationPhysicalTrace:
+        raise TypeError("trace must be a GenerationPhysicalTrace")
+    _validate_generation_physical_trace(trace)
+    return _canonical_json_bytes(_generation_physical_trace_value(trace))
+
+
+def generation_physical_trace_sha256(trace: GenerationPhysicalTrace) -> str:
+    """Hash :func:`generation_physical_trace_bytes` with SHA-256."""
+    return hashlib.sha256(generation_physical_trace_bytes(trace)).hexdigest()
+
+
+def validate_generation_physical_trace_response(
+    response: ModelResponse,
+    trace: GenerationPhysicalTrace,
+) -> None:
+    """Validate the ``ModelResponse`` fields represented in ``trace``.
+
+    The trace binds token IDs, stop reason, log-probability *count*, and output
+    version labels.  It intentionally does not bind log-probability values,
+    routed experts, tokenizer objects, or latency measurements.
+    """
+    generation_physical_trace_bytes(trace)
+    if type(response.input_tokens) is not list:
+        raise TypeError("response.input_tokens must be a list")
+    response_input_tokens = tuple(response.input_tokens)
+    _require_token_ids("response.input_tokens", response_input_tokens)
+    if response_input_tokens != trace.request_input_token_ids:
+        raise ValueError("response.input_tokens do not match request_input_token_ids")
+    if type(response.output_tokens) is not list:
+        raise TypeError("response.output_tokens must be a list")
+    response_output_tokens = tuple(response.output_tokens)
+    _require_token_ids("response.output_tokens", response_output_tokens)
+    if response_output_tokens != trace.final_output_token_ids:
+        raise ValueError("response.output_tokens do not match final_output_token_ids")
+    if (
+        type(response.stop_reason) is not str
+        or response.stop_reason != trace.final_stop_reason
+    ):
+        raise ValueError("response.stop_reason does not match final_stop_reason")
+    if type(response.output_logprobs) is not list:
+        raise TypeError("response.output_logprobs must be a list")
+    if len(response.output_logprobs) != len(trace.final_output_token_ids):
+        raise ValueError("response.output_logprobs count does not match traced output")
+    if type(response.output_versions) is not list or any(
+        type(version) is not int for version in response.output_versions
+    ):
+        raise TypeError("response.output_versions must be a list of exact ints")
+    traced_output_versions = tuple(
+        attempt.output_version_label
+        for attempt in trace.attempts
+        for _ in attempt.output_token_ids
+    )
+    if tuple(response.output_versions) != traced_output_versions:
+        raise ValueError(
+            "response.output_versions do not match traced output_version_label values"
+        )

--- a/areal/v2/inference_service/inf_bridge.py
+++ b/areal/v2/inference_service/inf_bridge.py
@@ -27,6 +27,9 @@ from areal.v2.inference_service.backend import (
 from areal.v2.inference_service.client_trace import (
     GenerationAttemptTrace,
     GenerationPhysicalTrace,
+    GenerationResponseEvidence,
+    ParsedResponseJSONEvidence,
+    canonical_parsed_response_json_bytes,
     generation_physical_trace_bytes,
     generation_physical_trace_sha256,
     parsed_response_json_sha256,
@@ -37,6 +40,7 @@ from areal.v2.inference_service.client_trace import (
 __all__ = [
     "GenerationAttemptTrace",
     "GenerationPhysicalTrace",
+    "GenerationResponseEvidence",
     "InfBridge",
     "generation_physical_trace_bytes",
     "generation_physical_trace_sha256",
@@ -104,6 +108,7 @@ class InfBridge:
         self.max_resubmit_retries = max_resubmit_retries
         self.resubmit_wait = resubmit_wait
         self._version = version
+        self._version_epoch = 0
         self._client = httpx.AsyncClient(timeout=request_timeout)
 
     async def aclose(self) -> None:
@@ -114,9 +119,15 @@ class InfBridge:
 
     def set_version(self, version: int) -> None:
         self._version = version
+        self._version_epoch += 1
 
     def get_version(self) -> int:
         return self._version
+
+    def get_version_epoch(self) -> int:
+        """Return a monotonic count of local :meth:`set_version` calls."""
+
+        return self._version_epoch
 
     # -- pause / resume -----------------------------------------------------
 
@@ -194,7 +205,11 @@ class InfBridge:
         Implements the ``_AsyncGenerateEngine`` protocol.
         Handles the pause → abort → resubmit loop transparently.
         """
-        result = await self._agenerate(req, collect_trace=False)
+        result = await self._agenerate(
+            req,
+            collect_trace=False,
+            collect_response_evidence=False,
+        )
         return cast(ModelResponse, result)
 
     async def agenerate_with_trace(
@@ -212,16 +227,57 @@ class InfBridge:
         fail-closed trace checks propagate without being converted to a
         ``length`` response.
         """
-        result = await self._agenerate(req, collect_trace=True)
+        result = await self._agenerate(
+            req,
+            collect_trace=True,
+            collect_response_evidence=False,
+        )
         return cast(tuple[ModelResponse, GenerationPhysicalTrace], result)
+
+    async def agenerate_with_trace_and_response_evidence(
+        self,
+        req: ModelRequest,
+    ) -> tuple[ModelResponse, GenerationPhysicalTrace, GenerationResponseEvidence]:
+        """Generate with a compact trace plus replayable response JSON sidecar.
+
+        The evidence sidecar can contain generated text and server metadata, so
+        callers should persist it only under prompt-equivalent data controls.
+        It supports offline parser replay but is still client-local evidence,
+        not remote-server or model attestation.
+        """
+
+        result = await self._agenerate(
+            req,
+            collect_trace=True,
+            collect_response_evidence=True,
+        )
+        return cast(
+            tuple[
+                ModelResponse,
+                GenerationPhysicalTrace,
+                GenerationResponseEvidence,
+            ],
+            result,
+        )
 
     async def _agenerate(
         self,
         req: ModelRequest,
         *,
         collect_trace: bool,
-    ) -> ModelResponse | tuple[ModelResponse, GenerationPhysicalTrace]:
+        collect_response_evidence: bool,
+    ) -> (
+        ModelResponse
+        | tuple[ModelResponse, GenerationPhysicalTrace]
+        | tuple[
+            ModelResponse,
+            GenerationPhysicalTrace,
+            GenerationResponseEvidence,
+        ]
+    ):
         """Shared generation loop; tracing is opt-in to preserve legacy behavior."""
+        if collect_response_evidence and not collect_trace:
+            raise ValueError("response evidence requires physical tracing")
         # The traced API snapshots mutable request/configuration state.  The
         # legacy API intentionally retains its existing object-sharing behavior.
         if collect_trace:
@@ -238,6 +294,7 @@ class InfBridge:
         backend_addr = self.backend_addr
         configured_attempt_limit = self.max_resubmit_retries
         initial_client_version = self._version
+        initial_client_version_epoch = self._version_epoch
 
         if generation_req.gconfig.n_samples != 1:
             raise ValueError(
@@ -300,6 +357,7 @@ class InfBridge:
         stop_reason: _StopReason | None = None
         final_routed_experts: np.ndarray | None = None
         attempt_traces: list[GenerationAttemptTrace] = []
+        response_evidence_attempts: list[ParsedResponseJSONEvidence] = []
         terminal_reason: _TerminalReason | None = None
 
         t0 = time.monotonic()
@@ -340,18 +398,23 @@ class InfBridge:
                 # This must remain the final synchronous observation before
                 # entering the transport await.
                 client_version_before_send = self._version
+                client_version_epoch_before_send = self._version_epoch
 
             data = await self._send_request(http_req)
             if collect_trace:
                 # Bracket the transport return before hashing/parsing locally.
                 client_version_after_receive = self._version
+                client_version_epoch_after_receive = self._version_epoch
                 parsed_response_hash = parsed_response_json_sha256(data)
+                if collect_response_evidence:
+                    parsed_response_bytes = canonical_parsed_response_json_bytes(data)
             result = backend.parse_generation_response(data)
 
             accumulated_tokens.extend(result.output_tokens)
             accumulated_logprobs.extend(result.output_logprobs)
             # Preserve the exact legacy read point used to label output tokens.
             output_version_label = self._version
+            output_version_epoch = self._version_epoch
             accumulated_versions.extend(
                 [output_version_label] * len(result.output_tokens)
             )
@@ -364,6 +427,13 @@ class InfBridge:
                         client_version_before_send=client_version_before_send,
                         client_version_after_receive=client_version_after_receive,
                         output_version_label=output_version_label,
+                        client_version_epoch_before_send=(
+                            client_version_epoch_before_send
+                        ),
+                        client_version_epoch_after_receive=(
+                            client_version_epoch_after_receive
+                        ),
+                        output_version_epoch=output_version_epoch,
                         remaining_new_tokens=remaining,
                         endpoint=endpoint,
                         method=method,
@@ -375,6 +445,14 @@ class InfBridge:
                         output_logprob_count=len(result.output_logprobs),
                     )
                 )
+                if collect_response_evidence:
+                    response_evidence_attempts.append(
+                        ParsedResponseJSONEvidence(
+                            attempt_index=_attempt,
+                            parsed_response_json_sha256=parsed_response_hash,
+                            canonical_json_bytes=parsed_response_bytes,
+                        )
+                    )
 
             if result.routed_experts is not None:
                 if final_routed_experts is None:
@@ -425,7 +503,7 @@ class InfBridge:
             raise RuntimeError("generation completed without a terminal reason")
 
         trace = GenerationPhysicalTrace(
-            schema_version=1,
+            schema_version=2,
             request_id=request_id,
             backend_kind=backend_kind,
             backend_addr_sha256=backend_addr_sha256,
@@ -434,10 +512,19 @@ class InfBridge:
             configured_attempt_limit=configured_attempt_limit,
             initial_client_version=initial_client_version,
             final_client_version=self._version,
+            initial_client_version_epoch=initial_client_version_epoch,
+            final_client_version_epoch=self._version_epoch,
             attempts=tuple(attempt_traces),
             final_output_token_ids=tuple(accumulated_tokens),
             final_stop_reason=stop_reason,
             terminal_reason=terminal_reason,
         )
         validate_generation_physical_trace_response(response, trace)
-        return response, trace
+        if not collect_response_evidence:
+            return response, trace
+        response_evidence = GenerationResponseEvidence(
+            schema_version=1,
+            generation_trace_sha256=generation_physical_trace_sha256(trace),
+            attempts=tuple(response_evidence_attempts),
+        )
+        return response, trace, response_evidence

--- a/areal/v2/inference_service/inf_bridge.py
+++ b/areal/v2/inference_service/inf_bridge.py
@@ -10,21 +10,50 @@ translates between ModelRequest / raw JSON and endpoint-specific payloads.
 from __future__ import annotations
 
 import asyncio
+import copy
+import hashlib
 import time
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import httpx
 import numpy as np
 
-from areal.api.io_struct import HttpRequest
+from areal.api.io_struct import HttpRequest, ModelRequest, ModelResponse
 from areal.utils import logging
-from areal.v2.inference_service.backend import InfBridgeBackend
+from areal.v2.inference_service.backend import (
+    InfBridgeBackend,
+    TraceableInfBridgeBackend,
+)
+from areal.v2.inference_service.client_trace import (
+    GenerationAttemptTrace,
+    GenerationPhysicalTrace,
+    generation_physical_trace_bytes,
+    generation_physical_trace_sha256,
+    parsed_response_json_sha256,
+    prepared_request_json_sha256,
+    validate_generation_physical_trace_response,
+)
+
+__all__ = [
+    "GenerationAttemptTrace",
+    "GenerationPhysicalTrace",
+    "InfBridge",
+    "generation_physical_trace_bytes",
+    "generation_physical_trace_sha256",
+    "validate_generation_physical_trace_response",
+]
 
 if TYPE_CHECKING:
-    from areal.api.io_struct import ModelRequest, ModelResponse
     from areal.v2.inference_service.data_proxy.pause import PauseState
 
 _StopReason = Literal["length", "stop", "tool_calls", "abort"]
+_TerminalReason = Literal[
+    "backend_stop",
+    "backend_tool_calls",
+    "backend_length",
+    "budget_exhausted",
+    "attempt_limit",
+]
 
 logger = logging.getLogger("InferenceInfBridge")
 
@@ -165,64 +194,187 @@ class InfBridge:
         Implements the ``_AsyncGenerateEngine`` protocol.
         Handles the pause → abort → resubmit loop transparently.
         """
-        from areal.api.io_struct import ModelResponse
+        result = await self._agenerate(req, collect_trace=False)
+        return cast(ModelResponse, result)
 
-        if req.gconfig.n_samples != 1:
+    async def agenerate_with_trace(
+        self,
+        req: ModelRequest,
+    ) -> tuple[ModelResponse, GenerationPhysicalTrace]:
+        """Generate and return immutable client-side physical-call evidence.
+
+        Unlike :meth:`agenerate`, this method content-addresses each patched
+        request and parsed response and records every abort/resubmit attempt.
+        It does not claim to attest the remote model or its weights.
+
+        A trace is returned only after successful transport, parsing, and
+        validation.  Transport errors, parser errors, cancellation, and
+        fail-closed trace checks propagate without being converted to a
+        ``length`` response.
+        """
+        result = await self._agenerate(req, collect_trace=True)
+        return cast(tuple[ModelResponse, GenerationPhysicalTrace], result)
+
+    async def _agenerate(
+        self,
+        req: ModelRequest,
+        *,
+        collect_trace: bool,
+    ) -> ModelResponse | tuple[ModelResponse, GenerationPhysicalTrace]:
+        """Shared generation loop; tracing is opt-in to preserve legacy behavior."""
+        # The traced API snapshots mutable request/configuration state.  The
+        # legacy API intentionally retains its existing object-sharing behavior.
+        if collect_trace:
+            generation_req = req.copy()
+            # ModelRequest.copy() intentionally keeps several nested objects
+            # shallow.  Trace mode isolates mutable JSON-facing state while
+            # retaining heavyweight tokenizer/processor references.
+            generation_req.metadata = copy.deepcopy(req.metadata)
+            generation_req.image_data = copy.deepcopy(req.image_data)
+            generation_req.vision_msg_vllm = copy.deepcopy(req.vision_msg_vllm)
+        else:
+            generation_req = req
+        backend = self.backend
+        backend_addr = self.backend_addr
+        configured_attempt_limit = self.max_resubmit_retries
+        initial_client_version = self._version
+
+        if generation_req.gconfig.n_samples != 1:
             raise ValueError(
-                f"InfBridge only supports n_samples=1, got {req.gconfig.n_samples}"
+                "InfBridge only supports n_samples=1, got "
+                f"{generation_req.gconfig.n_samples}"
             )
+        if collect_trace and (
+            type(configured_attempt_limit) is not int or configured_attempt_limit < 0
+        ):
+            raise ValueError(
+                "traced generation requires a non-negative integer max_resubmit_retries"
+            )
+        if collect_trace:
+            if type(generation_req.rid) is not str or not generation_req.rid:
+                raise ValueError("request_id must be a non-empty str")
+            if any(
+                type(token_id) is not int or token_id < 0
+                for token_id in generation_req.input_ids
+            ):
+                raise ValueError(
+                    "request_input_token_ids must contain non-negative ints"
+                )
+            if type(initial_client_version) is not int:
+                raise TypeError("initial_client_version must be an int")
 
-        # Build the initial HTTP request via the backend
-        http_req = self.backend.build_generation_request(
-            req,
-            with_lora=False,
-            version=self._version,
+        # Avoid hashing/copying trace-only evidence on the legacy path.
+        request_id = generation_req.rid if collect_trace else ""
+        request_input_token_ids = (
+            tuple(generation_req.input_ids) if collect_trace else ()
+        )
+        backend_kind = type(backend).__qualname__ if collect_trace else ""
+        backend_addr_sha256 = (
+            hashlib.sha256(backend_addr.encode("utf-8")).hexdigest()
+            if collect_trace
+            else ""
         )
 
-        # Extract effective max_new_tokens from the payload the backend built
-        ori_max_new_tokens = self.backend.get_generation_max_new_tokens(http_req)
+        # Build the initial HTTP request via the snapshotted backend/version.
+        http_req = backend.build_generation_request(
+            generation_req,
+            with_lora=False,
+            version=initial_client_version,
+        )
+
+        ori_max_new_tokens = backend.get_generation_max_new_tokens(http_req)
         if ori_max_new_tokens <= 0:
             raise ValueError(
                 f"max_new_tokens must be > 0, got {ori_max_new_tokens} "
-                f"(max_tokens={req.gconfig.max_tokens}, "
-                f"input_len={len(req.input_ids)}, "
-                f"max_new_tokens={req.gconfig.max_new_tokens})"
+                f"(max_tokens={generation_req.gconfig.max_tokens}, "
+                f"input_len={len(generation_req.input_ids)}, "
+                f"max_new_tokens={generation_req.gconfig.max_new_tokens})"
             )
+        if collect_trace:
+            if type(ori_max_new_tokens) is not int:
+                raise TypeError("effective_max_new_tokens must be an int")
 
         accumulated_tokens: list[int] = []
         accumulated_logprobs: list[float] = []
         accumulated_versions: list[int] = []
         stop_reason: _StopReason | None = None
         final_routed_experts: np.ndarray | None = None
+        attempt_traces: list[GenerationAttemptTrace] = []
+        terminal_reason: _TerminalReason | None = None
 
         t0 = time.monotonic()
 
-        for _attempt in range(self.max_resubmit_retries):
-            # Wait while paused (weight update in progress)
+        for _attempt in range(configured_attempt_limit):
             while await self.pause_state.is_paused():
                 await asyncio.sleep(self.resubmit_wait)
 
-            # Adjust max_new_tokens for already-generated tokens
             remaining = ori_max_new_tokens - len(accumulated_tokens)
             if remaining <= 0:
                 stop_reason = "length"
+                terminal_reason = "budget_exhausted"
                 break
 
-            # Patch the payload for this iteration (extend input, shrink budget)
-            self.backend.patch_generation_request(
+            backend.patch_generation_request(
                 http_req,
-                req,
+                generation_req,
                 accumulated_tokens,
                 remaining,
             )
 
+            if collect_trace:
+                if self.backend_addr != backend_addr:
+                    raise RuntimeError("backend_addr changed during traced generation")
+                prepared_budget = backend.get_generation_max_new_tokens(http_req)
+                if type(prepared_budget) is not int or prepared_budget != remaining:
+                    raise ValueError(
+                        "patched backend max_new_tokens does not match remaining budget"
+                    )
+                submitted_input_token_ids = (
+                    backend.snapshot_generation_input_ids(http_req)
+                    if isinstance(backend, TraceableInfBridgeBackend)
+                    else None
+                )
+                endpoint = http_req.endpoint
+                method = "GET" if http_req.method == "GET" else "POST"
+                prepared_request_hash = prepared_request_json_sha256(http_req.payload)
+                # This must remain the final synchronous observation before
+                # entering the transport await.
+                client_version_before_send = self._version
+
             data = await self._send_request(http_req)
-            result = self.backend.parse_generation_response(data)
+            if collect_trace:
+                # Bracket the transport return before hashing/parsing locally.
+                client_version_after_receive = self._version
+                parsed_response_hash = parsed_response_json_sha256(data)
+            result = backend.parse_generation_response(data)
 
             accumulated_tokens.extend(result.output_tokens)
             accumulated_logprobs.extend(result.output_logprobs)
-            accumulated_versions.extend([self._version] * len(result.output_tokens))
+            # Preserve the exact legacy read point used to label output tokens.
+            output_version_label = self._version
+            accumulated_versions.extend(
+                [output_version_label] * len(result.output_tokens)
+            )
             stop_reason = cast(_StopReason, result.stop_reason)
+
+            if collect_trace:
+                attempt_traces.append(
+                    GenerationAttemptTrace(
+                        attempt_index=_attempt,
+                        client_version_before_send=client_version_before_send,
+                        client_version_after_receive=client_version_after_receive,
+                        output_version_label=output_version_label,
+                        remaining_new_tokens=remaining,
+                        endpoint=endpoint,
+                        method=method,
+                        prepared_request_json_sha256=prepared_request_hash,
+                        parsed_response_json_sha256=parsed_response_hash,
+                        submitted_input_token_ids=submitted_input_token_ids,
+                        raw_stop_reason=result.stop_reason,
+                        output_token_ids=tuple(result.output_tokens),
+                        output_logprob_count=len(result.output_logprobs),
+                    )
+                )
 
             if result.routed_experts is not None:
                 if final_routed_experts is None:
@@ -233,32 +385,59 @@ class InfBridge:
                     )
 
             if stop_reason in ("stop", "tool_calls", "length"):
+                terminal_reason = {
+                    "stop": "backend_stop",
+                    "tool_calls": "backend_tool_calls",
+                    "length": "backend_length",
+                }[stop_reason]
                 break
 
             if len(accumulated_tokens) >= ori_max_new_tokens:
                 stop_reason = "length"
+                terminal_reason = "budget_exhausted"
                 break
 
-            # stop_reason == "abort" → continue loop (resubmit)
             logger.debug(
                 "Abort detected, resubmit attempt %d, accumulated %d tokens",
                 _attempt + 1,
                 len(accumulated_tokens),
             )
 
-        # Final abort at max retries → treat as length
         if stop_reason == "abort" or stop_reason is None:
             stop_reason = "length"
+            terminal_reason = "attempt_limit"
 
         latency = time.monotonic() - t0
-
-        return ModelResponse(
-            input_tokens=list(req.input_ids),
+        response = ModelResponse(
+            input_tokens=list(generation_req.input_ids),
             output_tokens=accumulated_tokens,
             output_logprobs=accumulated_logprobs,
             output_versions=accumulated_versions,
             stop_reason=stop_reason,
-            tokenizer=req.tokenizer,
+            tokenizer=generation_req.tokenizer,
             latency=latency,
             routed_experts=final_routed_experts,
         )
+
+        if not collect_trace:
+            return response
+        if terminal_reason is None:  # pragma: no cover - defensive invariant
+            raise RuntimeError("generation completed without a terminal reason")
+
+        trace = GenerationPhysicalTrace(
+            schema_version=1,
+            request_id=request_id,
+            backend_kind=backend_kind,
+            backend_addr_sha256=backend_addr_sha256,
+            request_input_token_ids=request_input_token_ids,
+            effective_max_new_tokens=ori_max_new_tokens,
+            configured_attempt_limit=configured_attempt_limit,
+            initial_client_version=initial_client_version,
+            final_client_version=self._version,
+            attempts=tuple(attempt_traces),
+            final_output_token_ids=tuple(accumulated_tokens),
+            final_stop_reason=stop_reason,
+            terminal_reason=terminal_reason,
+        )
+        validate_generation_physical_trace_response(response, trace)
+        return response, trace

--- a/areal/v2/inference_service/inf_bridge.py
+++ b/areal/v2/inference_service/inf_bridge.py
@@ -295,6 +295,10 @@ class InfBridge:
         configured_attempt_limit = self.max_resubmit_retries
         initial_client_version = self._version
         initial_client_version_epoch = self._version_epoch
+        if collect_trace:
+            traced_pause_state = self.pause_state
+            traced_request_timeout = self.request_timeout
+            traced_resubmit_wait = self.resubmit_wait
 
         if generation_req.gconfig.n_samples != 1:
             raise ValueError(
@@ -363,8 +367,11 @@ class InfBridge:
         t0 = time.monotonic()
 
         for _attempt in range(configured_attempt_limit):
-            while await self.pause_state.is_paused():
-                await asyncio.sleep(self.resubmit_wait)
+            pause_state = traced_pause_state if collect_trace else self.pause_state
+            while await pause_state.is_paused():
+                await asyncio.sleep(
+                    traced_resubmit_wait if collect_trace else self.resubmit_wait
+                )
 
             remaining = ori_max_new_tokens - len(accumulated_tokens)
             if remaining <= 0:
@@ -400,7 +407,13 @@ class InfBridge:
                 client_version_before_send = self._version
                 client_version_epoch_before_send = self._version_epoch
 
-            data = await self._send_request(http_req)
+            if collect_trace:
+                data = await self._send_request(
+                    http_req,
+                    timeout=traced_request_timeout,
+                )
+            else:
+                data = await self._send_request(http_req)
             if collect_trace:
                 # Bracket the transport return before hashing/parsing locally.
                 client_version_after_receive = self._version

--- a/areal/v2/inference_service/inf_bridge.py
+++ b/areal/v2/inference_service/inf_bridge.py
@@ -283,15 +283,17 @@ class InfBridge:
         """Shared generation loop; tracing is opt-in to preserve legacy behavior."""
         if collect_response_evidence and not collect_trace:
             raise ValueError("response evidence requires physical tracing")
-        # The traced API snapshots mutable request/configuration state.  The
-        # legacy API intentionally retains its existing object-sharing behavior.
+        # The traced API snapshots request containers and transport controls.
+        # The legacy API intentionally retains its existing object sharing.
         if collect_trace:
             generation_req = req.copy()
-            # ModelRequest.copy() intentionally keeps several nested objects
-            # shallow.  Trace mode isolates mutable JSON-facing state while
-            # retaining heavyweight tokenizer/processor references.
-            generation_req.metadata = copy.deepcopy(req.metadata)
-            generation_req.image_data = copy.deepcopy(req.image_data)
+            # ModelRequest.copy() already snapshots the metadata mapping and
+            # image-data list.  Preserve opaque metadata values by reference:
+            # metadata is public ``dict[str, Any]`` state and can contain
+            # intentionally non-copyable values.  Any payload derived from it
+            # is still hashed immediately before each physical send.
+            # vLLM mutates nested vision messages during payload construction,
+            # so those require an isolated deep copy.
             generation_req.vision_msg_vllm = copy.deepcopy(req.vision_msg_vllm)
         else:
             generation_req = req

--- a/areal/v2/inference_service/inf_bridge.py
+++ b/areal/v2/inference_service/inf_bridge.py
@@ -41,6 +41,7 @@ __all__ = [
     "GenerationAttemptTrace",
     "GenerationPhysicalTrace",
     "GenerationResponseEvidence",
+    "GenerationTraceValidationError",
     "InfBridge",
     "generation_physical_trace_bytes",
     "generation_physical_trace_sha256",
@@ -60,6 +61,10 @@ _TerminalReason = Literal[
 ]
 
 logger = logging.getLogger("InferenceInfBridge")
+
+
+class GenerationTraceValidationError(ValueError):
+    """A traced call completed but failed client-evidence invariants."""
 
 
 class InfBridge:
@@ -515,29 +520,32 @@ class InfBridge:
         if terminal_reason is None:  # pragma: no cover - defensive invariant
             raise RuntimeError("generation completed without a terminal reason")
 
-        trace = GenerationPhysicalTrace(
-            schema_version=2,
-            request_id=request_id,
-            backend_kind=backend_kind,
-            backend_addr_sha256=backend_addr_sha256,
-            request_input_token_ids=request_input_token_ids,
-            effective_max_new_tokens=ori_max_new_tokens,
-            configured_attempt_limit=configured_attempt_limit,
-            initial_client_version=initial_client_version,
-            final_client_version=self._version,
-            initial_client_version_epoch=initial_client_version_epoch,
-            final_client_version_epoch=self._version_epoch,
-            attempts=tuple(attempt_traces),
-            final_output_token_ids=tuple(accumulated_tokens),
-            final_stop_reason=stop_reason,
-            terminal_reason=terminal_reason,
-        )
-        validate_generation_physical_trace_response(response, trace)
-        if not collect_response_evidence:
-            return response, trace
-        response_evidence = GenerationResponseEvidence(
-            schema_version=1,
-            generation_trace_sha256=generation_physical_trace_sha256(trace),
-            attempts=tuple(response_evidence_attempts),
-        )
+        try:
+            trace = GenerationPhysicalTrace(
+                schema_version=2,
+                request_id=request_id,
+                backend_kind=backend_kind,
+                backend_addr_sha256=backend_addr_sha256,
+                request_input_token_ids=request_input_token_ids,
+                effective_max_new_tokens=ori_max_new_tokens,
+                configured_attempt_limit=configured_attempt_limit,
+                initial_client_version=initial_client_version,
+                final_client_version=self._version,
+                initial_client_version_epoch=initial_client_version_epoch,
+                final_client_version_epoch=self._version_epoch,
+                attempts=tuple(attempt_traces),
+                final_output_token_ids=tuple(accumulated_tokens),
+                final_stop_reason=stop_reason,
+                terminal_reason=terminal_reason,
+            )
+            validate_generation_physical_trace_response(response, trace)
+            if not collect_response_evidence:
+                return response, trace
+            response_evidence = GenerationResponseEvidence(
+                schema_version=1,
+                generation_trace_sha256=generation_physical_trace_sha256(trace),
+                attempts=tuple(response_evidence_attempts),
+            )
+        except (TypeError, ValueError) as error:
+            raise GenerationTraceValidationError(str(error)) from error
         return response, trace, response_evidence

--- a/areal/v2/inference_service/sglang/bridge.py
+++ b/areal/v2/inference_service/sglang/bridge.py
@@ -146,3 +146,15 @@ class SGLangBridgeBackend:
     ) -> None:
         http_req.payload["input_ids"] = list(req.input_ids) + accumulated_tokens
         http_req.payload["sampling_params"]["max_new_tokens"] = remaining_tokens
+
+    def snapshot_generation_input_ids(
+        self,
+        http_req: HttpRequest,
+    ) -> tuple[int, ...]:
+        """Snapshot the exact token IDs in the patched SGLang payload."""
+        input_ids = http_req.payload["input_ids"]
+        if not isinstance(input_ids, list) or any(
+            type(token_id) is not int or token_id < 0 for token_id in input_ids
+        ):
+            raise ValueError("SGLang input_ids must be a list of non-negative ints")
+        return tuple(input_ids)

--- a/areal/v2/inference_service/vllm/bridge.py
+++ b/areal/v2/inference_service/vllm/bridge.py
@@ -150,3 +150,17 @@ class VLLMBridgeBackend:
         http_req.payload["max_tokens"] = remaining_tokens
         if "prompt" in http_req.payload:
             http_req.payload["prompt"] = list(req.input_ids) + accumulated_tokens
+
+    def snapshot_generation_input_ids(
+        self,
+        http_req: HttpRequest,
+    ) -> tuple[int, ...] | None:
+        """Snapshot text prompt IDs; multimodal chat payloads have no flat IDs."""
+        if "prompt" not in http_req.payload:
+            return None
+        prompt = http_req.payload["prompt"]
+        if not isinstance(prompt, list) or any(
+            type(token_id) is not int or token_id < 0 for token_id in prompt
+        ):
+            raise ValueError("vLLM prompt must be a list of non-negative ints")
+        return tuple(prompt)

--- a/tests/v2/inference_service/test_inf_bridge_trace.py
+++ b/tests/v2/inference_service/test_inf_bridge_trace.py
@@ -29,9 +29,17 @@ from areal.v2.inference_service.backend import TraceableInfBridgeBackend
 from areal.v2.inference_service.client_trace import (
     GenerationAttemptTrace,
     GenerationPhysicalTrace,
+    GenerationResponseEvidence,
+    ParsedResponseJSONEvidence,
     generation_physical_trace_bytes,
+    generation_physical_trace_from_bytes,
     generation_physical_trace_sha256,
+    generation_response_evidence_bytes,
+    generation_response_evidence_from_bytes,
+    generation_response_evidence_sha256,
+    generation_response_evidence_values,
     validate_generation_physical_trace_response,
+    validate_generation_response_evidence,
 )
 from areal.v2.inference_service.sglang.bridge import SGLangBridgeBackend
 from areal.v2.inference_service.vllm.bridge import VLLMBridgeBackend
@@ -121,13 +129,15 @@ class TestInfBridgePhysicalTrace:
         assert isinstance(resp, ModelResponse)
         assert isinstance(trace, GenerationPhysicalTrace)
         assert resp.output_tokens == [100, 101]
-        assert trace.schema_version == 1
+        assert trace.schema_version == 2
         assert trace.request_id == "trace-normal"
         assert trace.backend_kind == "SGLangBridgeBackend"
         assert trace.backend_addr_sha256 == hashlib.sha256(b"http://mock").hexdigest()
         assert trace.request_input_token_ids == (1, 2, 3)
         assert trace.initial_client_version == 7
         assert trace.final_client_version == 7
+        assert trace.initial_client_version_epoch == 0
+        assert trace.final_client_version_epoch == 0
         assert trace.effective_max_new_tokens == 5
         assert trace.configured_attempt_limit == 20
         assert trace.final_output_token_ids == (100, 101)
@@ -141,6 +151,9 @@ class TestInfBridgePhysicalTrace:
         assert attempt.client_version_before_send == 7
         assert attempt.client_version_after_receive == 7
         assert attempt.output_version_label == 7
+        assert attempt.client_version_epoch_before_send == 0
+        assert attempt.client_version_epoch_after_receive == 0
+        assert attempt.output_version_epoch == 0
         assert attempt.remaining_new_tokens == 5
         assert attempt.endpoint == "/generate"
         assert attempt.method == "POST"
@@ -166,9 +179,11 @@ class TestInfBridgePhysicalTrace:
             "configured_attempt_limit",
             "effective_max_new_tokens",
             "final_client_version",
+            "final_client_version_epoch",
             "final_output_token_ids",
             "final_stop_reason",
             "initial_client_version",
+            "initial_client_version_epoch",
             "kind",
             "request_id",
             "request_input_token_ids",
@@ -179,23 +194,29 @@ class TestInfBridgePhysicalTrace:
             "attempt_index",
             "client_version_after_receive",
             "client_version_before_send",
+            "client_version_epoch_after_receive",
+            "client_version_epoch_before_send",
             "endpoint",
             "method",
             "output_logprob_count",
             "output_token_ids",
             "output_version_label",
+            "output_version_epoch",
             "parsed_response_json_sha256",
             "prepared_request_json_sha256",
             "raw_stop_reason",
             "remaining_new_tokens",
             "submitted_input_token_ids",
         }
-        assert decoded["kind"] == "areal-generation-physical-trace-v1"
+        assert decoded["kind"] == "areal-generation-physical-trace-v2"
         expected = (
             b'{"attempts":[{"attempt_index":0,"client_version_after_receive":7,'
-            b'"client_version_before_send":7,"endpoint":"/generate","method":"POST",'
+            b'"client_version_before_send":7,"client_version_epoch_after_receive":0,'
+            b'"client_version_epoch_before_send":0,"endpoint":"/generate",'
+            b'"method":"POST",'
             b'"output_logprob_count":2,"output_token_ids":[100,101],'
-            b'"output_version_label":7,"parsed_response_json_sha256":'
+            b'"output_version_epoch":0,"output_version_label":7,'
+            b'"parsed_response_json_sha256":'
             b'"a6139c5961208dbfa553d0c330516f9c234517dc1776cae35627aedbe308fb0d",'
             b'"prepared_request_json_sha256":'
             b'"edef4683dba2caa3a86090ef4a3a61876908d3a1307d348107df9f5fa97acab5",'
@@ -204,14 +225,19 @@ class TestInfBridgePhysicalTrace:
             b'"76f5495ef9aa27156aca83370226a757446a93e03858b06a5b58f9a0e75edfaf",'
             b'"backend_kind":"SGLangBridgeBackend","configured_attempt_limit":20,'
             b'"effective_max_new_tokens":5,"final_client_version":7,'
-            b'"final_output_token_ids":[100,101],"final_stop_reason":"stop",'
-            b'"initial_client_version":7,"kind":"areal-generation-physical-trace-v1",'
+            b'"final_client_version_epoch":0,"final_output_token_ids":[100,101],'
+            b'"final_stop_reason":"stop","initial_client_version":7,'
+            b'"initial_client_version_epoch":0,'
+            b'"kind":"areal-generation-physical-trace-v2",'
             b'"request_id":"trace-normal","request_input_token_ids":[1,2,3],'
-            b'"schema_version":1,"terminal_reason":"backend_stop"}'
+            b'"schema_version":2,"terminal_reason":"backend_stop"}'
         )
         assert encoded == expected
+        restored = generation_physical_trace_from_bytes(encoded)
+        assert restored == trace
+        assert generation_physical_trace_bytes(restored) == encoded
         assert generation_physical_trace_sha256(trace) == (
-            "6a192dae76682434a03a2fda2d20b139b6dcb582b04c99c9daa842c2a2c99e02"
+            "2b6971d8eebfb2ec6b3251f76dced0dc019083608ee399d9a693e514ed6f329d"
         )
 
     @pytest.mark.asyncio
@@ -261,6 +287,189 @@ class TestInfBridgePhysicalTrace:
         assert trace.request_input_token_ids == (1, 2, 3)
         assert trace.attempts[0].submitted_input_token_ids == (1, 2, 3)
         assert trace.attempts[1].submitted_input_token_ids == (1, 2, 3, 100, 101)
+
+    @pytest.mark.asyncio
+    async def test_optional_response_evidence_replays_every_parsed_json_attempt(self):
+        raw_responses = (
+            _make_sglang_response([(-0.5, 100)], "abort"),
+            _make_sglang_response([(-0.2, 200)], "stop"),
+        )
+        bridge = _make_bridge()
+        bridge._send_request = AsyncMock(side_effect=deepcopy(raw_responses))
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=5)
+        req.rid = "trace-response-evidence"
+
+        (
+            response,
+            trace,
+            evidence,
+        ) = await bridge.agenerate_with_trace_and_response_evidence(req)
+
+        assert response.output_tokens == [100, 200]
+        assert type(evidence) is GenerationResponseEvidence
+        assert evidence.schema_version == 1
+        assert evidence.generation_trace_sha256 == generation_physical_trace_sha256(
+            trace
+        )
+        assert all(
+            type(attempt) is ParsedResponseJSONEvidence for attempt in evidence.attempts
+        )
+        assert tuple(attempt.attempt_index for attempt in evidence.attempts) == (0, 1)
+        expected_values = tuple(
+            json.loads(json.dumps(value, allow_nan=False)) for value in raw_responses
+        )
+        assert generation_response_evidence_values(trace, evidence) == expected_values
+        assert validate_generation_response_evidence(trace, evidence) is None
+        encoded = generation_response_evidence_bytes(evidence)
+        assert encoded == json.dumps(
+            json.loads(encoded),
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("ascii")
+        assert len(encoded) == 648
+        assert generation_response_evidence_sha256(evidence) == (
+            "553b0ab264d1439189f90bea891fc329232f2b8d9a4ebea35894a4f25d898e0e"
+        )
+        assert (
+            generation_response_evidence_sha256(evidence)
+            == hashlib.sha256(encoded).hexdigest()
+        )
+        restored = generation_response_evidence_from_bytes(encoded)
+        assert restored == evidence
+        assert generation_response_evidence_bytes(restored) == encoded
+
+        changed_preimage = ParsedResponseJSONEvidence(
+            attempt_index=0,
+            parsed_response_json_sha256=_domain_separated_json_sha256(
+                raw_responses[1],
+                domain=b"areal-infbridge-parsed-response-json-v1\0",
+            ),
+            canonical_json_bytes=json.dumps(
+                raw_responses[1],
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("ascii"),
+        )
+        forged = replace(
+            evidence,
+            attempts=(changed_preimage, evidence.attempts[1]),
+        )
+        with pytest.raises(ValueError, match="attempt does not match trace"):
+            validate_generation_response_evidence(trace, forged)
+        assert "canonical_json_bytes" not in repr(evidence.attempts[0])
+        assert "meta_info" not in repr(evidence.attempts[0])
+
+    @pytest.mark.asyncio
+    async def test_compact_trace_api_does_not_collect_response_preimages(self):
+        bridge = _make_bridge()
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.5, 100)], "stop")
+        )
+        req = _make_request(input_ids=[1], max_new_tokens=2)
+
+        result = await bridge.agenerate_with_trace(req)
+
+        assert type(result) is tuple
+        assert len(result) == 2
+        assert all(
+            not hasattr(attempt, "canonical_json_bytes")
+            for attempt in result[1].attempts
+        )
+
+    @pytest.mark.parametrize(
+        "canonical_json_bytes",
+        (
+            b'{ "a":1}',
+            b'{"a":1,"a":1}',
+            b'{"value":NaN}',
+            b"[]",
+            bytearray(b'{"a":1}'),
+        ),
+        ids=("whitespace", "duplicate-key", "nan", "non-object", "wrong-type"),
+    )
+    def test_response_evidence_rejects_noncanonical_or_ambiguous_json(
+        self,
+        canonical_json_bytes: object,
+    ):
+        with pytest.raises(ValueError):
+            ParsedResponseJSONEvidence(
+                attempt_index=0,
+                parsed_response_json_sha256="0" * 64,
+                canonical_json_bytes=canonical_json_bytes,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.asyncio
+    async def test_persisted_trace_and_sidecar_loaders_fail_closed(self):
+        bridge = _make_bridge()
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.5, 100)], "stop")
+        )
+        req = _make_request(input_ids=[1], max_new_tokens=2)
+        req.rid = "trace-loader"
+        _, trace, evidence = await bridge.agenerate_with_trace_and_response_evidence(
+            req
+        )
+        trace_bytes = generation_physical_trace_bytes(trace)
+        evidence_bytes = generation_response_evidence_bytes(evidence)
+
+        def canonical(value: object) -> bytes:
+            return json.dumps(
+                value,
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("ascii")
+
+        trace_value = json.loads(trace_bytes)
+        wrong_trace_kind = deepcopy(trace_value)
+        wrong_trace_kind["kind"] = "areal-generation-physical-trace-v1"
+        wrong_trace_schema = deepcopy(trace_value)
+        wrong_trace_schema["schema_version"] = True
+        extra_trace_field = deepcopy(trace_value)
+        extra_trace_field["unknown"] = 0
+        duplicate_trace_key = trace_bytes.replace(
+            b'{"attempts":',
+            b'{"attempts":[],"attempts":',
+            1,
+        )
+        for malformed in (
+            b" " + trace_bytes,
+            canonical(wrong_trace_kind),
+            canonical(wrong_trace_schema),
+            canonical(extra_trace_field),
+            duplicate_trace_key,
+            bytearray(trace_bytes),
+        ):
+            with pytest.raises((TypeError, ValueError)):
+                generation_physical_trace_from_bytes(malformed)  # type: ignore[arg-type]
+
+        evidence_value = json.loads(evidence_bytes)
+        wrong_evidence_kind = deepcopy(evidence_value)
+        wrong_evidence_kind["kind"] = "wrong-kind"
+        wrong_evidence_schema = deepcopy(evidence_value)
+        wrong_evidence_schema["schema_version"] = True
+        extra_evidence_field = deepcopy(evidence_value)
+        extra_evidence_field["unknown"] = 0
+        duplicate_evidence_key = evidence_bytes.replace(
+            b'{"attempts":',
+            b'{"attempts":[],"attempts":',
+            1,
+        )
+        for malformed in (
+            b" " + evidence_bytes,
+            canonical(wrong_evidence_kind),
+            canonical(wrong_evidence_schema),
+            canonical(extra_evidence_field),
+            duplicate_evidence_key,
+            bytearray(evidence_bytes),
+        ):
+            with pytest.raises((TypeError, ValueError)):
+                generation_response_evidence_from_bytes(malformed)  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_attempt_limit_preserves_raw_abort_evidence(self):
@@ -315,6 +524,24 @@ class TestInfBridgePhysicalTrace:
         assert trace.terminal_reason == "budget_exhausted"
 
     @pytest.mark.asyncio
+    async def test_traced_api_rejects_backend_output_beyond_remaining_budget(self):
+        bridge = _make_bridge()
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response(
+                [(-0.1, token_id) for token_id in range(9)],
+                "stop",
+            )
+        )
+        req = _make_request(input_ids=[1, 2], max_new_tokens=8)
+        req.rid = "trace-over-budget"
+
+        with pytest.raises(ValueError, match="cannot exceed remaining_new_tokens"):
+            await bridge.agenerate_with_trace(req)
+
+        legacy = await bridge.agenerate(req)
+        assert legacy.output_tokens == list(range(9))
+
+    @pytest.mark.asyncio
     async def test_trace_snapshots_versions_before_send_and_after_receive(self):
         call_count = 0
         bridge = _make_bridge(version=1)
@@ -345,6 +572,38 @@ class TestInfBridgePhysicalTrace:
             3,
         ]
         assert [attempt.output_version_label for attempt in trace.attempts] == [2, 3]
+
+    @pytest.mark.asyncio
+    async def test_version_epoch_exposes_aba_changes_hidden_by_equal_labels(self):
+        bridge = _make_bridge(version=17)
+
+        async def change_and_restore_version(http_req, **kwargs):
+            bridge.set_version(18)
+            bridge.set_version(17)
+            return _make_sglang_response([(-0.5, 100)], "stop")
+
+        bridge._send_request = change_and_restore_version
+        req = _make_request(input_ids=[1], max_new_tokens=2)
+        req.rid = "trace-version-aba"
+
+        response, trace = await bridge.agenerate_with_trace(req)
+
+        assert response.output_versions == [17]
+        assert trace.initial_client_version == trace.final_client_version == 17
+        assert trace.initial_client_version_epoch == 0
+        assert trace.final_client_version_epoch == 2
+        attempt = trace.attempts[0]
+        assert attempt.client_version_before_send == 17
+        assert attempt.client_version_after_receive == 17
+        assert attempt.output_version_label == 17
+        assert attempt.client_version_epoch_before_send == 0
+        assert attempt.client_version_epoch_after_receive == 2
+        assert attempt.output_version_epoch == 2
+
+        forged = deepcopy(trace)
+        object.__setattr__(forged, "final_client_version", 18)
+        with pytest.raises(ValueError, match="one client version epoch"):
+            generation_physical_trace_bytes(forged)
 
     @pytest.mark.asyncio
     async def test_output_version_label_is_observed_after_backend_parsing(self):
@@ -718,6 +977,8 @@ class TestInfBridgePhysicalTrace:
         req.rid = "trace-validation"
         _, trace = await bridge.agenerate_with_trace(req)
 
+        with pytest.raises(ValueError, match="schema_version must be 2"):
+            replace(trace, schema_version=1)
         with pytest.raises(ValueError, match="final_output_token_ids"):
             generation_physical_trace_bytes(
                 replace(trace, final_output_token_ids=(999,))

--- a/tests/v2/inference_service/test_inf_bridge_trace.py
+++ b/tests/v2/inference_service/test_inf_bridge_trace.py
@@ -108,6 +108,13 @@ class _ThirdPartyBackendWithoutTrace:
         )
 
 
+class _OpaqueMetadata:
+    """Metadata value accepted by the backend but intentionally not copyable."""
+
+    def __deepcopy__(self, _memo: dict[int, Any]) -> _OpaqueMetadata:
+        raise TypeError("opaque metadata cannot be copied")
+
+
 class TestInfBridgePhysicalTrace:
     """Auditable, immutable client-local observations around HTTP attempts."""
 
@@ -792,6 +799,28 @@ class TestInfBridgePhysicalTrace:
         assert trace.attempts[0].submitted_input_token_ids is None
         assert trace.effective_max_new_tokens == 3
         assert trace.configured_attempt_limit == 20
+
+    @pytest.mark.asyncio
+    async def test_trace_preserves_opaque_metadata_accepted_by_legacy_path(self):
+        raw_response = _make_sglang_response([(-0.5, 100)], "stop")
+        bridge = _make_bridge()
+        bridge._send_request = AsyncMock(
+            side_effect=[deepcopy(raw_response), deepcopy(raw_response)]
+        )
+        req = _make_request(
+            input_ids=[1, 2, 3],
+            max_new_tokens=3,
+            metadata={"opaque": _OpaqueMetadata()},
+        )
+        req.rid = "trace-opaque-metadata"
+
+        legacy_response = await bridge.agenerate(req)
+        traced_response, trace = await bridge.agenerate_with_trace(req)
+
+        assert legacy_response.output_tokens == [100]
+        assert traced_response.output_tokens == [100]
+        assert trace.request_id == "trace-opaque-metadata"
+        assert bridge._send_request.await_count == 2
 
     @pytest.mark.asyncio
     async def test_trace_records_effective_post_method_for_non_get_request_label(self):

--- a/tests/v2/inference_service/test_inf_bridge_trace.py
+++ b/tests/v2/inference_service/test_inf_bridge_trace.py
@@ -1,0 +1,767 @@
+"""Tests for auditable InfBridge client-local call traces."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import FrozenInstanceError, replace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.v2.inference_service.test_inf_bridge import (
+    _make_bridge,
+    _make_request,
+    _make_sglang_response,
+    _make_vllm_response,
+)
+
+from areal.api.io_struct import (
+    HttpGenerationResult,
+    HttpRequest,
+    ModelRequest,
+    ModelResponse,
+)
+from areal.v2.inference_service.backend import TraceableInfBridgeBackend
+from areal.v2.inference_service.client_trace import (
+    GenerationAttemptTrace,
+    GenerationPhysicalTrace,
+    generation_physical_trace_bytes,
+    generation_physical_trace_sha256,
+    validate_generation_physical_trace_response,
+)
+from areal.v2.inference_service.sglang.bridge import SGLangBridgeBackend
+from areal.v2.inference_service.vllm.bridge import VLLMBridgeBackend
+
+
+def _domain_separated_json_sha256(value: Any, *, domain: bytes) -> str:
+    """Hash canonical JSON with an independently supplied semantic domain."""
+    payload = json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("ascii")
+    return hashlib.sha256(domain + payload).hexdigest()
+
+
+class _ThirdPartyBackendWithoutTrace:
+    """SGLang-compatible backend intentionally lacking the optional trace hook."""
+
+    def __init__(self) -> None:
+        self._delegate = SGLangBridgeBackend()
+
+    def build_generation_request(
+        self,
+        req: ModelRequest,
+        with_lora: bool,
+        version: int = -1,
+    ) -> HttpRequest:
+        return self._delegate.build_generation_request(req, with_lora, version)
+
+    def parse_generation_response(
+        self,
+        response: dict[str, Any],
+    ) -> HttpGenerationResult:
+        return self._delegate.parse_generation_response(response)
+
+    def get_pause_request(self) -> HttpRequest:
+        return self._delegate.get_pause_request()
+
+    def get_resume_request(self) -> HttpRequest:
+        return self._delegate.get_resume_request()
+
+    def get_offload_request(self) -> HttpRequest:
+        return self._delegate.get_offload_request()
+
+    def get_onload_request(self, tags: list[str] | None = None) -> HttpRequest:
+        return self._delegate.get_onload_request(tags)
+
+    def get_generation_max_new_tokens(self, http_req: HttpRequest) -> int:
+        return self._delegate.get_generation_max_new_tokens(http_req)
+
+    def patch_generation_request(
+        self,
+        http_req: HttpRequest,
+        req: ModelRequest,
+        accumulated_tokens: list[int],
+        remaining_tokens: int,
+    ) -> None:
+        self._delegate.patch_generation_request(
+            http_req,
+            req,
+            accumulated_tokens,
+            remaining_tokens,
+        )
+
+
+class TestInfBridgePhysicalTrace:
+    """Auditable, immutable client-local observations around HTTP attempts."""
+
+    @pytest.mark.asyncio
+    async def test_sglang_normal_stop_records_canonical_physical_trace(self):
+        sent_payloads: list[dict[str, Any]] = []
+        raw_response = _make_sglang_response([(-0.5, 100), (-0.3, 101)], "stop")
+
+        async def mock_send(http_req, **kwargs):
+            sent_payloads.append(deepcopy(http_req.payload))
+            return deepcopy(raw_response)
+
+        bridge = _make_bridge(version=7, backend_addr="http://mock/")
+        bridge._send_request = mock_send
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=5)
+        req.rid = "trace-normal"
+
+        resp, trace = await bridge.agenerate_with_trace(req)
+
+        assert isinstance(resp, ModelResponse)
+        assert isinstance(trace, GenerationPhysicalTrace)
+        assert resp.output_tokens == [100, 101]
+        assert trace.schema_version == 1
+        assert trace.request_id == "trace-normal"
+        assert trace.backend_kind == "SGLangBridgeBackend"
+        assert trace.backend_addr_sha256 == hashlib.sha256(b"http://mock").hexdigest()
+        assert trace.request_input_token_ids == (1, 2, 3)
+        assert trace.initial_client_version == 7
+        assert trace.final_client_version == 7
+        assert trace.effective_max_new_tokens == 5
+        assert trace.configured_attempt_limit == 20
+        assert trace.final_output_token_ids == (100, 101)
+        assert trace.final_stop_reason == "stop"
+        assert trace.terminal_reason == "backend_stop"
+
+        assert len(trace.attempts) == 1
+        attempt = trace.attempts[0]
+        assert isinstance(attempt, GenerationAttemptTrace)
+        assert attempt.attempt_index == 0
+        assert attempt.client_version_before_send == 7
+        assert attempt.client_version_after_receive == 7
+        assert attempt.output_version_label == 7
+        assert attempt.remaining_new_tokens == 5
+        assert attempt.endpoint == "/generate"
+        assert attempt.method == "POST"
+        assert attempt.prepared_request_json_sha256 == _domain_separated_json_sha256(
+            sent_payloads[0],
+            domain=b"areal-infbridge-prepared-request-json-v1\0",
+        )
+        assert attempt.parsed_response_json_sha256 == _domain_separated_json_sha256(
+            raw_response,
+            domain=b"areal-infbridge-parsed-response-json-v1\0",
+        )
+        assert attempt.submitted_input_token_ids == (1, 2, 3)
+        assert attempt.raw_stop_reason == "stop"
+        assert attempt.output_token_ids == (100, 101)
+        assert attempt.output_logprob_count == 2
+
+        encoded = generation_physical_trace_bytes(trace)
+        decoded = json.loads(encoded)
+        assert set(decoded) == {
+            "attempts",
+            "backend_addr_sha256",
+            "backend_kind",
+            "configured_attempt_limit",
+            "effective_max_new_tokens",
+            "final_client_version",
+            "final_output_token_ids",
+            "final_stop_reason",
+            "initial_client_version",
+            "kind",
+            "request_id",
+            "request_input_token_ids",
+            "schema_version",
+            "terminal_reason",
+        }
+        assert set(decoded["attempts"][0]) == {
+            "attempt_index",
+            "client_version_after_receive",
+            "client_version_before_send",
+            "endpoint",
+            "method",
+            "output_logprob_count",
+            "output_token_ids",
+            "output_version_label",
+            "parsed_response_json_sha256",
+            "prepared_request_json_sha256",
+            "raw_stop_reason",
+            "remaining_new_tokens",
+            "submitted_input_token_ids",
+        }
+        assert decoded["kind"] == "areal-generation-physical-trace-v1"
+        expected = (
+            b'{"attempts":[{"attempt_index":0,"client_version_after_receive":7,'
+            b'"client_version_before_send":7,"endpoint":"/generate","method":"POST",'
+            b'"output_logprob_count":2,"output_token_ids":[100,101],'
+            b'"output_version_label":7,"parsed_response_json_sha256":'
+            b'"a6139c5961208dbfa553d0c330516f9c234517dc1776cae35627aedbe308fb0d",'
+            b'"prepared_request_json_sha256":'
+            b'"edef4683dba2caa3a86090ef4a3a61876908d3a1307d348107df9f5fa97acab5",'
+            b'"raw_stop_reason":"stop","remaining_new_tokens":5,'
+            b'"submitted_input_token_ids":[1,2,3]}],"backend_addr_sha256":'
+            b'"76f5495ef9aa27156aca83370226a757446a93e03858b06a5b58f9a0e75edfaf",'
+            b'"backend_kind":"SGLangBridgeBackend","configured_attempt_limit":20,'
+            b'"effective_max_new_tokens":5,"final_client_version":7,'
+            b'"final_output_token_ids":[100,101],"final_stop_reason":"stop",'
+            b'"initial_client_version":7,"kind":"areal-generation-physical-trace-v1",'
+            b'"request_id":"trace-normal","request_input_token_ids":[1,2,3],'
+            b'"schema_version":1,"terminal_reason":"backend_stop"}'
+        )
+        assert encoded == expected
+        assert generation_physical_trace_sha256(trace) == (
+            "6a192dae76682434a03a2fda2d20b139b6dcb582b04c99c9daa842c2a2c99e02"
+        )
+
+    @pytest.mark.asyncio
+    async def test_abort_resubmit_records_each_patched_payload_immutably(self):
+        sent_requests = []
+
+        async def mock_send(http_req, **kwargs):
+            sent_requests.append(http_req)
+            if len(sent_requests) == 1:
+                return _make_sglang_response([(-0.5, 100), (-0.3, 101)], "abort")
+            return _make_sglang_response([(-0.2, 200)], "stop")
+
+        bridge = _make_bridge()
+        bridge._send_request = mock_send
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=5)
+        req.rid = "trace-resubmit"
+
+        resp, trace = await bridge.agenerate_with_trace(req)
+
+        assert resp.output_tokens == [100, 101, 200]
+        assert [attempt.attempt_index for attempt in trace.attempts] == [0, 1]
+        assert [attempt.remaining_new_tokens for attempt in trace.attempts] == [5, 3]
+        assert [attempt.submitted_input_token_ids for attempt in trace.attempts] == [
+            (1, 2, 3),
+            (1, 2, 3, 100, 101),
+        ]
+        assert [attempt.raw_stop_reason for attempt in trace.attempts] == [
+            "abort",
+            "stop",
+        ]
+        assert [attempt.output_token_ids for attempt in trace.attempts] == [
+            (100, 101),
+            (200,),
+        ]
+        assert trace.final_output_token_ids == (100, 101, 200)
+        assert trace.final_stop_reason == "stop"
+        assert trace.terminal_reason == "backend_stop"
+        assert (
+            trace.attempts[0].prepared_request_json_sha256
+            != trace.attempts[1].prepared_request_json_sha256
+        )
+
+        # The backend mutates and reuses one HttpRequest.  Later request/user
+        # mutation must not rewrite already-recorded evidence.
+        sent_requests[-1].payload["input_ids"][:] = [999]
+        req.input_ids[:] = [888]
+        assert trace.request_input_token_ids == (1, 2, 3)
+        assert trace.attempts[0].submitted_input_token_ids == (1, 2, 3)
+        assert trace.attempts[1].submitted_input_token_ids == (1, 2, 3, 100, 101)
+
+    @pytest.mark.asyncio
+    async def test_attempt_limit_preserves_raw_abort_evidence(self):
+        bridge = _make_bridge(max_resubmit_retries=3)
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.1, 10)], "abort")
+        )
+        req = _make_request(input_ids=[1, 2], max_new_tokens=100)
+        req.rid = "trace-attempt-limit"
+
+        resp, trace = await bridge.agenerate_with_trace(req)
+
+        assert resp.stop_reason == "length"
+        assert [attempt.attempt_index for attempt in trace.attempts] == [0, 1, 2]
+        assert [attempt.remaining_new_tokens for attempt in trace.attempts] == [
+            100,
+            99,
+            98,
+        ]
+        assert [attempt.raw_stop_reason for attempt in trace.attempts] == [
+            "abort",
+            "abort",
+            "abort",
+        ]
+        assert trace.final_output_token_ids == (10, 10, 10)
+        assert trace.effective_max_new_tokens == 100
+        assert trace.configured_attempt_limit == 3
+        assert trace.final_stop_reason == "length"
+        assert trace.terminal_reason == "attempt_limit"
+
+    @pytest.mark.asyncio
+    async def test_budget_exhaustion_is_distinct_from_attempt_limit(self):
+        bridge = _make_bridge(max_resubmit_retries=10)
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.1, 10), (-0.2, 11)], "abort")
+        )
+        req = _make_request(input_ids=[1, 2], max_new_tokens=4)
+        req.rid = "trace-budget"
+
+        resp, trace = await bridge.agenerate_with_trace(req)
+
+        assert resp.stop_reason == "length"
+        assert [attempt.remaining_new_tokens for attempt in trace.attempts] == [4, 2]
+        assert [attempt.raw_stop_reason for attempt in trace.attempts] == [
+            "abort",
+            "abort",
+        ]
+        assert trace.final_output_token_ids == (10, 11, 10, 11)
+        assert trace.effective_max_new_tokens == 4
+        assert trace.configured_attempt_limit == 10
+        assert trace.final_stop_reason == "length"
+        assert trace.terminal_reason == "budget_exhausted"
+
+    @pytest.mark.asyncio
+    async def test_trace_snapshots_versions_before_send_and_after_receive(self):
+        call_count = 0
+        bridge = _make_bridge(version=1)
+
+        async def mock_send(http_req, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            bridge.set_version(call_count + 1)
+            if call_count == 1:
+                return _make_sglang_response([(-0.5, 100)], "abort")
+            return _make_sglang_response([(-0.2, 200)], "stop")
+
+        bridge._send_request = mock_send
+        req = _make_request(input_ids=[1, 2], max_new_tokens=5)
+        req.rid = "trace-versions"
+
+        resp, trace = await bridge.agenerate_with_trace(req)
+
+        assert resp.output_versions == [2, 3]
+        assert trace.initial_client_version == 1
+        assert trace.final_client_version == 3
+        assert [attempt.client_version_before_send for attempt in trace.attempts] == [
+            1,
+            2,
+        ]
+        assert [attempt.client_version_after_receive for attempt in trace.attempts] == [
+            2,
+            3,
+        ]
+        assert [attempt.output_version_label for attempt in trace.attempts] == [2, 3]
+
+    @pytest.mark.asyncio
+    async def test_output_version_label_is_observed_after_backend_parsing(self):
+        backend = _ThirdPartyBackendWithoutTrace()
+        bridge = _make_bridge(backend=backend, version=4)
+        original_parse = backend.parse_generation_response
+
+        async def mock_send(http_req, **kwargs):
+            bridge.set_version(5)
+            return _make_sglang_response([(-0.5, 100), (-0.3, 101)], "stop")
+
+        def parse_and_advance_version(response):
+            bridge.set_version(6)
+            return original_parse(response)
+
+        backend.parse_generation_response = parse_and_advance_version
+        bridge._send_request = mock_send
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=3)
+        req.rid = "trace-parser-version"
+
+        resp, trace = await bridge.agenerate_with_trace(req)
+
+        attempt = trace.attempts[0]
+        assert attempt.client_version_before_send == 4
+        assert attempt.client_version_after_receive == 5
+        assert attempt.output_version_label == 6
+        assert trace.final_client_version == 6
+        reconstructed_versions = [
+            attempt.output_version_label
+            for attempt in trace.attempts
+            for _ in attempt.output_token_ids
+        ]
+        assert reconstructed_versions == [6, 6]
+        assert reconstructed_versions == resp.output_versions
+        validate_generation_physical_trace_response(resp, trace)
+
+        resp.output_versions = [5, 5]
+        with pytest.raises(ValueError, match="response.output_versions"):
+            validate_generation_physical_trace_response(resp, trace)
+
+    @pytest.mark.asyncio
+    async def test_output_version_label_preserves_legacy_post_extend_read_point(self):
+        class VersionChangingList(list):
+            def __init__(self, values, callback):
+                super().__init__(values)
+                self._callback = callback
+
+            def __iter__(self):
+                self._callback()
+                return super().__iter__()
+
+        async def run(*, traced: bool):
+            backend = _ThirdPartyBackendWithoutTrace()
+            bridge = _make_bridge(backend=backend, version=1)
+
+            def parse_with_version_changes(response):
+                return HttpGenerationResult(
+                    output_tokens=VersionChangingList(
+                        [100], lambda: bridge.set_version(8)
+                    ),
+                    output_logprobs=VersionChangingList(
+                        [-0.5], lambda: bridge.set_version(9)
+                    ),
+                    stop_reason="stop",
+                )
+
+            backend.parse_generation_response = parse_with_version_changes
+            bridge._send_request = AsyncMock(
+                return_value=_make_sglang_response([(-0.5, 100)], "stop")
+            )
+            req = _make_request(input_ids=[1, 2, 3], max_new_tokens=3)
+            req.rid = f"trace-post-extend-{traced}"
+            if traced:
+                return await bridge.agenerate_with_trace(req)
+            return await bridge.agenerate(req), None
+
+        legacy_resp, _ = await run(traced=False)
+        traced_resp, trace = await run(traced=True)
+
+        assert legacy_resp.output_versions == [9]
+        assert traced_resp.output_versions == [9]
+        assert trace is not None
+        assert trace.attempts[0].output_version_label == 9
+
+    @pytest.mark.parametrize(
+        "field_name,error_type",
+        [
+            ("input_tokens", ValueError),
+            ("output_tokens", ValueError),
+            ("output_versions", TypeError),
+        ],
+    )
+    @pytest.mark.parametrize("forged_value", [True, 1.0], ids=["bool", "float"])
+    @pytest.mark.asyncio
+    async def test_response_binding_rejects_equal_but_wrongly_typed_integers(
+        self,
+        field_name: str,
+        error_type: type[Exception],
+        forged_value: object,
+    ):
+        bridge = _make_bridge(version=1)
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.5, 1)], "stop")
+        )
+        req = _make_request(input_ids=[1], max_new_tokens=1)
+        req.rid = f"trace-wrong-type-{field_name}"
+        resp, trace = await bridge.agenerate_with_trace(req)
+        validate_generation_physical_trace_response(resp, trace)
+
+        setattr(resp, field_name, [forged_value])
+
+        with pytest.raises(error_type, match=rf"response\.{field_name}"):
+            validate_generation_physical_trace_response(resp, trace)
+
+    @pytest.mark.asyncio
+    async def test_vllm_text_trace_snapshots_submitted_prompt_token_ids(self):
+        bridge = _make_bridge(backend=VLLMBridgeBackend())
+        bridge._send_request = AsyncMock(
+            return_value=_make_vllm_response([100], [-0.5], "stop")
+        )
+        req = _make_request(input_ids=[11, 12], max_new_tokens=3)
+        req.rid = "trace-vllm-text"
+
+        _, trace = await bridge.agenerate_with_trace(req)
+
+        assert trace.backend_kind == "VLLMBridgeBackend"
+        assert trace.attempts[0].endpoint == "/v1/completions"
+        assert trace.attempts[0].submitted_input_token_ids == (11, 12)
+
+    @pytest.mark.asyncio
+    async def test_vllm_vision_trace_marks_physical_token_ids_unobservable(self):
+        bridge = _make_bridge(backend=VLLMBridgeBackend())
+        bridge._send_request = AsyncMock(
+            return_value=_make_vllm_response([100], [-0.5], "stop")
+        )
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=3)
+        req.rid = "trace-vllm-vision"
+        req.vision_msg_vllm = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "placeholder"},
+                        },
+                    ],
+                }
+            ]
+        ]
+        req.image_data = ["iVBOR-test-data"]
+        original_vision_messages = deepcopy(req.vision_msg_vllm)
+        original_image_data = deepcopy(req.image_data)
+
+        _, trace = await bridge.agenerate_with_trace(req)
+
+        assert trace.attempts[0].endpoint == "/v1/chat/completions"
+        assert trace.request_input_token_ids == (1, 2, 3)
+        assert trace.attempts[0].submitted_input_token_ids is None
+        assert req.vision_msg_vllm == original_vision_messages
+        assert req.image_data == original_image_data
+
+    @pytest.mark.asyncio
+    async def test_third_party_backend_without_optional_trace_hook_remains_compatible(
+        self,
+    ):
+        backend = _ThirdPartyBackendWithoutTrace()
+        assert not isinstance(backend, TraceableInfBridgeBackend)
+
+        bridge = _make_bridge(backend=backend)
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.5, 100)], "stop")
+        )
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=3)
+        req.rid = "trace-third-party"
+
+        resp, trace = await bridge.agenerate_with_trace(req)
+
+        assert resp.output_tokens == [100]
+        assert trace.backend_kind == "_ThirdPartyBackendWithoutTrace"
+        assert trace.attempts[0].submitted_input_token_ids is None
+        assert trace.effective_max_new_tokens == 3
+        assert trace.configured_attempt_limit == 20
+
+    @pytest.mark.asyncio
+    async def test_trace_records_effective_post_method_for_non_get_request_label(self):
+        backend = _ThirdPartyBackendWithoutTrace()
+        original_build = backend.build_generation_request
+
+        def build_with_put_method(req, with_lora, version=-1):
+            http_req = original_build(req, with_lora, version)
+            http_req.method = "PUT"
+            return http_req
+
+        backend.build_generation_request = build_with_put_method
+        bridge = _make_bridge(backend=backend)
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.5, 100)], "stop")
+        )
+
+        _, trace = await bridge.agenerate_with_trace(
+            _make_request(input_ids=[1, 2, 3], max_new_tokens=3)
+        )
+
+        assert bridge._send_request.await_args.args[0].method == "PUT"
+        assert trace.attempts[0].method == "POST"
+
+    @pytest.mark.asyncio
+    async def test_traced_api_rejects_corrupt_prepared_budget_before_transport(self):
+        backend = _ThirdPartyBackendWithoutTrace()
+        original_patch = backend.patch_generation_request
+
+        def patch_with_wrong_budget(
+            http_req,
+            req,
+            accumulated_tokens,
+            remaining_tokens,
+        ):
+            original_patch(http_req, req, accumulated_tokens, remaining_tokens)
+            http_req.payload["sampling_params"]["max_new_tokens"] = remaining_tokens - 1
+
+        backend.patch_generation_request = patch_with_wrong_budget
+        bridge = _make_bridge(backend=backend)
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.5, 100)], "stop")
+        )
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=3)
+
+        with pytest.raises(ValueError, match="patched backend max_new_tokens"):
+            await bridge.agenerate_with_trace(req)
+        bridge._send_request.assert_not_awaited()
+
+        legacy_resp = await bridge.agenerate(req)
+        assert legacy_resp.output_tokens == [100]
+        assert legacy_resp.stop_reason == "stop"
+        bridge._send_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_traced_api_propagates_transport_runtime_error_unchanged(self):
+        transport_error = RuntimeError("transport failed")
+        bridge = _make_bridge()
+        bridge._send_request = AsyncMock(side_effect=transport_error)
+
+        with pytest.raises(RuntimeError, match="transport failed") as caught:
+            await bridge.agenerate_with_trace(_make_request(max_new_tokens=3))
+
+        assert caught.value is transport_error
+        bridge._send_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_traced_api_propagates_backend_parse_error_unchanged(self):
+        parse_error = ValueError("backend parse failed")
+        backend = _ThirdPartyBackendWithoutTrace()
+
+        def fail_parse(response):
+            raise parse_error
+
+        backend.parse_generation_response = fail_parse
+        bridge = _make_bridge(backend=backend)
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.5, 100)], "stop")
+        )
+
+        with pytest.raises(ValueError, match="backend parse failed") as caught:
+            await bridge.agenerate_with_trace(_make_request(max_new_tokens=3))
+
+        assert caught.value is parse_error
+        bridge._send_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_traced_api_propagates_cancellation_unchanged(self):
+        cancellation = asyncio.CancelledError("generation cancelled")
+        bridge = _make_bridge()
+        bridge._send_request = AsyncMock(side_effect=cancellation)
+
+        with pytest.raises(asyncio.CancelledError) as caught:
+            await bridge.agenerate_with_trace(_make_request(max_new_tokens=3))
+
+        assert caught.value is cancellation
+        bridge._send_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_trace_snapshots_request_and_attempt_config_before_transport(self):
+        call_count = 0
+        bridge = _make_bridge(max_resubmit_retries=2)
+        req = _make_request(input_ids=[1, 2], max_new_tokens=5)
+        req.rid = "trace-original-request"
+
+        async def mutate_original_state_during_send(http_req, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                req.rid = "trace-mutated-request"
+                req.input_ids[:] = [9, 9, 9]
+                bridge.max_resubmit_retries = 99
+                return _make_sglang_response([(-0.5, 100)], "abort")
+            return _make_sglang_response([(-0.2, 200)], "stop")
+
+        bridge._send_request = mutate_original_state_during_send
+
+        resp, trace = await bridge.agenerate_with_trace(req)
+
+        assert call_count == 2
+        assert req.rid == "trace-mutated-request"
+        assert req.input_ids == [9, 9, 9]
+        assert bridge.max_resubmit_retries == 99
+        assert resp.input_tokens == [1, 2]
+        assert resp.output_tokens == [100, 200]
+        assert trace.request_id == "trace-original-request"
+        assert trace.request_input_token_ids == (1, 2)
+        assert trace.configured_attempt_limit == 2
+        assert trace.effective_max_new_tokens == 5
+        assert [attempt.submitted_input_token_ids for attempt in trace.attempts] == [
+            (1, 2),
+            (1, 2, 100),
+        ]
+
+    @pytest.mark.parametrize(
+        "backend,payload_key",
+        [
+            (SGLangBridgeBackend(), "input_ids"),
+            (VLLMBridgeBackend(), "prompt"),
+        ],
+        ids=["sglang", "vllm"],
+    )
+    @pytest.mark.parametrize("bad_token", [True, -1], ids=["bool", "negative"])
+    def test_builtin_backend_snapshot_rejects_invalid_token_ids(
+        self,
+        backend: SGLangBridgeBackend | VLLMBridgeBackend,
+        payload_key: str,
+        bad_token: object,
+    ):
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=3)
+        http_req = backend.build_generation_request(req, with_lora=False, version=0)
+        http_req.payload[payload_key] = [bad_token]
+
+        with pytest.raises(ValueError, match="non-negative ints"):
+            backend.snapshot_generation_input_ids(http_req)
+
+    @pytest.mark.asyncio
+    async def test_zero_attempt_limit_produces_valid_zero_attempt_trace(self):
+        bridge = _make_bridge(max_resubmit_retries=0, version=9)
+        bridge._send_request = AsyncMock()
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=5)
+        req.rid = "trace-zero-attempt-limit"
+
+        resp, trace = await bridge.agenerate_with_trace(req)
+
+        bridge._send_request.assert_not_awaited()
+        assert resp.output_tokens == []
+        assert resp.output_logprobs == []
+        assert resp.stop_reason == "length"
+        assert trace.effective_max_new_tokens == 5
+        assert trace.configured_attempt_limit == 0
+        assert trace.attempts == ()
+        assert trace.final_output_token_ids == ()
+        assert trace.initial_client_version == 9
+        assert trace.final_client_version == 9
+        assert trace.final_stop_reason == "length"
+        assert trace.terminal_reason == "attempt_limit"
+        assert json.loads(generation_physical_trace_bytes(trace))["attempts"] == []
+
+    @pytest.mark.asyncio
+    async def test_trace_validation_rejects_forged_or_wrongly_typed_evidence(self):
+        bridge = _make_bridge()
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.5, 100)], "stop")
+        )
+        req = _make_request(input_ids=[1, 2, 3], max_new_tokens=3)
+        req.rid = "trace-validation"
+        _, trace = await bridge.agenerate_with_trace(req)
+
+        with pytest.raises(ValueError, match="final_output_token_ids"):
+            generation_physical_trace_bytes(
+                replace(trace, final_output_token_ids=(999,))
+            )
+        with pytest.raises(TypeError, match="initial_client_version"):
+            generation_physical_trace_bytes(replace(trace, initial_client_version=True))
+        with pytest.raises(ValueError, match="prepared_request_json_sha256"):
+            bad_attempt = replace(
+                trace.attempts[0], prepared_request_json_sha256="not-a-sha256"
+            )
+            generation_physical_trace_bytes(replace(trace, attempts=(bad_attempt,)))
+        with pytest.raises(ValueError, match="remaining_new_tokens"):
+            generation_physical_trace_bytes(replace(trace, effective_max_new_tokens=4))
+        with pytest.raises(ValueError, match="configured_attempt_limit"):
+            generation_physical_trace_bytes(replace(trace, configured_attempt_limit=0))
+        with pytest.raises(ValueError, match="remaining_new_tokens"):
+            bad_attempt = replace(trace.attempts[0], remaining_new_tokens=2)
+            generation_physical_trace_bytes(replace(trace, attempts=(bad_attempt,)))
+        with pytest.raises(ValueError, match="configured_attempt_limit"):
+            generation_physical_trace_bytes(
+                replace(
+                    trace,
+                    attempts=(),
+                    final_client_version=trace.initial_client_version,
+                    final_output_token_ids=(),
+                    final_stop_reason="length",
+                    terminal_reason="attempt_limit",
+                )
+            )
+
+        with pytest.raises(FrozenInstanceError):
+            trace.final_stop_reason = "length"
+        with pytest.raises(FrozenInstanceError):
+            trace.attempts[0].raw_stop_reason = "abort"
+
+    @pytest.mark.asyncio
+    async def test_legacy_agenerate_still_returns_plain_model_response(self):
+        bridge = _make_bridge()
+        bridge._send_request = AsyncMock(
+            return_value=_make_sglang_response([(-0.5, 100)], "stop")
+        )
+
+        resp = await bridge.agenerate(_make_request(input_ids=[1, 2, 3]))
+
+        assert isinstance(resp, ModelResponse)
+        assert not isinstance(resp, tuple)
+        assert not hasattr(resp, "generation_trace")

--- a/tests/v2/inference_service/test_inf_bridge_trace.py
+++ b/tests/v2/inference_service/test_inf_bridge_trace.py
@@ -41,6 +41,7 @@ from areal.v2.inference_service.client_trace import (
     validate_generation_physical_trace_response,
     validate_generation_response_evidence,
 )
+from areal.v2.inference_service.inf_bridge import GenerationTraceValidationError
 from areal.v2.inference_service.sglang.bridge import SGLangBridgeBackend
 from areal.v2.inference_service.vllm.bridge import VLLMBridgeBackend
 
@@ -535,7 +536,10 @@ class TestInfBridgePhysicalTrace:
         req = _make_request(input_ids=[1, 2], max_new_tokens=8)
         req.rid = "trace-over-budget"
 
-        with pytest.raises(ValueError, match="cannot exceed remaining_new_tokens"):
+        with pytest.raises(
+            GenerationTraceValidationError,
+            match="cannot exceed remaining_new_tokens",
+        ):
             await bridge.agenerate_with_trace(req)
 
         legacy = await bridge.agenerate(req)

--- a/tests/v2/inference_service/test_inf_bridge_trace.py
+++ b/tests/v2/inference_service/test_inf_bridge_trace.py
@@ -887,19 +887,51 @@ class TestInfBridgePhysicalTrace:
         bridge._send_request.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_trace_snapshots_request_and_attempt_config_before_transport(self):
+    async def test_trace_snapshots_request_and_attempt_config_before_transport(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         call_count = 0
         bridge = _make_bridge(max_resubmit_retries=2)
+        original_pause_state = bridge.pause_state
+        replacement_pause_state = type(original_pause_state)()
         req = _make_request(input_ids=[1, 2], max_new_tokens=5)
         req.rid = "trace-original-request"
+        observed_timeouts: list[float] = []
+        observed_sleeps: list[float] = []
+        pause_check_count = 0
+
+        async def original_is_paused():
+            nonlocal pause_check_count
+            pause_check_count += 1
+            return pause_check_count == 2
+
+        replacement_is_paused = AsyncMock(
+            side_effect=AssertionError("replacement pause state must not be observed")
+        )
+
+        async def record_sleep(delay: float):
+            observed_sleeps.append(delay)
+
+        monkeypatch.setattr(original_pause_state, "is_paused", original_is_paused)
+        monkeypatch.setattr(
+            replacement_pause_state,
+            "is_paused",
+            replacement_is_paused,
+        )
+        monkeypatch.setattr(asyncio, "sleep", record_sleep)
 
         async def mutate_original_state_during_send(http_req, **kwargs):
             nonlocal call_count
             call_count += 1
+            observed_timeouts.append(kwargs["timeout"])
             if call_count == 1:
                 req.rid = "trace-mutated-request"
                 req.input_ids[:] = [9, 9, 9]
                 bridge.max_resubmit_retries = 99
+                bridge.request_timeout = 1e-6
+                bridge.resubmit_wait = 999.0
+                bridge.pause_state = replacement_pause_state
                 return _make_sglang_response([(-0.5, 100)], "abort")
             return _make_sglang_response([(-0.2, 200)], "stop")
 
@@ -911,6 +943,9 @@ class TestInfBridgePhysicalTrace:
         assert req.rid == "trace-mutated-request"
         assert req.input_ids == [9, 9, 9]
         assert bridge.max_resubmit_retries == 99
+        assert observed_timeouts == [120.0, 120.0]
+        assert observed_sleeps == [0.01]
+        assert replacement_is_paused.await_count == 0
         assert resp.input_tokens == [1, 2]
         assert resp.output_tokens == [100, 200]
         assert trace.request_id == "trace-original-request"


### PR DESCRIPTION
## Summary

- add opt-in `InfBridge.agenerate_with_trace()` without changing the existing async generation protocol
- record immutable schema-v2 client-local observations for every physical attempt, including abort/resubmit history, effective token budgets, stop/terminal reasons, submitted token IDs when observable, and client version labels plus monotonic update epochs
- content-address locally prepared request JSON and locally parsed response JSON with domain-separated canonical hashes, plus frozen trace bytes, strict loaders, and a response-binding validator
- add `agenerate_with_trace_and_response_evidence()` for an optional, separately retained canonical response-JSON sidecar that supports offline backend-parser replay without enlarging the compact trace by default
- reject traced server outputs that exceed the frozen remaining-token budget while preserving legacy `agenerate()` behavior
- add an optional `TraceableInfBridgeBackend` capability; built-in SGLang and vLLM text backends snapshot submitted IDs, while vLLM vision honestly reports them as unavailable

## Why

Memory and agent-evolution experiments need to distinguish a declared model call from the requests the client actually prepared, retried, received, and parsed. The current response object flattens abort/resubmit attempts, so downstream evaluation cannot audit attrition or retry behavior. A response hash alone is also insufficient for offline parser replay, which is why the full canonical response preimage is available as an explicit sensitive-data sidecar.

Version labels alone have an ABA blind spot: a local version may change A→B→A during one transport await. The monotonic update epoch exposes calls to `set_version()` even when the final label returns to A.

This PR deliberately provides **client-local evidence only**. It does not authenticate the remote server, deployed model, or model weights; the request ID is not proven to have been transmitted or echoed. Hashes and sidecars establish internal replay consistency, not tamper resistance against an actor who can rewrite the whole artifact. Remote attestation would require a separate server protocol such as nonce/idempotency echo plus model/weight identity.

## Compatibility and data handling

- existing `InfBridge.agenerate()` behavior and `ModelResponse` shape remain unchanged
- `agenerate_with_trace()` remains a two-tuple; the response sidecar uses a separate three-tuple API
- the existing `InfBridgeBackend` protocol remains unchanged
- third-party backends without the optional snapshot capability continue to work and record `submitted_input_token_ids=None`
- transport, parser, hash, and cancellation errors propagate instead of producing a misleading completed trace
- response evidence can include generated text and server metadata; its raw bytes are excluded from default dataclass repr and require prompt-equivalent access, encryption, and retention controls
- strict `from_bytes` loaders reject duplicate keys, non-canonical JSON, unknown fields, wrong kinds/schemas, and bool/int type confusion

## Validation

- `pytest -q tests/v2/inference_service/test_inf_bridge.py tests/v2/inference_service/test_inf_bridge_trace.py` — 65 passed
- broader local v2 inference unit slice — 348 passed, 5 skipped, 4 deselected
- the four deselected `TestOnlineCallbackFlow` cases fail identically on `origin/main` in this macOS environment because the generated `28.0.0.1` callback address is unreachable
- Ruff format/check, `git diff --check`, and all configured pre-commit hooks passed
- independent scientific-claim and code reviews found no remaining P0/P1/P2 issues
