### PR TITLE
[codex] add evidence-grounded Memory candidate revisions

### DIFF
--- a/areal/v2/memory_service/__init__.py
+++ b/areal/v2/memory_service/__init__.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public contracts for immutable Memory Service evidence."""
+
+from areal.v2.memory_service.errors import (
+    EvidenceConflictError,
+    EvidenceNotFoundError,
+    MemoryServiceError,
+)
+from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+__all__ = [
+    "EvidenceConflictError",
+    "EvidenceEvent",
+    "EvidenceKind",
+    "EvidenceNotFoundError",
+    "EvidenceRecord",
+    "EvidenceStore",
+    "InMemoryEvidenceStore",
+    "MemoryScope",
+    "MemoryServiceError",
+]

--- a/areal/v2/memory_service/__init__.py
+++ b/areal/v2/memory_service/__init__.py
@@ -1,11 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Public contracts for immutable Memory Service evidence."""
+"""Public contracts for immutable Memory Service evidence and history."""
 
 from areal.v2.memory_service.errors import (
+    CandidateConflictError,
+    CandidateNotFoundError,
     EvidenceConflictError,
     EvidenceNotFoundError,
     MemoryServiceError,
+    RevisionConflictError,
+    RevisionNotFoundError,
+)
+from areal.v2.memory_service.history_store import (
+    InMemoryMemoryHistoryStore,
+    MemoryHistoryStore,
+)
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
 )
 from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
@@ -16,6 +31,9 @@ from areal.v2.memory_service.types import (
 )
 
 __all__ = [
+    "CandidateConflictError",
+    "CandidateNotFoundError",
+    "CandidateProposal",
     "EvidenceConflictError",
     "EvidenceEvent",
     "EvidenceKind",
@@ -23,6 +41,14 @@ __all__ = [
     "EvidenceRecord",
     "EvidenceStore",
     "InMemoryEvidenceStore",
+    "InMemoryMemoryHistoryStore",
+    "MemoryCandidate",
+    "MemoryHistoryStore",
+    "MemoryRevision",
     "MemoryScope",
     "MemoryServiceError",
+    "RevisionConflictError",
+    "RevisionNotFoundError",
+    "RevisionOperation",
+    "RevisionProposal",
 ]

--- a/areal/v2/memory_service/_atomic.py
+++ b/areal/v2/memory_service/_atomic.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small rollback helper for process-local multi-index publication."""
+
+from __future__ import annotations
+
+_MISSING = object()
+
+
+def _atomic_publish(
+    *,
+    mapping_writes: tuple[tuple[dict, object, object], ...],
+    sequence_appends: tuple[tuple[dict, object, object], ...] = (),
+) -> None:
+    """Publish mapping writes and indexed list appends as one local unit.
+
+    The helper deliberately catches ``BaseException`` because cancellation,
+    ``KeyboardInterrupt``, and allocation failures must not leave only some
+    indexes visible.  Rollback is best-effort for hostile test doubles; normal
+    built-in dictionaries and lists restore their exact prior state.
+    """
+
+    undo: list[tuple[str, object, object, object]] = []
+    try:
+        for mapping, key, value in mapping_writes:
+            previous = mapping.get(key, _MISSING)
+            undo.append(("mapping", mapping, key, previous))
+            mapping[key] = value
+        for mapping, key, value in sequence_appends:
+            sequence = mapping.get(key, _MISSING)
+            if sequence is _MISSING:
+                undo.append(("mapping", mapping, key, _MISSING))
+                mapping[key] = [value]
+                continue
+            if type(sequence) is not list:
+                raise TypeError("indexed publication sequence must be a list")
+            undo.append(("sequence", sequence, len(sequence), _MISSING))
+            sequence.append(value)
+    except BaseException:
+        for kind, target, key_or_length, previous in reversed(undo):
+            try:
+                if kind == "sequence":
+                    del target[key_or_length:]
+                elif previous is _MISSING:
+                    target.pop(key_or_length, None)
+                else:
+                    target[key_or_length] = previous
+            except BaseException:
+                pass
+        raise

--- a/areal/v2/memory_service/_atomic.py
+++ b/areal/v2/memory_service/_atomic.py
@@ -16,8 +16,9 @@ def _atomic_publish(
 
     The helper deliberately catches ``BaseException`` because cancellation,
     ``KeyboardInterrupt``, and allocation failures must not leave only some
-    indexes visible.  Rollback is best-effort for hostile test doubles; normal
-    built-in dictionaries and lists restore their exact prior state.
+    indexes visible.  Store indexes are private built-in dictionaries and
+    lists.  Rollback calls the built-in mutation methods directly so a fault-
+    injection subclass cannot interrupt both publication and its own undo.
     """
 
     undo: list[tuple[str, object, object, object]] = []
@@ -40,11 +41,14 @@ def _atomic_publish(
         for kind, target, key_or_length, previous in reversed(undo):
             try:
                 if kind == "sequence":
-                    del target[key_or_length:]
+                    list.__delitem__(target, slice(key_or_length, None))
                 elif previous is _MISSING:
-                    target.pop(key_or_length, None)
+                    dict.pop(target, key_or_length, None)
                 else:
-                    target[key_or_length] = previous
+                    dict.__setitem__(target, key_or_length, previous)
             except BaseException:
+                # A second process-level interruption can still make rollback
+                # impossible.  Continue undoing the other independent indexes
+                # and preserve the original publication exception.
                 pass
         raise

--- a/areal/v2/memory_service/errors.py
+++ b/areal/v2/memory_service/errors.py
@@ -2,6 +2,8 @@
 
 """Errors raised by the Memory Service."""
 
+from __future__ import annotations
+
 
 class MemoryServiceError(Exception):
     """Base class for Memory Service failures."""
@@ -13,3 +15,11 @@ class EvidenceNotFoundError(MemoryServiceError):
 
 class EvidenceConflictError(MemoryServiceError):
     """Raised when evidence conflicts with an existing immutable record."""
+
+
+class CandidateNotFoundError(MemoryServiceError):
+    """Raised when a candidate is unavailable in the requested scope."""
+
+
+class CandidateConflictError(MemoryServiceError):
+    """Raised when a candidate write conflicts with immutable history."""

--- a/areal/v2/memory_service/errors.py
+++ b/areal/v2/memory_service/errors.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Errors raised by the Memory Service."""
+
+
+class MemoryServiceError(Exception):
+    """Base class for Memory Service failures."""
+
+
+class EvidenceNotFoundError(MemoryServiceError):
+    """Raised when requested evidence is unavailable in the requested scope."""
+
+
+class EvidenceConflictError(MemoryServiceError):
+    """Raised when evidence conflicts with an existing immutable record."""

--- a/areal/v2/memory_service/errors.py
+++ b/areal/v2/memory_service/errors.py
@@ -23,3 +23,11 @@ class CandidateNotFoundError(MemoryServiceError):
 
 class CandidateConflictError(MemoryServiceError):
     """Raised when a candidate write conflicts with immutable history."""
+
+
+class RevisionNotFoundError(MemoryServiceError):
+    """Raised when a revision is unavailable in the requested scope."""
+
+
+class RevisionConflictError(MemoryServiceError):
+    """Raised when a revision write conflicts with immutable history."""

--- a/areal/v2/memory_service/history_store.py
+++ b/areal/v2/memory_service/history_store.py
@@ -12,10 +12,15 @@ from typing import Protocol
 from areal.v2.memory_service.errors import (
     CandidateConflictError,
     CandidateNotFoundError,
+    RevisionConflictError,
+    RevisionNotFoundError,
 )
 from areal.v2.memory_service.history_types import (
     CandidateProposal,
     MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
 )
 from areal.v2.memory_service.store import EvidenceStore
 from areal.v2.memory_service.types import (
@@ -26,7 +31,7 @@ from areal.v2.memory_service.types import (
 
 
 class MemoryHistoryStore(Protocol):
-    """Storage contract for immutable memory candidates."""
+    """Storage contract for immutable memory candidates and revisions."""
 
     def append_candidate(self, proposal: CandidateProposal) -> MemoryCandidate:
         """Persist one evidence-grounded candidate."""
@@ -50,9 +55,26 @@ class MemoryHistoryStore(Protocol):
 
         ...
 
+    def append_revision(self, proposal: RevisionProposal) -> MemoryRevision:
+        """Persist one immutable candidate transition."""
+
+        ...
+
+    def get_revision(self, scope: MemoryScope, revision_id: str) -> MemoryRevision:
+        """Return one scoped revision."""
+
+        ...
+
+    def list_revisions(
+        self, scope: MemoryScope, *, memory_id: str | None = None
+    ) -> tuple[MemoryRevision, ...]:
+        """Return parent-before-child immutable revisions."""
+
+        ...
+
 
 class InMemoryMemoryHistoryStore:
-    """Lock-protected process-local storage for immutable memory candidates."""
+    """Lock-protected process-local immutable memory history."""
 
     def __init__(self, evidence_store: EvidenceStore) -> None:
         self._evidence_store = evidence_store
@@ -62,6 +84,12 @@ class InMemoryMemoryHistoryStore:
             tuple[MemoryScope, str], MemoryCandidate
         ] = {}
         self._candidates_by_scope: dict[MemoryScope, list[MemoryCandidate]] = {}
+        self._revision_by_id: dict[tuple[MemoryScope, str], MemoryRevision] = {}
+        self._revision_by_idempotency: dict[
+            tuple[MemoryScope, str], MemoryRevision
+        ] = {}
+        self._revision_by_candidate: dict[tuple[MemoryScope, str], MemoryRevision] = {}
+        self._revisions_by_scope: dict[MemoryScope, list[MemoryRevision]] = {}
 
     def append_candidate(self, proposal: CandidateProposal) -> MemoryCandidate:
         """Persist a candidate after validating all referenced evidence."""
@@ -149,5 +177,115 @@ class InMemoryMemoryHistoryStore:
                 sorted(
                     self._candidates_by_scope.get(scope, ()),
                     key=lambda item: item.candidate_id,
+                )
+            )
+
+    def append_revision(self, proposal: RevisionProposal) -> MemoryRevision:
+        """Persist one immutable candidate transition."""
+
+        if type(proposal) is not RevisionProposal:
+            raise TypeError("proposal must be a RevisionProposal")
+        canonical_bytes = proposal.canonical_bytes()
+        content_hash = hashlib.sha256(canonical_bytes).hexdigest()
+        revision_id = f"rev_{content_hash[:24]}"
+        revision_index = (proposal.scope, revision_id)
+        idempotency_index = (proposal.scope, proposal.idempotency_key)
+        candidate_index = (proposal.scope, proposal.candidate_id)
+
+        with self._lock:
+            existing = self._revision_by_idempotency.get(idempotency_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise RevisionConflictError(
+                    "scoped revision idempotency key already refers to different content"
+                )
+
+            existing = self._revision_by_id.get(revision_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise RevisionConflictError(
+                    f"revision ID collision for {revision_id!r}"
+                )
+
+            candidate = self._candidate_by_id.get(candidate_index)
+            if candidate is None:
+                raise CandidateNotFoundError(
+                    f"candidate {proposal.candidate_id!r} was not found"
+                )
+            if candidate_index in self._revision_by_candidate:
+                raise RevisionConflictError(
+                    f"candidate {proposal.candidate_id!r} already backs a revision"
+                )
+
+            if proposal.operation is RevisionOperation.ADD:
+                memory_id = f"mem_{content_hash[:24]}"
+                generation = 0
+            else:
+                assert proposal.parent_revision_id is not None
+                parent = self._revision_by_id.get(
+                    (proposal.scope, proposal.parent_revision_id)
+                )
+                if parent is None:
+                    raise RevisionNotFoundError(
+                        f"revision {proposal.parent_revision_id!r} was not found"
+                    )
+                if parent.generation == 2**63 - 1:
+                    raise RevisionConflictError(
+                        "revision generation exceeds the signed-64 range"
+                    )
+                memory_id = parent.memory_id
+                generation = parent.generation + 1
+
+            revision = MemoryRevision(
+                revision_id=revision_id,
+                memory_id=memory_id,
+                generation=generation,
+                proposal=proposal,
+                content_hash=content_hash,
+                created_at=datetime.now(UTC),
+            )
+            self._revision_by_id[revision_index] = revision
+            self._revision_by_idempotency[idempotency_index] = revision
+            self._revision_by_candidate[candidate_index] = revision
+            self._revisions_by_scope.setdefault(proposal.scope, []).append(revision)
+            return revision
+
+    def get_revision(self, scope: MemoryScope, revision_id: str) -> MemoryRevision:
+        """Return a revision only when it belongs to the requested scope."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        revision_id = _validate_string(revision_id, "revision_id", allow_blank=True)
+        with self._lock:
+            revision = self._revision_by_id.get((scope, revision_id))
+            if revision is None:
+                raise RevisionNotFoundError(f"revision {revision_id!r} was not found")
+            return revision
+
+    def list_revisions(
+        self, scope: MemoryScope, *, memory_id: str | None = None
+    ) -> tuple[MemoryRevision, ...]:
+        """Return a stable, parent-before-child revision snapshot."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        if memory_id is not None:
+            memory_id = _validate_string(memory_id, "memory_id", allow_blank=True)
+        with self._lock:
+            matches = (
+                revision
+                for revision in self._revisions_by_scope.get(scope, ())
+                if memory_id is None or revision.memory_id == memory_id
+            )
+            return tuple(
+                sorted(
+                    matches,
+                    key=lambda item: (
+                        item.memory_id,
+                        item.generation,
+                        item.revision_id,
+                    ),
                 )
             )

--- a/areal/v2/memory_service/history_store.py
+++ b/areal/v2/memory_service/history_store.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""History storage contracts and an in-memory reference implementation."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from threading import RLock
+from typing import Protocol
+
+from areal.v2.memory_service.errors import (
+    CandidateConflictError,
+    CandidateNotFoundError,
+)
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+)
+from areal.v2.memory_service.store import EvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceRecord,
+    MemoryScope,
+    _validate_string,
+)
+
+
+class MemoryHistoryStore(Protocol):
+    """Storage contract for immutable memory candidates."""
+
+    def append_candidate(self, proposal: CandidateProposal) -> MemoryCandidate:
+        """Persist one evidence-grounded candidate."""
+
+        ...
+
+    def get_candidate(self, scope: MemoryScope, candidate_id: str) -> MemoryCandidate:
+        """Return one scoped candidate."""
+
+        ...
+
+    def get_candidate_evidence(
+        self, scope: MemoryScope, candidate_id: str
+    ) -> tuple[EvidenceRecord, ...]:
+        """Resolve candidate evidence in proposal order."""
+
+        ...
+
+    def list_candidates(self, scope: MemoryScope) -> tuple[MemoryCandidate, ...]:
+        """Return candidates in stable identifier order."""
+
+        ...
+
+
+class InMemoryMemoryHistoryStore:
+    """Lock-protected process-local storage for immutable memory candidates."""
+
+    def __init__(self, evidence_store: EvidenceStore) -> None:
+        self._evidence_store = evidence_store
+        self._lock = RLock()
+        self._candidate_by_id: dict[tuple[MemoryScope, str], MemoryCandidate] = {}
+        self._candidate_by_idempotency: dict[
+            tuple[MemoryScope, str], MemoryCandidate
+        ] = {}
+        self._candidates_by_scope: dict[MemoryScope, list[MemoryCandidate]] = {}
+
+    def append_candidate(self, proposal: CandidateProposal) -> MemoryCandidate:
+        """Persist a candidate after validating all referenced evidence."""
+
+        if type(proposal) is not CandidateProposal:
+            raise TypeError("proposal must be a CandidateProposal")
+        canonical_bytes = proposal.canonical_bytes()
+        content_hash = hashlib.sha256(canonical_bytes).hexdigest()
+        candidate_id = f"cand_{content_hash[:24]}"
+        candidate_index = (proposal.scope, candidate_id)
+        idempotency_index = (proposal.scope, proposal.idempotency_key)
+
+        with self._lock:
+            existing = self._candidate_by_idempotency.get(idempotency_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise CandidateConflictError(
+                    "scoped candidate idempotency key already refers to different content"
+                )
+
+        # Evidence is append-only, so this outside-lock preflight cannot be invalidated.
+        for evidence_id in proposal.evidence_ids:
+            self._evidence_store.get(proposal.scope, evidence_id)
+
+        with self._lock:
+            # Mandatory recheck closes the validation/insertion race.
+            existing = self._candidate_by_idempotency.get(idempotency_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise CandidateConflictError(
+                    "scoped candidate idempotency key already refers to different content"
+                )
+            existing = self._candidate_by_id.get(candidate_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise CandidateConflictError(
+                    f"candidate ID collision for {candidate_id!r}"
+                )
+            candidate = MemoryCandidate(
+                candidate_id=candidate_id,
+                proposal=proposal,
+                content_hash=content_hash,
+                created_at=datetime.now(UTC),
+            )
+            self._candidate_by_id[candidate_index] = candidate
+            self._candidate_by_idempotency[idempotency_index] = candidate
+            self._candidates_by_scope.setdefault(proposal.scope, []).append(candidate)
+            return candidate
+
+    def get_candidate(self, scope: MemoryScope, candidate_id: str) -> MemoryCandidate:
+        """Return a candidate only when it belongs to the requested scope."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        candidate_id = _validate_string(candidate_id, "candidate_id", allow_blank=True)
+        with self._lock:
+            candidate = self._candidate_by_id.get((scope, candidate_id))
+            if candidate is None:
+                raise CandidateNotFoundError(
+                    f"candidate {candidate_id!r} was not found"
+                )
+            return candidate
+
+    def get_candidate_evidence(
+        self, scope: MemoryScope, candidate_id: str
+    ) -> tuple[EvidenceRecord, ...]:
+        """Resolve a candidate's evidence in its proposal order."""
+
+        candidate = self.get_candidate(scope, candidate_id)
+        return tuple(
+            self._evidence_store.get(scope, evidence_id)
+            for evidence_id in candidate.proposal.evidence_ids
+        )
+
+    def list_candidates(self, scope: MemoryScope) -> tuple[MemoryCandidate, ...]:
+        """Return a stable snapshot of candidates in the requested scope."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        with self._lock:
+            return tuple(
+                sorted(
+                    self._candidates_by_scope.get(scope, ()),
+                    key=lambda item: item.candidate_id,
+                )
+            )

--- a/areal/v2/memory_service/history_store.py
+++ b/areal/v2/memory_service/history_store.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from threading import RLock
 from typing import Protocol
 
+from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
     CandidateConflictError,
     CandidateNotFoundError,
@@ -137,9 +138,19 @@ class InMemoryMemoryHistoryStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._candidate_by_id[candidate_index] = candidate
-            self._candidate_by_idempotency[idempotency_index] = candidate
-            self._candidates_by_scope.setdefault(proposal.scope, []).append(candidate)
+            _atomic_publish(
+                mapping_writes=(
+                    (self._candidate_by_id, candidate_index, candidate),
+                    (
+                        self._candidate_by_idempotency,
+                        idempotency_index,
+                        candidate,
+                    ),
+                ),
+                sequence_appends=(
+                    (self._candidates_by_scope, proposal.scope, candidate),
+                ),
+            )
             return candidate
 
     def get_candidate(self, scope: MemoryScope, candidate_id: str) -> MemoryCandidate:
@@ -246,10 +257,20 @@ class InMemoryMemoryHistoryStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._revision_by_id[revision_index] = revision
-            self._revision_by_idempotency[idempotency_index] = revision
-            self._revision_by_candidate[candidate_index] = revision
-            self._revisions_by_scope.setdefault(proposal.scope, []).append(revision)
+            _atomic_publish(
+                mapping_writes=(
+                    (self._revision_by_id, revision_index, revision),
+                    (
+                        self._revision_by_idempotency,
+                        idempotency_index,
+                        revision,
+                    ),
+                    (self._revision_by_candidate, candidate_index, revision),
+                ),
+                sequence_appends=(
+                    (self._revisions_by_scope, proposal.scope, revision),
+                ),
+            )
             return revision
 
     def get_revision(self, scope: MemoryScope, revision_id: str) -> MemoryRevision:

--- a/areal/v2/memory_service/history_types.py
+++ b/areal/v2/memory_service/history_types.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable candidate and revision values for the Memory Service."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from areal.v2.memory_service.types import (
+    MemoryScope,
+    _validate_aware_datetime,
+    _validate_string,
+)
+
+_SCHEMA_VERSION = 1
+_MAX_GENERATION = 2**63 - 1
+
+
+def _canonical_json_bytes(value: dict[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _snapshot_evidence_ids(value: object) -> tuple[str, ...]:
+    if not isinstance(value, tuple):
+        raise TypeError("evidence_ids must be a tuple")
+    snapshot = tuple(
+        _validate_string(item, "evidence_ids") for item in tuple.__iter__(value)
+    )
+    if not snapshot:
+        raise ValueError("evidence_ids must not be empty")
+    if len(set(snapshot)) != len(snapshot):
+        raise ValueError("evidence_ids must not contain duplicates")
+    return snapshot
+
+
+class RevisionOperation(StrEnum):
+    ADD = "add"
+    REFINE = "refine"
+    SUPERSEDE = "supersede"
+    CONTRADICT = "contradict"
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateProposal:
+    scope: MemoryScope
+    content: str
+    evidence_ids: tuple[str, ...]
+    idempotency_key: str
+
+    def __post_init__(self) -> None:
+        if type(self.scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        content = _validate_string(self.content, "content")
+        evidence_ids = _snapshot_evidence_ids(self.evidence_ids)
+        idempotency_key = _validate_string(self.idempotency_key, "idempotency_key")
+        object.__setattr__(self, "content", content)
+        object.__setattr__(self, "evidence_ids", evidence_ids)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
+
+    def canonical_bytes(self) -> bytes:
+        value = {
+            "schema_version": _SCHEMA_VERSION,
+            "scope": {
+                "tenant_id": self.scope.tenant_id,
+                "namespace": self.scope.namespace,
+                "subject_id": self.scope.subject_id,
+            },
+            "content": self.content,
+            "evidence_ids": list(self.evidence_ids),
+            "idempotency_key": self.idempotency_key,
+        }
+        return _canonical_json_bytes(value)
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryCandidate:
+    candidate_id: str
+    proposal: CandidateProposal
+    content_hash: str
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        if type(self.proposal) is not CandidateProposal:
+            raise TypeError("proposal must be a CandidateProposal")
+        candidate_id = _validate_string(self.candidate_id, "candidate_id")
+        content_hash = _validate_string(self.content_hash, "content_hash")
+        created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "content_hash", content_hash)
+        object.__setattr__(self, "created_at", created_at)
+
+
+@dataclass(frozen=True, slots=True)
+class RevisionProposal:
+    scope: MemoryScope
+    candidate_id: str
+    operation: RevisionOperation
+    parent_revision_id: str | None
+    idempotency_key: str
+
+    def __post_init__(self) -> None:
+        if type(self.scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        candidate_id = _validate_string(self.candidate_id, "candidate_id")
+        if type(self.operation) is not RevisionOperation:
+            raise TypeError("operation must be a RevisionOperation")
+        parent_revision_id = self.parent_revision_id
+        if parent_revision_id is not None:
+            parent_revision_id = _validate_string(
+                parent_revision_id, "parent_revision_id"
+            )
+        if self.operation is RevisionOperation.ADD and parent_revision_id is not None:
+            raise ValueError("parent_revision_id must be absent for ADD")
+        if self.operation is not RevisionOperation.ADD and parent_revision_id is None:
+            raise ValueError("parent_revision_id is required for non-ADD operations")
+        idempotency_key = _validate_string(self.idempotency_key, "idempotency_key")
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "parent_revision_id", parent_revision_id)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
+
+    def canonical_bytes(self) -> bytes:
+        value = {
+            "schema_version": _SCHEMA_VERSION,
+            "scope": {
+                "tenant_id": self.scope.tenant_id,
+                "namespace": self.scope.namespace,
+                "subject_id": self.scope.subject_id,
+            },
+            "candidate_id": self.candidate_id,
+            "operation": self.operation.value,
+            "parent_revision_id": self.parent_revision_id,
+            "idempotency_key": self.idempotency_key,
+        }
+        return _canonical_json_bytes(value)
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRevision:
+    revision_id: str
+    memory_id: str
+    generation: int
+    proposal: RevisionProposal
+    content_hash: str
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        revision_id = _validate_string(self.revision_id, "revision_id")
+        memory_id = _validate_string(self.memory_id, "memory_id")
+        if type(self.generation) is not int:
+            raise TypeError("generation must be an integer")
+        if self.generation < 0 or self.generation > _MAX_GENERATION:
+            raise ValueError("generation must fit the non-negative signed-64 range")
+        if type(self.proposal) is not RevisionProposal:
+            raise TypeError("proposal must be a RevisionProposal")
+        content_hash = _validate_string(self.content_hash, "content_hash")
+        created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "revision_id", revision_id)
+        object.__setattr__(self, "memory_id", memory_id)
+        object.__setattr__(self, "content_hash", content_hash)
+        object.__setattr__(self, "created_at", created_at)

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -46,10 +46,8 @@ class InMemoryEvidenceStore:
 
     def __init__(self) -> None:
         self._lock = RLock()
-        self._by_evidence_id: dict[str, tuple[EvidenceRecord, bytes]] = {}
-        self._by_idempotency_key: dict[
-            tuple[MemoryScope, str], tuple[EvidenceRecord, bytes]
-        ] = {}
+        self._by_evidence_id: dict[str, EvidenceRecord] = {}
+        self._by_idempotency_key: dict[tuple[MemoryScope, str], EvidenceRecord] = {}
         self._by_scope: dict[MemoryScope, list[EvidenceRecord]] = {}
 
     def append(self, event: EvidenceEvent) -> EvidenceRecord:
@@ -61,19 +59,17 @@ class InMemoryEvidenceStore:
         idempotency_index = (event.scope, event.idempotency_key)
 
         with self._lock:
-            existing_idempotency = self._by_idempotency_key.get(idempotency_index)
-            if existing_idempotency is not None:
-                existing_record, existing_bytes = existing_idempotency
-                if existing_bytes == canonical_bytes:
+            existing_record = self._by_idempotency_key.get(idempotency_index)
+            if existing_record is not None:
+                if existing_record.event.canonical_bytes() == canonical_bytes:
                     return existing_record
                 raise EvidenceConflictError(
                     "scoped idempotency key already refers to different evidence"
                 )
 
-            existing_id = self._by_evidence_id.get(evidence_id)
-            if existing_id is not None:
-                existing_record, existing_bytes = existing_id
-                if existing_bytes == canonical_bytes:
+            existing_record = self._by_evidence_id.get(evidence_id)
+            if existing_record is not None:
+                if existing_record.event.canonical_bytes() == canonical_bytes:
                     return existing_record
                 raise EvidenceConflictError(
                     f"evidence ID collision for {evidence_id!r}"
@@ -85,9 +81,8 @@ class InMemoryEvidenceStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            indexed_record = (record, canonical_bytes)
-            self._by_evidence_id[evidence_id] = indexed_record
-            self._by_idempotency_key[idempotency_index] = indexed_record
+            self._by_evidence_id[evidence_id] = record
+            self._by_idempotency_key[idempotency_index] = record
             self._by_scope.setdefault(event.scope, []).append(record)
             return record
 
@@ -95,10 +90,10 @@ class InMemoryEvidenceStore:
         """Return evidence only when it belongs to the requested scope."""
 
         with self._lock:
-            indexed_record = self._by_evidence_id.get(evidence_id)
-            if indexed_record is None or indexed_record[0].event.scope != scope:
+            record = self._by_evidence_id.get(evidence_id)
+            if record is None or record.event.scope != scope:
                 raise EvidenceNotFoundError(f"evidence {evidence_id!r} was not found")
-            return indexed_record[0]
+            return record
 
     def list(
         self,

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -46,7 +46,7 @@ class InMemoryEvidenceStore:
 
     def __init__(self) -> None:
         self._lock = RLock()
-        self._by_evidence_id: dict[str, EvidenceRecord] = {}
+        self._by_evidence_id: dict[tuple[MemoryScope, str], EvidenceRecord] = {}
         self._by_idempotency_key: dict[tuple[MemoryScope, str], EvidenceRecord] = {}
         self._by_scope: dict[MemoryScope, list[EvidenceRecord]] = {}
 
@@ -56,6 +56,7 @@ class InMemoryEvidenceStore:
         canonical_bytes = event.canonical_bytes()
         content_hash = hashlib.sha256(canonical_bytes).hexdigest()
         evidence_id = f"evd_{content_hash[:24]}"
+        evidence_index = (event.scope, evidence_id)
         idempotency_index = (event.scope, event.idempotency_key)
 
         with self._lock:
@@ -67,7 +68,7 @@ class InMemoryEvidenceStore:
                     "scoped idempotency key already refers to different evidence"
                 )
 
-            existing_record = self._by_evidence_id.get(evidence_id)
+            existing_record = self._by_evidence_id.get(evidence_index)
             if existing_record is not None:
                 if existing_record.event.canonical_bytes() == canonical_bytes:
                     return existing_record
@@ -81,7 +82,7 @@ class InMemoryEvidenceStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._by_evidence_id[evidence_id] = record
+            self._by_evidence_id[evidence_index] = record
             self._by_idempotency_key[idempotency_index] = record
             self._by_scope.setdefault(event.scope, []).append(record)
             return record
@@ -90,8 +91,8 @@ class InMemoryEvidenceStore:
         """Return evidence only when it belongs to the requested scope."""
 
         with self._lock:
-            record = self._by_evidence_id.get(evidence_id)
-            if record is None or record.event.scope != scope:
+            record = self._by_evidence_id.get((scope, evidence_id))
+            if record is None:
                 raise EvidenceNotFoundError(f"evidence {evidence_id!r} was not found")
             return record
 

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -53,6 +53,8 @@ class InMemoryEvidenceStore:
     def append(self, event: EvidenceEvent) -> EvidenceRecord:
         """Persist an event, enforcing scoped idempotency and collision safety."""
 
+        if type(event) is not EvidenceEvent:
+            raise TypeError("event must be an EvidenceEvent")
         canonical_bytes = event.canonical_bytes()
         content_hash = hashlib.sha256(canonical_bytes).hexdigest()
         evidence_id = f"evd_{content_hash[:24]}"
@@ -90,6 +92,8 @@ class InMemoryEvidenceStore:
     def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:
         """Return evidence only when it belongs to the requested scope."""
 
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
         with self._lock:
             record = self._by_evidence_id.get((scope, evidence_id))
             if record is None:
@@ -105,6 +109,8 @@ class InMemoryEvidenceStore:
     ) -> tuple[EvidenceRecord, ...]:
         """Return a stable snapshot of records belonging to the requested scope."""
 
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
         with self._lock:
             matches = (
                 record

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -120,6 +120,6 @@ def _record_sort_key(record: EvidenceRecord) -> tuple[str, str, int, datetime, s
         event.session_id,
         event.run_id,
         event.sequence_no,
-        event.observed_at.astimezone(UTC),
+        event.observed_at,
         record.evidence_id,
     )

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -13,7 +13,12 @@ from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
 )
-from areal.v2.memory_service.types import EvidenceEvent, EvidenceRecord, MemoryScope
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceRecord,
+    MemoryScope,
+    _validate_string,
+)
 
 
 class EvidenceStore(Protocol):
@@ -94,6 +99,7 @@ class InMemoryEvidenceStore:
 
         if type(scope) is not MemoryScope:
             raise TypeError("scope must be a MemoryScope")
+        evidence_id = _validate_string(evidence_id, "evidence_id", allow_blank=True)
         with self._lock:
             record = self._by_evidence_id.get((scope, evidence_id))
             if record is None:
@@ -111,6 +117,10 @@ class InMemoryEvidenceStore:
 
         if type(scope) is not MemoryScope:
             raise TypeError("scope must be a MemoryScope")
+        if session_id is not None:
+            session_id = _validate_string(session_id, "session_id", allow_blank=True)
+        if run_id is not None:
+            run_id = _validate_string(run_id, "run_id", allow_blank=True)
         with self._lock:
             matches = (
                 record

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from threading import RLock
 from typing import Protocol
 
+from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
@@ -89,9 +90,13 @@ class InMemoryEvidenceStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._by_evidence_id[evidence_index] = record
-            self._by_idempotency_key[idempotency_index] = record
-            self._by_scope.setdefault(event.scope, []).append(record)
+            _atomic_publish(
+                mapping_writes=(
+                    (self._by_evidence_id, evidence_index, record),
+                    (self._by_idempotency_key, idempotency_index, record),
+                ),
+                sequence_appends=((self._by_scope, event.scope, record),),
+            )
             return record
 
     def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evidence store contracts and an in-memory implementation."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from threading import RLock
+from typing import Protocol
+
+from areal.v2.memory_service.errors import (
+    EvidenceConflictError,
+    EvidenceNotFoundError,
+)
+from areal.v2.memory_service.types import EvidenceEvent, EvidenceRecord, MemoryScope
+
+
+class EvidenceStore(Protocol):
+    """Storage contract for immutable evidence records."""
+
+    def append(self, event: EvidenceEvent) -> EvidenceRecord:
+        """Persist an event or return its existing idempotent record."""
+
+        ...
+
+    def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:
+        """Return evidence from a scope or raise ``EvidenceNotFoundError``."""
+
+        ...
+
+    def list(
+        self,
+        scope: MemoryScope,
+        *,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ...]:
+        """Return deterministically ordered evidence matching the filters."""
+
+        ...
+
+
+class InMemoryEvidenceStore:
+    """Lock-protected process-local storage for immutable evidence records."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._by_evidence_id: dict[str, tuple[EvidenceRecord, bytes]] = {}
+        self._by_idempotency_key: dict[
+            tuple[MemoryScope, str], tuple[EvidenceRecord, bytes]
+        ] = {}
+        self._by_scope: dict[MemoryScope, list[EvidenceRecord]] = {}
+
+    def append(self, event: EvidenceEvent) -> EvidenceRecord:
+        """Persist an event, enforcing scoped idempotency and collision safety."""
+
+        canonical_bytes = event.canonical_bytes()
+        content_hash = hashlib.sha256(canonical_bytes).hexdigest()
+        evidence_id = f"evd_{content_hash[:24]}"
+        idempotency_index = (event.scope, event.idempotency_key)
+
+        with self._lock:
+            existing_idempotency = self._by_idempotency_key.get(idempotency_index)
+            if existing_idempotency is not None:
+                existing_record, existing_bytes = existing_idempotency
+                if existing_bytes == canonical_bytes:
+                    return existing_record
+                raise EvidenceConflictError(
+                    "scoped idempotency key already refers to different evidence"
+                )
+
+            existing_id = self._by_evidence_id.get(evidence_id)
+            if existing_id is not None:
+                existing_record, existing_bytes = existing_id
+                if existing_bytes == canonical_bytes:
+                    return existing_record
+                raise EvidenceConflictError(
+                    f"evidence ID collision for {evidence_id!r}"
+                )
+
+            record = EvidenceRecord(
+                evidence_id=evidence_id,
+                event=event,
+                content_hash=content_hash,
+                created_at=datetime.now(UTC),
+            )
+            indexed_record = (record, canonical_bytes)
+            self._by_evidence_id[evidence_id] = indexed_record
+            self._by_idempotency_key[idempotency_index] = indexed_record
+            self._by_scope.setdefault(event.scope, []).append(record)
+            return record
+
+    def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:
+        """Return evidence only when it belongs to the requested scope."""
+
+        with self._lock:
+            indexed_record = self._by_evidence_id.get(evidence_id)
+            if indexed_record is None or indexed_record[0].event.scope != scope:
+                raise EvidenceNotFoundError(f"evidence {evidence_id!r} was not found")
+            return indexed_record[0]
+
+    def list(
+        self,
+        scope: MemoryScope,
+        *,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ...]:
+        """Return a stable snapshot of records belonging to the requested scope."""
+
+        with self._lock:
+            matches = (
+                record
+                for record in self._by_scope.get(scope, ())
+                if (session_id is None or record.event.session_id == session_id)
+                and (run_id is None or record.event.run_id == run_id)
+            )
+            return tuple(sorted(matches, key=_record_sort_key))
+
+
+def _record_sort_key(record: EvidenceRecord) -> tuple[str, str, int, datetime, str]:
+    event = record.event
+    return (
+        event.session_id,
+        event.run_id,
+        event.sequence_no,
+        event.observed_at.astimezone(UTC),
+        record.evidence_id,
+    )

--- a/areal/v2/memory_service/types.py
+++ b/areal/v2/memory_service/types.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable evidence value objects for the Memory Service."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+
+_MAX_SEQUENCE_NO = 2**63 - 1
+
+
+def _validate_string(
+    value: object, field_name: str, *, allow_blank: bool = False
+) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not allow_blank and not value.strip():
+        raise ValueError(f"{field_name} must not be blank")
+    try:
+        value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{field_name} must be valid UTF-8") from exc
+
+
+def _validate_aware_datetime(value: object, field_name: str) -> None:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field_name} must be a datetime")
+    if value.tzinfo is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    try:
+        offset = value.utcoffset()
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be normalizable to UTC") from exc
+    if offset is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    try:
+        value.astimezone(UTC)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be normalizable to UTC") from exc
+
+
+class EvidenceKind(StrEnum):
+    """The source or role represented by an evidence event."""
+
+    USER_MESSAGE = "user_message"
+    AGENT_MESSAGE = "agent_message"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    ENVIRONMENT = "environment"
+    FEEDBACK = "feedback"
+    OUTCOME = "outcome"
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryScope:
+    """The tenant, namespace, and subject that own a memory."""
+
+    tenant_id: str
+    namespace: str
+    subject_id: str
+
+    def __post_init__(self) -> None:
+        _validate_string(self.tenant_id, "tenant_id")
+        _validate_string(self.namespace, "namespace")
+        _validate_string(self.subject_id, "subject_id")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceEvent:
+    """An immutable observation submitted to the Memory Service."""
+
+    scope: MemoryScope
+    session_id: str
+    run_id: str
+    sequence_no: int
+    kind: EvidenceKind
+    payload: str
+    observed_at: datetime
+    idempotency_key: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope, MemoryScope):
+            raise TypeError("scope must be a MemoryScope")
+        _validate_string(self.session_id, "session_id")
+        _validate_string(self.run_id, "run_id")
+        _validate_string(self.idempotency_key, "idempotency_key")
+        if isinstance(self.sequence_no, bool) or not isinstance(self.sequence_no, int):
+            raise TypeError("sequence_no must be an integer")
+        if self.sequence_no < 0:
+            raise ValueError("sequence_no must be non-negative")
+        if self.sequence_no > _MAX_SEQUENCE_NO:
+            raise ValueError("sequence_no must fit in a signed 64-bit integer")
+        if not isinstance(self.kind, EvidenceKind):
+            raise TypeError("kind must be an EvidenceKind")
+        _validate_string(self.payload, "payload", allow_blank=True)
+        _validate_aware_datetime(self.observed_at, "observed_at")
+
+    def canonical_bytes(self) -> bytes:
+        """Serialize the event as deterministic, compact UTF-8 JSON."""
+
+        value = {
+            "scope": {
+                "tenant_id": self.scope.tenant_id,
+                "namespace": self.scope.namespace,
+                "subject_id": self.scope.subject_id,
+            },
+            "session_id": self.session_id,
+            "run_id": self.run_id,
+            "sequence_no": self.sequence_no,
+            "kind": self.kind.value,
+            "payload": self.payload,
+            "observed_at": self.observed_at.astimezone(UTC).isoformat(),
+            "idempotency_key": self.idempotency_key,
+        }
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRecord:
+    """A persisted evidence event and its storage metadata."""
+
+    evidence_id: str
+    event: EvidenceEvent
+    content_hash: str
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.event, EvidenceEvent):
+            raise TypeError("event must be an EvidenceEvent")
+        _validate_string(self.evidence_id, "evidence_id")
+        _validate_string(self.content_hash, "content_hash")
+        _validate_aware_datetime(self.created_at, "created_at")

--- a/areal/v2/memory_service/types.py
+++ b/areal/v2/memory_service/types.py
@@ -14,15 +14,17 @@ _MAX_SEQUENCE_NO = 2**63 - 1
 
 def _validate_string(
     value: object, field_name: str, *, allow_blank: bool = False
-) -> None:
+) -> str:
     if not isinstance(value, str):
         raise TypeError(f"{field_name} must be a string")
-    if not allow_blank and not value.strip():
+    snapshot = str.__str__(value)
+    if not allow_blank and not str.strip(snapshot):
         raise ValueError(f"{field_name} must not be blank")
     try:
-        value.encode("utf-8", errors="strict")
+        str.encode(snapshot, "utf-8", "strict")
     except UnicodeEncodeError as exc:
         raise ValueError(f"{field_name} must be valid UTF-8") from exc
+    return snapshot
 
 
 def _validate_aware_datetime(value: object, field_name: str) -> datetime:
@@ -73,9 +75,12 @@ class MemoryScope:
     subject_id: str
 
     def __post_init__(self) -> None:
-        _validate_string(self.tenant_id, "tenant_id")
-        _validate_string(self.namespace, "namespace")
-        _validate_string(self.subject_id, "subject_id")
+        tenant_id = _validate_string(self.tenant_id, "tenant_id")
+        namespace = _validate_string(self.namespace, "namespace")
+        subject_id = _validate_string(self.subject_id, "subject_id")
+        object.__setattr__(self, "tenant_id", tenant_id)
+        object.__setattr__(self, "namespace", namespace)
+        object.__setattr__(self, "subject_id", subject_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,12 +97,12 @@ class EvidenceEvent:
     idempotency_key: str
 
     def __post_init__(self) -> None:
-        if not isinstance(self.scope, MemoryScope):
+        if type(self.scope) is not MemoryScope:
             raise TypeError("scope must be a MemoryScope")
-        _validate_string(self.session_id, "session_id")
-        _validate_string(self.run_id, "run_id")
-        _validate_string(self.idempotency_key, "idempotency_key")
-        if isinstance(self.sequence_no, bool) or not isinstance(self.sequence_no, int):
+        session_id = _validate_string(self.session_id, "session_id")
+        run_id = _validate_string(self.run_id, "run_id")
+        idempotency_key = _validate_string(self.idempotency_key, "idempotency_key")
+        if type(self.sequence_no) is not int:
             raise TypeError("sequence_no must be an integer")
         if self.sequence_no < 0:
             raise ValueError("sequence_no must be non-negative")
@@ -105,8 +110,12 @@ class EvidenceEvent:
             raise ValueError("sequence_no must fit in a signed 64-bit integer")
         if not isinstance(self.kind, EvidenceKind):
             raise TypeError("kind must be an EvidenceKind")
-        _validate_string(self.payload, "payload", allow_blank=True)
+        payload = _validate_string(self.payload, "payload", allow_blank=True)
         observed_at = _validate_aware_datetime(self.observed_at, "observed_at")
+        object.__setattr__(self, "session_id", session_id)
+        object.__setattr__(self, "run_id", run_id)
+        object.__setattr__(self, "payload", payload)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
         object.__setattr__(self, "observed_at", observed_at)
 
     def canonical_bytes(self) -> bytes:
@@ -144,9 +153,11 @@ class EvidenceRecord:
     created_at: datetime
 
     def __post_init__(self) -> None:
-        if not isinstance(self.event, EvidenceEvent):
+        if type(self.event) is not EvidenceEvent:
             raise TypeError("event must be an EvidenceEvent")
-        _validate_string(self.evidence_id, "evidence_id")
-        _validate_string(self.content_hash, "content_hash")
+        evidence_id = _validate_string(self.evidence_id, "evidence_id")
+        content_hash = _validate_string(self.content_hash, "content_hash")
         created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "evidence_id", evidence_id)
+        object.__setattr__(self, "content_hash", content_hash)
         object.__setattr__(self, "created_at", created_at)

--- a/areal/v2/memory_service/types.py
+++ b/areal/v2/memory_service/types.py
@@ -25,7 +25,7 @@ def _validate_string(
         raise ValueError(f"{field_name} must be valid UTF-8") from exc
 
 
-def _validate_aware_datetime(value: object, field_name: str) -> None:
+def _validate_aware_datetime(value: object, field_name: str) -> datetime:
     if not isinstance(value, datetime):
         raise TypeError(f"{field_name} must be a datetime")
     if value.tzinfo is None:
@@ -37,9 +37,19 @@ def _validate_aware_datetime(value: object, field_name: str) -> None:
     if offset is None:
         raise ValueError(f"{field_name} must be timezone-aware")
     try:
-        value.astimezone(UTC)
+        normalized = datetime.astimezone(value, UTC)
     except (OverflowError, ValueError) as exc:
         raise ValueError(f"{field_name} must be normalizable to UTC") from exc
+    return datetime(
+        normalized.year,
+        normalized.month,
+        normalized.day,
+        normalized.hour,
+        normalized.minute,
+        normalized.second,
+        normalized.microsecond,
+        tzinfo=UTC,
+    )
 
 
 class EvidenceKind(StrEnum):
@@ -96,7 +106,8 @@ class EvidenceEvent:
         if not isinstance(self.kind, EvidenceKind):
             raise TypeError("kind must be an EvidenceKind")
         _validate_string(self.payload, "payload", allow_blank=True)
-        _validate_aware_datetime(self.observed_at, "observed_at")
+        observed_at = _validate_aware_datetime(self.observed_at, "observed_at")
+        object.__setattr__(self, "observed_at", observed_at)
 
     def canonical_bytes(self) -> bytes:
         """Serialize the event as deterministic, compact UTF-8 JSON."""
@@ -137,4 +148,5 @@ class EvidenceRecord:
             raise TypeError("event must be an EvidenceEvent")
         _validate_string(self.evidence_id, "evidence_id")
         _validate_string(self.content_hash, "content_hash")
-        _validate_aware_datetime(self.created_at, "created_at")
+        created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "created_at", created_at)

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -8,7 +8,7 @@ import faulthandler
 import inspect
 import re
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from hashlib import sha256
 from threading import Barrier, RLock
@@ -145,27 +145,17 @@ def run_race(
         except MemoryServiceError as error:
             return error
 
-    executor = ThreadPoolExecutor(max_workers=len(items))
-    futures = ()
-    completed = False
     faulthandler.dump_traceback_later(HARD_RACE_TIMEOUT_SECONDS, exit=True)
     try:
-        futures = tuple(executor.submit(worker, item) for item in items)
-        deadline = monotonic() + RACE_TIMEOUT_SECONDS
-        results = tuple(
-            future.result(timeout=max(0.0, deadline - monotonic()))
-            for future in futures
-        )
-        completed = True
-        return results
+        with ThreadPoolExecutor(max_workers=len(items)) as executor:
+            futures = tuple(executor.submit(worker, item) for item in items)
+            deadline = monotonic() + RACE_TIMEOUT_SECONDS
+            return tuple(
+                future.result(timeout=max(0.0, deadline - monotonic()))
+                for future in futures
+            )
     finally:
-        executor.shutdown(wait=completed, cancel_futures=not completed)
-        if completed:
-            faulthandler.cancel_dump_traceback_later()
-        else:
-            _, unfinished = wait(futures, timeout=1.0)
-            if not unfinished:
-                faulthandler.cancel_dump_traceback_later()
+        faulthandler.cancel_dump_traceback_later()
 
 
 def install_digest_map(
@@ -180,7 +170,7 @@ def install_digest_map(
     monkeypatch.setattr(history_store_module.hashlib, "sha256", fake_sha256)
 
 
-def test_run_race_cancels_watchdog_only_after_workers_finish(
+def test_run_race_waits_for_workers_before_cancelling_watchdog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     events: list[tuple[object, ...]] = []
@@ -202,27 +192,91 @@ def test_run_race_cancels_watchdog_only_after_workers_finish(
         ("cancel",),
     ]
 
-    def fail(_: int) -> object:
-        raise RuntimeError("worker failed")
+    finished: set[int] = set()
+    finished_lock = RLock()
+
+    def fail_or_finish(item: int) -> object:
+        if item == 0:
+            raise RuntimeError("worker failed")
+        sleep(0.15)
+        with finished_lock:
+            finished.add(item)
+        return item
 
     events.clear()
+    started_at = monotonic()
     with pytest.raises(RuntimeError, match="worker failed"):
-        run_race(tuple(range(RACE_SIZE)), fail)
+        run_race(tuple(range(RACE_SIZE)), fail_or_finish)
+    assert monotonic() - started_at >= 0.1
+    assert finished == set(range(1, RACE_SIZE))
     assert events == [
         ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
         ("cancel",),
     ]
 
-    events.clear()
+
+def test_run_race_watchdog_wraps_executor_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[object, ...]] = []
+
+    def record_arm(timeout: float, *, exit: bool) -> None:
+        events.append(("arm", timeout, exit))
+
+    def record_cancel() -> None:
+        events.append(("cancel",))
+
+    class FailingFuture:
+        def result(self, timeout: float) -> object:
+            events.append(("result",))
+            raise RuntimeError("worker failed")
+
+    class StubExecutor:
+        def __init__(self, *, max_workers: int) -> None:
+            events.append(("executor:init", max_workers))
+
+        def __enter__(self) -> StubExecutor:
+            events.append(("executor:enter",))
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: object,
+        ) -> None:
+            events.append(("executor:exit", exc_type))
+
+        def submit(
+            self,
+            operation: Callable[[int], object],
+            item: int,
+        ) -> FailingFuture:
+            events.append(("submit", item))
+            return FailingFuture()
+
+        def shutdown(self, *, wait: bool, cancel_futures: bool) -> None:
+            events.append(("executor:shutdown", wait, cancel_futures))
+
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", record_arm)
+    monkeypatch.setattr(faulthandler, "cancel_dump_traceback_later", record_cancel)
     monkeypatch.setitem(
         run_race.__globals__,
-        "wait",
-        lambda futures, timeout: (set(), set(futures)),
+        "ThreadPoolExecutor",
+        StubExecutor,
     )
 
     with pytest.raises(RuntimeError, match="worker failed"):
-        run_race(tuple(range(RACE_SIZE)), fail)
-    assert events == [("arm", HARD_RACE_TIMEOUT_SECONDS, True)]
+        run_race((0,), lambda item: item)
+    assert events == [
+        ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("executor:init", 1),
+        ("executor:enter",),
+        ("submit", 0),
+        ("result",),
+        ("executor:exit", RuntimeError),
+        ("cancel",),
+    ]
 
 
 def make_scope(**overrides: str) -> MemoryScope:

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -4,10 +4,16 @@
 
 from __future__ import annotations
 
+import faulthandler
+import inspect
 import re
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import UTC, datetime
 from hashlib import sha256
-from threading import RLock
+from threading import Barrier, RLock
+from time import monotonic, sleep
+from typing import TypeVar
 
 import pytest
 
@@ -89,6 +95,134 @@ class RevisionProposalSubclass(RevisionProposal):
 
 
 UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, tzinfo=UTC)
+RACE_SIZE = 16
+RACE_TIMEOUT_SECONDS = 10.0
+HARD_RACE_TIMEOUT_SECONDS = 15.0
+T = TypeVar("T")
+
+
+class YieldingMissingDict(dict[object, object]):
+    """Yield after a missing lookup to expose an unprotected check/write race."""
+
+    def get(self, key: object, default: object = None) -> object:
+        value = super().get(key, default)
+        if value is default:
+            sleep(0.02)
+        return value
+
+
+class YieldingMissingContainsDict(dict[object, object]):
+    """Yield after a missing membership test to expose an unprotected race."""
+
+    def __contains__(self, key: object) -> bool:
+        exists = super().__contains__(key)
+        if not exists:
+            sleep(0.02)
+        return exists
+
+
+class StubHash:
+    """Return one test-controlled hexadecimal digest."""
+
+    def __init__(self, digest: str) -> None:
+        self._digest = digest
+
+    def hexdigest(self) -> str:
+        return self._digest
+
+
+def run_race(
+    items: tuple[T, ...], operation: Callable[[T], object]
+) -> tuple[object, ...]:
+    """Release callers together and apply one deadline to result collection."""
+
+    barrier = Barrier(len(items), timeout=RACE_TIMEOUT_SECONDS)
+
+    def worker(item: T) -> object:
+        barrier.wait()
+        try:
+            return operation(item)
+        except MemoryServiceError as error:
+            return error
+
+    executor = ThreadPoolExecutor(max_workers=len(items))
+    futures = ()
+    completed = False
+    faulthandler.dump_traceback_later(HARD_RACE_TIMEOUT_SECONDS, exit=True)
+    try:
+        futures = tuple(executor.submit(worker, item) for item in items)
+        deadline = monotonic() + RACE_TIMEOUT_SECONDS
+        results = tuple(
+            future.result(timeout=max(0.0, deadline - monotonic()))
+            for future in futures
+        )
+        completed = True
+        return results
+    finally:
+        executor.shutdown(wait=completed, cancel_futures=not completed)
+        if completed:
+            faulthandler.cancel_dump_traceback_later()
+        else:
+            _, unfinished = wait(futures, timeout=1.0)
+            if not unfinished:
+                faulthandler.cancel_dump_traceback_later()
+
+
+def install_digest_map(
+    monkeypatch: pytest.MonkeyPatch,
+    digest_by_bytes: dict[bytes, str],
+) -> None:
+    """Install deterministic SHA-256 results for pre-seeded canonical bytes."""
+
+    def fake_sha256(canonical_bytes: bytes) -> StubHash:
+        return StubHash(digest_by_bytes[canonical_bytes])
+
+    monkeypatch.setattr(history_store_module.hashlib, "sha256", fake_sha256)
+
+
+def test_run_race_cancels_watchdog_only_after_workers_finish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[object, ...]] = []
+
+    def record_arm(timeout: float, *, exit: bool) -> None:
+        events.append(("arm", timeout, exit))
+
+    def record_cancel() -> None:
+        events.append(("cancel",))
+
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", record_arm)
+    monkeypatch.setattr(faulthandler, "cancel_dump_traceback_later", record_cancel)
+
+    assert run_race(tuple(range(RACE_SIZE)), lambda item: item) == tuple(
+        range(RACE_SIZE)
+    )
+    assert events == [
+        ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("cancel",),
+    ]
+
+    def fail(_: int) -> object:
+        raise RuntimeError("worker failed")
+
+    events.clear()
+    with pytest.raises(RuntimeError, match="worker failed"):
+        run_race(tuple(range(RACE_SIZE)), fail)
+    assert events == [
+        ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("cancel",),
+    ]
+
+    events.clear()
+    monkeypatch.setitem(
+        run_race.__globals__,
+        "wait",
+        lambda futures, timeout: (set(), set(futures)),
+    )
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        run_race(tuple(range(RACE_SIZE)), fail)
+    assert events == [("arm", HARD_RACE_TIMEOUT_SECONDS, True)]
 
 
 def make_scope(**overrides: str) -> MemoryScope:
@@ -145,26 +279,59 @@ def seeded_evidence_store() -> tuple[InMemoryEvidenceStore, EvidenceRecord]:
     return evidence_store, evidence
 
 
+def seed_candidates(
+    count: int,
+) -> tuple[
+    InMemoryMemoryHistoryStore,
+    InMemoryEvidenceStore,
+    tuple[MemoryCandidate, ...],
+]:
+    """Create candidates before any test replaces the shared hashlib function."""
+
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidates = tuple(
+        history.append_candidate(
+            make_candidate_proposal(
+                content=f"candidate-{index}",
+                evidence_ids=(evidence.evidence_id,),
+                idempotency_key=f"candidate-{index}",
+            )
+        )
+        for index in range(count)
+    )
+    return history, evidence_store, candidates
+
+
 def assert_candidate_indexes_empty(history: InMemoryMemoryHistoryStore) -> None:
     assert history._candidate_by_id == {}
     assert history._candidate_by_idempotency == {}
     assert history._candidates_by_scope == {}
 
 
-def test_history_store_contract_exposes_only_candidate_and_revision_surface() -> None:
-    public_members = {
-        name for name in MemoryHistoryStore.__dict__ if not name.startswith("_")
-    }
-
-    assert public_members == {
+def test_history_contract_exposes_no_mutation_or_activation_api() -> None:
+    expected = {
         "append_candidate",
+        "append_revision",
         "get_candidate",
         "get_candidate_evidence",
-        "list_candidates",
-        "append_revision",
         "get_revision",
+        "list_candidates",
         "list_revisions",
     }
+    protocol_methods = {
+        name
+        for name, value in inspect.getmembers(MemoryHistoryStore)
+        if not name.startswith("_") and callable(value)
+    }
+    implementation_methods = {
+        name
+        for name, value in inspect.getmembers(InMemoryMemoryHistoryStore)
+        if not name.startswith("_") and callable(value)
+    }
+
+    assert protocol_methods == expected
+    assert implementation_methods == expected
 
 
 def test_history_errors_share_memory_service_base() -> None:
@@ -1263,3 +1430,427 @@ def test_generation_overflow_leaves_all_revision_indexes_unchanged() -> None:
         history._revisions_by_scope,
     )
     assert after == before
+
+
+def test_concurrent_identical_candidate_and_revision_requests_converge() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    history._candidate_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    history._candidate_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    candidate_proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+
+    candidate_results = run_race(
+        (candidate_proposal,) * RACE_SIZE,
+        history.append_candidate,
+    )
+
+    candidate = candidate_results[0]
+    assert isinstance(candidate, MemoryCandidate)
+    assert all(item is candidate for item in candidate_results)
+
+    history._revision_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    history._revision_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    revision_proposal = make_revision_proposal(candidate_id=candidate.candidate_id)
+
+    revision_results = run_race(
+        (revision_proposal,) * RACE_SIZE,
+        history.append_revision,
+    )
+
+    revision = revision_results[0]
+    assert isinstance(revision, MemoryRevision)
+    assert all(item is revision for item in revision_results)
+    assert history.list_candidates(make_scope()) == (candidate,)
+    assert history.list_revisions(make_scope()) == (revision,)
+
+
+def test_concurrent_candidate_idempotency_conflicts_have_one_winner() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    history._candidate_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    history._candidate_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_candidate_proposal(
+            content=f"candidate-{index}",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="shared-candidate-key",
+        )
+        for index in range(RACE_SIZE)
+    )
+
+    outcomes = run_race(proposals, history.append_candidate)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryCandidate))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, CandidateConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    winner = winners[0]
+    assert history._candidate_by_id == {(make_scope(), winner.candidate_id): winner}
+    assert history._candidate_by_idempotency == {
+        (make_scope(), winner.proposal.idempotency_key): winner
+    }
+    assert history._candidates_by_scope == {make_scope(): [winner]}
+    assert history.list_candidates(make_scope()) == (winner,)
+
+
+def test_concurrent_revision_idempotency_conflicts_leave_loser_candidates_usable() -> (
+    None
+):
+    history, _, candidates = seed_candidates(RACE_SIZE)
+    history._revision_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    history._revision_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            idempotency_key="shared-revision-key",
+        )
+        for candidate in candidates
+    )
+
+    outcomes = run_race(proposals, history.append_revision)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryRevision))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, RevisionConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    winner = winners[0]
+    assert history._revision_by_id == {(make_scope(), winner.revision_id): winner}
+    assert history._revision_by_idempotency == {
+        (make_scope(), winner.proposal.idempotency_key): winner
+    }
+    assert history._revision_by_candidate == {
+        (make_scope(), winner.proposal.candidate_id): winner
+    }
+    assert history._revisions_by_scope == {make_scope(): [winner]}
+    assert history.list_revisions(make_scope()) == (winner,)
+
+    winner_candidate_id = winner.proposal.candidate_id
+    loser = next(
+        item for item in candidates if item.candidate_id != winner_candidate_id
+    )
+    recovered = history.append_revision(
+        make_revision_proposal(
+            candidate_id=loser.candidate_id,
+            idempotency_key="recovered-revision-key",
+        )
+    )
+    assert recovered.proposal.candidate_id == loser.candidate_id
+
+
+def test_concurrent_different_transitions_using_one_candidate_have_one_winner() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    history._revision_by_candidate = YieldingMissingContainsDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            idempotency_key=f"revision-{index}",
+        )
+        for index in range(RACE_SIZE)
+    )
+
+    outcomes = run_race(proposals, history.append_revision)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryRevision))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, RevisionConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    winner = winners[0]
+    assert history._revision_by_id == {(make_scope(), winner.revision_id): winner}
+    assert history._revision_by_idempotency == {
+        (make_scope(), winner.proposal.idempotency_key): winner
+    }
+    assert history._revision_by_candidate == {
+        (make_scope(), candidate.candidate_id): winner
+    }
+    assert history._revisions_by_scope == {make_scope(): [winner]}
+    assert history.list_revisions(make_scope()) == (winner,)
+
+
+def test_concurrent_sibling_revisions_all_survive() -> None:
+    history, _, candidates = seed_candidates(RACE_SIZE + 1)
+    parent = history.append_revision(
+        make_revision_proposal(candidate_id=candidates[0].candidate_id)
+    )
+    proposals = tuple(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=parent.revision_id,
+            idempotency_key=f"sibling-{index}",
+        )
+        for index, candidate in enumerate(candidates[1:])
+    )
+
+    outcomes = run_race(proposals, history.append_revision)
+
+    siblings = tuple(item for item in outcomes if isinstance(item, MemoryRevision))
+    assert len(siblings) == RACE_SIZE
+    assert len({item.revision_id for item in siblings}) == RACE_SIZE
+    assert {item.proposal.candidate_id for item in siblings} == {
+        candidate.candidate_id for candidate in candidates[1:]
+    }
+    assert {item.proposal.parent_revision_id for item in siblings} == {
+        parent.revision_id
+    }
+    assert {item.memory_id for item in siblings} == {parent.memory_id}
+    assert {item.generation for item in siblings} == {parent.generation + 1}
+    stored = history.list_revisions(make_scope())
+    expected_revision_ids = {parent.revision_id} | {
+        item.revision_id for item in siblings
+    }
+    assert len(stored) == RACE_SIZE + 1
+    assert {item.revision_id for item in stored} == expected_revision_ids
+    assert len(history._revision_by_id) == RACE_SIZE + 1
+    assert len(history._revision_by_idempotency) == RACE_SIZE + 1
+    assert len(history._revision_by_candidate) == RACE_SIZE + 1
+    assert set(history._revisions_by_scope) == {make_scope()}
+    assert {
+        item.revision_id for item in history._revisions_by_scope[make_scope()]
+    } == expected_revision_ids
+
+
+@pytest.mark.parametrize("same_full_hash", [True, False], ids=["full", "prefix"])
+def test_concurrent_candidate_collision_is_atomic_and_loser_key_is_reusable(
+    monkeypatch: pytest.MonkeyPatch,
+    same_full_hash: bool,
+) -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    history._candidate_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_candidate_proposal(
+            content=f"collision-{index}",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key=f"collision-{index}",
+        )
+        for index in range(RACE_SIZE)
+    )
+    prefix = "a" * 24
+    digest_by_bytes = {
+        proposal.canonical_bytes(): (
+            prefix + ("b" * 40 if same_full_hash else f"{index:040x}")
+        )
+        for index, proposal in enumerate(proposals)
+    }
+    assert {digest[:24] for digest in digest_by_bytes.values()} == {prefix}
+    assert len(set(digest_by_bytes.values())) == (1 if same_full_hash else RACE_SIZE)
+    install_digest_map(monkeypatch, digest_by_bytes)
+
+    outcomes = run_race(proposals, history.append_candidate)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryCandidate))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, CandidateConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    assert len(history._candidate_by_id) == 1
+    assert len(history._candidate_by_idempotency) == 1
+    assert history._candidates_by_scope == {make_scope(): [winners[0]]}
+    assert history.list_candidates(make_scope()) == winners
+    assert set(history._candidate_by_id) == {(make_scope(), winners[0].candidate_id)}
+    assert set(history._candidate_by_idempotency) == {
+        (make_scope(), winners[0].proposal.idempotency_key)
+    }
+
+    winner_key = winners[0].proposal.idempotency_key
+    loser_proposal = next(
+        proposal for proposal in proposals if proposal.idempotency_key != winner_key
+    )
+    monkeypatch.undo()
+    recovered = history.append_candidate(loser_proposal)
+    assert recovered.proposal.idempotency_key == loser_proposal.idempotency_key
+
+
+@pytest.mark.parametrize("same_full_hash", [True, False], ids=["full", "prefix"])
+def test_concurrent_revision_collision_is_atomic_and_loser_candidate_is_reusable(
+    monkeypatch: pytest.MonkeyPatch,
+    same_full_hash: bool,
+) -> None:
+    history, _, candidates = seed_candidates(RACE_SIZE)
+    history._revision_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            idempotency_key=f"collision-revision-{index}",
+        )
+        for index, candidate in enumerate(candidates)
+    )
+    prefix = "c" * 24
+    digest_by_bytes = {
+        proposal.canonical_bytes(): (
+            prefix + ("d" * 40 if same_full_hash else f"{index:040x}")
+        )
+        for index, proposal in enumerate(proposals)
+    }
+    assert {digest[:24] for digest in digest_by_bytes.values()} == {prefix}
+    assert len(set(digest_by_bytes.values())) == (1 if same_full_hash else RACE_SIZE)
+    install_digest_map(monkeypatch, digest_by_bytes)
+
+    outcomes = run_race(proposals, history.append_revision)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryRevision))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, RevisionConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    assert len(history._revision_by_id) == 1
+    assert len(history._revision_by_idempotency) == 1
+    assert len(history._revision_by_candidate) == 1
+    assert history._revisions_by_scope == {make_scope(): [winners[0]]}
+    assert history.list_revisions(make_scope()) == winners
+    assert set(history._revision_by_id) == {(make_scope(), winners[0].revision_id)}
+    assert set(history._revision_by_idempotency) == {
+        (make_scope(), winners[0].proposal.idempotency_key)
+    }
+    assert set(history._revision_by_candidate) == {
+        (make_scope(), winners[0].proposal.candidate_id)
+    }
+
+    winner_candidate_id = winners[0].proposal.candidate_id
+    loser_proposal = next(
+        proposal
+        for proposal in proposals
+        if proposal.candidate_id != winner_candidate_id
+    )
+    monkeypatch.undo()
+    recovered = history.append_revision(loser_proposal)
+    assert recovered.proposal.candidate_id == loser_proposal.candidate_id
+
+
+@pytest.mark.parametrize("same_full_hash", [True, False], ids=["full", "prefix"])
+def test_forced_cross_scope_collisions_coexist_for_candidates_and_revisions(
+    monkeypatch: pytest.MonkeyPatch,
+    same_full_hash: bool,
+) -> None:
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    evidence_store = InMemoryEvidenceStore()
+    first_evidence = evidence_store.append(make_evidence_event(scope=first_scope))
+    second_evidence = evidence_store.append(
+        make_evidence_event(
+            scope=second_scope,
+            idempotency_key="second-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate_proposals = (
+        make_candidate_proposal(
+            scope=first_scope,
+            content="first",
+            evidence_ids=(first_evidence.evidence_id,),
+            idempotency_key="shared-candidate-key",
+        ),
+        make_candidate_proposal(
+            scope=second_scope,
+            content="second",
+            evidence_ids=(second_evidence.evidence_id,),
+            idempotency_key="shared-candidate-key",
+        ),
+    )
+    candidate_prefix = "e" * 24
+    candidate_digests = tuple(
+        candidate_prefix + ("a" * 40 if same_full_hash else f"{index:040x}")
+        for index in range(2)
+    )
+    install_digest_map(
+        monkeypatch,
+        {
+            proposal.canonical_bytes(): digest
+            for proposal, digest in zip(
+                candidate_proposals,
+                candidate_digests,
+                strict=True,
+            )
+        },
+    )
+
+    candidates = tuple(history.append_candidate(item) for item in candidate_proposals)
+
+    assert candidates[0].candidate_id == candidates[1].candidate_id
+    assert (candidates[0].content_hash == candidates[1].content_hash) is same_full_hash
+    assert (
+        history.get_candidate(first_scope, candidates[0].candidate_id) is candidates[0]
+    )
+    assert (
+        history.get_candidate(second_scope, candidates[1].candidate_id) is candidates[1]
+    )
+    assert history.list_candidates(first_scope) == (candidates[0],)
+    assert history.list_candidates(second_scope) == (candidates[1],)
+    assert history.append_candidate(candidate_proposals[0]) is candidates[0]
+    assert history.append_candidate(candidate_proposals[1]) is candidates[1]
+    assert history._candidate_by_id == {
+        (first_scope, candidates[0].candidate_id): candidates[0],
+        (second_scope, candidates[1].candidate_id): candidates[1],
+    }
+    assert history._candidate_by_idempotency == {
+        (first_scope, "shared-candidate-key"): candidates[0],
+        (second_scope, "shared-candidate-key"): candidates[1],
+    }
+    assert history._candidates_by_scope == {
+        first_scope: [candidates[0]],
+        second_scope: [candidates[1]],
+    }
+
+    revision_proposals = (
+        make_revision_proposal(
+            scope=first_scope,
+            candidate_id=candidates[0].candidate_id,
+            idempotency_key="shared-revision-key",
+        ),
+        make_revision_proposal(
+            scope=second_scope,
+            candidate_id=candidates[1].candidate_id,
+            idempotency_key="shared-revision-key",
+        ),
+    )
+    revision_prefix = "f" * 24
+    revision_digests = tuple(
+        revision_prefix + ("b" * 40 if same_full_hash else f"{index + 2:040x}")
+        for index in range(2)
+    )
+    install_digest_map(
+        monkeypatch,
+        {
+            proposal.canonical_bytes(): digest
+            for proposal, digest in zip(
+                revision_proposals,
+                revision_digests,
+                strict=True,
+            )
+        },
+    )
+
+    revisions = tuple(history.append_revision(item) for item in revision_proposals)
+
+    assert revisions[0].revision_id == revisions[1].revision_id
+    assert (revisions[0].content_hash == revisions[1].content_hash) is same_full_hash
+    assert history.get_revision(first_scope, revisions[0].revision_id) is revisions[0]
+    assert history.get_revision(second_scope, revisions[1].revision_id) is revisions[1]
+    assert history.list_revisions(first_scope) == (revisions[0],)
+    assert history.list_revisions(second_scope) == (revisions[1],)
+    assert history.append_revision(revision_proposals[0]) is revisions[0]
+    assert history.append_revision(revision_proposals[1]) is revisions[1]
+    assert history._revision_by_id == {
+        (first_scope, revisions[0].revision_id): revisions[0],
+        (second_scope, revisions[1].revision_id): revisions[1],
+    }
+    assert history._revision_by_idempotency == {
+        (first_scope, "shared-revision-key"): revisions[0],
+        (second_scope, "shared-revision-key"): revisions[1],
+    }
+    assert history._revision_by_candidate == {
+        (first_scope, candidates[0].candidate_id): revisions[0],
+        (second_scope, candidates[1].candidate_id): revisions[1],
+    }
+    assert history._revisions_by_scope == {
+        first_scope: [revisions[0]],
+        second_scope: [revisions[1]],
+    }

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the evidence-grounded in-memory history store."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from hashlib import sha256
+
+import pytest
+
+from areal.v2.memory_service.errors import (
+    CandidateConflictError,
+    CandidateNotFoundError,
+    EvidenceNotFoundError,
+    MemoryServiceError,
+)
+from areal.v2.memory_service.history_store import (
+    InMemoryMemoryHistoryStore,
+    MemoryHistoryStore,
+)
+from areal.v2.memory_service.history_types import CandidateProposal
+from areal.v2.memory_service.store import InMemoryEvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+
+class MutableHashStr(str):
+    """String subclass that records unsafe hashing by store queries."""
+
+    hash_calls: int
+    hash_salt: int
+
+    def __new__(cls, value: str) -> MutableHashStr:
+        instance = str.__new__(cls, value)
+        instance.hash_calls = 0
+        instance.hash_salt = 0
+        return instance
+
+    def __hash__(self) -> int:
+        self.hash_calls += 1
+        return str.__hash__(self) + self.hash_salt
+
+
+class MemoryScopeSubclass(MemoryScope):
+    pass
+
+
+class CandidateProposalSubclass(CandidateProposal):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
+UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, tzinfo=UTC)
+
+
+def make_scope(**overrides: str) -> MemoryScope:
+    values = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)
+
+
+def make_candidate_proposal(**overrides: object) -> CandidateProposal:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "content": "remember this",
+        "evidence_ids": ("evd_missing",),
+        "idempotency_key": "candidate-1",
+    }
+    values.update(overrides)
+    return CandidateProposal(**values)  # type: ignore[arg-type]
+
+
+def make_evidence_event(**overrides: object) -> EvidenceEvent:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "sequence_no": 0,
+        "kind": EvidenceKind.USER_MESSAGE,
+        "payload": "remember this",
+        "observed_at": UTC_INSTANT,
+        "idempotency_key": "evidence-1",
+    }
+    values.update(overrides)
+    return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+def seeded_evidence_store() -> tuple[InMemoryEvidenceStore, EvidenceRecord]:
+    evidence_store = InMemoryEvidenceStore()
+    evidence = evidence_store.append(make_evidence_event())
+    return evidence_store, evidence
+
+
+def assert_candidate_indexes_empty(history: InMemoryMemoryHistoryStore) -> None:
+    assert history._candidate_by_id == {}
+    assert history._candidate_by_idempotency == {}
+    assert history._candidates_by_scope == {}
+
+
+def test_history_store_contract_exposes_only_candidate_surface() -> None:
+    public_members = {
+        name for name in MemoryHistoryStore.__dict__ if not name.startswith("_")
+    }
+
+    assert public_members == {
+        "append_candidate",
+        "get_candidate",
+        "get_candidate_evidence",
+        "list_candidates",
+    }
+
+
+def test_candidate_error_types_share_memory_service_base_error() -> None:
+    assert issubclass(CandidateNotFoundError, MemoryServiceError)
+    assert issubclass(CandidateConflictError, MemoryServiceError)
+
+
+def test_append_candidate_requires_existing_evidence_in_same_scope() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+
+    candidate = history.append_candidate(proposal)
+
+    assert candidate.proposal is proposal
+    assert candidate.proposal.evidence_ids == (evidence.evidence_id,)
+    assert history.get_candidate(proposal.scope, candidate.candidate_id) is candidate
+    assert history.get_candidate_evidence(proposal.scope, candidate.candidate_id) == (
+        evidence,
+    )
+
+
+def test_append_candidate_rejects_proposal_subclass_before_any_write() -> None:
+    proposal = CandidateProposalSubclass(
+        make_scope(), "remember this", ("evd_missing",), "candidate-1"
+    )
+    history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+
+    with pytest.raises(TypeError, match="CandidateProposal"):
+        history.append_candidate(proposal)
+
+    assert_candidate_indexes_empty(history)
+
+
+def test_first_missing_evidence_leaves_every_candidate_index_empty() -> None:
+    history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+    proposal = make_candidate_proposal(evidence_ids=("evd_missing",))
+
+    with pytest.raises(EvidenceNotFoundError):
+        history.append_candidate(proposal)
+
+    assert_candidate_indexes_empty(history)
+    assert history.list_candidates(proposal.scope) == ()
+
+
+def test_late_missing_evidence_leaves_every_candidate_index_empty() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    proposal = make_candidate_proposal(
+        evidence_ids=(evidence.evidence_id, "evd_missing")
+    )
+
+    with pytest.raises(EvidenceNotFoundError):
+        history.append_candidate(proposal)
+
+    assert_candidate_indexes_empty(history)
+
+
+def test_candidate_evidence_preserves_proposal_order() -> None:
+    evidence_store, first = seeded_evidence_store()
+    second = evidence_store.append(
+        make_evidence_event(
+            sequence_no=1,
+            payload="second",
+            idempotency_key="evidence-2",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(second.evidence_id, first.evidence_id))
+    )
+
+    assert history.get_candidate_evidence(
+        candidate.proposal.scope, candidate.candidate_id
+    ) == (second, first)
+
+
+def test_foreign_scope_evidence_is_indistinguishable_from_missing() -> None:
+    evidence_store = InMemoryEvidenceStore()
+    foreign = evidence_store.append(
+        make_evidence_event(scope=make_scope(subject_id="user-2"))
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    missing_history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+    proposal = make_candidate_proposal(evidence_ids=(foreign.evidence_id,))
+
+    with pytest.raises(EvidenceNotFoundError) as foreign_error:
+        history.append_candidate(proposal)
+    with pytest.raises(EvidenceNotFoundError) as missing_error:
+        missing_history.append_candidate(proposal)
+
+    assert type(foreign_error.value) is EvidenceNotFoundError
+    assert str(foreign_error.value) == str(missing_error.value)
+    assert_candidate_indexes_empty(history)
+
+
+def test_identical_candidate_retry_returns_original_record() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+
+    first = history.append_candidate(proposal)
+    retry = history.append_candidate(
+        CandidateProposal(
+            scope=proposal.scope,
+            content=proposal.content,
+            evidence_ids=proposal.evidence_ids,
+            idempotency_key=proposal.idempotency_key,
+        )
+    )
+
+    assert retry is first
+    assert history.list_candidates(proposal.scope) == (first,)
+    assert len(history._candidate_by_id) == 1
+    assert len(history._candidate_by_idempotency) == 1
+
+
+def test_changed_candidate_idempotency_key_reuse_conflicts_without_partial_write() -> (
+    None
+):
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+
+    with pytest.raises(CandidateConflictError, match="idempotency"):
+        history.append_candidate(
+            make_candidate_proposal(
+                content="changed",
+                evidence_ids=(evidence.evidence_id,),
+            )
+        )
+
+    assert history.list_candidates(first.proposal.scope) == (first,)
+    assert tuple(history._candidate_by_id.values()) == (first,)
+    assert tuple(history._candidate_by_idempotency.values()) == (first,)
+
+
+def test_committed_idempotency_conflict_precedes_missing_or_foreign_evidence() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    foreign = evidence_store.append(
+        make_evidence_event(
+            scope=make_scope(subject_id="user-2"),
+            idempotency_key="foreign-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+
+    for invalid_evidence_id in ("evd_missing", foreign.evidence_id):
+        with pytest.raises(CandidateConflictError, match="idempotency"):
+            history.append_candidate(
+                make_candidate_proposal(
+                    content="changed",
+                    evidence_ids=(invalid_evidence_id,),
+                )
+            )
+
+    assert history.list_candidates(first.proposal.scope) == (first,)
+    assert tuple(history._candidate_by_id.values()) == (first,)
+    assert tuple(history._candidate_by_idempotency.values()) == (first,)
+
+
+def test_candidate_uses_full_sha256_truncated_identifier_and_utc_timestamp() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    expected_hash = sha256(proposal.canonical_bytes()).hexdigest()
+
+    candidate = history.append_candidate(proposal)
+
+    assert candidate.content_hash == expected_hash
+    assert re.fullmatch(r"[0-9a-f]{64}", candidate.content_hash)
+    assert candidate.candidate_id == f"cand_{expected_hash[:24]}"
+    assert re.fullmatch(r"cand_[0-9a-f]{24}", candidate.candidate_id)
+    assert candidate.created_at.tzinfo is UTC
+
+
+def test_candidate_lookup_and_lists_are_scope_isolated_and_deterministic() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    other_scope = make_scope(subject_id="user-2")
+    other_evidence = evidence_store.append(
+        make_evidence_event(
+            scope=other_scope,
+            payload="other",
+            idempotency_key="other-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    right = history.append_candidate(
+        make_candidate_proposal(
+            content="right",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="right",
+        )
+    )
+    left = history.append_candidate(
+        make_candidate_proposal(
+            content="left",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="left",
+        )
+    )
+    other = history.append_candidate(
+        make_candidate_proposal(
+            scope=other_scope,
+            content="other",
+            evidence_ids=(other_evidence.evidence_id,),
+            idempotency_key="other",
+        )
+    )
+    expected = tuple(sorted((left, right), key=lambda item: item.candidate_id))
+
+    assert (right, left) != expected
+    assert history.list_candidates(make_scope()) == expected
+    assert history.list_candidates(other_scope) == (other,)
+    assert history.get_candidate(make_scope(), left.candidate_id) is left
+    with pytest.raises(CandidateNotFoundError):
+        history.get_candidate(other_scope, left.candidate_id)
+
+
+def test_equal_candidate_content_under_new_attempt_is_not_semantically_deduplicated() -> (
+    None
+):
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first = history.append_candidate(
+        make_candidate_proposal(
+            evidence_ids=(evidence.evidence_id,), idempotency_key="attempt-a"
+        )
+    )
+    second = history.append_candidate(
+        make_candidate_proposal(
+            evidence_ids=(evidence.evidence_id,), idempotency_key="attempt-b"
+        )
+    )
+
+    assert first.candidate_id != second.candidate_id
+    assert history.list_candidates(make_scope()) == tuple(
+        sorted((first, second), key=lambda item: item.candidate_id)
+    )
+
+
+def test_candidate_list_snapshot_does_not_change_after_later_append() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    snapshot = history.list_candidates(make_scope())
+
+    history.append_candidate(
+        make_candidate_proposal(
+            content="later",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="later",
+        )
+    )
+
+    assert snapshot == (first,)
+
+
+def test_candidate_queries_snapshot_ids_and_reject_scope_subclasses() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    query_id = MutableHashStr(candidate.candidate_id)
+    query_id.hash_salt = 1_000_003
+
+    assert history.get_candidate(make_scope(), query_id) is candidate
+    assert history.get_candidate_evidence(make_scope(), query_id) == (evidence,)
+    assert query_id.hash_calls == 0
+    invalid_scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+    with pytest.raises(TypeError, match="scope"):
+        history.get_candidate(invalid_scope, candidate.candidate_id)
+    with pytest.raises(TypeError, match="scope"):
+        history.list_candidates(invalid_scope)
+
+
+def test_foreign_candidate_error_matches_genuinely_missing_error() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    empty_history = InMemoryMemoryHistoryStore(evidence_store)
+
+    with pytest.raises(CandidateNotFoundError) as foreign:
+        history.get_candidate(make_scope(subject_id="user-2"), candidate.candidate_id)
+    with pytest.raises(CandidateNotFoundError) as missing:
+        empty_history.get_candidate(make_scope(), candidate.candidate_id)
+
+    assert str(foreign.value) == str(missing.value)

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -7,20 +7,30 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 from hashlib import sha256
+from threading import RLock
 
 import pytest
 
+from areal.v2.memory_service import history_store as history_store_module
 from areal.v2.memory_service.errors import (
     CandidateConflictError,
     CandidateNotFoundError,
     EvidenceNotFoundError,
     MemoryServiceError,
+    RevisionConflictError,
+    RevisionNotFoundError,
 )
 from areal.v2.memory_service.history_store import (
     InMemoryMemoryHistoryStore,
     MemoryHistoryStore,
 )
-from areal.v2.memory_service.history_types import CandidateProposal
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
+)
 from areal.v2.memory_service.store import InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
     EvidenceEvent,
@@ -47,11 +57,33 @@ class MutableHashStr(str):
         return str.__hash__(self) + self.hash_salt
 
 
+class AlwaysEqualStr(str):
+    """String subclass that records unsafe equality by store queries."""
+
+    equality_calls: int
+
+    def __new__(cls, value: str) -> AlwaysEqualStr:
+        instance = str.__new__(cls, value)
+        instance.equality_calls = 0
+        return instance
+
+    def __eq__(self, other: object) -> bool:
+        self.equality_calls += 1
+        return True
+
+    __hash__ = str.__hash__
+
+
 class MemoryScopeSubclass(MemoryScope):
     pass
 
 
 class CandidateProposalSubclass(CandidateProposal):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
+class RevisionProposalSubclass(RevisionProposal):
     def canonical_bytes(self) -> bytes:
         return b"overridden"
 
@@ -78,6 +110,18 @@ def make_candidate_proposal(**overrides: object) -> CandidateProposal:
     }
     values.update(overrides)
     return CandidateProposal(**values)  # type: ignore[arg-type]
+
+
+def make_revision_proposal(**overrides: object) -> RevisionProposal:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "candidate_id": "cand_missing",
+        "operation": RevisionOperation.ADD,
+        "parent_revision_id": None,
+        "idempotency_key": "revision-1",
+    }
+    values.update(overrides)
+    return RevisionProposal(**values)  # type: ignore[arg-type]
 
 
 def make_evidence_event(**overrides: object) -> EvidenceEvent:
@@ -107,7 +151,7 @@ def assert_candidate_indexes_empty(history: InMemoryMemoryHistoryStore) -> None:
     assert history._candidates_by_scope == {}
 
 
-def test_history_store_contract_exposes_only_candidate_surface() -> None:
+def test_history_store_contract_exposes_only_candidate_and_revision_surface() -> None:
     public_members = {
         name for name in MemoryHistoryStore.__dict__ if not name.startswith("_")
     }
@@ -117,12 +161,17 @@ def test_history_store_contract_exposes_only_candidate_surface() -> None:
         "get_candidate",
         "get_candidate_evidence",
         "list_candidates",
+        "append_revision",
+        "get_revision",
+        "list_revisions",
     }
 
 
-def test_candidate_error_types_share_memory_service_base_error() -> None:
+def test_history_errors_share_memory_service_base() -> None:
     assert issubclass(CandidateNotFoundError, MemoryServiceError)
     assert issubclass(CandidateConflictError, MemoryServiceError)
+    assert issubclass(RevisionNotFoundError, MemoryServiceError)
+    assert issubclass(RevisionConflictError, MemoryServiceError)
 
 
 def test_append_candidate_requires_existing_evidence_in_same_scope() -> None:
@@ -416,3 +465,801 @@ def test_foreign_candidate_error_matches_genuinely_missing_error() -> None:
         empty_history.get_candidate(make_scope(), candidate.candidate_id)
 
     assert str(foreign.value) == str(missing.value)
+
+
+def append_candidate(
+    history: InMemoryMemoryHistoryStore,
+    evidence_store: InMemoryEvidenceStore,
+    *,
+    candidate_key: str,
+    evidence_key: str,
+) -> MemoryCandidate:
+    evidence = evidence_store.append(
+        make_evidence_event(
+            sequence_no=len(evidence_store.list(make_scope())),
+            payload=candidate_key,
+            idempotency_key=evidence_key,
+        )
+    )
+    return history.append_candidate(
+        make_candidate_proposal(
+            content=candidate_key,
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key=candidate_key,
+        )
+    )
+
+
+def seeded_history_candidate() -> tuple[
+    InMemoryMemoryHistoryStore, MemoryCandidate, EvidenceRecord
+]:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    return history, candidate, evidence
+
+
+def seeded_parent_and_candidate() -> tuple[
+    InMemoryMemoryHistoryStore, MemoryRevision, MemoryCandidate
+]:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    root_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    parent = history.append_revision(
+        make_revision_proposal(candidate_id=root_candidate.candidate_id)
+    )
+    child_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="child-candidate",
+        evidence_key="child-evidence",
+    )
+    return history, parent, child_candidate
+
+
+def seeded_parent_and_two_candidates() -> tuple[
+    InMemoryMemoryHistoryStore,
+    MemoryRevision,
+    MemoryCandidate,
+    MemoryCandidate,
+]:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    root_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    parent = history.append_revision(
+        make_revision_proposal(candidate_id=root_candidate.candidate_id)
+    )
+    left = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="left-candidate",
+        evidence_key="left-evidence",
+    )
+    right = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="right-candidate",
+        evidence_key="right-evidence",
+    )
+    return history, parent, left, right
+
+
+def test_add_creates_generation_zero_logical_memory() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    revision = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+
+    assert revision.proposal.operation is RevisionOperation.ADD
+    assert revision.proposal.parent_revision_id is None
+    assert revision.generation == 0
+    assert revision.memory_id == "mem_" + revision.content_hash[:24]
+
+
+def test_append_revision_rejects_proposal_subclass_before_any_write() -> None:
+    proposal = RevisionProposalSubclass(
+        make_scope(), "cand_missing", RevisionOperation.ADD, None, "revision-1"
+    )
+    history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+
+    with pytest.raises(TypeError, match="RevisionProposal"):
+        history.append_revision(proposal)
+
+    assert history._revision_by_id == {}
+    assert history._revision_by_idempotency == {}
+    assert history._revision_by_candidate == {}
+    assert history._revisions_by_scope == {}
+
+
+def test_revision_identity_is_derived_before_history_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history, candidate, _ = seeded_history_candidate()
+    proposal = make_revision_proposal(candidate_id=candidate.candidate_id)
+    expected_hash = sha256(proposal.canonical_bytes()).hexdigest()
+    events: list[str] = []
+
+    class ProbeLock:
+        def __init__(self) -> None:
+            self._lock = RLock()
+            self.held = False
+
+        def __enter__(self) -> ProbeLock:
+            assert events == ["canonical", "sha256", "hexdigest", "revision-id"]
+            self._lock.acquire()
+            self.held = True
+            return self
+
+        def __exit__(
+            self,
+            exc_type: object,
+            exc_value: object,
+            traceback: object,
+        ) -> None:
+            self.held = False
+            self._lock.release()
+
+    probe_lock = ProbeLock()
+    history._lock = probe_lock  # type: ignore[assignment]
+    original_canonical_bytes = RevisionProposal.canonical_bytes
+    original_sha256 = history_store_module.hashlib.sha256
+
+    def observed_canonical_bytes(value: RevisionProposal) -> bytes:
+        assert not probe_lock.held
+        events.append("canonical")
+        return original_canonical_bytes(value)
+
+    class ObservedHexDigest(str):
+        slice_count: int
+
+        def __new__(cls, value: str) -> ObservedHexDigest:
+            instance = str.__new__(cls, value)
+            instance.slice_count = 0
+            return instance
+
+        def __getitem__(self, key: object) -> str:
+            self.slice_count += 1
+            if self.slice_count == 1:
+                assert not probe_lock.held
+                events.append("revision-id")
+            return str.__getitem__(self, key)  # type: ignore[index]
+
+    class ObservedHash:
+        def __init__(self, canonical_bytes: bytes) -> None:
+            self._hash = original_sha256(canonical_bytes)
+
+        def hexdigest(self) -> ObservedHexDigest:
+            assert not probe_lock.held
+            events.append("hexdigest")
+            return ObservedHexDigest(self._hash.hexdigest())
+
+    def observed_sha256(canonical_bytes: bytes) -> ObservedHash:
+        assert not probe_lock.held
+        events.append("sha256")
+        return ObservedHash(canonical_bytes)
+
+    monkeypatch.setattr(RevisionProposal, "canonical_bytes", observed_canonical_bytes)
+    monkeypatch.setattr(history_store_module.hashlib, "sha256", observed_sha256)
+
+    revision = history.append_revision(proposal)
+
+    assert revision.content_hash == expected_hash
+    assert revision.revision_id == f"rev_{expected_hash[:24]}"
+    assert events == ["canonical", "sha256", "hexdigest", "revision-id"]
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        RevisionOperation.REFINE,
+        RevisionOperation.SUPERSEDE,
+        RevisionOperation.CONTRADICT,
+    ],
+)
+def test_child_transition_inherits_memory_and_preserves_parent(
+    operation: RevisionOperation,
+) -> None:
+    history, parent, child_candidate = seeded_parent_and_candidate()
+    parent_bytes = parent.proposal.canonical_bytes()
+
+    child = history.append_revision(
+        make_revision_proposal(
+            candidate_id=child_candidate.candidate_id,
+            operation=operation,
+            parent_revision_id=parent.revision_id,
+            idempotency_key=f"{operation.value}-1",
+        )
+    )
+
+    assert child.memory_id == parent.memory_id
+    assert child.generation == parent.generation + 1
+    assert parent.proposal.canonical_bytes() == parent_bytes
+    assert history.get_revision(parent.proposal.scope, parent.revision_id) is parent
+
+
+def test_different_candidates_from_one_parent_survive_as_siblings() -> None:
+    history, parent, left_candidate, right_candidate = (
+        seeded_parent_and_two_candidates()
+    )
+    left = history.append_revision(
+        make_revision_proposal(
+            candidate_id=left_candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=parent.revision_id,
+            idempotency_key="left",
+        )
+    )
+    right = history.append_revision(
+        make_revision_proposal(
+            candidate_id=right_candidate.candidate_id,
+            operation=RevisionOperation.CONTRADICT,
+            parent_revision_id=parent.revision_id,
+            idempotency_key="right",
+        )
+    )
+
+    assert left.memory_id == right.memory_id == parent.memory_id
+    assert left.generation == right.generation == 1
+    assert set(history.list_revisions(parent.proposal.scope)) == {parent, left, right}
+
+
+def test_missing_parent_does_not_consume_candidate() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    invalid = make_revision_proposal(
+        candidate_id=candidate.candidate_id,
+        operation=RevisionOperation.REFINE,
+        parent_revision_id="rev_missing",
+    )
+    with pytest.raises(RevisionNotFoundError):
+        history.append_revision(invalid)
+
+    valid = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+    assert valid.generation == 0
+
+
+def test_foreign_candidate_and_parent_are_hidden_as_missing() -> None:
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    evidence_store = InMemoryEvidenceStore()
+    first_evidence = evidence_store.append(make_evidence_event(scope=first_scope))
+    second_evidence = evidence_store.append(
+        make_evidence_event(
+            scope=second_scope,
+            idempotency_key="second-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first_candidate = history.append_candidate(
+        make_candidate_proposal(
+            scope=first_scope,
+            evidence_ids=(first_evidence.evidence_id,),
+            idempotency_key="first-candidate",
+        )
+    )
+    second_candidate = history.append_candidate(
+        make_candidate_proposal(
+            scope=second_scope,
+            evidence_ids=(second_evidence.evidence_id,),
+            idempotency_key="second-candidate",
+        )
+    )
+    foreign_parent = history.append_revision(
+        make_revision_proposal(
+            scope=second_scope,
+            candidate_id=second_candidate.candidate_id,
+            idempotency_key="foreign-parent",
+        )
+    )
+
+    with pytest.raises(CandidateNotFoundError):
+        history.append_revision(
+            make_revision_proposal(candidate_id=second_candidate.candidate_id)
+        )
+    with pytest.raises(RevisionNotFoundError):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id=first_candidate.candidate_id,
+                operation=RevisionOperation.REFINE,
+                parent_revision_id=foreign_parent.revision_id,
+            )
+        )
+
+
+def test_revision_idempotency_and_lists_are_scope_isolated() -> None:
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    evidence_store = InMemoryEvidenceStore()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+
+    def append_root(scope: MemoryScope) -> MemoryRevision:
+        evidence = evidence_store.append(
+            make_evidence_event(
+                scope=scope,
+                idempotency_key="shared-evidence",
+            )
+        )
+        candidate = history.append_candidate(
+            make_candidate_proposal(
+                scope=scope,
+                evidence_ids=(evidence.evidence_id,),
+                idempotency_key="shared-candidate",
+            )
+        )
+        return history.append_revision(
+            make_revision_proposal(
+                scope=scope,
+                candidate_id=candidate.candidate_id,
+                idempotency_key="shared-revision",
+            )
+        )
+
+    first = append_root(first_scope)
+    second = append_root(second_scope)
+
+    assert first is not second
+    assert history.list_revisions(first_scope) == (first,)
+    assert history.list_revisions(second_scope) == (second,)
+
+
+def test_revision_retry_and_conflicting_idempotency_are_atomic() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    parent_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    proposal = make_revision_proposal(candidate_id=parent_candidate.candidate_id)
+    first = history.append_revision(proposal)
+    retry = history.append_revision(
+        RevisionProposal(
+            scope=proposal.scope,
+            candidate_id=proposal.candidate_id,
+            operation=proposal.operation,
+            parent_revision_id=proposal.parent_revision_id,
+            idempotency_key=proposal.idempotency_key,
+        )
+    )
+    assert retry is first
+
+    other_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="other-candidate",
+        evidence_key="other-evidence",
+    )
+    before = (
+        dict(history._revision_by_id),
+        dict(history._revision_by_idempotency),
+        dict(history._revision_by_candidate),
+        {scope: list(items) for scope, items in history._revisions_by_scope.items()},
+    )
+    with pytest.raises(RevisionConflictError, match="idempotency"):
+        history.append_revision(
+            make_revision_proposal(candidate_id=other_candidate.candidate_id)
+        )
+    assert (
+        history._revision_by_id,
+        history._revision_by_idempotency,
+        history._revision_by_candidate,
+        history._revisions_by_scope,
+    ) == before
+
+    recovered = history.append_revision(
+        make_revision_proposal(
+            candidate_id=other_candidate.candidate_id,
+            idempotency_key="other-revision",
+        )
+    )
+    assert recovered.proposal.candidate_id == other_candidate.candidate_id
+
+
+def test_revision_error_precedence_and_id_collision_are_atomic() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    first = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+
+    def revision_indexes() -> tuple[object, ...]:
+        return (
+            dict(history._revision_by_id),
+            dict(history._revision_by_idempotency),
+            dict(history._revision_by_candidate),
+            {
+                scope: list(revisions)
+                for scope, revisions in history._revisions_by_scope.items()
+            },
+        )
+
+    idempotency_attempt = make_revision_proposal(
+        candidate_id="cand_missing",
+        operation=RevisionOperation.REFINE,
+        parent_revision_id="rev_missing",
+    )
+    idempotency_hash = sha256(idempotency_attempt.canonical_bytes()).hexdigest()
+    idempotency_index = (
+        idempotency_attempt.scope,
+        f"rev_{idempotency_hash[:24]}",
+    )
+    history._revision_by_id[idempotency_index] = first
+    before = revision_indexes()
+    with pytest.raises(RevisionConflictError, match="idempotency"):
+        history.append_revision(idempotency_attempt)
+    assert revision_indexes() == before
+    del history._revision_by_id[idempotency_index]
+
+    collision_attempt = make_revision_proposal(
+        candidate_id="cand_missing",
+        operation=RevisionOperation.REFINE,
+        parent_revision_id="rev_missing",
+        idempotency_key="collision-attempt",
+    )
+    collision_hash = sha256(collision_attempt.canonical_bytes()).hexdigest()
+    collision_index = (
+        collision_attempt.scope,
+        f"rev_{collision_hash[:24]}",
+    )
+    history._revision_by_id[collision_index] = first
+    before = revision_indexes()
+    with pytest.raises(RevisionConflictError, match="collision"):
+        history.append_revision(collision_attempt)
+    assert revision_indexes() == before
+    del history._revision_by_id[collision_index]
+
+    with pytest.raises(CandidateNotFoundError):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id="cand_missing",
+                operation=RevisionOperation.REFINE,
+                parent_revision_id="rev_missing",
+                idempotency_key="missing-relationships",
+            )
+        )
+    with pytest.raises(RevisionConflictError, match="candidate"):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id=candidate.candidate_id,
+                operation=RevisionOperation.REFINE,
+                parent_revision_id="rev_missing",
+                idempotency_key="used-candidate",
+            )
+        )
+
+
+def test_one_candidate_can_back_only_one_revision() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    history.append_revision(make_revision_proposal(candidate_id=candidate.candidate_id))
+
+    with pytest.raises(RevisionConflictError, match="candidate"):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id=candidate.candidate_id,
+                idempotency_key="second-use",
+            )
+        )
+
+
+def test_revision_relationship_checks_and_writes_share_one_lock_epoch() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    records: list[tuple[str, int]] = []
+
+    class EpochLock:
+        def __init__(self) -> None:
+            self._lock = RLock()
+            self.held = False
+            self.epoch = 0
+            self.enter_count = 0
+
+        def __enter__(self) -> EpochLock:
+            self._lock.acquire()
+            assert not self.held
+            self.held = True
+            self.epoch += 1
+            self.enter_count += 1
+            return self
+
+        def __exit__(
+            self,
+            exc_type: object,
+            exc_value: object,
+            traceback: object,
+        ) -> None:
+            self.held = False
+            self._lock.release()
+
+        def current_epoch(self) -> int:
+            assert self.held, "revision index accessed outside history lock"
+            return self.epoch
+
+    epoch_lock = EpochLock()
+
+    def record(event: str) -> None:
+        records.append((event, epoch_lock.current_epoch()))
+
+    class RecordingList(list[object]):
+        def append(self, item: object) -> None:
+            record("scope:append")
+            super().append(item)
+
+    class RecordingDict(dict[object, object]):
+        def __init__(self, values: dict[object, object], name: str) -> None:
+            super().__init__(values)
+            self._name = name
+
+        def get(self, key: object, default: object = None) -> object:
+            record(f"{self._name}:get")
+            return super().get(key, default)
+
+        def __contains__(self, key: object) -> bool:
+            record(f"{self._name}:contains")
+            return super().__contains__(key)
+
+        def __setitem__(self, key: object, value: object) -> None:
+            record(f"{self._name}:set")
+            super().__setitem__(key, value)
+
+        def setdefault(self, key: object, default: object = None) -> object:
+            record(f"{self._name}:setdefault")
+            if not dict.__contains__(self, key):
+                default = RecordingList(default or ())
+            return super().setdefault(key, default)
+
+    history._lock = epoch_lock  # type: ignore[assignment]
+    history._candidate_by_id = RecordingDict(  # type: ignore[assignment]
+        history._candidate_by_id,
+        "candidate",
+    )
+    history._revision_by_id = RecordingDict(  # type: ignore[assignment]
+        history._revision_by_id,
+        "revision",
+    )
+    history._revision_by_idempotency = RecordingDict(  # type: ignore[assignment]
+        history._revision_by_idempotency,
+        "idempotency",
+    )
+    history._revision_by_candidate = RecordingDict(  # type: ignore[assignment]
+        history._revision_by_candidate,
+        "candidate-revision",
+    )
+    history._revisions_by_scope = RecordingDict(  # type: ignore[assignment]
+        history._revisions_by_scope,
+        "scope",
+    )
+    revision = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+
+    assert epoch_lock.enter_count == 1
+    assert {epoch for _, epoch in records} == {1}
+    assert [event for event, _ in records] == [
+        "idempotency:get",
+        "revision:get",
+        "candidate:get",
+        "candidate-revision:contains",
+        "revision:set",
+        "idempotency:set",
+        "candidate-revision:set",
+        "scope:setdefault",
+        "scope:append",
+    ]
+    assert tuple(history._revision_by_id.values()) == (revision,)
+    assert tuple(history._revision_by_idempotency.values()) == (revision,)
+    assert tuple(history._revision_by_candidate.values()) == (revision,)
+    assert tuple(history._revisions_by_scope.values()) == ([revision],)
+
+
+def test_revision_identity_order_filter_and_public_provenance() -> None:
+    history, parent, child_candidate = seeded_parent_and_candidate()
+    child = history.append_revision(
+        make_revision_proposal(
+            candidate_id=child_candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=parent.revision_id,
+            idempotency_key="child-revision",
+        )
+    )
+    expected_hash = sha256(child.proposal.canonical_bytes()).hexdigest()
+
+    assert child.content_hash == expected_hash
+    assert re.fullmatch(r"[0-9a-f]{64}", child.content_hash)
+    assert child.revision_id == f"rev_{expected_hash[:24]}"
+    assert re.fullmatch(r"rev_[0-9a-f]{24}", child.revision_id)
+    assert history.list_revisions(parent.proposal.scope) == (parent, child)
+    assert history.list_revisions(
+        parent.proposal.scope, memory_id=parent.memory_id
+    ) == (parent, child)
+    assert history.list_revisions(parent.proposal.scope, memory_id="mem_missing") == ()
+    resolved = history.get_revision(child.proposal.scope, child.revision_id)
+    candidate = history.get_candidate(
+        resolved.proposal.scope, resolved.proposal.candidate_id
+    )
+    assert history.get_candidate_evidence(
+        candidate.proposal.scope, candidate.candidate_id
+    )
+    with pytest.raises(RevisionNotFoundError):
+        history.get_revision(make_scope(subject_id="user-2"), child.revision_id)
+
+
+def test_candidate_and_revision_idempotency_domains_are_independent() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="shared-key",
+        )
+    )
+    revision = history.append_revision(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            idempotency_key="shared-key",
+        )
+    )
+    assert revision.proposal.candidate_id == candidate.candidate_id
+
+
+def test_revision_queries_snapshot_strings_and_hide_scope_occupancy() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    revision = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+    query_id = MutableHashStr(revision.revision_id)
+    query_id.hash_salt = 1_000_003
+    false_filter = AlwaysEqualStr("mem_missing")
+
+    assert history.get_revision(make_scope(), query_id) is revision
+    assert query_id.hash_calls == 0
+    assert history.list_revisions(make_scope(), memory_id=false_filter) == ()
+    assert false_filter.equality_calls == 0
+    invalid_scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+    with pytest.raises(TypeError, match="scope"):
+        history.get_revision(invalid_scope, revision.revision_id)
+    with pytest.raises(TypeError, match="scope"):
+        history.list_revisions(invalid_scope)
+
+    empty_history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+    with pytest.raises(RevisionNotFoundError) as foreign:
+        history.get_revision(make_scope(subject_id="user-2"), revision.revision_id)
+    with pytest.raises(RevisionNotFoundError) as missing:
+        empty_history.get_revision(make_scope(), revision.revision_id)
+    assert str(foreign.value) == str(missing.value)
+
+
+def test_revision_order_and_returned_snapshot_cover_roots_and_siblings() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first_root_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    first_root = history.append_revision(
+        make_revision_proposal(candidate_id=first_root_candidate.candidate_id)
+    )
+    left_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="left",
+        evidence_key="left-evidence",
+    )
+    right_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="right",
+        evidence_key="right-evidence",
+    )
+    right = history.append_revision(
+        make_revision_proposal(
+            candidate_id=right_candidate.candidate_id,
+            operation=RevisionOperation.CONTRADICT,
+            parent_revision_id=first_root.revision_id,
+            idempotency_key="right-revision",
+        )
+    )
+    left = history.append_revision(
+        make_revision_proposal(
+            candidate_id=left_candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=first_root.revision_id,
+            idempotency_key="left-revision",
+        )
+    )
+    second_root_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="second-root",
+        evidence_key="second-root-evidence",
+    )
+    second_root = history.append_revision(
+        make_revision_proposal(
+            candidate_id=second_root_candidate.candidate_id,
+            idempotency_key="second-root-revision",
+        )
+    )
+    expected = tuple(
+        sorted(
+            (first_root, left, right, second_root),
+            key=lambda item: (item.memory_id, item.generation, item.revision_id),
+        )
+    )
+    snapshot = history.list_revisions(make_scope())
+    assert snapshot == expected
+
+    later_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="later",
+        evidence_key="later-evidence",
+    )
+    history.append_revision(
+        make_revision_proposal(
+            candidate_id=later_candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=first_root.revision_id,
+            idempotency_key="later-revision",
+        )
+    )
+    assert snapshot == expected
+
+
+def test_generation_overflow_leaves_all_revision_indexes_unchanged() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    parent_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    parent_proposal = make_revision_proposal(
+        candidate_id=parent_candidate.candidate_id,
+        idempotency_key="max-parent",
+    )
+    parent = MemoryRevision(
+        revision_id="rev_max",
+        memory_id="mem_max",
+        generation=2**63 - 1,
+        proposal=parent_proposal,
+        content_hash="a" * 64,
+        created_at=datetime.now(UTC),
+    )
+    history._revision_by_id[(make_scope(), parent.revision_id)] = parent
+    history._revision_by_idempotency[(make_scope(), "max-parent")] = parent
+    history._revision_by_candidate[
+        (
+            make_scope(),
+            parent_candidate.candidate_id,
+        )
+    ] = parent
+    history._revisions_by_scope[make_scope()] = [parent]
+    child_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="overflow-child",
+        evidence_key="overflow-evidence",
+    )
+    before = (
+        dict(history._revision_by_id),
+        dict(history._revision_by_idempotency),
+        dict(history._revision_by_candidate),
+        {scope: list(items) for scope, items in history._revisions_by_scope.items()},
+    )
+
+    with pytest.raises(RevisionConflictError, match="generation"):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id=child_candidate.candidate_id,
+                operation=RevisionOperation.REFINE,
+                parent_revision_id=parent.revision_id,
+                idempotency_key="overflow-child-revision",
+            )
+        )
+
+    after = (
+        history._revision_by_id,
+        history._revision_by_idempotency,
+        history._revision_by_candidate,
+        history._revisions_by_scope,
+    )
+    assert after == before

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -121,6 +121,20 @@ class YieldingMissingContainsDict(dict[object, object]):
         return exists
 
 
+class SetThenInterruptDict(dict[object, object]):
+    """Mutate once before raising to exercise BaseException rollback."""
+
+    def __init__(self, values: dict[object, object] | None = None) -> None:
+        super().__init__({} if values is None else values)
+        self.should_interrupt = True
+
+    def __setitem__(self, key: object, value: object) -> None:
+        super().__setitem__(key, value)
+        if self.should_interrupt:
+            self.should_interrupt = False
+            raise KeyboardInterrupt("injected publication interruption")
+
+
 class StubHash:
     """Return one test-controlled hexadecimal digest."""
 
@@ -408,6 +422,27 @@ def test_append_candidate_requires_existing_evidence_in_same_scope() -> None:
     assert history.get_candidate_evidence(proposal.scope, candidate.candidate_id) == (
         evidence,
     )
+
+
+@pytest.mark.parametrize(
+    "failing_index",
+    ("_candidate_by_idempotency", "_candidates_by_scope"),
+)
+def test_candidate_publication_rolls_back_every_index_after_base_exception(
+    failing_index: str,
+) -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    setattr(history, failing_index, SetThenInterruptDict())
+    proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        history.append_candidate(proposal)
+
+    assert_candidate_indexes_empty(history)
+    candidate = history.append_candidate(proposal)
+    assert history.get_candidate(proposal.scope, candidate.candidate_id) == candidate
+    assert history.list_candidates(proposal.scope) == (candidate,)
 
 
 def test_append_candidate_rejects_proposal_subclass_before_any_write() -> None:
@@ -781,6 +816,33 @@ def test_add_creates_generation_zero_logical_memory() -> None:
     assert revision.proposal.parent_revision_id is None
     assert revision.generation == 0
     assert revision.memory_id == "mem_" + revision.content_hash[:24]
+
+
+@pytest.mark.parametrize(
+    "failing_index",
+    (
+        "_revision_by_idempotency",
+        "_revision_by_candidate",
+        "_revisions_by_scope",
+    ),
+)
+def test_revision_publication_rolls_back_every_index_after_base_exception(
+    failing_index: str,
+) -> None:
+    history, candidate, _evidence = seeded_history_candidate()
+    setattr(history, failing_index, SetThenInterruptDict())
+    proposal = make_revision_proposal(candidate_id=candidate.candidate_id)
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        history.append_revision(proposal)
+
+    assert history._revision_by_id == {}
+    assert history._revision_by_idempotency == {}
+    assert history._revision_by_candidate == {}
+    assert history._revisions_by_scope == {}
+    revision = history.append_revision(proposal)
+    assert history.get_revision(proposal.scope, revision.revision_id) == revision
+    assert history.list_revisions(proposal.scope) == (revision,)
 
 
 def test_append_revision_rejects_proposal_subclass_before_any_write() -> None:
@@ -1263,11 +1325,14 @@ def test_revision_relationship_checks_and_writes_share_one_lock_epoch() -> None:
         "revision:get",
         "candidate:get",
         "candidate-revision:contains",
+        "revision:get",
         "revision:set",
+        "idempotency:get",
         "idempotency:set",
+        "candidate-revision:get",
         "candidate-revision:set",
-        "scope:setdefault",
-        "scope:append",
+        "scope:get",
+        "scope:set",
     ]
     assert tuple(history._revision_by_id.values()) == (revision,)
     assert tuple(history._revision_by_idempotency.values()) == (revision,)

--- a/tests/v2/memory_service/test_history_types.py
+++ b/tests/v2/memory_service/test_history_types.py
@@ -254,6 +254,13 @@ def test_proposals_require_exact_scope_and_revision_operation() -> None:
         make_revision_proposal(operation="add")
 
 
+def test_revision_proposal_requires_exact_scope() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope"):
+        make_revision_proposal(scope=scope)
+
+
 def test_persisted_records_reject_proposal_subclasses() -> None:
     candidate_proposal = CandidateProposalSubclass(
         make_scope(), "remember this", ("evd_a",), "candidate-1"

--- a/tests/v2/memory_service/test_history_types.py
+++ b/tests/v2/memory_service/test_history_types.py
@@ -1,0 +1,481 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for immutable Memory Service candidate and revision values."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError, fields
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
+
+import pytest
+
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
+)
+from areal.v2.memory_service.types import MemoryScope
+
+
+class StringSubclass(str):
+    pass
+
+
+class TupleSubclass(tuple[str, ...]):
+    def __iter__(self):
+        return iter(("overridden",))
+
+
+class IntSubclass(int):
+    pass
+
+
+class MemoryScopeSubclass(MemoryScope):
+    pass
+
+
+class CandidateProposalSubclass(CandidateProposal):
+    pass
+
+
+class RevisionProposalSubclass(RevisionProposal):
+    pass
+
+
+class MutableTimezone(tzinfo):
+    def __init__(self) -> None:
+        self.offset = timedelta(hours=1)
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        return self.offset
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(0)
+
+    def tzname(self, value: datetime | None) -> str:
+        return "MUTABLE"
+
+
+class StatefulDatetime(datetime):
+    def astimezone(self, timezone: tzinfo | None = None) -> StatefulDatetime:
+        return self
+
+
+LONE_SURROGATE = "\ud800"
+
+
+def make_scope(**overrides: str) -> MemoryScope:
+    values = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)
+
+
+def make_candidate_proposal(**overrides: object) -> CandidateProposal:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "content": "remember this",
+        "evidence_ids": ("evd_a",),
+        "idempotency_key": "candidate-1",
+    }
+    values.update(overrides)
+    return CandidateProposal(**values)  # type: ignore[arg-type]
+
+
+def make_revision_proposal(**overrides: object) -> RevisionProposal:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "candidate_id": "cand_a",
+        "operation": RevisionOperation.ADD,
+        "parent_revision_id": None,
+        "idempotency_key": "revision-1",
+    }
+    values.update(overrides)
+    return RevisionProposal(**values)  # type: ignore[arg-type]
+
+
+def test_revision_operation_wire_values_are_stable() -> None:
+    assert {item.name: item.value for item in RevisionOperation} == {
+        "ADD": "add",
+        "REFINE": "refine",
+        "SUPERSEDE": "supersede",
+        "CONTRADICT": "contradict",
+    }
+
+
+def test_candidate_proposal_canonical_schema_v1_is_frozen() -> None:
+    proposal = CandidateProposal(
+        scope=make_scope(),
+        content="remember this",
+        evidence_ids=("evd_a", "evd_b"),
+        idempotency_key="candidate-1",
+    )
+    assert proposal.canonical_bytes() == (
+        b'{"content":"remember this","evidence_ids":["evd_a","evd_b"],'
+        b'"idempotency_key":"candidate-1","schema_version":1,'
+        b'"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        b'"tenant_id":"tenant-1"}}'
+    )
+
+
+def test_candidate_proposal_canonical_schema_preserves_literal_utf8() -> None:
+    proposal = CandidateProposal(
+        scope=make_scope(),
+        content="记住🙂",
+        evidence_ids=("evd_a",),
+        idempotency_key="candidate-1",
+    )
+
+    canonical_bytes = proposal.canonical_bytes()
+    expected = (
+        '{"content":"记住🙂","evidence_ids":["evd_a"],'
+        '"idempotency_key":"candidate-1","schema_version":1,'
+        '"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        '"tenant_id":"tenant-1"}}'
+    ).encode()
+
+    assert canonical_bytes == expected
+    assert b"\\u" not in canonical_bytes
+
+
+def test_revision_proposal_canonical_schema_v1_is_frozen() -> None:
+    proposal = RevisionProposal(
+        scope=make_scope(),
+        candidate_id="cand_a",
+        operation=RevisionOperation.ADD,
+        parent_revision_id=None,
+        idempotency_key="revision-1",
+    )
+    assert proposal.canonical_bytes() == (
+        b'{"candidate_id":"cand_a","idempotency_key":"revision-1",'
+        b'"operation":"add","parent_revision_id":null,"schema_version":1,'
+        b'"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        b'"tenant_id":"tenant-1"}}'
+    )
+
+
+def test_non_add_canonical_schema_serializes_parent_as_exact_string() -> None:
+    proposal = make_revision_proposal(
+        operation=RevisionOperation.REFINE,
+        parent_revision_id=StringSubclass("rev_parent"),
+    )
+    value = json.loads(proposal.canonical_bytes())
+
+    assert type(proposal.parent_revision_id) is str
+    assert value["parent_revision_id"] == "rev_parent"
+    assert type(value["parent_revision_id"]) is str
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        RevisionOperation.REFINE,
+        RevisionOperation.SUPERSEDE,
+        RevisionOperation.CONTRADICT,
+    ],
+)
+def test_non_add_revision_requires_one_parent(operation: RevisionOperation) -> None:
+    with pytest.raises(ValueError, match="parent_revision_id"):
+        make_revision_proposal(operation=operation, parent_revision_id=None)
+
+
+def test_add_revision_rejects_parent() -> None:
+    with pytest.raises(ValueError, match="parent_revision_id"):
+        make_revision_proposal(
+            operation=RevisionOperation.ADD,
+            parent_revision_id="rev_parent",
+        )
+
+
+def test_candidate_proposal_snapshots_tuple_and_string_subclasses() -> None:
+    proposal = make_candidate_proposal(
+        content=StringSubclass(" remember this "),
+        evidence_ids=TupleSubclass((StringSubclass("evd_a"), StringSubclass("evd_b"))),
+        idempotency_key=StringSubclass(" candidate-1 "),
+    )
+
+    assert type(proposal.content) is str
+    assert proposal.content == " remember this "
+    assert type(proposal.evidence_ids) is tuple
+    assert proposal.evidence_ids == ("evd_a", "evd_b")
+    assert all(type(item) is str for item in proposal.evidence_ids)
+    assert type(proposal.idempotency_key) is str
+    assert proposal.idempotency_key == " candidate-1 "
+
+
+def test_revision_proposal_snapshots_string_subclasses() -> None:
+    proposal = make_revision_proposal(
+        candidate_id=StringSubclass(" cand_a "),
+        operation=RevisionOperation.REFINE,
+        parent_revision_id=StringSubclass(" rev_parent "),
+        idempotency_key=StringSubclass(" revision-1 "),
+    )
+
+    assert type(proposal.candidate_id) is str
+    assert proposal.candidate_id == " cand_a "
+    assert type(proposal.parent_revision_id) is str
+    assert proposal.parent_revision_id == " rev_parent "
+    assert type(proposal.idempotency_key) is str
+    assert proposal.idempotency_key == " revision-1 "
+
+
+@pytest.mark.parametrize("evidence_ids", [(), ("evd_a", "evd_a")])
+def test_candidate_proposal_rejects_empty_or_duplicate_evidence(
+    evidence_ids: tuple[str, ...],
+) -> None:
+    with pytest.raises(ValueError, match="evidence_ids"):
+        make_candidate_proposal(evidence_ids=evidence_ids)
+
+
+@pytest.mark.parametrize("evidence_ids", [["evd_a"], {"evd_a"}])
+def test_candidate_proposal_rejects_non_tuple_evidence(evidence_ids: object) -> None:
+    with pytest.raises(TypeError, match="evidence_ids"):
+        make_candidate_proposal(evidence_ids=evidence_ids)
+
+
+def test_candidate_proposal_rejects_blank_content_and_evidence_id() -> None:
+    with pytest.raises(ValueError, match="content"):
+        make_candidate_proposal(content=" \t\n")
+    with pytest.raises(ValueError, match="evidence_ids"):
+        make_candidate_proposal(evidence_ids=(" ",))
+
+
+def test_proposals_require_exact_scope_and_revision_operation() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+    with pytest.raises(TypeError, match="scope"):
+        make_candidate_proposal(scope=scope)
+    with pytest.raises(TypeError, match="operation"):
+        make_revision_proposal(operation="add")
+
+
+def test_persisted_records_reject_proposal_subclasses() -> None:
+    candidate_proposal = CandidateProposalSubclass(
+        make_scope(), "remember this", ("evd_a",), "candidate-1"
+    )
+    revision_proposal = RevisionProposalSubclass(
+        make_scope(), "cand_a", RevisionOperation.ADD, None, "revision-1"
+    )
+    with pytest.raises(TypeError, match="CandidateProposal"):
+        MemoryCandidate("cand_a", candidate_proposal, "a" * 64, datetime.now(UTC))
+    with pytest.raises(TypeError, match="RevisionProposal"):
+        MemoryRevision(
+            "rev_a",
+            "mem_a",
+            0,
+            revision_proposal,
+            "b" * 64,
+            datetime.now(UTC),
+        )
+
+
+def test_all_proposal_text_rejects_lone_surrogates() -> None:
+    with pytest.raises(ValueError, match="content"):
+        make_candidate_proposal(content=LONE_SURROGATE)
+    with pytest.raises(ValueError, match="evidence_ids"):
+        make_candidate_proposal(evidence_ids=(LONE_SURROGATE,))
+    with pytest.raises(ValueError, match="idempotency_key"):
+        make_candidate_proposal(idempotency_key=LONE_SURROGATE)
+    with pytest.raises(ValueError, match="candidate_id"):
+        make_revision_proposal(candidate_id=LONE_SURROGATE)
+    with pytest.raises(ValueError, match="parent_revision_id"):
+        make_revision_proposal(
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=LONE_SURROGATE,
+        )
+    with pytest.raises(ValueError, match="idempotency_key"):
+        make_revision_proposal(idempotency_key=LONE_SURROGATE)
+
+
+@pytest.mark.parametrize("field", ["candidate_id", "content_hash"])
+def test_memory_candidate_rejects_lone_surrogate_persisted_text(field: str) -> None:
+    values: dict[str, object] = {
+        "candidate_id": "cand_a",
+        "proposal": make_candidate_proposal(),
+        "content_hash": "a" * 64,
+        "created_at": datetime.now(UTC),
+    }
+    values[field] = LONE_SURROGATE
+
+    with pytest.raises(ValueError, match=rf"^{field} must be valid UTF-8$"):
+        MemoryCandidate(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", ["revision_id", "memory_id", "content_hash"])
+def test_memory_revision_rejects_lone_surrogate_persisted_text(field: str) -> None:
+    values: dict[str, object] = {
+        "revision_id": "rev_a",
+        "memory_id": "mem_a",
+        "generation": 0,
+        "proposal": make_revision_proposal(),
+        "content_hash": "b" * 64,
+        "created_at": datetime.now(UTC),
+    }
+    values[field] = LONE_SURROGATE
+
+    with pytest.raises(ValueError, match=rf"^{field} must be valid UTF-8$"):
+        MemoryRevision(**values)  # type: ignore[arg-type]
+
+
+def test_persisted_records_snapshot_identifiers_and_utc_datetime() -> None:
+    created_at = datetime(2026, 7, 7, 12, tzinfo=timezone(timedelta(hours=8)))
+    candidate = MemoryCandidate(
+        candidate_id=StringSubclass("cand_a"),
+        proposal=make_candidate_proposal(),
+        content_hash=StringSubclass("a" * 64),
+        created_at=created_at,
+    )
+    revision = MemoryRevision(
+        revision_id=StringSubclass("rev_a"),
+        memory_id=StringSubclass("mem_a"),
+        generation=0,
+        proposal=make_revision_proposal(),
+        content_hash=StringSubclass("b" * 64),
+        created_at=created_at,
+    )
+
+    assert type(candidate.candidate_id) is str
+    assert type(candidate.content_hash) is str
+    assert type(candidate.created_at) is datetime
+    assert candidate.created_at == datetime(2026, 7, 7, 4, tzinfo=UTC)
+    assert type(revision.revision_id) is str
+    assert type(revision.memory_id) is str
+    assert type(revision.content_hash) is str
+    assert type(revision.created_at) is datetime
+    assert revision.created_at.tzinfo is UTC
+
+
+def test_persisted_records_detach_mutable_timezone_and_datetime_subclass() -> None:
+    mutable_timezone = MutableTimezone()
+    source = datetime(2026, 7, 7, 5, tzinfo=mutable_timezone)
+    candidate = MemoryCandidate("cand_a", make_candidate_proposal(), "a" * 64, source)
+    subclass_source = StatefulDatetime(2026, 7, 7, 4, tzinfo=UTC)
+    revision = MemoryRevision(
+        "rev_a",
+        "mem_a",
+        0,
+        make_revision_proposal(),
+        "b" * 64,
+        subclass_source,
+    )
+    mutable_timezone.offset = timedelta(hours=2)
+
+    assert type(candidate.created_at) is datetime
+    assert candidate.created_at == datetime(2026, 7, 7, 4, tzinfo=UTC)
+    assert type(revision.created_at) is datetime
+    assert revision.created_at == datetime(2026, 7, 7, 4, tzinfo=UTC)
+
+
+def test_persisted_records_reject_naive_or_non_normalizable_datetime() -> None:
+    with pytest.raises(ValueError, match="created_at"):
+        MemoryCandidate(
+            "cand_a",
+            make_candidate_proposal(),
+            "a" * 64,
+            datetime(2026, 7, 7),
+        )
+    with pytest.raises(ValueError, match="created_at"):
+        MemoryRevision(
+            "rev_a",
+            "mem_a",
+            0,
+            make_revision_proposal(),
+            "b" * 64,
+            datetime.min.replace(tzinfo=timezone(timedelta(hours=1))),
+        )
+
+
+@pytest.mark.parametrize("generation", [True, IntSubclass(1), -1, 2**63])
+def test_revision_rejects_invalid_generation(generation: object) -> None:
+    with pytest.raises((TypeError, ValueError), match="generation"):
+        MemoryRevision(
+            revision_id="rev_a",
+            memory_id="mem_a",
+            generation=generation,  # type: ignore[arg-type]
+            proposal=make_revision_proposal(),
+            content_hash="a" * 64,
+            created_at=datetime.now(UTC),
+        )
+
+
+@pytest.mark.parametrize("generation", [0, 2**63 - 1])
+def test_revision_accepts_generation_boundaries(generation: int) -> None:
+    revision = MemoryRevision(
+        "rev_a",
+        "mem_a",
+        generation,
+        make_revision_proposal(),
+        "a" * 64,
+        datetime.now(UTC),
+    )
+    assert revision.generation == generation
+
+
+def test_values_are_frozen_and_slotted() -> None:
+    values_and_fields = (
+        (make_candidate_proposal(), "content"),
+        (
+            MemoryCandidate(
+                "cand_a", make_candidate_proposal(), "a" * 64, datetime.now(UTC)
+            ),
+            "candidate_id",
+        ),
+        (make_revision_proposal(), "candidate_id"),
+        (
+            MemoryRevision(
+                "rev_a",
+                "mem_a",
+                0,
+                make_revision_proposal(),
+                "b" * 64,
+                datetime.now(UTC),
+            ),
+            "revision_id",
+        ),
+    )
+
+    for value, field_name in values_and_fields:
+        assert not hasattr(value, "__dict__")
+        with pytest.raises(FrozenInstanceError):
+            setattr(value, field_name, "changed")
+
+
+def test_idempotency_key_is_part_of_candidate_identity() -> None:
+    left = make_candidate_proposal(idempotency_key="attempt-a")
+    right = make_candidate_proposal(idempotency_key="attempt-b")
+    assert left.canonical_bytes() != right.canonical_bytes()
+
+
+def test_exact_field_order_excludes_status_metadata_and_duplicated_evidence() -> None:
+    assert tuple(field.name for field in fields(CandidateProposal)) == (
+        "scope",
+        "content",
+        "evidence_ids",
+        "idempotency_key",
+    )
+    assert tuple(field.name for field in fields(MemoryCandidate)) == (
+        "candidate_id",
+        "proposal",
+        "content_hash",
+        "created_at",
+    )
+    assert tuple(field.name for field in fields(RevisionProposal)) == (
+        "scope",
+        "candidate_id",
+        "operation",
+        "parent_revision_id",
+        "idempotency_key",
+    )
+    assert tuple(field.name for field in fields(MemoryRevision)) == (
+        "revision_id",
+        "memory_id",
+        "generation",
+        "proposal",
+        "content_hash",
+        "created_at",
+    )

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -176,6 +176,20 @@ class AlwaysEqualStr(str):
     __hash__ = str.__hash__
 
 
+class SetThenInterruptDict(dict[object, object]):
+    """Expose rollback bugs where a mapping mutates before interruption."""
+
+    def __init__(self, values: dict[object, object] | None = None) -> None:
+        super().__init__({} if values is None else values)
+        self.should_interrupt = True
+
+    def __setitem__(self, key: object, value: object) -> None:
+        super().__setitem__(key, value)
+        if self.should_interrupt:
+            self.should_interrupt = False
+            raise KeyboardInterrupt("injected publication interruption")
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -199,6 +213,28 @@ def make_event(**overrides: object) -> EvidenceEvent:
     }
     values.update(overrides)
     return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("failing_index", ("idempotency", "scope"))
+def test_append_rolls_back_every_index_after_base_exception(
+    failing_index: str,
+) -> None:
+    store = InMemoryEvidenceStore()
+    if failing_index == "idempotency":
+        store._by_idempotency_key = SetThenInterruptDict()
+    else:
+        store._by_scope = SetThenInterruptDict()
+    event = make_event()
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        store.append(event)
+
+    assert store._by_evidence_id == {}
+    assert store._by_idempotency_key == {}
+    assert store._by_scope == {}
+    record = store.append(event)
+    assert store.get(event.scope, record.evidence_id) == record
+    assert store.list(event.scope) == (record,)
 
 
 def test_error_types_share_memory_service_base_error() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -20,9 +20,24 @@ import areal.v2.memory_service as memory_service
 from areal.v2.memory_service import store as store_module
 from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
+    CandidateConflictError,
+    CandidateNotFoundError,
     EvidenceConflictError,
     EvidenceNotFoundError,
     MemoryServiceError,
+    RevisionConflictError,
+    RevisionNotFoundError,
+)
+from areal.v2.memory_service.history_store import (
+    InMemoryMemoryHistoryStore,
+    MemoryHistoryStore,
+)
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
 )
 from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
@@ -284,8 +299,41 @@ def test_error_types_share_memory_service_base_error() -> None:
     assert issubclass(EvidenceConflictError, MemoryServiceError)
 
 
-def test_public_module_exports_only_stable_evidence_contract() -> None:
-    """Expose only the intended immutable evidence API at package level."""
+def test_public_module_exports_stable_memory_contracts() -> None:
+    """Expose only the intended immutable evidence and history contracts."""
+    assert memory_service.__doc__ == (
+        "Public contracts for immutable Memory Service evidence and history."
+    )
+    assert memory_service.__all__ == [
+        "CandidateConflictError",
+        "CandidateNotFoundError",
+        "CandidateProposal",
+        "EvidenceConflictError",
+        "EvidenceEvent",
+        "EvidenceKind",
+        "EvidenceNotFoundError",
+        "EvidenceRecord",
+        "EvidenceStore",
+        "InMemoryEvidenceStore",
+        "InMemoryMemoryHistoryStore",
+        "MemoryCandidate",
+        "MemoryHistoryStore",
+        "MemoryRevision",
+        "MemoryScope",
+        "MemoryServiceError",
+        "RevisionConflictError",
+        "RevisionNotFoundError",
+        "RevisionOperation",
+        "RevisionProposal",
+    ]
+
+    from areal.v2.memory_service import (
+        CandidateConflictError as PublicCandidateConflictError,
+    )
+    from areal.v2.memory_service import (
+        CandidateNotFoundError as PublicCandidateNotFoundError,
+    )
+    from areal.v2.memory_service import CandidateProposal as PublicCandidateProposal
     from areal.v2.memory_service import (
         EvidenceConflictError as PublicEvidenceConflictError,
     )
@@ -299,21 +347,27 @@ def test_public_module_exports_only_stable_evidence_contract() -> None:
     from areal.v2.memory_service import (
         InMemoryEvidenceStore as PublicInMemoryEvidenceStore,
     )
+    from areal.v2.memory_service import (
+        InMemoryMemoryHistoryStore as PublicInMemoryMemoryHistoryStore,
+    )
+    from areal.v2.memory_service import MemoryCandidate as PublicMemoryCandidate
+    from areal.v2.memory_service import MemoryHistoryStore as PublicMemoryHistoryStore
+    from areal.v2.memory_service import MemoryRevision as PublicMemoryRevision
     from areal.v2.memory_service import MemoryScope as PublicMemoryScope
     from areal.v2.memory_service import MemoryServiceError as PublicMemoryServiceError
+    from areal.v2.memory_service import (
+        RevisionConflictError as PublicRevisionConflictError,
+    )
+    from areal.v2.memory_service import (
+        RevisionNotFoundError as PublicRevisionNotFoundError,
+    )
+    from areal.v2.memory_service import RevisionOperation as PublicRevisionOperation
+    from areal.v2.memory_service import RevisionProposal as PublicRevisionProposal
 
-    assert memory_service.__all__ == [
-        "EvidenceConflictError",
-        "EvidenceEvent",
-        "EvidenceKind",
-        "EvidenceNotFoundError",
-        "EvidenceRecord",
-        "EvidenceStore",
-        "InMemoryEvidenceStore",
-        "MemoryScope",
-        "MemoryServiceError",
-    ]
-    assert (
+    public_symbols = (
+        PublicCandidateConflictError,
+        PublicCandidateNotFoundError,
+        PublicCandidateProposal,
         PublicEvidenceConflictError,
         PublicEvidenceEvent,
         PublicEvidenceKind,
@@ -321,9 +375,21 @@ def test_public_module_exports_only_stable_evidence_contract() -> None:
         PublicEvidenceRecord,
         PublicEvidenceStore,
         PublicInMemoryEvidenceStore,
+        PublicInMemoryMemoryHistoryStore,
+        PublicMemoryCandidate,
+        PublicMemoryHistoryStore,
+        PublicMemoryRevision,
         PublicMemoryScope,
         PublicMemoryServiceError,
-    ) == (
+        PublicRevisionConflictError,
+        PublicRevisionNotFoundError,
+        PublicRevisionOperation,
+        PublicRevisionProposal,
+    )
+    defining_symbols = (
+        CandidateConflictError,
+        CandidateNotFoundError,
+        CandidateProposal,
         EvidenceConflictError,
         EvidenceEvent,
         EvidenceKind,
@@ -331,9 +397,23 @@ def test_public_module_exports_only_stable_evidence_contract() -> None:
         EvidenceRecord,
         EvidenceStore,
         InMemoryEvidenceStore,
+        InMemoryMemoryHistoryStore,
+        MemoryCandidate,
+        MemoryHistoryStore,
+        MemoryRevision,
         MemoryScope,
         MemoryServiceError,
+        RevisionConflictError,
+        RevisionNotFoundError,
+        RevisionOperation,
+        RevisionProposal,
     )
+    for public_symbol, defining_symbol in zip(
+        public_symbols,
+        defining_symbols,
+        strict=True,
+    ):
+        assert public_symbol is defining_symbol
 
 
 def test_evidence_store_contract_exposes_no_update_or_delete() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -55,6 +55,16 @@ class FoldAwareTimezone(tzinfo):
         return "FOLD-DST" if value is not None and value.fold == 0 else "FOLD-STD"
 
 
+class MemoryScopeSubclass(MemoryScope):
+    def __hash__(self) -> int:
+        return 0
+
+
+class EvidenceEventSubclass(EvidenceEvent):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -145,6 +155,37 @@ def test_evidence_store_contract_exposes_no_update_or_delete() -> None:
     assert not hasattr(EvidenceStore, "delete")
     assert not hasattr(store, "update")
     assert not hasattr(store, "delete")
+
+
+def test_append_rejects_evidence_event_subclass() -> None:
+    event = make_event()
+    event_subclass = EvidenceEventSubclass(
+        scope=event.scope,
+        session_id=event.session_id,
+        run_id=event.run_id,
+        sequence_no=event.sequence_no,
+        kind=event.kind,
+        payload=event.payload,
+        observed_at=event.observed_at,
+        idempotency_key=event.idempotency_key,
+    )
+
+    with pytest.raises(TypeError, match="event must be an EvidenceEvent"):
+        InMemoryEvidenceStore().append(event_subclass)
+
+
+def test_get_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        InMemoryEvidenceStore().get(scope, "evd_missing")
+
+
+def test_list_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        InMemoryEvidenceStore().list(scope)
 
 
 def test_append_and_get_round_trip_returns_persisted_record() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -18,6 +18,7 @@ import pytest
 
 import areal.v2.memory_service as memory_service
 from areal.v2.memory_service import store as store_module
+from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
@@ -190,6 +191,13 @@ class SetThenInterruptDict(dict[object, object]):
             raise KeyboardInterrupt("injected publication interruption")
 
 
+class InterruptingRollbackDict(SetThenInterruptDict):
+    """Try to interrupt rollback through an overridden mapping method."""
+
+    def pop(self, key: object, default: object = None) -> object:
+        raise KeyboardInterrupt("rollback override must be bypassed")
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -235,6 +243,40 @@ def test_append_rolls_back_every_index_after_base_exception(
     record = store.append(event)
     assert store.get(event.scope, record.evidence_id) == record
     assert store.list(event.scope) == (record,)
+
+
+def test_rollback_bypasses_fault_injection_mapping_overrides() -> None:
+    store = InMemoryEvidenceStore()
+    store._by_idempotency_key = InterruptingRollbackDict()
+    event = make_event()
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        store.append(event)
+
+    assert store._by_evidence_id == {}
+    assert store._by_idempotency_key == {}
+    assert store._by_scope == {}
+    record = store.append(event)
+    assert store.get(event.scope, record.evidence_id) == record
+
+
+def test_atomic_publish_restores_an_existing_scope_list() -> None:
+    old_record = object()
+    new_record = object()
+    scope_index: dict[object, list[object]] = {"scope": [old_record]}
+    failing_index = SetThenInterruptDict()
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        _atomic_publish(
+            mapping_writes=(),
+            sequence_appends=(
+                (scope_index, "scope", new_record),
+                (failing_index, "later-scope", new_record),
+            ),
+        )
+
+    assert scope_index == {"scope": [old_record]}
+    assert failing_index == {}
 
 
 def test_error_types_share_memory_service_base_error() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -546,3 +546,56 @@ def test_hash_prefix_collision_fails_without_overwriting(
     assert original.evidence_id == f"evd_{shared_prefix}"
     assert store.get(original.event.scope, original.evidence_id) is original
     assert store.list(original.event.scope) == (original,)
+
+
+def test_hash_prefix_collision_is_isolated_across_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared_prefix = "a" * 24
+    first_digest = shared_prefix + "b" * 40
+    second_digest = shared_prefix + "c" * 40
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    missing_scope = make_scope(subject_id="user-3")
+    first_event = make_event(
+        scope=first_scope,
+        payload="first",
+        idempotency_key="shared-key",
+    )
+    second_event = make_event(
+        scope=second_scope,
+        payload="second",
+        idempotency_key="shared-key",
+    )
+    digest_by_canonical_bytes = {
+        first_event.canonical_bytes(): first_digest,
+        second_event.canonical_bytes(): second_digest,
+    }
+
+    class StubHash:
+        def __init__(self, digest: str) -> None:
+            self._digest = digest
+
+        def hexdigest(self) -> str:
+            return self._digest
+
+    def prefix_colliding_sha256(canonical_bytes: bytes) -> StubHash:
+        return StubHash(digest_by_canonical_bytes[canonical_bytes])
+
+    monkeypatch.setattr(store_module.hashlib, "sha256", prefix_colliding_sha256)
+    store = InMemoryEvidenceStore()
+
+    first = store.append(first_event)
+    second = store.append(second_event)
+
+    assert first is not second
+    assert first.evidence_id == second.evidence_id == f"evd_{shared_prefix}"
+    assert first.content_hash == first_digest
+    assert second.content_hash == second_digest
+    assert store.get(first_scope, first.evidence_id) is first
+    assert store.get(second_scope, second.evidence_id) is second
+    with pytest.raises(EvidenceNotFoundError):
+        store.get(missing_scope, first.evidence_id)
+    assert store.list(first_scope) == (first,)
+    assert store.list(second_scope) == (second,)
+    assert store.list(missing_scope) == ()

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import re
 from concurrent.futures import ThreadPoolExecutor
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
 from hashlib import sha256 as calculate_sha256
 from threading import Barrier
 from time import sleep
@@ -40,6 +40,19 @@ class YieldingMissingDict(dict[object, object]):
         if value is default:
             sleep(0.05)
         return value
+
+
+class FoldAwareTimezone(tzinfo):
+    """Minimal repeated-hour timezone independent of the system tz database."""
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        return timedelta(hours=-4 if value is not None and value.fold == 0 else -5)
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(hours=1 if value is not None and value.fold == 0 else 0)
+
+    def tzname(self, value: datetime | None) -> str:
+        return "FOLD-DST" if value is not None and value.fold == 0 else "FOLD-STD"
 
 
 def make_scope(**overrides: str) -> MemoryScope:
@@ -406,6 +419,39 @@ def test_list_returns_deterministic_order_using_normalized_instants() -> None:
         later_run,
         later_session,
     )
+
+
+def test_list_orders_folded_datetimes_by_absolute_instant() -> None:
+    """Normalize before sorting when one repeated wall-clock hour folds backward."""
+    store = InMemoryEvidenceStore()
+    scope = make_scope()
+    fold_timezone = FoldAwareTimezone()
+    earlier_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(2026, 11, 1, 1, 45, tzinfo=fold_timezone, fold=0),
+            idempotency_key="earlier-fold-instant",
+        )
+    )
+    later_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(2026, 11, 1, 1, 15, tzinfo=fold_timezone, fold=1),
+            idempotency_key="later-fold-instant",
+        )
+    )
+
+    assert later_instant.event.observed_at < earlier_instant.event.observed_at
+    assert earlier_instant.event.observed_at.astimezone(
+        UTC
+    ) < later_instant.event.observed_at.astimezone(UTC)
+    assert store.list(scope) == (earlier_instant, later_instant)
 
 
 def test_append_sets_aware_utc_created_at() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -65,6 +65,36 @@ class EvidenceEventSubclass(EvidenceEvent):
         return b"overridden"
 
 
+class MutableHashStr(str):
+    hash_calls: int
+    hash_salt: int
+
+    def __new__(cls, value: str) -> MutableHashStr:
+        instance = str.__new__(cls, value)
+        instance.hash_calls = 0
+        instance.hash_salt = 0
+        return instance
+
+    def __hash__(self) -> int:
+        self.hash_calls += 1
+        return str.__hash__(self) + self.hash_salt
+
+
+class AlwaysEqualStr(str):
+    equality_calls: int
+
+    def __new__(cls, value: str) -> AlwaysEqualStr:
+        instance = str.__new__(cls, value)
+        instance.equality_calls = 0
+        return instance
+
+    def __eq__(self, other: object) -> bool:
+        self.equality_calls += 1
+        return True
+
+    __hash__ = str.__hash__
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -305,6 +335,26 @@ def test_get_missing_evidence_raises_not_found() -> None:
     assert type(error.value) is EvidenceNotFoundError
 
 
+def test_get_snapshots_evidence_id_before_lookup() -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+    query_id = MutableHashStr(record.evidence_id)
+    query_id.hash_salt = 1_000_003
+
+    assert store.get(record.event.scope, query_id) is record
+    assert query_id.hash_calls == 0
+
+
+def test_blank_query_values_remain_no_match() -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+
+    with pytest.raises(EvidenceNotFoundError):
+        store.get(record.event.scope, "")
+    assert store.list(record.event.scope, session_id="") == ()
+    assert store.list(record.event.scope, run_id="") == ()
+
+
 def test_get_hides_record_that_belongs_to_another_scope() -> None:
     store = InMemoryEvidenceStore()
     record = store.append(make_event())
@@ -375,6 +425,16 @@ def test_list_filters_by_scope_session_and_run() -> None:
         session_one_run_two,
     )
     assert store.list(scope, session_id="missing") == ()
+
+
+@pytest.mark.parametrize("field", ["session_id", "run_id"])
+def test_list_snapshots_filter_before_comparison(field: str) -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+    query = AlwaysEqualStr(f"missing-{field}")
+
+    assert store.list(record.event.scope, **{field: query}) == ()
+    assert query.equality_calls == 0
 
 
 def test_list_returns_deterministic_order_using_normalized_instants() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the in-memory Memory Service evidence store."""
+
+from __future__ import annotations
+
+import re
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta, timezone
+from hashlib import sha256 as calculate_sha256
+from threading import Barrier
+from time import sleep
+
+import pytest
+
+import areal.v2.memory_service as memory_service
+from areal.v2.memory_service import store as store_module
+from areal.v2.memory_service.errors import (
+    EvidenceConflictError,
+    EvidenceNotFoundError,
+    MemoryServiceError,
+)
+from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
+CONCURRENCY_TIMEOUT_SECONDS = 10.0
+
+
+class YieldingMissingDict(dict[object, object]):
+    """Yield after a missing lookup to expose an unprotected check/write race."""
+
+    def get(self, key: object, default: object = None) -> object:
+        value = super().get(key, default)
+        if value is default:
+            sleep(0.05)
+        return value
+
+
+def make_scope(**overrides: str) -> MemoryScope:
+    values = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)
+
+
+def make_event(**overrides: object) -> EvidenceEvent:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "sequence_no": 0,
+        "kind": EvidenceKind.USER_MESSAGE,
+        "payload": "hello",
+        "observed_at": UTC_INSTANT,
+        "idempotency_key": "idempotency-1",
+    }
+    values.update(overrides)
+    return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+def test_error_types_share_memory_service_base_error() -> None:
+    assert issubclass(EvidenceNotFoundError, MemoryServiceError)
+    assert issubclass(EvidenceConflictError, MemoryServiceError)
+
+
+def test_public_module_exports_only_stable_evidence_contract() -> None:
+    """Expose only the intended immutable evidence API at package level."""
+    from areal.v2.memory_service import (
+        EvidenceConflictError as PublicEvidenceConflictError,
+    )
+    from areal.v2.memory_service import EvidenceEvent as PublicEvidenceEvent
+    from areal.v2.memory_service import EvidenceKind as PublicEvidenceKind
+    from areal.v2.memory_service import (
+        EvidenceNotFoundError as PublicEvidenceNotFoundError,
+    )
+    from areal.v2.memory_service import EvidenceRecord as PublicEvidenceRecord
+    from areal.v2.memory_service import EvidenceStore as PublicEvidenceStore
+    from areal.v2.memory_service import (
+        InMemoryEvidenceStore as PublicInMemoryEvidenceStore,
+    )
+    from areal.v2.memory_service import MemoryScope as PublicMemoryScope
+    from areal.v2.memory_service import MemoryServiceError as PublicMemoryServiceError
+
+    assert memory_service.__all__ == [
+        "EvidenceConflictError",
+        "EvidenceEvent",
+        "EvidenceKind",
+        "EvidenceNotFoundError",
+        "EvidenceRecord",
+        "EvidenceStore",
+        "InMemoryEvidenceStore",
+        "MemoryScope",
+        "MemoryServiceError",
+    ]
+    assert (
+        PublicEvidenceConflictError,
+        PublicEvidenceEvent,
+        PublicEvidenceKind,
+        PublicEvidenceNotFoundError,
+        PublicEvidenceRecord,
+        PublicEvidenceStore,
+        PublicInMemoryEvidenceStore,
+        PublicMemoryScope,
+        PublicMemoryServiceError,
+    ) == (
+        EvidenceConflictError,
+        EvidenceEvent,
+        EvidenceKind,
+        EvidenceNotFoundError,
+        EvidenceRecord,
+        EvidenceStore,
+        InMemoryEvidenceStore,
+        MemoryScope,
+        MemoryServiceError,
+    )
+
+
+def test_evidence_store_contract_exposes_no_update_or_delete() -> None:
+    """Keep both the protocol and implementation append-only."""
+    store = InMemoryEvidenceStore()
+
+    assert not hasattr(EvidenceStore, "update")
+    assert not hasattr(EvidenceStore, "delete")
+    assert not hasattr(store, "update")
+    assert not hasattr(store, "delete")
+
+
+def test_append_and_get_round_trip_returns_persisted_record() -> None:
+    store = InMemoryEvidenceStore()
+    event = make_event()
+
+    record = store.append(event)
+
+    assert record.event is event
+    assert store.get(event.scope, record.evidence_id) is record
+
+
+def test_append_identical_retry_returns_exact_original_record() -> None:
+    store = InMemoryEvidenceStore()
+    original_event = make_event()
+    equivalent_retry = make_event()
+    assert equivalent_retry is not original_event
+    assert equivalent_retry.canonical_bytes() == original_event.canonical_bytes()
+
+    original_record = store.append(original_event)
+    retry_record = store.append(equivalent_retry)
+
+    assert retry_record is original_record
+    assert retry_record.event is original_event
+    assert store.list(original_event.scope) == (original_record,)
+
+
+def test_concurrent_identical_appends_return_exact_original_record() -> None:
+    """Serialize same-event races into one record without duplicate writes."""
+    store = InMemoryEvidenceStore()
+    store._by_evidence_id = YieldingMissingDict()
+    store._by_idempotency_key = YieldingMissingDict()
+    event = make_event()
+    caller_count = 32
+    start = Barrier(caller_count, timeout=CONCURRENCY_TIMEOUT_SECONDS)
+
+    def append_after_start() -> EvidenceRecord:
+        start.wait()
+        return store.append(event)
+
+    with ThreadPoolExecutor(max_workers=caller_count) as executor:
+        futures = [executor.submit(append_after_start) for _ in range(caller_count)]
+        records = tuple(
+            future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS) for future in futures
+        )
+
+    original = records[0]
+    assert all(record is original for record in records)
+    assert {record.evidence_id for record in records} == {original.evidence_id}
+    assert store.list(event.scope) == (original,)
+
+
+def test_append_rejects_changed_event_with_same_scoped_idempotency_key() -> None:
+    store = InMemoryEvidenceStore()
+    original = store.append(make_event(payload="first"))
+
+    with pytest.raises(EvidenceConflictError, match="idempotency"):
+        store.append(make_event(payload="changed"))
+
+    assert store.get(original.event.scope, original.evidence_id) is original
+    assert store.list(original.event.scope) == (original,)
+
+
+def test_concurrent_scoped_idempotency_conflicts_leave_only_winner_indexed() -> None:
+    """Commit one racing event atomically and reject every conflicting writer."""
+    store = InMemoryEvidenceStore()
+    store._by_evidence_id = YieldingMissingDict()
+    store._by_idempotency_key = YieldingMissingDict()
+    scope = make_scope()
+    events = tuple(
+        make_event(scope=scope, sequence_no=index, payload=f"payload-{index}")
+        for index in range(32)
+    )
+    start = Barrier(len(events), timeout=CONCURRENCY_TIMEOUT_SECONDS)
+
+    def append_after_start(event: EvidenceEvent) -> EvidenceRecord:
+        start.wait()
+        return store.append(event)
+
+    with ThreadPoolExecutor(max_workers=len(events)) as executor:
+        futures = [executor.submit(append_after_start, event) for event in events]
+        winners: list[EvidenceRecord] = []
+        conflicts: list[EvidenceConflictError] = []
+        for future in futures:
+            try:
+                winners.append(future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS))
+            except EvidenceConflictError as error:
+                conflicts.append(error)
+
+    assert len(winners) == 1
+    assert len(conflicts) == len(events) - 1
+    assert {type(error) for error in conflicts} == {EvidenceConflictError}
+
+    winner = winners[0]
+    losers = tuple(event for event in events if event is not winner.event)
+    assert len(losers) == len(events) - 1
+    assert store.list(scope) == (winner,)
+    assert store.get(scope, winner.evidence_id) is winner
+    assert store.append(winner.event) is winner
+
+    for loser in losers:
+        with pytest.raises(EvidenceConflictError, match="idempotency"):
+            store.append(loser)
+        loser_hash = calculate_sha256(loser.canonical_bytes()).hexdigest()
+        with pytest.raises(EvidenceNotFoundError):
+            store.get(scope, f"evd_{loser_hash[:24]}")
+
+    assert store.list(scope) == (winner,)
+
+
+def test_get_missing_evidence_raises_not_found() -> None:
+    store = InMemoryEvidenceStore()
+
+    with pytest.raises(EvidenceNotFoundError) as error:
+        store.get(make_scope(), "evd_missing")
+
+    assert type(error.value) is EvidenceNotFoundError
+
+
+def test_get_hides_record_that_belongs_to_another_scope() -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+    other_scope = make_scope(subject_id="user-2")
+
+    with pytest.raises(EvidenceNotFoundError) as missing_error:
+        store.get(record.event.scope, "evd_missing")
+    with pytest.raises(EvidenceNotFoundError) as wrong_scope_error:
+        store.get(other_scope, record.evidence_id)
+
+    assert type(wrong_scope_error.value) is EvidenceNotFoundError
+    assert str(wrong_scope_error.value) == str(missing_error.value).replace(
+        "evd_missing", record.evidence_id
+    )
+
+
+def test_list_filters_by_scope_session_and_run() -> None:
+    store = InMemoryEvidenceStore()
+    scope = make_scope()
+    other_scope = make_scope(subject_id="user-2")
+    session_one_run_one = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-1",
+            run_id="run-1",
+            idempotency_key="one-one",
+        )
+    )
+    session_one_run_two = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-1",
+            run_id="run-2",
+            idempotency_key="one-two",
+        )
+    )
+    session_two_run_one = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-2",
+            run_id="run-1",
+            idempotency_key="two-one",
+        )
+    )
+    store.append(
+        make_event(
+            scope=other_scope,
+            session_id="session-1",
+            run_id="run-1",
+            idempotency_key="one-one",
+        )
+    )
+
+    assert store.list(scope) == (
+        session_one_run_one,
+        session_one_run_two,
+        session_two_run_one,
+    )
+    assert store.list(scope, session_id="session-1") == (
+        session_one_run_one,
+        session_one_run_two,
+    )
+    assert store.list(scope, run_id="run-1") == (
+        session_one_run_one,
+        session_two_run_one,
+    )
+    assert store.list(scope, session_id="session-1", run_id="run-2") == (
+        session_one_run_two,
+    )
+    assert store.list(scope, session_id="missing") == ()
+
+
+def test_list_returns_deterministic_order_using_normalized_instants() -> None:
+    store = InMemoryEvidenceStore()
+    scope = make_scope()
+    earlier_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(
+                2026, 7, 7, 12, 0, tzinfo=timezone(timedelta(hours=8))
+            ),
+            idempotency_key="earlier-instant",
+        )
+    )
+    later_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(2026, 7, 7, 4, 30, tzinfo=UTC),
+            idempotency_key="later-instant",
+        )
+    )
+    tied_a = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=2,
+            payload="tie-a",
+            idempotency_key="tie-a",
+        )
+    )
+    tied_b = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=2,
+            payload="tie-b",
+            idempotency_key="tie-b",
+        )
+    )
+    later_sequence = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=3,
+            observed_at=datetime(2020, 1, 1, tzinfo=UTC),
+            idempotency_key="later-sequence",
+        )
+    )
+    later_run = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-b",
+            sequence_no=0,
+            idempotency_key="later-run",
+        )
+    )
+    later_session = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-b",
+            run_id="run-a",
+            sequence_no=0,
+            idempotency_key="later-session",
+        )
+    )
+    tied_by_id = tuple(sorted((tied_a, tied_b), key=lambda item: item.evidence_id))
+
+    assert store.list(scope) == (
+        earlier_instant,
+        later_instant,
+        *tied_by_id,
+        later_sequence,
+        later_run,
+        later_session,
+    )
+
+
+def test_append_sets_aware_utc_created_at() -> None:
+    record = InMemoryEvidenceStore().append(make_event())
+
+    assert record.created_at.tzinfo is UTC
+    assert record.created_at.utcoffset() == timedelta(0)
+
+
+def test_append_uses_sha256_content_hash_and_derived_evidence_id() -> None:
+    event = make_event()
+    expected_hash = calculate_sha256(event.canonical_bytes()).hexdigest()
+
+    record = InMemoryEvidenceStore().append(event)
+
+    assert record.content_hash == expected_hash
+    assert re.fullmatch(r"[0-9a-f]{64}", record.content_hash)
+    assert record.evidence_id == f"evd_{expected_hash[:24]}"
+    assert re.fullmatch(r"evd_[0-9a-f]{24}", record.evidence_id)
+
+
+def test_same_idempotency_key_is_independent_across_scopes() -> None:
+    store = InMemoryEvidenceStore()
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+
+    first = store.append(make_event(scope=first_scope, payload="first"))
+    second = store.append(make_event(scope=second_scope, payload="second"))
+
+    assert first is not second
+    assert first.evidence_id != second.evidence_id
+    assert store.list(first_scope) == (first,)
+    assert store.list(second_scope) == (second,)
+
+
+def test_full_hash_collision_fails_without_overwriting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ConstantHash:
+        def hexdigest(self) -> str:
+            return "a" * 64
+
+    def constant_sha256(_: bytes) -> ConstantHash:
+        return ConstantHash()
+
+    monkeypatch.setattr(store_module.hashlib, "sha256", constant_sha256)
+    store = InMemoryEvidenceStore()
+    original = store.append(make_event(idempotency_key="first"))
+    colliding_event = make_event(payload="different", idempotency_key="second")
+
+    with pytest.raises(EvidenceConflictError, match="collision"):
+        store.append(colliding_event)
+
+    assert store.get(original.event.scope, original.evidence_id) is original
+    assert store.list(original.event.scope) == (original,)
+
+
+def test_hash_prefix_collision_fails_without_overwriting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject distinct full hashes that derive the same truncated evidence ID."""
+    shared_prefix = "a" * 24
+    original_digest = shared_prefix + "b" * 40
+    colliding_digest = shared_prefix + "c" * 40
+    original_event = make_event(idempotency_key="first")
+    colliding_event = make_event(payload="different", idempotency_key="second")
+    digest_by_canonical_bytes = {
+        original_event.canonical_bytes(): original_digest,
+        colliding_event.canonical_bytes(): colliding_digest,
+    }
+
+    class StubHash:
+        def __init__(self, digest: str) -> None:
+            self._digest = digest
+
+        def hexdigest(self) -> str:
+            return self._digest
+
+    def prefix_colliding_sha256(canonical_bytes: bytes) -> StubHash:
+        return StubHash(digest_by_canonical_bytes[canonical_bytes])
+
+    monkeypatch.setattr(store_module.hashlib, "sha256", prefix_colliding_sha256)
+    store = InMemoryEvidenceStore()
+    original = store.append(original_event)
+
+    with pytest.raises(EvidenceConflictError, match="collision"):
+        store.append(colliding_event)
+
+    assert original.content_hash == original_digest
+    assert original.evidence_id == f"evd_{shared_prefix}"
+    assert store.get(original.event.scope, original.evidence_id) is original
+    assert store.list(original.event.scope) == (original,)

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -4,11 +4,14 @@
 
 from __future__ import annotations
 
+import faulthandler
 import re
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta, timezone, tzinfo
 from hashlib import sha256 as calculate_sha256
-from threading import Barrier
+from threading import Barrier, Event
 from time import sleep
 
 import pytest
@@ -30,6 +33,84 @@ from areal.v2.memory_service.types import (
 
 UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
 CONCURRENCY_TIMEOUT_SECONDS = 10.0
+HARD_CONCURRENCY_TIMEOUT_SECONDS = CONCURRENCY_TIMEOUT_SECONDS + 5.0
+
+
+@contextmanager
+def _hard_bounded_executor(*, max_workers: int) -> Iterator[ThreadPoolExecutor]:
+    faulthandler.dump_traceback_later(
+        HARD_CONCURRENCY_TIMEOUT_SECONDS,
+        exit=True,
+    )
+    try:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            yield executor
+    finally:
+        faulthandler.cancel_dump_traceback_later()
+
+
+def test_hard_bounded_executor_waits_for_workers_before_cancel_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bounded_executor = _hard_bounded_executor
+    watchdog_events: list[object] = []
+    worker_started = Event()
+    shutdown_started = Event()
+    shutdown_finished = Event()
+    worker_finished = Event()
+    shutdown_wait_values: list[bool] = []
+    original_shutdown = ThreadPoolExecutor.shutdown
+    original_error = RuntimeError("body failed")
+
+    def arm_watchdog(timeout: float, *, exit: bool) -> None:
+        watchdog_events.append(("arm", timeout, exit))
+
+    def cancel_watchdog() -> None:
+        watchdog_events.append(
+            (
+                "cancel",
+                worker_finished.is_set(),
+                shutdown_finished.is_set(),
+            )
+        )
+
+    def observe_shutdown(
+        executor: ThreadPoolExecutor,
+        wait: bool = True,
+        *,
+        cancel_futures: bool = False,
+    ) -> None:
+        shutdown_wait_values.append(wait)
+        shutdown_started.set()
+        original_shutdown(
+            executor,
+            wait=wait,
+            cancel_futures=cancel_futures,
+        )
+        shutdown_finished.set()
+
+    def slow_worker() -> None:
+        worker_started.set()
+        assert shutdown_started.wait(timeout=CONCURRENCY_TIMEOUT_SECONDS)
+        worker_finished.set()
+
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", arm_watchdog)
+    monkeypatch.setattr(faulthandler, "cancel_dump_traceback_later", cancel_watchdog)
+    monkeypatch.setattr(ThreadPoolExecutor, "shutdown", observe_shutdown)
+
+    with pytest.raises(RuntimeError) as raised:
+        with bounded_executor(max_workers=1) as executor:
+            future = executor.submit(slow_worker)
+            assert worker_started.wait(timeout=CONCURRENCY_TIMEOUT_SECONDS)
+            raise original_error
+
+    assert raised.value is original_error
+    assert future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS) is None
+    assert watchdog_events == [
+        ("arm", CONCURRENCY_TIMEOUT_SECONDS + 5.0, True),
+        ("cancel", True, True),
+    ]
+    assert shutdown_wait_values == [True]
 
 
 class YieldingMissingDict(dict[object, object]):
@@ -256,7 +337,7 @@ def test_concurrent_identical_appends_return_exact_original_record() -> None:
         start.wait()
         return store.append(event)
 
-    with ThreadPoolExecutor(max_workers=caller_count) as executor:
+    with _hard_bounded_executor(max_workers=caller_count) as executor:
         futures = [executor.submit(append_after_start) for _ in range(caller_count)]
         records = tuple(
             future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS) for future in futures
@@ -295,7 +376,7 @@ def test_concurrent_scoped_idempotency_conflicts_leave_only_winner_indexed() -> 
         start.wait()
         return store.append(event)
 
-    with ThreadPoolExecutor(max_workers=len(events)) as executor:
+    with _hard_bounded_executor(max_workers=len(events)) as executor:
         futures = [executor.submit(append_after_start, event) for event in events]
         winners: list[EvidenceRecord] = []
         conflicts: list[EvidenceConflictError] = []

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -422,17 +422,19 @@ def test_list_returns_deterministic_order_using_normalized_instants() -> None:
 
 
 def test_list_orders_folded_datetimes_by_absolute_instant() -> None:
-    """Normalize before sorting when one repeated wall-clock hour folds backward."""
+    """Snapshot and sort absolute instants when a wall-clock hour folds backward."""
     store = InMemoryEvidenceStore()
     scope = make_scope()
     fold_timezone = FoldAwareTimezone()
+    earlier_source = datetime(2026, 11, 1, 1, 45, tzinfo=fold_timezone, fold=0)
+    later_source = datetime(2026, 11, 1, 1, 15, tzinfo=fold_timezone, fold=1)
     earlier_instant = store.append(
         make_event(
             scope=scope,
             session_id="session-a",
             run_id="run-a",
             sequence_no=1,
-            observed_at=datetime(2026, 11, 1, 1, 45, tzinfo=fold_timezone, fold=0),
+            observed_at=earlier_source,
             idempotency_key="earlier-fold-instant",
         )
     )
@@ -442,15 +444,15 @@ def test_list_orders_folded_datetimes_by_absolute_instant() -> None:
             session_id="session-a",
             run_id="run-a",
             sequence_no=1,
-            observed_at=datetime(2026, 11, 1, 1, 15, tzinfo=fold_timezone, fold=1),
+            observed_at=later_source,
             idempotency_key="later-fold-instant",
         )
     )
 
-    assert later_instant.event.observed_at < earlier_instant.event.observed_at
-    assert earlier_instant.event.observed_at.astimezone(
-        UTC
-    ) < later_instant.event.observed_at.astimezone(UTC)
+    assert earlier_instant.event.observed_at == datetime(2026, 11, 1, 5, 45, tzinfo=UTC)
+    assert later_instant.event.observed_at == datetime(2026, 11, 1, 6, 15, tzinfo=UTC)
+    assert earlier_instant.event.observed_at.tzinfo is UTC
+    assert later_instant.event.observed_at.tzinfo is UTC
     assert store.list(scope) == (earlier_instant, later_instant)
 
 

--- a/tests/v2/memory_service/test_types.py
+++ b/tests/v2/memory_service/test_types.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for immutable Memory Service evidence value objects."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
+LONE_SURROGATE = "\ud800"
+PLUS_ONE_HOUR = timezone(timedelta(hours=1))
+MINUS_ONE_HOUR = timezone(-timedelta(hours=1))
+UTC_OVERFLOWING_DATETIMES = (
+    datetime.min.replace(tzinfo=PLUS_ONE_HOUR),
+    datetime.max.replace(tzinfo=MINUS_ONE_HOUR),
+)
+VALID_UTC_BOUNDARIES = (
+    (
+        (datetime.min + timedelta(hours=1)).replace(tzinfo=PLUS_ONE_HOUR),
+        datetime.min.replace(tzinfo=UTC),
+    ),
+    (
+        (datetime.max - timedelta(hours=1)).replace(tzinfo=MINUS_ONE_HOUR),
+        datetime.max.replace(tzinfo=UTC),
+    ),
+)
+
+
+def make_scope(**overrides: object) -> MemoryScope:
+    values: dict[str, object] = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)  # type: ignore[arg-type]
+
+
+def make_event(**overrides: object) -> EvidenceEvent:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "sequence_no": 0,
+        "kind": EvidenceKind.USER_MESSAGE,
+        "payload": "hello",
+        "observed_at": UTC_INSTANT,
+        "idempotency_key": "idempotency-1",
+    }
+    values.update(overrides)
+    return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+def make_record(**overrides: object) -> EvidenceRecord:
+    values: dict[str, object] = {
+        "evidence_id": "evidence-1",
+        "event": make_event(),
+        "content_hash": "sha256:abc123",
+        "created_at": UTC_INSTANT,
+    }
+    values.update(overrides)
+    return EvidenceRecord(**values)  # type: ignore[arg-type]
+
+
+def test_evidence_kind_values_are_lowercase_snake_case() -> None:
+    assert {kind.name: kind.value for kind in EvidenceKind} == {
+        "USER_MESSAGE": "user_message",
+        "AGENT_MESSAGE": "agent_message",
+        "TOOL_CALL": "tool_call",
+        "TOOL_RESULT": "tool_result",
+        "ENVIRONMENT": "environment",
+        "FEEDBACK": "feedback",
+        "OUTCOME": "outcome",
+    }
+
+
+@pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
+@pytest.mark.parametrize("value", ["", " \t\n"])
+def test_memory_scope_rejects_blank_identifiers(field: str, value: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_scope(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
+@pytest.mark.parametrize("value", [None, 7])
+def test_memory_scope_rejects_non_string_identifiers(field: str, value: object) -> None:
+    with pytest.raises(TypeError, match=field):
+        make_scope(**{field: value})
+
+
+def test_memory_scope_preserves_identifier_whitespace() -> None:
+    scope = MemoryScope(
+        tenant_id=" tenant-1 ",
+        namespace=" assistant-memory ",
+        subject_id=" user-1 ",
+    )
+
+    assert scope.tenant_id == " tenant-1 "
+    assert scope.namespace == " assistant-memory "
+    assert scope.subject_id == " user-1 "
+
+
+@pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
+def test_memory_scope_rejects_invalid_unicode_identifier(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_scope(**{field: LONE_SURROGATE})
+
+
+@pytest.mark.parametrize("field", ["session_id", "run_id", "idempotency_key"])
+@pytest.mark.parametrize("value", ["", " \t\n"])
+def test_evidence_event_rejects_blank_identifiers(field: str, value: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_event(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["session_id", "run_id", "idempotency_key"])
+@pytest.mark.parametrize("value", [None, 7])
+def test_evidence_event_rejects_non_string_identifiers(
+    field: str, value: object
+) -> None:
+    with pytest.raises(TypeError, match=field):
+        make_event(**{field: value})
+
+
+def test_evidence_event_preserves_identifier_whitespace() -> None:
+    event = make_event(
+        session_id=" session-1 ",
+        run_id=" run-1 ",
+        idempotency_key=" idempotency-1 ",
+    )
+
+    assert event.session_id == " session-1 "
+    assert event.run_id == " run-1 "
+    assert event.idempotency_key == " idempotency-1 "
+
+
+@pytest.mark.parametrize(
+    "field", ["session_id", "run_id", "idempotency_key", "payload"]
+)
+def test_evidence_event_rejects_invalid_unicode_string(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_event(**{field: LONE_SURROGATE})
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        {
+            "tenant_id": "tenant-1",
+            "namespace": "assistant-memory",
+            "subject_id": "user-1",
+        },
+        object(),
+    ],
+    ids=["dict", "object"],
+)
+def test_evidence_event_requires_memory_scope(scope: object) -> None:
+    with pytest.raises(TypeError, match="scope"):
+        make_event(scope=scope)
+
+
+def test_evidence_event_accepts_empty_string_payload() -> None:
+    assert make_event(payload="").payload == ""
+
+
+@pytest.mark.parametrize("payload", [None, b"hello", 7])
+def test_evidence_event_rejects_non_string_payload(payload: object) -> None:
+    with pytest.raises(TypeError, match="payload"):
+        make_event(payload=payload)
+
+
+@pytest.mark.parametrize("sequence_no", [True, False, 1.0, "1", None])
+def test_evidence_event_rejects_non_integer_sequence_numbers(
+    sequence_no: object,
+) -> None:
+    with pytest.raises(TypeError, match="sequence_no"):
+        make_event(sequence_no=sequence_no)
+
+
+def test_evidence_event_rejects_negative_sequence_number() -> None:
+    with pytest.raises(ValueError, match="sequence_no"):
+        make_event(sequence_no=-1)
+
+
+def test_evidence_event_accepts_zero_sequence_number() -> None:
+    assert make_event(sequence_no=0).sequence_no == 0
+
+
+def test_evidence_event_accepts_maximum_protocol_sequence_number() -> None:
+    sequence_no = 2**63 - 1
+    event = make_event(sequence_no=sequence_no)
+
+    assert event.sequence_no == sequence_no
+    assert json.loads(event.canonical_bytes())["sequence_no"] == sequence_no
+
+
+@pytest.mark.parametrize(
+    "sequence_no",
+    [2**63, 10**4300],
+    ids=["past-int64", "past-python-json-digit-limit"],
+)
+def test_evidence_event_rejects_sequence_number_above_protocol_maximum(
+    sequence_no: int,
+) -> None:
+    with pytest.raises(ValueError, match="sequence_no"):
+        make_event(sequence_no=sequence_no)
+
+
+@pytest.mark.parametrize("kind", ["user_message", None, 7])
+def test_evidence_event_requires_evidence_kind(kind: object) -> None:
+    with pytest.raises(TypeError, match="kind"):
+        make_event(kind=kind)
+
+
+@pytest.mark.parametrize("observed_at", [None, "2026-07-07T04:05:06Z"])
+def test_evidence_event_rejects_non_datetime_observed_at(
+    observed_at: object,
+) -> None:
+    with pytest.raises(TypeError, match="observed_at"):
+        make_event(observed_at=observed_at)
+
+
+def test_evidence_event_rejects_naive_observed_at() -> None:
+    with pytest.raises(ValueError, match="observed_at"):
+        make_event(observed_at=datetime(2026, 7, 7, 4, 5, 6))
+
+
+@pytest.mark.parametrize(
+    "observed_at",
+    UTC_OVERFLOWING_DATETIMES,
+    ids=["minimum-at-plus-one", "maximum-at-minus-one"],
+)
+def test_evidence_event_rejects_datetime_that_cannot_normalize_to_utc(
+    observed_at: datetime,
+) -> None:
+    with pytest.raises(ValueError, match="observed_at"):
+        make_event(observed_at=observed_at)
+
+
+def test_canonical_bytes_are_sorted_compact_and_deterministic() -> None:
+    event = make_event()
+
+    expected = (
+        b'{"idempotency_key":"idempotency-1","kind":"user_message",'
+        b'"observed_at":"2026-07-07T04:05:06.789000+00:00",'
+        b'"payload":"hello","run_id":"run-1",'
+        b'"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        b'"tenant_id":"tenant-1"},"sequence_no":0,"session_id":"session-1"}'
+    )
+
+    assert event.canonical_bytes() == expected
+    assert event.canonical_bytes() == make_event().canonical_bytes()
+
+
+def test_canonical_bytes_preserve_valid_non_ascii_payload() -> None:
+    payload = "你好，世界 🌍"
+    canonical = make_event(payload=payload).canonical_bytes()
+
+    assert payload.encode("utf-8") in canonical
+    assert json.loads(canonical)["payload"] == payload
+
+
+@pytest.mark.parametrize(
+    ("observed_at", "expected_utc"),
+    VALID_UTC_BOUNDARIES,
+    ids=["minimum", "maximum"],
+)
+def test_canonical_bytes_support_valid_utc_datetime_boundaries(
+    observed_at: datetime, expected_utc: datetime
+) -> None:
+    event = make_event(observed_at=observed_at)
+
+    assert event.observed_at is observed_at
+    assert (
+        json.loads(event.canonical_bytes())["observed_at"] == expected_utc.isoformat()
+    )
+
+
+def test_canonical_bytes_normalize_semantically_equal_instants_to_utc() -> None:
+    utc_event = make_event(observed_at=UTC_INSTANT)
+    utc_plus_eight_event = make_event(
+        observed_at=UTC_INSTANT.astimezone(timezone(timedelta(hours=8)))
+    )
+
+    assert utc_event.observed_at != utc_plus_eight_event.observed_at or (
+        utc_event.observed_at.tzinfo != utc_plus_eight_event.observed_at.tzinfo
+    )
+    assert utc_event.canonical_bytes() == utc_plus_eight_event.canonical_bytes()
+
+
+@pytest.mark.parametrize(
+    "event",
+    ["not-an-event", {"payload": "hello"}, object()],
+    ids=["string", "dict", "object"],
+)
+def test_evidence_record_requires_evidence_event(event: object) -> None:
+    with pytest.raises(TypeError, match="event"):
+        make_record(event=event)
+
+
+@pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
+@pytest.mark.parametrize("value", ["", " \t\n"])
+def test_evidence_record_rejects_blank_identifiers_and_hash(
+    field: str, value: str
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_record(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
+@pytest.mark.parametrize("value", [None, 7])
+def test_evidence_record_rejects_non_string_identifiers_and_hash(
+    field: str, value: object
+) -> None:
+    with pytest.raises(TypeError, match=field):
+        make_record(**{field: value})
+
+
+def test_evidence_record_preserves_identifier_and_hash_whitespace() -> None:
+    record = make_record(evidence_id=" evidence-1 ", content_hash=" sha256:abc123 ")
+
+    assert record.evidence_id == " evidence-1 "
+    assert record.content_hash == " sha256:abc123 "
+
+
+@pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
+def test_evidence_record_rejects_invalid_unicode_string(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_record(**{field: LONE_SURROGATE})
+
+
+@pytest.mark.parametrize("created_at", [None, "2026-07-07T04:05:06Z"])
+def test_evidence_record_rejects_non_datetime_created_at(created_at: object) -> None:
+    with pytest.raises(TypeError, match="created_at"):
+        make_record(created_at=created_at)
+
+
+def test_evidence_record_rejects_naive_created_at() -> None:
+    with pytest.raises(ValueError, match="created_at"):
+        make_record(created_at=datetime(2026, 7, 7, 4, 5, 6))
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    UTC_OVERFLOWING_DATETIMES,
+    ids=["minimum-at-plus-one", "maximum-at-minus-one"],
+)
+def test_evidence_record_rejects_datetime_that_cannot_normalize_to_utc(
+    created_at: datetime,
+) -> None:
+    with pytest.raises(ValueError, match="created_at"):
+        make_record(created_at=created_at)
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    [value for value, _ in VALID_UTC_BOUNDARIES],
+    ids=["minimum", "maximum"],
+)
+def test_evidence_record_accepts_valid_utc_datetime_boundaries(
+    created_at: datetime,
+) -> None:
+    assert make_record(created_at=created_at).created_at is created_at
+
+
+@pytest.mark.parametrize(
+    ("instance", "field", "new_value"),
+    [
+        (make_scope(), "tenant_id", "other-tenant"),
+        (make_event(), "payload", "other payload"),
+        (make_record(), "content_hash", "sha256:other"),
+    ],
+    ids=["memory-scope", "evidence-event", "evidence-record"],
+)
+def test_value_objects_are_frozen_and_slotted(
+    instance: object, field: str, new_value: str
+) -> None:
+    assert not hasattr(instance, "__dict__")
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(instance, field, new_value)

--- a/tests/v2/memory_service/test_types.py
+++ b/tests/v2/memory_service/test_types.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta, timezone, tzinfo
 
 import pytest
 
+from areal.v2.memory_service.store import InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
     EvidenceEvent,
     EvidenceKind,
@@ -63,6 +64,51 @@ class StatefulDatetime(datetime):
 
     def isoformat(self, sep: str = "T", timespec: str = "auto") -> str:
         return f"{datetime.isoformat(self, sep, timespec)}{self.suffix}"
+
+
+class MutableHashStr(str):
+    """String subclass whose hash can change after construction."""
+
+    hash_salt: int
+
+    def __new__(cls, value: str) -> MutableHashStr:
+        instance = str.__new__(cls, value)
+        instance.hash_salt = 0
+        return instance
+
+    def __hash__(self) -> int:
+        return str.__hash__(self) + self.hash_salt
+
+    def __str__(self) -> str:
+        return "overridden"
+
+
+class AdversarialStr(str):
+    """String subclass overriding validation and conversion operations."""
+
+    def __str__(self) -> str:
+        return "overridden"
+
+    def strip(self, chars: str | None = None) -> str:
+        return "overridden"
+
+    def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
+        return b"overridden"
+
+
+class MemoryScopeSubclass(MemoryScope):
+    def __hash__(self) -> int:
+        return 0
+
+
+class EvidenceEventSubclass(EvidenceEvent):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
+class OverriddenInt(int):
+    def __int__(self) -> int:
+        return 999
 
 
 def make_scope(**overrides: object) -> MemoryScope:
@@ -139,10 +185,52 @@ def test_memory_scope_preserves_identifier_whitespace() -> None:
     assert scope.subject_id == " user-1 "
 
 
+def test_memory_scope_snapshots_mutable_hash_strings_for_store_indexes() -> None:
+    tenant_id = MutableHashStr("tenant-1")
+    namespace = MutableHashStr("assistant-memory")
+    subject_id = MutableHashStr("user-1")
+    scope = MemoryScope(
+        tenant_id=tenant_id,
+        namespace=namespace,
+        subject_id=subject_id,
+    )
+    event = make_event(scope=scope)
+    store = InMemoryEvidenceStore()
+    scope_hash = hash(scope)
+    original = store.append(event)
+
+    tenant_id.hash_salt = 1_000_003
+    namespace.hash_salt = 1_000_003
+    subject_id.hash_salt = 1_000_003
+    retry = store.append(event)
+
+    assert retry is original
+    assert hash(scope) == scope_hash
+    assert type(scope.tenant_id) is str
+    assert type(scope.namespace) is str
+    assert type(scope.subject_id) is str
+    assert scope == make_scope()
+    assert store.get(scope, original.evidence_id) is original
+    assert store.list(scope) == (original,)
+    assert len(store._by_evidence_id) == 1
+    assert len(store._by_idempotency_key) == 1
+    assert len(store._by_scope) == 1
+
+
 @pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
 def test_memory_scope_rejects_invalid_unicode_identifier(field: str) -> None:
     with pytest.raises(ValueError, match=field):
         make_scope(**{field: LONE_SURROGATE})
+
+
+def test_string_snapshot_uses_base_blank_validation() -> None:
+    with pytest.raises(ValueError, match="session_id"):
+        make_event(session_id=AdversarialStr(" \t\n"))
+
+
+def test_string_snapshot_uses_base_utf8_validation() -> None:
+    with pytest.raises(ValueError, match="payload"):
+        make_event(payload=AdversarialStr(LONE_SURROGATE))
 
 
 @pytest.mark.parametrize("field", ["session_id", "run_id", "idempotency_key"])
@@ -198,8 +286,32 @@ def test_evidence_event_requires_memory_scope(scope: object) -> None:
         make_event(scope=scope)
 
 
+def test_evidence_event_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        make_event(scope=scope)
+
+
 def test_evidence_event_accepts_empty_string_payload() -> None:
     assert make_event(payload="").payload == ""
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("session_id", " session-1 "),
+        ("run_id", " run-1 "),
+        ("payload", " payload "),
+        ("idempotency_key", " idempotency-1 "),
+    ],
+)
+def test_evidence_event_snapshots_string_subclasses(field: str, value: str) -> None:
+    event = make_event(**{field: AdversarialStr(value)})
+    stored = getattr(event, field)
+
+    assert type(stored) is str
+    assert stored == value
 
 
 @pytest.mark.parametrize("payload", [None, b"hello", 7])
@@ -208,7 +320,7 @@ def test_evidence_event_rejects_non_string_payload(payload: object) -> None:
         make_event(payload=payload)
 
 
-@pytest.mark.parametrize("sequence_no", [True, False, 1.0, "1", None])
+@pytest.mark.parametrize("sequence_no", [True, False, OverriddenInt(1), 1.0, "1", None])
 def test_evidence_event_rejects_non_integer_sequence_numbers(
     sequence_no: object,
 ) -> None:
@@ -374,6 +486,23 @@ def test_evidence_record_requires_evidence_event(event: object) -> None:
         make_record(event=event)
 
 
+def test_evidence_record_rejects_evidence_event_subclass() -> None:
+    event = make_event()
+    event_subclass = EvidenceEventSubclass(
+        scope=event.scope,
+        session_id=event.session_id,
+        run_id=event.run_id,
+        sequence_no=event.sequence_no,
+        kind=event.kind,
+        payload=event.payload,
+        observed_at=event.observed_at,
+        idempotency_key=event.idempotency_key,
+    )
+
+    with pytest.raises(TypeError, match="event must be an EvidenceEvent"):
+        make_record(event=event_subclass)
+
+
 @pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
 @pytest.mark.parametrize("value", ["", " \t\n"])
 def test_evidence_record_rejects_blank_identifiers_and_hash(
@@ -397,6 +526,21 @@ def test_evidence_record_preserves_identifier_and_hash_whitespace() -> None:
 
     assert record.evidence_id == " evidence-1 "
     assert record.content_hash == " sha256:abc123 "
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("evidence_id", " evidence-1 "),
+        ("content_hash", " sha256:abc123 "),
+    ],
+)
+def test_evidence_record_snapshots_string_subclasses(field: str, value: str) -> None:
+    record = make_record(**{field: AdversarialStr(value)})
+    stored = getattr(record, field)
+
+    assert type(stored) is str
+    assert stored == value
 
 
 @pytest.mark.parametrize("field", ["evidence_id", "content_hash"])

--- a/tests/v2/memory_service/test_types.py
+++ b/tests/v2/memory_service/test_types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import FrozenInstanceError
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
 
 import pytest
 
@@ -35,6 +35,34 @@ VALID_UTC_BOUNDARIES = (
         datetime.max.replace(tzinfo=UTC),
     ),
 )
+
+
+class MutableTimezone(tzinfo):
+    """Timezone whose offset can change after a datetime is constructed."""
+
+    def __init__(self, offset: timedelta) -> None:
+        self.offset = offset
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        return self.offset
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(0)
+
+    def tzname(self, value: datetime | None) -> str:
+        return "MUTABLE"
+
+
+class StatefulDatetime(datetime):
+    """Datetime subclass with unsafe conversion and serialization overrides."""
+
+    suffix: str = ""
+
+    def astimezone(self, timezone: tzinfo | None = None) -> StatefulDatetime:
+        return self
+
+    def isoformat(self, sep: str = "T", timespec: str = "auto") -> str:
+        return f"{datetime.isoformat(self, sep, timespec)}{self.suffix}"
 
 
 def make_scope(**overrides: object) -> MemoryScope:
@@ -248,6 +276,42 @@ def test_evidence_event_rejects_datetime_that_cannot_normalize_to_utc(
         make_event(observed_at=observed_at)
 
 
+def test_evidence_event_snapshots_mutable_observed_at_as_utc() -> None:
+    source_timezone = MutableTimezone(timedelta(hours=1))
+    source = datetime(2026, 7, 7, 5, 5, 6, 789000, tzinfo=source_timezone)
+    event = make_event(observed_at=source)
+    canonical_bytes = event.canonical_bytes()
+
+    source_timezone.offset = timedelta(hours=2)
+
+    assert event.canonical_bytes() == canonical_bytes
+    assert event.observed_at == UTC_INSTANT
+    assert event.observed_at.tzinfo is UTC
+
+
+def test_evidence_event_snapshots_datetime_subclass_as_plain_utc() -> None:
+    source = StatefulDatetime(
+        2026,
+        7,
+        7,
+        5,
+        5,
+        6,
+        789000,
+        tzinfo=timezone(timedelta(hours=1)),
+    )
+    source.suffix = "-before"
+    event = make_event(observed_at=source)
+    canonical_bytes = event.canonical_bytes()
+
+    source.suffix = "-after"
+
+    assert type(event.observed_at) is datetime
+    assert event.observed_at == UTC_INSTANT
+    assert event.canonical_bytes() == canonical_bytes
+    assert b"-before" not in canonical_bytes
+
+
 def test_canonical_bytes_are_sorted_compact_and_deterministic() -> None:
     event = make_event()
 
@@ -281,7 +345,8 @@ def test_canonical_bytes_support_valid_utc_datetime_boundaries(
 ) -> None:
     event = make_event(observed_at=observed_at)
 
-    assert event.observed_at is observed_at
+    assert event.observed_at == expected_utc
+    assert event.observed_at.tzinfo is UTC
     assert (
         json.loads(event.canonical_bytes())["observed_at"] == expected_utc.isoformat()
     )
@@ -293,9 +358,9 @@ def test_canonical_bytes_normalize_semantically_equal_instants_to_utc() -> None:
         observed_at=UTC_INSTANT.astimezone(timezone(timedelta(hours=8)))
     )
 
-    assert utc_event.observed_at != utc_plus_eight_event.observed_at or (
-        utc_event.observed_at.tzinfo != utc_plus_eight_event.observed_at.tzinfo
-    )
+    assert utc_event.observed_at == utc_plus_eight_event.observed_at == UTC_INSTANT
+    assert utc_event.observed_at.tzinfo is UTC
+    assert utc_plus_eight_event.observed_at.tzinfo is UTC
     assert utc_event.canonical_bytes() == utc_plus_eight_event.canonical_bytes()
 
 
@@ -363,15 +428,29 @@ def test_evidence_record_rejects_datetime_that_cannot_normalize_to_utc(
         make_record(created_at=created_at)
 
 
+def test_evidence_record_snapshots_mutable_created_at_as_utc() -> None:
+    source_timezone = MutableTimezone(timedelta(hours=1))
+    source = datetime(2026, 7, 7, 5, 5, 6, 789000, tzinfo=source_timezone)
+    record = make_record(created_at=source)
+
+    source_timezone.offset = timedelta(hours=2)
+
+    assert record.created_at == UTC_INSTANT
+    assert record.created_at.tzinfo is UTC
+
+
 @pytest.mark.parametrize(
-    "created_at",
-    [value for value, _ in VALID_UTC_BOUNDARIES],
+    ("created_at", "expected_utc"),
+    VALID_UTC_BOUNDARIES,
     ids=["minimum", "maximum"],
 )
 def test_evidence_record_accepts_valid_utc_datetime_boundaries(
-    created_at: datetime,
+    created_at: datetime, expected_utc: datetime
 ) -> None:
-    assert make_record(created_at=created_at).created_at is created_at
+    record = make_record(created_at=created_at)
+
+    assert record.created_at == expected_utc
+    assert record.created_at.tzinfo is UTC
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Add the next Memory Service layer after the immutable evidence ledger in #1491: evidence-grounded candidates and immutable, parent-linked memory revision histories.

This PR is intentionally limited to history construction. It does not add releases, runtime retrieval, Agent Service integration, prompt mutation, or training.

## Dependency

- Depends on #1491.
- Until #1491 lands, GitHub shows its commits in this draft. The new work in this PR is the candidate/revision stack after `codex/memory-core-contracts`.

## What changed

- add frozen candidate and revision value objects with canonical content hashes;
- require every candidate to cite immutable evidence IDs in the same scope;
- model revision transitions explicitly as `ADD`, `REFINE`, `SUPERSEDE`, and `CONTRADICT`;
- preserve immutable parent links, exact derived generations, and memory identity across transitions;
- allow branch histories: multiple children may cite the same parent, while a later release selects at most one revision for a logical memory;
- add a lock-protected in-memory history store with scoped idempotency and collision protection;
- reject cross-scope references, missing evidence, invalid parents, candidate reuse, hash/address conflicts, and partial multi-index publication;
- harden the reference implementation against mutable subclasses, hash-prefix collisions, callback re-entry, and concurrent conflicting writers.

## Why

The runtime Memory service must be able to explain where a memory came from and how it changed before it can safely retrieve or evolve that memory. Branches are intentional: competing refinements can coexist immutably, and release construction later chooses the exact revision set to evaluate.

## Validation

- focused evidence/history suite — **222 passed**;
- BaseException rollback tests cover interrupted candidate and revision multi-index publication;
- independent integrity, concurrency, scope-isolation, and final-audit reviews completed;
- `git diff --check` and Ruff checks passed.

## Non-goals

- no release manifests or promotion policy;
- no embeddings/vector database;
- no runtime query/exposure ledger;
- no automatic system-prompt, skill, or long-term-memory update policy;
- no changes to existing AReaL training or rollout paths.

Refs #1490.
