### PR TITLE
[codex] add immutable Memory release manifests

### DIFF
--- a/areal/v2/memory_service/__init__.py
+++ b/areal/v2/memory_service/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Public contracts for immutable Memory Service evidence and history."""
+"""Public contracts for immutable Memory Service evidence, history, and releases."""
 
 from areal.v2.memory_service.errors import (
     CandidateConflictError,
@@ -8,6 +8,8 @@ from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
     MemoryServiceError,
+    ReleaseConflictError,
+    ReleaseNotFoundError,
     RevisionConflictError,
     RevisionNotFoundError,
 )
@@ -22,6 +24,11 @@ from areal.v2.memory_service.history_types import (
     RevisionOperation,
     RevisionProposal,
 )
+from areal.v2.memory_service.release_store import (
+    InMemoryMemoryReleaseStore,
+    MemoryReleaseStore,
+)
+from areal.v2.memory_service.release_types import MemoryRelease, ReleaseManifest
 from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
     EvidenceEvent,
@@ -42,11 +49,17 @@ __all__ = [
     "EvidenceStore",
     "InMemoryEvidenceStore",
     "InMemoryMemoryHistoryStore",
+    "InMemoryMemoryReleaseStore",
     "MemoryCandidate",
     "MemoryHistoryStore",
+    "MemoryRelease",
+    "MemoryReleaseStore",
     "MemoryRevision",
     "MemoryScope",
     "MemoryServiceError",
+    "ReleaseConflictError",
+    "ReleaseManifest",
+    "ReleaseNotFoundError",
     "RevisionConflictError",
     "RevisionNotFoundError",
     "RevisionOperation",

--- a/areal/v2/memory_service/__init__.py
+++ b/areal/v2/memory_service/__init__.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public contracts for immutable Memory Service evidence."""
+
+from areal.v2.memory_service.errors import (
+    EvidenceConflictError,
+    EvidenceNotFoundError,
+    MemoryServiceError,
+)
+from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+__all__ = [
+    "EvidenceConflictError",
+    "EvidenceEvent",
+    "EvidenceKind",
+    "EvidenceNotFoundError",
+    "EvidenceRecord",
+    "EvidenceStore",
+    "InMemoryEvidenceStore",
+    "MemoryScope",
+    "MemoryServiceError",
+]

--- a/areal/v2/memory_service/__init__.py
+++ b/areal/v2/memory_service/__init__.py
@@ -1,11 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Public contracts for immutable Memory Service evidence."""
+"""Public contracts for immutable Memory Service evidence and history."""
 
 from areal.v2.memory_service.errors import (
+    CandidateConflictError,
+    CandidateNotFoundError,
     EvidenceConflictError,
     EvidenceNotFoundError,
     MemoryServiceError,
+    RevisionConflictError,
+    RevisionNotFoundError,
+)
+from areal.v2.memory_service.history_store import (
+    InMemoryMemoryHistoryStore,
+    MemoryHistoryStore,
+)
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
 )
 from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
@@ -16,6 +31,9 @@ from areal.v2.memory_service.types import (
 )
 
 __all__ = [
+    "CandidateConflictError",
+    "CandidateNotFoundError",
+    "CandidateProposal",
     "EvidenceConflictError",
     "EvidenceEvent",
     "EvidenceKind",
@@ -23,6 +41,14 @@ __all__ = [
     "EvidenceRecord",
     "EvidenceStore",
     "InMemoryEvidenceStore",
+    "InMemoryMemoryHistoryStore",
+    "MemoryCandidate",
+    "MemoryHistoryStore",
+    "MemoryRevision",
     "MemoryScope",
     "MemoryServiceError",
+    "RevisionConflictError",
+    "RevisionNotFoundError",
+    "RevisionOperation",
+    "RevisionProposal",
 ]

--- a/areal/v2/memory_service/_atomic.py
+++ b/areal/v2/memory_service/_atomic.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small rollback helper for process-local multi-index publication."""
+
+from __future__ import annotations
+
+_MISSING = object()
+
+
+def _atomic_publish(
+    *,
+    mapping_writes: tuple[tuple[dict, object, object], ...],
+    sequence_appends: tuple[tuple[dict, object, object], ...] = (),
+) -> None:
+    """Publish mapping writes and indexed list appends as one local unit.
+
+    The helper deliberately catches ``BaseException`` because cancellation,
+    ``KeyboardInterrupt``, and allocation failures must not leave only some
+    indexes visible.  Rollback is best-effort for hostile test doubles; normal
+    built-in dictionaries and lists restore their exact prior state.
+    """
+
+    undo: list[tuple[str, object, object, object]] = []
+    try:
+        for mapping, key, value in mapping_writes:
+            previous = mapping.get(key, _MISSING)
+            undo.append(("mapping", mapping, key, previous))
+            mapping[key] = value
+        for mapping, key, value in sequence_appends:
+            sequence = mapping.get(key, _MISSING)
+            if sequence is _MISSING:
+                undo.append(("mapping", mapping, key, _MISSING))
+                mapping[key] = [value]
+                continue
+            if type(sequence) is not list:
+                raise TypeError("indexed publication sequence must be a list")
+            undo.append(("sequence", sequence, len(sequence), _MISSING))
+            sequence.append(value)
+    except BaseException:
+        for kind, target, key_or_length, previous in reversed(undo):
+            try:
+                if kind == "sequence":
+                    del target[key_or_length:]
+                elif previous is _MISSING:
+                    target.pop(key_or_length, None)
+                else:
+                    target[key_or_length] = previous
+            except BaseException:
+                pass
+        raise

--- a/areal/v2/memory_service/_atomic.py
+++ b/areal/v2/memory_service/_atomic.py
@@ -16,8 +16,9 @@ def _atomic_publish(
 
     The helper deliberately catches ``BaseException`` because cancellation,
     ``KeyboardInterrupt``, and allocation failures must not leave only some
-    indexes visible.  Rollback is best-effort for hostile test doubles; normal
-    built-in dictionaries and lists restore their exact prior state.
+    indexes visible.  Store indexes are private built-in dictionaries and
+    lists.  Rollback calls the built-in mutation methods directly so a fault-
+    injection subclass cannot interrupt both publication and its own undo.
     """
 
     undo: list[tuple[str, object, object, object]] = []
@@ -40,11 +41,14 @@ def _atomic_publish(
         for kind, target, key_or_length, previous in reversed(undo):
             try:
                 if kind == "sequence":
-                    del target[key_or_length:]
+                    list.__delitem__(target, slice(key_or_length, None))
                 elif previous is _MISSING:
-                    target.pop(key_or_length, None)
+                    dict.pop(target, key_or_length, None)
                 else:
-                    target[key_or_length] = previous
+                    dict.__setitem__(target, key_or_length, previous)
             except BaseException:
+                # A second process-level interruption can still make rollback
+                # impossible.  Continue undoing the other independent indexes
+                # and preserve the original publication exception.
                 pass
         raise

--- a/areal/v2/memory_service/errors.py
+++ b/areal/v2/memory_service/errors.py
@@ -2,6 +2,8 @@
 
 """Errors raised by the Memory Service."""
 
+from __future__ import annotations
+
 
 class MemoryServiceError(Exception):
     """Base class for Memory Service failures."""
@@ -13,3 +15,11 @@ class EvidenceNotFoundError(MemoryServiceError):
 
 class EvidenceConflictError(MemoryServiceError):
     """Raised when evidence conflicts with an existing immutable record."""
+
+
+class CandidateNotFoundError(MemoryServiceError):
+    """Raised when a candidate is unavailable in the requested scope."""
+
+
+class CandidateConflictError(MemoryServiceError):
+    """Raised when a candidate write conflicts with immutable history."""

--- a/areal/v2/memory_service/errors.py
+++ b/areal/v2/memory_service/errors.py
@@ -31,3 +31,11 @@ class RevisionNotFoundError(MemoryServiceError):
 
 class RevisionConflictError(MemoryServiceError):
     """Raised when a revision write conflicts with immutable history."""
+
+
+class ReleaseNotFoundError(MemoryServiceError):
+    """Raised when a release is unavailable in the requested scope."""
+
+
+class ReleaseConflictError(MemoryServiceError):
+    """Raised when a release write conflicts with immutable history."""

--- a/areal/v2/memory_service/errors.py
+++ b/areal/v2/memory_service/errors.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Errors raised by the Memory Service."""
+
+
+class MemoryServiceError(Exception):
+    """Base class for Memory Service failures."""
+
+
+class EvidenceNotFoundError(MemoryServiceError):
+    """Raised when requested evidence is unavailable in the requested scope."""
+
+
+class EvidenceConflictError(MemoryServiceError):
+    """Raised when evidence conflicts with an existing immutable record."""

--- a/areal/v2/memory_service/errors.py
+++ b/areal/v2/memory_service/errors.py
@@ -23,3 +23,11 @@ class CandidateNotFoundError(MemoryServiceError):
 
 class CandidateConflictError(MemoryServiceError):
     """Raised when a candidate write conflicts with immutable history."""
+
+
+class RevisionNotFoundError(MemoryServiceError):
+    """Raised when a revision is unavailable in the requested scope."""
+
+
+class RevisionConflictError(MemoryServiceError):
+    """Raised when a revision write conflicts with immutable history."""

--- a/areal/v2/memory_service/history_store.py
+++ b/areal/v2/memory_service/history_store.py
@@ -12,10 +12,15 @@ from typing import Protocol
 from areal.v2.memory_service.errors import (
     CandidateConflictError,
     CandidateNotFoundError,
+    RevisionConflictError,
+    RevisionNotFoundError,
 )
 from areal.v2.memory_service.history_types import (
     CandidateProposal,
     MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
 )
 from areal.v2.memory_service.store import EvidenceStore
 from areal.v2.memory_service.types import (
@@ -26,7 +31,7 @@ from areal.v2.memory_service.types import (
 
 
 class MemoryHistoryStore(Protocol):
-    """Storage contract for immutable memory candidates."""
+    """Storage contract for immutable memory candidates and revisions."""
 
     def append_candidate(self, proposal: CandidateProposal) -> MemoryCandidate:
         """Persist one evidence-grounded candidate."""
@@ -50,9 +55,26 @@ class MemoryHistoryStore(Protocol):
 
         ...
 
+    def append_revision(self, proposal: RevisionProposal) -> MemoryRevision:
+        """Persist one immutable candidate transition."""
+
+        ...
+
+    def get_revision(self, scope: MemoryScope, revision_id: str) -> MemoryRevision:
+        """Return one scoped revision."""
+
+        ...
+
+    def list_revisions(
+        self, scope: MemoryScope, *, memory_id: str | None = None
+    ) -> tuple[MemoryRevision, ...]:
+        """Return parent-before-child immutable revisions."""
+
+        ...
+
 
 class InMemoryMemoryHistoryStore:
-    """Lock-protected process-local storage for immutable memory candidates."""
+    """Lock-protected process-local immutable memory history."""
 
     def __init__(self, evidence_store: EvidenceStore) -> None:
         self._evidence_store = evidence_store
@@ -62,6 +84,12 @@ class InMemoryMemoryHistoryStore:
             tuple[MemoryScope, str], MemoryCandidate
         ] = {}
         self._candidates_by_scope: dict[MemoryScope, list[MemoryCandidate]] = {}
+        self._revision_by_id: dict[tuple[MemoryScope, str], MemoryRevision] = {}
+        self._revision_by_idempotency: dict[
+            tuple[MemoryScope, str], MemoryRevision
+        ] = {}
+        self._revision_by_candidate: dict[tuple[MemoryScope, str], MemoryRevision] = {}
+        self._revisions_by_scope: dict[MemoryScope, list[MemoryRevision]] = {}
 
     def append_candidate(self, proposal: CandidateProposal) -> MemoryCandidate:
         """Persist a candidate after validating all referenced evidence."""
@@ -149,5 +177,115 @@ class InMemoryMemoryHistoryStore:
                 sorted(
                     self._candidates_by_scope.get(scope, ()),
                     key=lambda item: item.candidate_id,
+                )
+            )
+
+    def append_revision(self, proposal: RevisionProposal) -> MemoryRevision:
+        """Persist one immutable candidate transition."""
+
+        if type(proposal) is not RevisionProposal:
+            raise TypeError("proposal must be a RevisionProposal")
+        canonical_bytes = proposal.canonical_bytes()
+        content_hash = hashlib.sha256(canonical_bytes).hexdigest()
+        revision_id = f"rev_{content_hash[:24]}"
+        revision_index = (proposal.scope, revision_id)
+        idempotency_index = (proposal.scope, proposal.idempotency_key)
+        candidate_index = (proposal.scope, proposal.candidate_id)
+
+        with self._lock:
+            existing = self._revision_by_idempotency.get(idempotency_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise RevisionConflictError(
+                    "scoped revision idempotency key already refers to different content"
+                )
+
+            existing = self._revision_by_id.get(revision_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise RevisionConflictError(
+                    f"revision ID collision for {revision_id!r}"
+                )
+
+            candidate = self._candidate_by_id.get(candidate_index)
+            if candidate is None:
+                raise CandidateNotFoundError(
+                    f"candidate {proposal.candidate_id!r} was not found"
+                )
+            if candidate_index in self._revision_by_candidate:
+                raise RevisionConflictError(
+                    f"candidate {proposal.candidate_id!r} already backs a revision"
+                )
+
+            if proposal.operation is RevisionOperation.ADD:
+                memory_id = f"mem_{content_hash[:24]}"
+                generation = 0
+            else:
+                assert proposal.parent_revision_id is not None
+                parent = self._revision_by_id.get(
+                    (proposal.scope, proposal.parent_revision_id)
+                )
+                if parent is None:
+                    raise RevisionNotFoundError(
+                        f"revision {proposal.parent_revision_id!r} was not found"
+                    )
+                if parent.generation == 2**63 - 1:
+                    raise RevisionConflictError(
+                        "revision generation exceeds the signed-64 range"
+                    )
+                memory_id = parent.memory_id
+                generation = parent.generation + 1
+
+            revision = MemoryRevision(
+                revision_id=revision_id,
+                memory_id=memory_id,
+                generation=generation,
+                proposal=proposal,
+                content_hash=content_hash,
+                created_at=datetime.now(UTC),
+            )
+            self._revision_by_id[revision_index] = revision
+            self._revision_by_idempotency[idempotency_index] = revision
+            self._revision_by_candidate[candidate_index] = revision
+            self._revisions_by_scope.setdefault(proposal.scope, []).append(revision)
+            return revision
+
+    def get_revision(self, scope: MemoryScope, revision_id: str) -> MemoryRevision:
+        """Return a revision only when it belongs to the requested scope."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        revision_id = _validate_string(revision_id, "revision_id", allow_blank=True)
+        with self._lock:
+            revision = self._revision_by_id.get((scope, revision_id))
+            if revision is None:
+                raise RevisionNotFoundError(f"revision {revision_id!r} was not found")
+            return revision
+
+    def list_revisions(
+        self, scope: MemoryScope, *, memory_id: str | None = None
+    ) -> tuple[MemoryRevision, ...]:
+        """Return a stable, parent-before-child revision snapshot."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        if memory_id is not None:
+            memory_id = _validate_string(memory_id, "memory_id", allow_blank=True)
+        with self._lock:
+            matches = (
+                revision
+                for revision in self._revisions_by_scope.get(scope, ())
+                if memory_id is None or revision.memory_id == memory_id
+            )
+            return tuple(
+                sorted(
+                    matches,
+                    key=lambda item: (
+                        item.memory_id,
+                        item.generation,
+                        item.revision_id,
+                    ),
                 )
             )

--- a/areal/v2/memory_service/history_store.py
+++ b/areal/v2/memory_service/history_store.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""History storage contracts and an in-memory reference implementation."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from threading import RLock
+from typing import Protocol
+
+from areal.v2.memory_service.errors import (
+    CandidateConflictError,
+    CandidateNotFoundError,
+)
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+)
+from areal.v2.memory_service.store import EvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceRecord,
+    MemoryScope,
+    _validate_string,
+)
+
+
+class MemoryHistoryStore(Protocol):
+    """Storage contract for immutable memory candidates."""
+
+    def append_candidate(self, proposal: CandidateProposal) -> MemoryCandidate:
+        """Persist one evidence-grounded candidate."""
+
+        ...
+
+    def get_candidate(self, scope: MemoryScope, candidate_id: str) -> MemoryCandidate:
+        """Return one scoped candidate."""
+
+        ...
+
+    def get_candidate_evidence(
+        self, scope: MemoryScope, candidate_id: str
+    ) -> tuple[EvidenceRecord, ...]:
+        """Resolve candidate evidence in proposal order."""
+
+        ...
+
+    def list_candidates(self, scope: MemoryScope) -> tuple[MemoryCandidate, ...]:
+        """Return candidates in stable identifier order."""
+
+        ...
+
+
+class InMemoryMemoryHistoryStore:
+    """Lock-protected process-local storage for immutable memory candidates."""
+
+    def __init__(self, evidence_store: EvidenceStore) -> None:
+        self._evidence_store = evidence_store
+        self._lock = RLock()
+        self._candidate_by_id: dict[tuple[MemoryScope, str], MemoryCandidate] = {}
+        self._candidate_by_idempotency: dict[
+            tuple[MemoryScope, str], MemoryCandidate
+        ] = {}
+        self._candidates_by_scope: dict[MemoryScope, list[MemoryCandidate]] = {}
+
+    def append_candidate(self, proposal: CandidateProposal) -> MemoryCandidate:
+        """Persist a candidate after validating all referenced evidence."""
+
+        if type(proposal) is not CandidateProposal:
+            raise TypeError("proposal must be a CandidateProposal")
+        canonical_bytes = proposal.canonical_bytes()
+        content_hash = hashlib.sha256(canonical_bytes).hexdigest()
+        candidate_id = f"cand_{content_hash[:24]}"
+        candidate_index = (proposal.scope, candidate_id)
+        idempotency_index = (proposal.scope, proposal.idempotency_key)
+
+        with self._lock:
+            existing = self._candidate_by_idempotency.get(idempotency_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise CandidateConflictError(
+                    "scoped candidate idempotency key already refers to different content"
+                )
+
+        # Evidence is append-only, so this outside-lock preflight cannot be invalidated.
+        for evidence_id in proposal.evidence_ids:
+            self._evidence_store.get(proposal.scope, evidence_id)
+
+        with self._lock:
+            # Mandatory recheck closes the validation/insertion race.
+            existing = self._candidate_by_idempotency.get(idempotency_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise CandidateConflictError(
+                    "scoped candidate idempotency key already refers to different content"
+                )
+            existing = self._candidate_by_id.get(candidate_index)
+            if existing is not None:
+                if existing.proposal.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise CandidateConflictError(
+                    f"candidate ID collision for {candidate_id!r}"
+                )
+            candidate = MemoryCandidate(
+                candidate_id=candidate_id,
+                proposal=proposal,
+                content_hash=content_hash,
+                created_at=datetime.now(UTC),
+            )
+            self._candidate_by_id[candidate_index] = candidate
+            self._candidate_by_idempotency[idempotency_index] = candidate
+            self._candidates_by_scope.setdefault(proposal.scope, []).append(candidate)
+            return candidate
+
+    def get_candidate(self, scope: MemoryScope, candidate_id: str) -> MemoryCandidate:
+        """Return a candidate only when it belongs to the requested scope."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        candidate_id = _validate_string(candidate_id, "candidate_id", allow_blank=True)
+        with self._lock:
+            candidate = self._candidate_by_id.get((scope, candidate_id))
+            if candidate is None:
+                raise CandidateNotFoundError(
+                    f"candidate {candidate_id!r} was not found"
+                )
+            return candidate
+
+    def get_candidate_evidence(
+        self, scope: MemoryScope, candidate_id: str
+    ) -> tuple[EvidenceRecord, ...]:
+        """Resolve a candidate's evidence in its proposal order."""
+
+        candidate = self.get_candidate(scope, candidate_id)
+        return tuple(
+            self._evidence_store.get(scope, evidence_id)
+            for evidence_id in candidate.proposal.evidence_ids
+        )
+
+    def list_candidates(self, scope: MemoryScope) -> tuple[MemoryCandidate, ...]:
+        """Return a stable snapshot of candidates in the requested scope."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        with self._lock:
+            return tuple(
+                sorted(
+                    self._candidates_by_scope.get(scope, ()),
+                    key=lambda item: item.candidate_id,
+                )
+            )

--- a/areal/v2/memory_service/history_store.py
+++ b/areal/v2/memory_service/history_store.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from threading import RLock
 from typing import Protocol
 
+from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
     CandidateConflictError,
     CandidateNotFoundError,
@@ -137,9 +138,19 @@ class InMemoryMemoryHistoryStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._candidate_by_id[candidate_index] = candidate
-            self._candidate_by_idempotency[idempotency_index] = candidate
-            self._candidates_by_scope.setdefault(proposal.scope, []).append(candidate)
+            _atomic_publish(
+                mapping_writes=(
+                    (self._candidate_by_id, candidate_index, candidate),
+                    (
+                        self._candidate_by_idempotency,
+                        idempotency_index,
+                        candidate,
+                    ),
+                ),
+                sequence_appends=(
+                    (self._candidates_by_scope, proposal.scope, candidate),
+                ),
+            )
             return candidate
 
     def get_candidate(self, scope: MemoryScope, candidate_id: str) -> MemoryCandidate:
@@ -246,10 +257,20 @@ class InMemoryMemoryHistoryStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._revision_by_id[revision_index] = revision
-            self._revision_by_idempotency[idempotency_index] = revision
-            self._revision_by_candidate[candidate_index] = revision
-            self._revisions_by_scope.setdefault(proposal.scope, []).append(revision)
+            _atomic_publish(
+                mapping_writes=(
+                    (self._revision_by_id, revision_index, revision),
+                    (
+                        self._revision_by_idempotency,
+                        idempotency_index,
+                        revision,
+                    ),
+                    (self._revision_by_candidate, candidate_index, revision),
+                ),
+                sequence_appends=(
+                    (self._revisions_by_scope, proposal.scope, revision),
+                ),
+            )
             return revision
 
     def get_revision(self, scope: MemoryScope, revision_id: str) -> MemoryRevision:

--- a/areal/v2/memory_service/history_types.py
+++ b/areal/v2/memory_service/history_types.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable candidate and revision values for the Memory Service."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from areal.v2.memory_service.types import (
+    MemoryScope,
+    _validate_aware_datetime,
+    _validate_string,
+)
+
+_SCHEMA_VERSION = 1
+_MAX_GENERATION = 2**63 - 1
+
+
+def _canonical_json_bytes(value: dict[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _snapshot_evidence_ids(value: object) -> tuple[str, ...]:
+    if not isinstance(value, tuple):
+        raise TypeError("evidence_ids must be a tuple")
+    snapshot = tuple(
+        _validate_string(item, "evidence_ids") for item in tuple.__iter__(value)
+    )
+    if not snapshot:
+        raise ValueError("evidence_ids must not be empty")
+    if len(set(snapshot)) != len(snapshot):
+        raise ValueError("evidence_ids must not contain duplicates")
+    return snapshot
+
+
+class RevisionOperation(StrEnum):
+    ADD = "add"
+    REFINE = "refine"
+    SUPERSEDE = "supersede"
+    CONTRADICT = "contradict"
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateProposal:
+    scope: MemoryScope
+    content: str
+    evidence_ids: tuple[str, ...]
+    idempotency_key: str
+
+    def __post_init__(self) -> None:
+        if type(self.scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        content = _validate_string(self.content, "content")
+        evidence_ids = _snapshot_evidence_ids(self.evidence_ids)
+        idempotency_key = _validate_string(self.idempotency_key, "idempotency_key")
+        object.__setattr__(self, "content", content)
+        object.__setattr__(self, "evidence_ids", evidence_ids)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
+
+    def canonical_bytes(self) -> bytes:
+        value = {
+            "schema_version": _SCHEMA_VERSION,
+            "scope": {
+                "tenant_id": self.scope.tenant_id,
+                "namespace": self.scope.namespace,
+                "subject_id": self.scope.subject_id,
+            },
+            "content": self.content,
+            "evidence_ids": list(self.evidence_ids),
+            "idempotency_key": self.idempotency_key,
+        }
+        return _canonical_json_bytes(value)
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryCandidate:
+    candidate_id: str
+    proposal: CandidateProposal
+    content_hash: str
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        if type(self.proposal) is not CandidateProposal:
+            raise TypeError("proposal must be a CandidateProposal")
+        candidate_id = _validate_string(self.candidate_id, "candidate_id")
+        content_hash = _validate_string(self.content_hash, "content_hash")
+        created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "content_hash", content_hash)
+        object.__setattr__(self, "created_at", created_at)
+
+
+@dataclass(frozen=True, slots=True)
+class RevisionProposal:
+    scope: MemoryScope
+    candidate_id: str
+    operation: RevisionOperation
+    parent_revision_id: str | None
+    idempotency_key: str
+
+    def __post_init__(self) -> None:
+        if type(self.scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        candidate_id = _validate_string(self.candidate_id, "candidate_id")
+        if type(self.operation) is not RevisionOperation:
+            raise TypeError("operation must be a RevisionOperation")
+        parent_revision_id = self.parent_revision_id
+        if parent_revision_id is not None:
+            parent_revision_id = _validate_string(
+                parent_revision_id, "parent_revision_id"
+            )
+        if self.operation is RevisionOperation.ADD and parent_revision_id is not None:
+            raise ValueError("parent_revision_id must be absent for ADD")
+        if self.operation is not RevisionOperation.ADD and parent_revision_id is None:
+            raise ValueError("parent_revision_id is required for non-ADD operations")
+        idempotency_key = _validate_string(self.idempotency_key, "idempotency_key")
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "parent_revision_id", parent_revision_id)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
+
+    def canonical_bytes(self) -> bytes:
+        value = {
+            "schema_version": _SCHEMA_VERSION,
+            "scope": {
+                "tenant_id": self.scope.tenant_id,
+                "namespace": self.scope.namespace,
+                "subject_id": self.scope.subject_id,
+            },
+            "candidate_id": self.candidate_id,
+            "operation": self.operation.value,
+            "parent_revision_id": self.parent_revision_id,
+            "idempotency_key": self.idempotency_key,
+        }
+        return _canonical_json_bytes(value)
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRevision:
+    revision_id: str
+    memory_id: str
+    generation: int
+    proposal: RevisionProposal
+    content_hash: str
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        revision_id = _validate_string(self.revision_id, "revision_id")
+        memory_id = _validate_string(self.memory_id, "memory_id")
+        if type(self.generation) is not int:
+            raise TypeError("generation must be an integer")
+        if self.generation < 0 or self.generation > _MAX_GENERATION:
+            raise ValueError("generation must fit the non-negative signed-64 range")
+        if type(self.proposal) is not RevisionProposal:
+            raise TypeError("proposal must be a RevisionProposal")
+        content_hash = _validate_string(self.content_hash, "content_hash")
+        created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "revision_id", revision_id)
+        object.__setattr__(self, "memory_id", memory_id)
+        object.__setattr__(self, "content_hash", content_hash)
+        object.__setattr__(self, "created_at", created_at)

--- a/areal/v2/memory_service/release_store.py
+++ b/areal/v2/memory_service/release_store.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-import hashlib
 from datetime import UTC, datetime
+from hashlib import sha256
 from threading import RLock
 from typing import Protocol
 
@@ -66,7 +66,7 @@ class InMemoryMemoryReleaseStore:
             raise TypeError("manifest must be a ReleaseManifest")
         idempotency_key = _validate_string(idempotency_key, "idempotency_key")
         canonical_bytes = manifest.canonical_bytes()
-        content_hash = hashlib.sha256(canonical_bytes).hexdigest()
+        content_hash = sha256(canonical_bytes).hexdigest()
         release_id = f"rel_{content_hash[:24]}"
         release_index = (manifest.scope, release_id)
         idempotency_index = (manifest.scope, idempotency_key)

--- a/areal/v2/memory_service/release_store.py
+++ b/areal/v2/memory_service/release_store.py
@@ -80,9 +80,12 @@ class InMemoryMemoryReleaseStore:
                     "scoped release idempotency key already refers to different content"
                 )
 
+        revisions = tuple(
+            self._history_store.get_revision(manifest.scope, revision_id)
+            for revision_id in manifest.revision_ids
+        )
         memory_ids: set[str] = set()
-        for revision_id in manifest.revision_ids:
-            revision = self._history_store.get_revision(manifest.scope, revision_id)
+        for revision in revisions:
             if revision.memory_id in memory_ids:
                 raise ReleaseConflictError(
                     f"release contains more than one revision for memory_id "

--- a/areal/v2/memory_service/release_store.py
+++ b/areal/v2/memory_service/release_store.py
@@ -4,19 +4,52 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from hashlib import sha256
 from threading import RLock
 from typing import Protocol
 
+from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
+    MemoryServiceError,
     ReleaseConflictError,
     ReleaseNotFoundError,
 )
 from areal.v2.memory_service.history_store import MemoryHistoryStore
-from areal.v2.memory_service.history_types import MemoryRevision
-from areal.v2.memory_service.release_types import MemoryRelease, ReleaseManifest
-from areal.v2.memory_service.types import MemoryScope, _validate_string
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
+)
+from areal.v2.memory_service.release_types import (
+    MemoryRelease,
+    ReleaseManifest,
+    _release_commitment_bytes,
+)
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceRecord,
+    MemoryScope,
+    _validate_string,
+)
+
+_RELEASE_GRAPH_SCHEMA_VERSION = 1
+
+
+def _canonical_json_bytes(value: dict[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _commitment_error(message: str) -> ReleaseConflictError:
+    return ReleaseConflictError(f"release graph integrity failure: {message}")
 
 
 class MemoryReleaseStore(Protocol):
@@ -57,6 +90,258 @@ class InMemoryMemoryReleaseStore:
         self._release_by_idempotency: dict[tuple[MemoryScope, str], MemoryRelease] = {}
         self._releases_by_scope: dict[MemoryScope, list[MemoryRelease]] = {}
 
+    def _validated_candidate_node(
+        self,
+        scope: MemoryScope,
+        candidate_id: str,
+    ) -> dict[str, object]:
+        candidate = self._history_store.get_candidate(scope, candidate_id)
+        if type(candidate) is not MemoryCandidate:
+            raise _commitment_error("history returned a non-MemoryCandidate value")
+        proposal = candidate.proposal
+        if (
+            type(proposal) is not CandidateProposal
+            or type(proposal.scope) is not MemoryScope
+            or proposal.scope != scope
+            or type(proposal.evidence_ids) is not tuple
+            or any(type(item) is not str for item in proposal.evidence_ids)
+            or type(proposal.content) is not str
+            or type(proposal.idempotency_key) is not str
+        ):
+            raise _commitment_error("candidate does not belong to the requested scope")
+        if (
+            type(candidate.candidate_id) is not str
+            or type(candidate.content_hash) is not str
+        ):
+            raise _commitment_error("candidate returned malformed commitment fields")
+        if candidate.candidate_id != candidate_id:
+            raise _commitment_error("candidate address does not match the request")
+        candidate_hash = sha256(proposal.canonical_bytes()).hexdigest()
+        if (
+            candidate.content_hash != candidate_hash
+            or candidate.candidate_id != f"cand_{candidate_hash[:24]}"
+        ):
+            raise _commitment_error("candidate canonical commitment is invalid")
+
+        evidence = self._history_store.get_candidate_evidence(scope, candidate_id)
+        if type(evidence) is not tuple:
+            raise _commitment_error("candidate evidence must be an exact tuple")
+        records = tuple(tuple.__iter__(evidence))
+        if tuple(record.evidence_id for record in records) != proposal.evidence_ids:
+            raise _commitment_error(
+                "candidate evidence addresses do not match proposal"
+            )
+
+        evidence_nodes: list[dict[str, str]] = []
+        for expected_evidence_id, record in zip(
+            proposal.evidence_ids,
+            records,
+            strict=True,
+        ):
+            if (
+                type(record) is not EvidenceRecord
+                or type(record.event) is not EvidenceEvent
+            ):
+                raise _commitment_error("history returned a non-EvidenceRecord value")
+            if (
+                type(record.evidence_id) is not str
+                or type(record.content_hash) is not str
+            ):
+                raise _commitment_error("evidence returned malformed commitment fields")
+            if (
+                type(record.event.scope) is not MemoryScope
+                or record.event.scope != scope
+            ):
+                raise _commitment_error("evidence does not belong to requested scope")
+            if record.evidence_id != expected_evidence_id:
+                raise _commitment_error("evidence address does not match proposal")
+            evidence_hash = sha256(record.event.canonical_bytes()).hexdigest()
+            if (
+                record.content_hash != evidence_hash
+                or record.evidence_id != f"evd_{evidence_hash[:24]}"
+            ):
+                raise _commitment_error("evidence canonical commitment is invalid")
+            evidence_nodes.append(
+                {
+                    "evidence_id": record.evidence_id,
+                    "evidence_sha256": evidence_hash,
+                }
+            )
+
+        repeated_candidate_hash = sha256(proposal.canonical_bytes()).hexdigest()
+        if (
+            repeated_candidate_hash != candidate_hash
+            or candidate.content_hash != candidate_hash
+            or candidate.candidate_id != candidate_id
+            or candidate.candidate_id != f"cand_{candidate_hash[:24]}"
+        ):
+            raise _commitment_error(
+                "candidate changed while its evidence was being validated"
+            )
+        return {
+            "candidate_id": candidate.candidate_id,
+            "candidate_sha256": candidate_hash,
+            "evidence": evidence_nodes,
+        }
+
+    def _validated_revision_node(
+        self,
+        scope: MemoryScope,
+        requested_revision_id: str,
+    ) -> tuple[MemoryRevision, dict[str, object]]:
+        revision = self._history_store.get_revision(scope, requested_revision_id)
+        if type(revision) is not MemoryRevision:
+            raise _commitment_error("history returned a non-MemoryRevision value")
+        proposal = revision.proposal
+        if (
+            type(proposal) is not RevisionProposal
+            or type(proposal.scope) is not MemoryScope
+            or proposal.scope != scope
+            or type(proposal.candidate_id) is not str
+            or type(proposal.operation) is not RevisionOperation
+            or (
+                proposal.parent_revision_id is not None
+                and type(proposal.parent_revision_id) is not str
+            )
+            or type(proposal.idempotency_key) is not str
+        ):
+            raise _commitment_error("revision does not belong to requested scope")
+        if (
+            type(revision.revision_id) is not str
+            or type(revision.content_hash) is not str
+            or type(revision.memory_id) is not str
+            or type(revision.generation) is not int
+        ):
+            raise _commitment_error("revision returned malformed commitment fields")
+        if revision.revision_id != requested_revision_id:
+            raise _commitment_error("revision address does not match the request")
+        revision_hash = sha256(proposal.canonical_bytes()).hexdigest()
+        if (
+            revision.content_hash != revision_hash
+            or revision.revision_id != f"rev_{revision_hash[:24]}"
+        ):
+            raise _commitment_error("revision canonical commitment is invalid")
+
+        candidate_node = self._validated_candidate_node(
+            scope,
+            proposal.candidate_id,
+        )
+        repeated_revision_hash = sha256(proposal.canonical_bytes()).hexdigest()
+        if (
+            repeated_revision_hash != revision_hash
+            or revision.content_hash != revision_hash
+            or revision.revision_id != requested_revision_id
+            or revision.revision_id != f"rev_{revision_hash[:24]}"
+        ):
+            raise _commitment_error(
+                "revision changed while its source graph was being validated"
+            )
+        return revision, {
+            "candidate": candidate_node,
+            "generation": revision.generation,
+            "memory_id": revision.memory_id,
+            "revision_id": revision.revision_id,
+            "revision_sha256": revision_hash,
+        }
+
+    def _derive_release_graph(
+        self,
+        manifest: ReleaseManifest,
+    ) -> tuple[bytes, tuple[MemoryRevision, ...]]:
+        """Resolve and validate every selected path without recursion."""
+
+        selected_nodes: list[dict[str, object]] = []
+        selected_revisions: list[MemoryRevision] = []
+        resolved_nodes: dict[str, dict[str, object]] = {}
+
+        try:
+            for selected_revision_id in manifest.revision_ids:
+                ancestry: list[dict[str, object]] = []
+                visiting: set[str] = set()
+                current_revision_id = selected_revision_id
+                child: MemoryRevision | None = None
+                selected: MemoryRevision | None = None
+
+                while True:
+                    if current_revision_id in visiting:
+                        raise _commitment_error("revision ancestry contains a cycle")
+                    visiting.add(current_revision_id)
+                    revision, node = self._validated_revision_node(
+                        manifest.scope,
+                        current_revision_id,
+                    )
+                    previous_node = resolved_nodes.get(revision.revision_id)
+                    if previous_node is not None and previous_node != node:
+                        raise _commitment_error(
+                            "one revision address resolved to different graph nodes"
+                        )
+                    resolved_nodes[revision.revision_id] = node
+                    ancestry.append(node)
+                    if selected is None:
+                        selected = revision
+
+                    if child is not None and (
+                        child.memory_id != revision.memory_id
+                        or child.generation != revision.generation + 1
+                    ):
+                        raise _commitment_error(
+                            "revision lineage derived fields are invalid"
+                        )
+
+                    if revision.proposal.operation is RevisionOperation.ADD:
+                        if (
+                            revision.proposal.parent_revision_id is not None
+                            or revision.generation != 0
+                            or revision.memory_id != f"mem_{revision.content_hash[:24]}"
+                        ):
+                            raise _commitment_error(
+                                "ADD revision derived fields are invalid"
+                            )
+                        break
+
+                    parent_revision_id = revision.proposal.parent_revision_id
+                    if type(parent_revision_id) is not str:
+                        raise _commitment_error(
+                            "non-ADD revision has no exact parent address"
+                        )
+                    child = revision
+                    current_revision_id = parent_revision_id
+
+                assert selected is not None
+                selected_revisions.append(selected)
+                selected_nodes.append(
+                    {
+                        "ancestry": ancestry,
+                        "selected_revision_id": selected_revision_id,
+                    }
+                )
+            selected_memory_ids: set[str] = set()
+            for revision in selected_revisions:
+                if revision.memory_id in selected_memory_ids:
+                    raise ReleaseConflictError(
+                        "release contains more than one revision for memory_id "
+                        f"{revision.memory_id!r}"
+                    )
+                selected_memory_ids.add(revision.memory_id)
+        except MemoryServiceError:
+            raise
+        except Exception as error:
+            raise _commitment_error(
+                "history lookup did not satisfy its contract"
+            ) from error
+
+        return (
+            _canonical_json_bytes(
+                {
+                    "ancestry_order": "selected_to_add_root",
+                    "record_kind": "memory_release_graph",
+                    "schema_version": _RELEASE_GRAPH_SCHEMA_VERSION,
+                    "selected_revisions": selected_nodes,
+                }
+            ),
+            tuple(selected_revisions),
+        )
+
     def append_release(
         self, manifest: ReleaseManifest, *, idempotency_key: str
     ) -> MemoryRelease:
@@ -66,37 +351,39 @@ class InMemoryMemoryReleaseStore:
             raise TypeError("manifest must be a ReleaseManifest")
         idempotency_key = _validate_string(idempotency_key, "idempotency_key")
         canonical_bytes = manifest.canonical_bytes()
-        content_hash = sha256(canonical_bytes).hexdigest()
-        release_id = f"rel_{content_hash[:24]}"
-        release_index = (manifest.scope, release_id)
+        manifest_sha256 = sha256(canonical_bytes).hexdigest()
         idempotency_index = (manifest.scope, idempotency_key)
 
         with self._lock:
             existing = self._release_by_idempotency.get(idempotency_index)
             if existing is not None:
-                if existing.manifest.canonical_bytes() == canonical_bytes:
-                    return existing
-                raise ReleaseConflictError(
-                    "scoped release idempotency key already refers to different content"
-                )
+                if existing.manifest.canonical_bytes() != canonical_bytes:
+                    raise ReleaseConflictError(
+                        "scoped release idempotency key already refers to different "
+                        "content"
+                    )
 
-        revisions = tuple(
-            self._history_store.get_revision(manifest.scope, revision_id)
-            for revision_id in manifest.revision_ids
+        graph_bytes, _ = self._derive_release_graph(manifest)
+        repeated_graph_bytes, _ = self._derive_release_graph(manifest)
+        if repeated_graph_bytes != graph_bytes:
+            raise _commitment_error("history changed during final graph recheck")
+        release_graph_sha256 = sha256(graph_bytes).hexdigest()
+        commitment_bytes = _release_commitment_bytes(
+            manifest_sha256,
+            release_graph_sha256,
         )
-        memory_ids: set[str] = set()
-        for revision in revisions:
-            if revision.memory_id in memory_ids:
-                raise ReleaseConflictError(
-                    f"release contains more than one revision for memory_id "
-                    f"{revision.memory_id!r}"
-                )
-            memory_ids.add(revision.memory_id)
+        content_hash = sha256(commitment_bytes).hexdigest()
+        release_id = f"rel_{content_hash[:24]}"
+        release_index = (manifest.scope, release_id)
 
         with self._lock:
             existing = self._release_by_idempotency.get(idempotency_index)
             if existing is not None:
-                if existing.manifest.canonical_bytes() == canonical_bytes:
+                if (
+                    existing.manifest.canonical_bytes() == canonical_bytes
+                    and existing.release_graph_sha256 == release_graph_sha256
+                    and existing.content_hash == content_hash
+                ):
                     return existing
                 raise ReleaseConflictError(
                     "scoped release idempotency key already refers to different content"
@@ -104,22 +391,35 @@ class InMemoryMemoryReleaseStore:
 
             existing = self._release_by_id.get(release_index)
             if existing is not None:
-                if existing.manifest.canonical_bytes() != canonical_bytes:
+                if (
+                    existing.manifest.canonical_bytes() != canonical_bytes
+                    or existing.release_graph_sha256 != release_graph_sha256
+                    or existing.content_hash != content_hash
+                ):
                     raise ReleaseConflictError(
                         f"release ID collision for {release_id!r}"
                     )
-                self._release_by_idempotency[idempotency_index] = existing
+                _atomic_publish(
+                    mapping_writes=(
+                        (self._release_by_idempotency, idempotency_index, existing),
+                    ),
+                )
                 return existing
 
             release = MemoryRelease(
                 release_id=release_id,
                 manifest=manifest,
                 content_hash=content_hash,
+                release_graph_sha256=release_graph_sha256,
                 created_at=datetime.now(UTC),
             )
-            self._release_by_id[release_index] = release
-            self._release_by_idempotency[idempotency_index] = release
-            self._releases_by_scope.setdefault(manifest.scope, []).append(release)
+            _atomic_publish(
+                mapping_writes=(
+                    (self._release_by_id, release_index, release),
+                    (self._release_by_idempotency, idempotency_index, release),
+                ),
+                sequence_appends=((self._releases_by_scope, manifest.scope, release),),
+            )
             return release
 
     def get_release(self, scope: MemoryScope, release_id: str) -> MemoryRelease:
@@ -140,10 +440,24 @@ class InMemoryMemoryReleaseStore:
         """Resolve a release's revisions in manifest order."""
 
         release = self.get_release(scope, release_id)
-        return tuple(
-            self._history_store.get_revision(scope, revision_id)
-            for revision_id in release.manifest.revision_ids
-        )
+        graph_bytes, _ = self._derive_release_graph(release.manifest)
+        repeated_graph_bytes, revisions = self._derive_release_graph(release.manifest)
+        if repeated_graph_bytes != graph_bytes:
+            raise _commitment_error("history changed during final graph recheck")
+        release_graph_sha256 = sha256(graph_bytes).hexdigest()
+        manifest_sha256 = sha256(release.manifest.canonical_bytes()).hexdigest()
+        content_hash = sha256(
+            _release_commitment_bytes(manifest_sha256, release_graph_sha256)
+        ).hexdigest()
+        if (
+            release.release_graph_sha256 != release_graph_sha256
+            or release.content_hash != content_hash
+            or release.release_id != f"rel_{content_hash[:24]}"
+        ):
+            raise _commitment_error(
+                "resolved graph does not match the committed release identity"
+            )
+        return revisions
 
     def list_releases(self, scope: MemoryScope) -> tuple[MemoryRelease, ...]:
         """Return a stable release snapshot for the requested scope."""

--- a/areal/v2/memory_service/release_store.py
+++ b/areal/v2/memory_service/release_store.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Release storage contracts and an in-memory reference implementation."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from threading import RLock
+from typing import Protocol
+
+from areal.v2.memory_service.errors import (
+    ReleaseConflictError,
+    ReleaseNotFoundError,
+)
+from areal.v2.memory_service.history_store import MemoryHistoryStore
+from areal.v2.memory_service.history_types import MemoryRevision
+from areal.v2.memory_service.release_types import MemoryRelease, ReleaseManifest
+from areal.v2.memory_service.types import MemoryScope, _validate_string
+
+
+class MemoryReleaseStore(Protocol):
+    """Storage contract for immutable release manifests."""
+
+    def append_release(
+        self, manifest: ReleaseManifest, *, idempotency_key: str
+    ) -> MemoryRelease:
+        """Validate and persist one immutable release manifest."""
+
+        ...
+
+    def get_release(self, scope: MemoryScope, release_id: str) -> MemoryRelease:
+        """Return one release from the requested scope."""
+
+        ...
+
+    def get_release_revisions(
+        self, scope: MemoryScope, release_id: str
+    ) -> tuple[MemoryRevision, ...]:
+        """Resolve release members in manifest order."""
+
+        ...
+
+    def list_releases(self, scope: MemoryScope) -> tuple[MemoryRelease, ...]:
+        """Return releases in stable identifier order."""
+
+        ...
+
+
+class InMemoryMemoryReleaseStore:
+    """Lock-protected process-local immutable release storage."""
+
+    def __init__(self, history_store: MemoryHistoryStore) -> None:
+        self._history_store = history_store
+        self._lock = RLock()
+        self._release_by_id: dict[tuple[MemoryScope, str], MemoryRelease] = {}
+        self._release_by_idempotency: dict[tuple[MemoryScope, str], MemoryRelease] = {}
+        self._releases_by_scope: dict[MemoryScope, list[MemoryRelease]] = {}
+
+    def append_release(
+        self, manifest: ReleaseManifest, *, idempotency_key: str
+    ) -> MemoryRelease:
+        """Persist a release after validating all referenced revisions."""
+
+        if type(manifest) is not ReleaseManifest:
+            raise TypeError("manifest must be a ReleaseManifest")
+        idempotency_key = _validate_string(idempotency_key, "idempotency_key")
+        canonical_bytes = manifest.canonical_bytes()
+        content_hash = hashlib.sha256(canonical_bytes).hexdigest()
+        release_id = f"rel_{content_hash[:24]}"
+        release_index = (manifest.scope, release_id)
+        idempotency_index = (manifest.scope, idempotency_key)
+
+        with self._lock:
+            existing = self._release_by_idempotency.get(idempotency_index)
+            if existing is not None:
+                if existing.manifest.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise ReleaseConflictError(
+                    "scoped release idempotency key already refers to different content"
+                )
+
+        memory_ids: set[str] = set()
+        for revision_id in manifest.revision_ids:
+            revision = self._history_store.get_revision(manifest.scope, revision_id)
+            if revision.memory_id in memory_ids:
+                raise ReleaseConflictError(
+                    f"release contains more than one revision for memory_id "
+                    f"{revision.memory_id!r}"
+                )
+            memory_ids.add(revision.memory_id)
+
+        with self._lock:
+            existing = self._release_by_idempotency.get(idempotency_index)
+            if existing is not None:
+                if existing.manifest.canonical_bytes() == canonical_bytes:
+                    return existing
+                raise ReleaseConflictError(
+                    "scoped release idempotency key already refers to different content"
+                )
+
+            existing = self._release_by_id.get(release_index)
+            if existing is not None:
+                if existing.manifest.canonical_bytes() != canonical_bytes:
+                    raise ReleaseConflictError(
+                        f"release ID collision for {release_id!r}"
+                    )
+                self._release_by_idempotency[idempotency_index] = existing
+                return existing
+
+            release = MemoryRelease(
+                release_id=release_id,
+                manifest=manifest,
+                content_hash=content_hash,
+                created_at=datetime.now(UTC),
+            )
+            self._release_by_id[release_index] = release
+            self._release_by_idempotency[idempotency_index] = release
+            self._releases_by_scope.setdefault(manifest.scope, []).append(release)
+            return release
+
+    def get_release(self, scope: MemoryScope, release_id: str) -> MemoryRelease:
+        """Return a release only when it belongs to the requested scope."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        release_id = _validate_string(release_id, "release_id", allow_blank=True)
+        with self._lock:
+            release = self._release_by_id.get((scope, release_id))
+            if release is None:
+                raise ReleaseNotFoundError(f"release {release_id!r} was not found")
+            return release
+
+    def get_release_revisions(
+        self, scope: MemoryScope, release_id: str
+    ) -> tuple[MemoryRevision, ...]:
+        """Resolve a release's revisions in manifest order."""
+
+        release = self.get_release(scope, release_id)
+        return tuple(
+            self._history_store.get_revision(scope, revision_id)
+            for revision_id in release.manifest.revision_ids
+        )
+
+    def list_releases(self, scope: MemoryScope) -> tuple[MemoryRelease, ...]:
+        """Return a stable release snapshot for the requested scope."""
+
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        with self._lock:
+            return tuple(
+                sorted(
+                    self._releases_by_scope.get(scope, ()),
+                    key=lambda item: item.release_id,
+                )
+            )

--- a/areal/v2/memory_service/release_types.py
+++ b/areal/v2/memory_service/release_types.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable release values for the Memory Service."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+
+from areal.v2.memory_service.types import (
+    MemoryScope,
+    _validate_aware_datetime,
+    _validate_string,
+)
+
+_SCHEMA_VERSION = 1
+
+
+def _canonical_json_bytes(value: dict[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _snapshot_revision_ids(value: object) -> tuple[str, ...]:
+    if not isinstance(value, tuple):
+        raise TypeError("revision_ids must be a tuple")
+    snapshot = tuple(
+        _validate_string(item, "revision_ids") for item in tuple.__iter__(value)
+    )
+    if len(set(snapshot)) != len(snapshot):
+        raise ValueError("revision_ids must not contain duplicates")
+    return snapshot
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseManifest:
+    scope: MemoryScope
+    revision_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
+        revision_ids = _snapshot_revision_ids(self.revision_ids)
+        object.__setattr__(self, "revision_ids", revision_ids)
+
+    def canonical_bytes(self) -> bytes:
+        value = {
+            "schema_version": _SCHEMA_VERSION,
+            "scope": {
+                "tenant_id": self.scope.tenant_id,
+                "namespace": self.scope.namespace,
+                "subject_id": self.scope.subject_id,
+            },
+            "revision_ids": list(self.revision_ids),
+        }
+        return _canonical_json_bytes(value)
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRelease:
+    release_id: str
+    manifest: ReleaseManifest
+    content_hash: str
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        if type(self.manifest) is not ReleaseManifest:
+            raise TypeError("manifest must be a ReleaseManifest")
+        release_id = _validate_string(self.release_id, "release_id")
+        content_hash = _validate_string(self.content_hash, "content_hash")
+        created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "release_id", release_id)
+        object.__setattr__(self, "content_hash", content_hash)
+        object.__setattr__(self, "created_at", created_at)

--- a/areal/v2/memory_service/release_types.py
+++ b/areal/v2/memory_service/release_types.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime
+from hashlib import sha256
 
 from areal.v2.memory_service.types import (
     MemoryScope,
@@ -26,6 +27,22 @@ def _canonical_json_bytes(value: dict[str, object]) -> bytes:
     ).encode("utf-8")
 
 
+def _release_commitment_bytes(
+    manifest_sha256: str,
+    release_graph_sha256: str,
+) -> bytes:
+    """Bind the caller's selection and the store-derived source graph."""
+
+    return _canonical_json_bytes(
+        {
+            "manifest_sha256": manifest_sha256,
+            "record_kind": "memory_release_commitment",
+            "release_graph_sha256": release_graph_sha256,
+            "schema_version": _SCHEMA_VERSION,
+        }
+    )
+
+
 def _snapshot_revision_ids(value: object) -> tuple[str, ...]:
     if not isinstance(value, tuple):
         raise TypeError("revision_ids must be a tuple")
@@ -35,6 +52,15 @@ def _snapshot_revision_ids(value: object) -> tuple[str, ...]:
     if len(set(snapshot)) != len(snapshot):
         raise ValueError("revision_ids must not contain duplicates")
     return snapshot
+
+
+def _validate_sha256(value: object, field_name: str) -> str:
+    digest = _validate_string(value, field_name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{field_name} must be a lowercase SHA-256 hex digest")
+    return digest
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,14 +92,39 @@ class MemoryRelease:
     release_id: str
     manifest: ReleaseManifest
     content_hash: str
+    release_graph_sha256: str
     created_at: datetime
 
     def __post_init__(self) -> None:
         if type(self.manifest) is not ReleaseManifest:
             raise TypeError("manifest must be a ReleaseManifest")
         release_id = _validate_string(self.release_id, "release_id")
-        content_hash = _validate_string(self.content_hash, "content_hash")
+        content_hash = _validate_sha256(self.content_hash, "content_hash")
+        release_graph_sha256 = _validate_sha256(
+            self.release_graph_sha256,
+            "release_graph_sha256",
+        )
         created_at = _validate_aware_datetime(self.created_at, "created_at")
         object.__setattr__(self, "release_id", release_id)
         object.__setattr__(self, "content_hash", content_hash)
+        object.__setattr__(self, "release_graph_sha256", release_graph_sha256)
         object.__setattr__(self, "created_at", created_at)
+        expected_content_hash = sha256(self.commitment_bytes()).hexdigest()
+        if content_hash != expected_content_hash:
+            raise ValueError("content_hash does not match the release commitment")
+        if release_id != f"rel_{content_hash[:24]}":
+            raise ValueError("release_id does not match content_hash")
+
+    def commitment_bytes(self) -> bytes:
+        """Return the canonical release-identity commitment.
+
+        The manifest identifies the requested selection.  The graph digest is
+        independently derived by the release store from the immutable history
+        it resolved; it is not supplied by the manifest caller.
+        """
+
+        manifest_sha256 = sha256(self.manifest.canonical_bytes()).hexdigest()
+        return _release_commitment_bytes(
+            manifest_sha256,
+            self.release_graph_sha256,
+        )

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -46,10 +46,8 @@ class InMemoryEvidenceStore:
 
     def __init__(self) -> None:
         self._lock = RLock()
-        self._by_evidence_id: dict[str, tuple[EvidenceRecord, bytes]] = {}
-        self._by_idempotency_key: dict[
-            tuple[MemoryScope, str], tuple[EvidenceRecord, bytes]
-        ] = {}
+        self._by_evidence_id: dict[str, EvidenceRecord] = {}
+        self._by_idempotency_key: dict[tuple[MemoryScope, str], EvidenceRecord] = {}
         self._by_scope: dict[MemoryScope, list[EvidenceRecord]] = {}
 
     def append(self, event: EvidenceEvent) -> EvidenceRecord:
@@ -61,19 +59,17 @@ class InMemoryEvidenceStore:
         idempotency_index = (event.scope, event.idempotency_key)
 
         with self._lock:
-            existing_idempotency = self._by_idempotency_key.get(idempotency_index)
-            if existing_idempotency is not None:
-                existing_record, existing_bytes = existing_idempotency
-                if existing_bytes == canonical_bytes:
+            existing_record = self._by_idempotency_key.get(idempotency_index)
+            if existing_record is not None:
+                if existing_record.event.canonical_bytes() == canonical_bytes:
                     return existing_record
                 raise EvidenceConflictError(
                     "scoped idempotency key already refers to different evidence"
                 )
 
-            existing_id = self._by_evidence_id.get(evidence_id)
-            if existing_id is not None:
-                existing_record, existing_bytes = existing_id
-                if existing_bytes == canonical_bytes:
+            existing_record = self._by_evidence_id.get(evidence_id)
+            if existing_record is not None:
+                if existing_record.event.canonical_bytes() == canonical_bytes:
                     return existing_record
                 raise EvidenceConflictError(
                     f"evidence ID collision for {evidence_id!r}"
@@ -85,9 +81,8 @@ class InMemoryEvidenceStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            indexed_record = (record, canonical_bytes)
-            self._by_evidence_id[evidence_id] = indexed_record
-            self._by_idempotency_key[idempotency_index] = indexed_record
+            self._by_evidence_id[evidence_id] = record
+            self._by_idempotency_key[idempotency_index] = record
             self._by_scope.setdefault(event.scope, []).append(record)
             return record
 
@@ -95,10 +90,10 @@ class InMemoryEvidenceStore:
         """Return evidence only when it belongs to the requested scope."""
 
         with self._lock:
-            indexed_record = self._by_evidence_id.get(evidence_id)
-            if indexed_record is None or indexed_record[0].event.scope != scope:
+            record = self._by_evidence_id.get(evidence_id)
+            if record is None or record.event.scope != scope:
                 raise EvidenceNotFoundError(f"evidence {evidence_id!r} was not found")
-            return indexed_record[0]
+            return record
 
     def list(
         self,

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -46,7 +46,7 @@ class InMemoryEvidenceStore:
 
     def __init__(self) -> None:
         self._lock = RLock()
-        self._by_evidence_id: dict[str, EvidenceRecord] = {}
+        self._by_evidence_id: dict[tuple[MemoryScope, str], EvidenceRecord] = {}
         self._by_idempotency_key: dict[tuple[MemoryScope, str], EvidenceRecord] = {}
         self._by_scope: dict[MemoryScope, list[EvidenceRecord]] = {}
 
@@ -56,6 +56,7 @@ class InMemoryEvidenceStore:
         canonical_bytes = event.canonical_bytes()
         content_hash = hashlib.sha256(canonical_bytes).hexdigest()
         evidence_id = f"evd_{content_hash[:24]}"
+        evidence_index = (event.scope, evidence_id)
         idempotency_index = (event.scope, event.idempotency_key)
 
         with self._lock:
@@ -67,7 +68,7 @@ class InMemoryEvidenceStore:
                     "scoped idempotency key already refers to different evidence"
                 )
 
-            existing_record = self._by_evidence_id.get(evidence_id)
+            existing_record = self._by_evidence_id.get(evidence_index)
             if existing_record is not None:
                 if existing_record.event.canonical_bytes() == canonical_bytes:
                     return existing_record
@@ -81,7 +82,7 @@ class InMemoryEvidenceStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._by_evidence_id[evidence_id] = record
+            self._by_evidence_id[evidence_index] = record
             self._by_idempotency_key[idempotency_index] = record
             self._by_scope.setdefault(event.scope, []).append(record)
             return record
@@ -90,8 +91,8 @@ class InMemoryEvidenceStore:
         """Return evidence only when it belongs to the requested scope."""
 
         with self._lock:
-            record = self._by_evidence_id.get(evidence_id)
-            if record is None or record.event.scope != scope:
+            record = self._by_evidence_id.get((scope, evidence_id))
+            if record is None:
                 raise EvidenceNotFoundError(f"evidence {evidence_id!r} was not found")
             return record
 

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -53,6 +53,8 @@ class InMemoryEvidenceStore:
     def append(self, event: EvidenceEvent) -> EvidenceRecord:
         """Persist an event, enforcing scoped idempotency and collision safety."""
 
+        if type(event) is not EvidenceEvent:
+            raise TypeError("event must be an EvidenceEvent")
         canonical_bytes = event.canonical_bytes()
         content_hash = hashlib.sha256(canonical_bytes).hexdigest()
         evidence_id = f"evd_{content_hash[:24]}"
@@ -90,6 +92,8 @@ class InMemoryEvidenceStore:
     def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:
         """Return evidence only when it belongs to the requested scope."""
 
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
         with self._lock:
             record = self._by_evidence_id.get((scope, evidence_id))
             if record is None:
@@ -105,6 +109,8 @@ class InMemoryEvidenceStore:
     ) -> tuple[EvidenceRecord, ...]:
         """Return a stable snapshot of records belonging to the requested scope."""
 
+        if type(scope) is not MemoryScope:
+            raise TypeError("scope must be a MemoryScope")
         with self._lock:
             matches = (
                 record

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -120,6 +120,6 @@ def _record_sort_key(record: EvidenceRecord) -> tuple[str, str, int, datetime, s
         event.session_id,
         event.run_id,
         event.sequence_no,
-        event.observed_at.astimezone(UTC),
+        event.observed_at,
         record.evidence_id,
     )

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -13,7 +13,12 @@ from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
 )
-from areal.v2.memory_service.types import EvidenceEvent, EvidenceRecord, MemoryScope
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceRecord,
+    MemoryScope,
+    _validate_string,
+)
 
 
 class EvidenceStore(Protocol):
@@ -94,6 +99,7 @@ class InMemoryEvidenceStore:
 
         if type(scope) is not MemoryScope:
             raise TypeError("scope must be a MemoryScope")
+        evidence_id = _validate_string(evidence_id, "evidence_id", allow_blank=True)
         with self._lock:
             record = self._by_evidence_id.get((scope, evidence_id))
             if record is None:
@@ -111,6 +117,10 @@ class InMemoryEvidenceStore:
 
         if type(scope) is not MemoryScope:
             raise TypeError("scope must be a MemoryScope")
+        if session_id is not None:
+            session_id = _validate_string(session_id, "session_id", allow_blank=True)
+        if run_id is not None:
+            run_id = _validate_string(run_id, "run_id", allow_blank=True)
         with self._lock:
             matches = (
                 record

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from threading import RLock
 from typing import Protocol
 
+from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
@@ -89,9 +90,13 @@ class InMemoryEvidenceStore:
                 content_hash=content_hash,
                 created_at=datetime.now(UTC),
             )
-            self._by_evidence_id[evidence_index] = record
-            self._by_idempotency_key[idempotency_index] = record
-            self._by_scope.setdefault(event.scope, []).append(record)
+            _atomic_publish(
+                mapping_writes=(
+                    (self._by_evidence_id, evidence_index, record),
+                    (self._by_idempotency_key, idempotency_index, record),
+                ),
+                sequence_appends=((self._by_scope, event.scope, record),),
+            )
             return record
 
     def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:

--- a/areal/v2/memory_service/store.py
+++ b/areal/v2/memory_service/store.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evidence store contracts and an in-memory implementation."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from threading import RLock
+from typing import Protocol
+
+from areal.v2.memory_service.errors import (
+    EvidenceConflictError,
+    EvidenceNotFoundError,
+)
+from areal.v2.memory_service.types import EvidenceEvent, EvidenceRecord, MemoryScope
+
+
+class EvidenceStore(Protocol):
+    """Storage contract for immutable evidence records."""
+
+    def append(self, event: EvidenceEvent) -> EvidenceRecord:
+        """Persist an event or return its existing idempotent record."""
+
+        ...
+
+    def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:
+        """Return evidence from a scope or raise ``EvidenceNotFoundError``."""
+
+        ...
+
+    def list(
+        self,
+        scope: MemoryScope,
+        *,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ...]:
+        """Return deterministically ordered evidence matching the filters."""
+
+        ...
+
+
+class InMemoryEvidenceStore:
+    """Lock-protected process-local storage for immutable evidence records."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._by_evidence_id: dict[str, tuple[EvidenceRecord, bytes]] = {}
+        self._by_idempotency_key: dict[
+            tuple[MemoryScope, str], tuple[EvidenceRecord, bytes]
+        ] = {}
+        self._by_scope: dict[MemoryScope, list[EvidenceRecord]] = {}
+
+    def append(self, event: EvidenceEvent) -> EvidenceRecord:
+        """Persist an event, enforcing scoped idempotency and collision safety."""
+
+        canonical_bytes = event.canonical_bytes()
+        content_hash = hashlib.sha256(canonical_bytes).hexdigest()
+        evidence_id = f"evd_{content_hash[:24]}"
+        idempotency_index = (event.scope, event.idempotency_key)
+
+        with self._lock:
+            existing_idempotency = self._by_idempotency_key.get(idempotency_index)
+            if existing_idempotency is not None:
+                existing_record, existing_bytes = existing_idempotency
+                if existing_bytes == canonical_bytes:
+                    return existing_record
+                raise EvidenceConflictError(
+                    "scoped idempotency key already refers to different evidence"
+                )
+
+            existing_id = self._by_evidence_id.get(evidence_id)
+            if existing_id is not None:
+                existing_record, existing_bytes = existing_id
+                if existing_bytes == canonical_bytes:
+                    return existing_record
+                raise EvidenceConflictError(
+                    f"evidence ID collision for {evidence_id!r}"
+                )
+
+            record = EvidenceRecord(
+                evidence_id=evidence_id,
+                event=event,
+                content_hash=content_hash,
+                created_at=datetime.now(UTC),
+            )
+            indexed_record = (record, canonical_bytes)
+            self._by_evidence_id[evidence_id] = indexed_record
+            self._by_idempotency_key[idempotency_index] = indexed_record
+            self._by_scope.setdefault(event.scope, []).append(record)
+            return record
+
+    def get(self, scope: MemoryScope, evidence_id: str) -> EvidenceRecord:
+        """Return evidence only when it belongs to the requested scope."""
+
+        with self._lock:
+            indexed_record = self._by_evidence_id.get(evidence_id)
+            if indexed_record is None or indexed_record[0].event.scope != scope:
+                raise EvidenceNotFoundError(f"evidence {evidence_id!r} was not found")
+            return indexed_record[0]
+
+    def list(
+        self,
+        scope: MemoryScope,
+        *,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ...]:
+        """Return a stable snapshot of records belonging to the requested scope."""
+
+        with self._lock:
+            matches = (
+                record
+                for record in self._by_scope.get(scope, ())
+                if (session_id is None or record.event.session_id == session_id)
+                and (run_id is None or record.event.run_id == run_id)
+            )
+            return tuple(sorted(matches, key=_record_sort_key))
+
+
+def _record_sort_key(record: EvidenceRecord) -> tuple[str, str, int, datetime, str]:
+    event = record.event
+    return (
+        event.session_id,
+        event.run_id,
+        event.sequence_no,
+        event.observed_at.astimezone(UTC),
+        record.evidence_id,
+    )

--- a/areal/v2/memory_service/types.py
+++ b/areal/v2/memory_service/types.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable evidence value objects for the Memory Service."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+
+_MAX_SEQUENCE_NO = 2**63 - 1
+
+
+def _validate_string(
+    value: object, field_name: str, *, allow_blank: bool = False
+) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not allow_blank and not value.strip():
+        raise ValueError(f"{field_name} must not be blank")
+    try:
+        value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{field_name} must be valid UTF-8") from exc
+
+
+def _validate_aware_datetime(value: object, field_name: str) -> None:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field_name} must be a datetime")
+    if value.tzinfo is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    try:
+        offset = value.utcoffset()
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be normalizable to UTC") from exc
+    if offset is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    try:
+        value.astimezone(UTC)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be normalizable to UTC") from exc
+
+
+class EvidenceKind(StrEnum):
+    """The source or role represented by an evidence event."""
+
+    USER_MESSAGE = "user_message"
+    AGENT_MESSAGE = "agent_message"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    ENVIRONMENT = "environment"
+    FEEDBACK = "feedback"
+    OUTCOME = "outcome"
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryScope:
+    """The tenant, namespace, and subject that own a memory."""
+
+    tenant_id: str
+    namespace: str
+    subject_id: str
+
+    def __post_init__(self) -> None:
+        _validate_string(self.tenant_id, "tenant_id")
+        _validate_string(self.namespace, "namespace")
+        _validate_string(self.subject_id, "subject_id")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceEvent:
+    """An immutable observation submitted to the Memory Service."""
+
+    scope: MemoryScope
+    session_id: str
+    run_id: str
+    sequence_no: int
+    kind: EvidenceKind
+    payload: str
+    observed_at: datetime
+    idempotency_key: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope, MemoryScope):
+            raise TypeError("scope must be a MemoryScope")
+        _validate_string(self.session_id, "session_id")
+        _validate_string(self.run_id, "run_id")
+        _validate_string(self.idempotency_key, "idempotency_key")
+        if isinstance(self.sequence_no, bool) or not isinstance(self.sequence_no, int):
+            raise TypeError("sequence_no must be an integer")
+        if self.sequence_no < 0:
+            raise ValueError("sequence_no must be non-negative")
+        if self.sequence_no > _MAX_SEQUENCE_NO:
+            raise ValueError("sequence_no must fit in a signed 64-bit integer")
+        if not isinstance(self.kind, EvidenceKind):
+            raise TypeError("kind must be an EvidenceKind")
+        _validate_string(self.payload, "payload", allow_blank=True)
+        _validate_aware_datetime(self.observed_at, "observed_at")
+
+    def canonical_bytes(self) -> bytes:
+        """Serialize the event as deterministic, compact UTF-8 JSON."""
+
+        value = {
+            "scope": {
+                "tenant_id": self.scope.tenant_id,
+                "namespace": self.scope.namespace,
+                "subject_id": self.scope.subject_id,
+            },
+            "session_id": self.session_id,
+            "run_id": self.run_id,
+            "sequence_no": self.sequence_no,
+            "kind": self.kind.value,
+            "payload": self.payload,
+            "observed_at": self.observed_at.astimezone(UTC).isoformat(),
+            "idempotency_key": self.idempotency_key,
+        }
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRecord:
+    """A persisted evidence event and its storage metadata."""
+
+    evidence_id: str
+    event: EvidenceEvent
+    content_hash: str
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.event, EvidenceEvent):
+            raise TypeError("event must be an EvidenceEvent")
+        _validate_string(self.evidence_id, "evidence_id")
+        _validate_string(self.content_hash, "content_hash")
+        _validate_aware_datetime(self.created_at, "created_at")

--- a/areal/v2/memory_service/types.py
+++ b/areal/v2/memory_service/types.py
@@ -14,15 +14,17 @@ _MAX_SEQUENCE_NO = 2**63 - 1
 
 def _validate_string(
     value: object, field_name: str, *, allow_blank: bool = False
-) -> None:
+) -> str:
     if not isinstance(value, str):
         raise TypeError(f"{field_name} must be a string")
-    if not allow_blank and not value.strip():
+    snapshot = str.__str__(value)
+    if not allow_blank and not str.strip(snapshot):
         raise ValueError(f"{field_name} must not be blank")
     try:
-        value.encode("utf-8", errors="strict")
+        str.encode(snapshot, "utf-8", "strict")
     except UnicodeEncodeError as exc:
         raise ValueError(f"{field_name} must be valid UTF-8") from exc
+    return snapshot
 
 
 def _validate_aware_datetime(value: object, field_name: str) -> datetime:
@@ -73,9 +75,12 @@ class MemoryScope:
     subject_id: str
 
     def __post_init__(self) -> None:
-        _validate_string(self.tenant_id, "tenant_id")
-        _validate_string(self.namespace, "namespace")
-        _validate_string(self.subject_id, "subject_id")
+        tenant_id = _validate_string(self.tenant_id, "tenant_id")
+        namespace = _validate_string(self.namespace, "namespace")
+        subject_id = _validate_string(self.subject_id, "subject_id")
+        object.__setattr__(self, "tenant_id", tenant_id)
+        object.__setattr__(self, "namespace", namespace)
+        object.__setattr__(self, "subject_id", subject_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,12 +97,12 @@ class EvidenceEvent:
     idempotency_key: str
 
     def __post_init__(self) -> None:
-        if not isinstance(self.scope, MemoryScope):
+        if type(self.scope) is not MemoryScope:
             raise TypeError("scope must be a MemoryScope")
-        _validate_string(self.session_id, "session_id")
-        _validate_string(self.run_id, "run_id")
-        _validate_string(self.idempotency_key, "idempotency_key")
-        if isinstance(self.sequence_no, bool) or not isinstance(self.sequence_no, int):
+        session_id = _validate_string(self.session_id, "session_id")
+        run_id = _validate_string(self.run_id, "run_id")
+        idempotency_key = _validate_string(self.idempotency_key, "idempotency_key")
+        if type(self.sequence_no) is not int:
             raise TypeError("sequence_no must be an integer")
         if self.sequence_no < 0:
             raise ValueError("sequence_no must be non-negative")
@@ -105,8 +110,12 @@ class EvidenceEvent:
             raise ValueError("sequence_no must fit in a signed 64-bit integer")
         if not isinstance(self.kind, EvidenceKind):
             raise TypeError("kind must be an EvidenceKind")
-        _validate_string(self.payload, "payload", allow_blank=True)
+        payload = _validate_string(self.payload, "payload", allow_blank=True)
         observed_at = _validate_aware_datetime(self.observed_at, "observed_at")
+        object.__setattr__(self, "session_id", session_id)
+        object.__setattr__(self, "run_id", run_id)
+        object.__setattr__(self, "payload", payload)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
         object.__setattr__(self, "observed_at", observed_at)
 
     def canonical_bytes(self) -> bytes:
@@ -144,9 +153,11 @@ class EvidenceRecord:
     created_at: datetime
 
     def __post_init__(self) -> None:
-        if not isinstance(self.event, EvidenceEvent):
+        if type(self.event) is not EvidenceEvent:
             raise TypeError("event must be an EvidenceEvent")
-        _validate_string(self.evidence_id, "evidence_id")
-        _validate_string(self.content_hash, "content_hash")
+        evidence_id = _validate_string(self.evidence_id, "evidence_id")
+        content_hash = _validate_string(self.content_hash, "content_hash")
         created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "evidence_id", evidence_id)
+        object.__setattr__(self, "content_hash", content_hash)
         object.__setattr__(self, "created_at", created_at)

--- a/areal/v2/memory_service/types.py
+++ b/areal/v2/memory_service/types.py
@@ -25,7 +25,7 @@ def _validate_string(
         raise ValueError(f"{field_name} must be valid UTF-8") from exc
 
 
-def _validate_aware_datetime(value: object, field_name: str) -> None:
+def _validate_aware_datetime(value: object, field_name: str) -> datetime:
     if not isinstance(value, datetime):
         raise TypeError(f"{field_name} must be a datetime")
     if value.tzinfo is None:
@@ -37,9 +37,19 @@ def _validate_aware_datetime(value: object, field_name: str) -> None:
     if offset is None:
         raise ValueError(f"{field_name} must be timezone-aware")
     try:
-        value.astimezone(UTC)
+        normalized = datetime.astimezone(value, UTC)
     except (OverflowError, ValueError) as exc:
         raise ValueError(f"{field_name} must be normalizable to UTC") from exc
+    return datetime(
+        normalized.year,
+        normalized.month,
+        normalized.day,
+        normalized.hour,
+        normalized.minute,
+        normalized.second,
+        normalized.microsecond,
+        tzinfo=UTC,
+    )
 
 
 class EvidenceKind(StrEnum):
@@ -96,7 +106,8 @@ class EvidenceEvent:
         if not isinstance(self.kind, EvidenceKind):
             raise TypeError("kind must be an EvidenceKind")
         _validate_string(self.payload, "payload", allow_blank=True)
-        _validate_aware_datetime(self.observed_at, "observed_at")
+        observed_at = _validate_aware_datetime(self.observed_at, "observed_at")
+        object.__setattr__(self, "observed_at", observed_at)
 
     def canonical_bytes(self) -> bytes:
         """Serialize the event as deterministic, compact UTF-8 JSON."""
@@ -137,4 +148,5 @@ class EvidenceRecord:
             raise TypeError("event must be an EvidenceEvent")
         _validate_string(self.evidence_id, "evidence_id")
         _validate_string(self.content_hash, "content_hash")
-        _validate_aware_datetime(self.created_at, "created_at")
+        created_at = _validate_aware_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "created_at", created_at)

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -8,7 +8,7 @@ import faulthandler
 import inspect
 import re
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from hashlib import sha256
 from threading import Barrier, RLock
@@ -145,27 +145,17 @@ def run_race(
         except MemoryServiceError as error:
             return error
 
-    executor = ThreadPoolExecutor(max_workers=len(items))
-    futures = ()
-    completed = False
     faulthandler.dump_traceback_later(HARD_RACE_TIMEOUT_SECONDS, exit=True)
     try:
-        futures = tuple(executor.submit(worker, item) for item in items)
-        deadline = monotonic() + RACE_TIMEOUT_SECONDS
-        results = tuple(
-            future.result(timeout=max(0.0, deadline - monotonic()))
-            for future in futures
-        )
-        completed = True
-        return results
+        with ThreadPoolExecutor(max_workers=len(items)) as executor:
+            futures = tuple(executor.submit(worker, item) for item in items)
+            deadline = monotonic() + RACE_TIMEOUT_SECONDS
+            return tuple(
+                future.result(timeout=max(0.0, deadline - monotonic()))
+                for future in futures
+            )
     finally:
-        executor.shutdown(wait=completed, cancel_futures=not completed)
-        if completed:
-            faulthandler.cancel_dump_traceback_later()
-        else:
-            _, unfinished = wait(futures, timeout=1.0)
-            if not unfinished:
-                faulthandler.cancel_dump_traceback_later()
+        faulthandler.cancel_dump_traceback_later()
 
 
 def install_digest_map(
@@ -180,7 +170,7 @@ def install_digest_map(
     monkeypatch.setattr(history_store_module.hashlib, "sha256", fake_sha256)
 
 
-def test_run_race_cancels_watchdog_only_after_workers_finish(
+def test_run_race_waits_for_workers_before_cancelling_watchdog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     events: list[tuple[object, ...]] = []
@@ -202,27 +192,91 @@ def test_run_race_cancels_watchdog_only_after_workers_finish(
         ("cancel",),
     ]
 
-    def fail(_: int) -> object:
-        raise RuntimeError("worker failed")
+    finished: set[int] = set()
+    finished_lock = RLock()
+
+    def fail_or_finish(item: int) -> object:
+        if item == 0:
+            raise RuntimeError("worker failed")
+        sleep(0.15)
+        with finished_lock:
+            finished.add(item)
+        return item
 
     events.clear()
+    started_at = monotonic()
     with pytest.raises(RuntimeError, match="worker failed"):
-        run_race(tuple(range(RACE_SIZE)), fail)
+        run_race(tuple(range(RACE_SIZE)), fail_or_finish)
+    assert monotonic() - started_at >= 0.1
+    assert finished == set(range(1, RACE_SIZE))
     assert events == [
         ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
         ("cancel",),
     ]
 
-    events.clear()
+
+def test_run_race_watchdog_wraps_executor_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[object, ...]] = []
+
+    def record_arm(timeout: float, *, exit: bool) -> None:
+        events.append(("arm", timeout, exit))
+
+    def record_cancel() -> None:
+        events.append(("cancel",))
+
+    class FailingFuture:
+        def result(self, timeout: float) -> object:
+            events.append(("result",))
+            raise RuntimeError("worker failed")
+
+    class StubExecutor:
+        def __init__(self, *, max_workers: int) -> None:
+            events.append(("executor:init", max_workers))
+
+        def __enter__(self) -> StubExecutor:
+            events.append(("executor:enter",))
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: object,
+        ) -> None:
+            events.append(("executor:exit", exc_type))
+
+        def submit(
+            self,
+            operation: Callable[[int], object],
+            item: int,
+        ) -> FailingFuture:
+            events.append(("submit", item))
+            return FailingFuture()
+
+        def shutdown(self, *, wait: bool, cancel_futures: bool) -> None:
+            events.append(("executor:shutdown", wait, cancel_futures))
+
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", record_arm)
+    monkeypatch.setattr(faulthandler, "cancel_dump_traceback_later", record_cancel)
     monkeypatch.setitem(
         run_race.__globals__,
-        "wait",
-        lambda futures, timeout: (set(), set(futures)),
+        "ThreadPoolExecutor",
+        StubExecutor,
     )
 
     with pytest.raises(RuntimeError, match="worker failed"):
-        run_race(tuple(range(RACE_SIZE)), fail)
-    assert events == [("arm", HARD_RACE_TIMEOUT_SECONDS, True)]
+        run_race((0,), lambda item: item)
+    assert events == [
+        ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("executor:init", 1),
+        ("executor:enter",),
+        ("submit", 0),
+        ("result",),
+        ("executor:exit", RuntimeError),
+        ("cancel",),
+    ]
 
 
 def make_scope(**overrides: str) -> MemoryScope:

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -4,10 +4,16 @@
 
 from __future__ import annotations
 
+import faulthandler
+import inspect
 import re
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import UTC, datetime
 from hashlib import sha256
-from threading import RLock
+from threading import Barrier, RLock
+from time import monotonic, sleep
+from typing import TypeVar
 
 import pytest
 
@@ -89,6 +95,134 @@ class RevisionProposalSubclass(RevisionProposal):
 
 
 UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, tzinfo=UTC)
+RACE_SIZE = 16
+RACE_TIMEOUT_SECONDS = 10.0
+HARD_RACE_TIMEOUT_SECONDS = 15.0
+T = TypeVar("T")
+
+
+class YieldingMissingDict(dict[object, object]):
+    """Yield after a missing lookup to expose an unprotected check/write race."""
+
+    def get(self, key: object, default: object = None) -> object:
+        value = super().get(key, default)
+        if value is default:
+            sleep(0.02)
+        return value
+
+
+class YieldingMissingContainsDict(dict[object, object]):
+    """Yield after a missing membership test to expose an unprotected race."""
+
+    def __contains__(self, key: object) -> bool:
+        exists = super().__contains__(key)
+        if not exists:
+            sleep(0.02)
+        return exists
+
+
+class StubHash:
+    """Return one test-controlled hexadecimal digest."""
+
+    def __init__(self, digest: str) -> None:
+        self._digest = digest
+
+    def hexdigest(self) -> str:
+        return self._digest
+
+
+def run_race(
+    items: tuple[T, ...], operation: Callable[[T], object]
+) -> tuple[object, ...]:
+    """Release callers together and apply one deadline to result collection."""
+
+    barrier = Barrier(len(items), timeout=RACE_TIMEOUT_SECONDS)
+
+    def worker(item: T) -> object:
+        barrier.wait()
+        try:
+            return operation(item)
+        except MemoryServiceError as error:
+            return error
+
+    executor = ThreadPoolExecutor(max_workers=len(items))
+    futures = ()
+    completed = False
+    faulthandler.dump_traceback_later(HARD_RACE_TIMEOUT_SECONDS, exit=True)
+    try:
+        futures = tuple(executor.submit(worker, item) for item in items)
+        deadline = monotonic() + RACE_TIMEOUT_SECONDS
+        results = tuple(
+            future.result(timeout=max(0.0, deadline - monotonic()))
+            for future in futures
+        )
+        completed = True
+        return results
+    finally:
+        executor.shutdown(wait=completed, cancel_futures=not completed)
+        if completed:
+            faulthandler.cancel_dump_traceback_later()
+        else:
+            _, unfinished = wait(futures, timeout=1.0)
+            if not unfinished:
+                faulthandler.cancel_dump_traceback_later()
+
+
+def install_digest_map(
+    monkeypatch: pytest.MonkeyPatch,
+    digest_by_bytes: dict[bytes, str],
+) -> None:
+    """Install deterministic SHA-256 results for pre-seeded canonical bytes."""
+
+    def fake_sha256(canonical_bytes: bytes) -> StubHash:
+        return StubHash(digest_by_bytes[canonical_bytes])
+
+    monkeypatch.setattr(history_store_module.hashlib, "sha256", fake_sha256)
+
+
+def test_run_race_cancels_watchdog_only_after_workers_finish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[object, ...]] = []
+
+    def record_arm(timeout: float, *, exit: bool) -> None:
+        events.append(("arm", timeout, exit))
+
+    def record_cancel() -> None:
+        events.append(("cancel",))
+
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", record_arm)
+    monkeypatch.setattr(faulthandler, "cancel_dump_traceback_later", record_cancel)
+
+    assert run_race(tuple(range(RACE_SIZE)), lambda item: item) == tuple(
+        range(RACE_SIZE)
+    )
+    assert events == [
+        ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("cancel",),
+    ]
+
+    def fail(_: int) -> object:
+        raise RuntimeError("worker failed")
+
+    events.clear()
+    with pytest.raises(RuntimeError, match="worker failed"):
+        run_race(tuple(range(RACE_SIZE)), fail)
+    assert events == [
+        ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("cancel",),
+    ]
+
+    events.clear()
+    monkeypatch.setitem(
+        run_race.__globals__,
+        "wait",
+        lambda futures, timeout: (set(), set(futures)),
+    )
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        run_race(tuple(range(RACE_SIZE)), fail)
+    assert events == [("arm", HARD_RACE_TIMEOUT_SECONDS, True)]
 
 
 def make_scope(**overrides: str) -> MemoryScope:
@@ -145,26 +279,59 @@ def seeded_evidence_store() -> tuple[InMemoryEvidenceStore, EvidenceRecord]:
     return evidence_store, evidence
 
 
+def seed_candidates(
+    count: int,
+) -> tuple[
+    InMemoryMemoryHistoryStore,
+    InMemoryEvidenceStore,
+    tuple[MemoryCandidate, ...],
+]:
+    """Create candidates before any test replaces the shared hashlib function."""
+
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidates = tuple(
+        history.append_candidate(
+            make_candidate_proposal(
+                content=f"candidate-{index}",
+                evidence_ids=(evidence.evidence_id,),
+                idempotency_key=f"candidate-{index}",
+            )
+        )
+        for index in range(count)
+    )
+    return history, evidence_store, candidates
+
+
 def assert_candidate_indexes_empty(history: InMemoryMemoryHistoryStore) -> None:
     assert history._candidate_by_id == {}
     assert history._candidate_by_idempotency == {}
     assert history._candidates_by_scope == {}
 
 
-def test_history_store_contract_exposes_only_candidate_and_revision_surface() -> None:
-    public_members = {
-        name for name in MemoryHistoryStore.__dict__ if not name.startswith("_")
-    }
-
-    assert public_members == {
+def test_history_contract_exposes_no_mutation_or_activation_api() -> None:
+    expected = {
         "append_candidate",
+        "append_revision",
         "get_candidate",
         "get_candidate_evidence",
-        "list_candidates",
-        "append_revision",
         "get_revision",
+        "list_candidates",
         "list_revisions",
     }
+    protocol_methods = {
+        name
+        for name, value in inspect.getmembers(MemoryHistoryStore)
+        if not name.startswith("_") and callable(value)
+    }
+    implementation_methods = {
+        name
+        for name, value in inspect.getmembers(InMemoryMemoryHistoryStore)
+        if not name.startswith("_") and callable(value)
+    }
+
+    assert protocol_methods == expected
+    assert implementation_methods == expected
 
 
 def test_history_errors_share_memory_service_base() -> None:
@@ -1263,3 +1430,427 @@ def test_generation_overflow_leaves_all_revision_indexes_unchanged() -> None:
         history._revisions_by_scope,
     )
     assert after == before
+
+
+def test_concurrent_identical_candidate_and_revision_requests_converge() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    history._candidate_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    history._candidate_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    candidate_proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+
+    candidate_results = run_race(
+        (candidate_proposal,) * RACE_SIZE,
+        history.append_candidate,
+    )
+
+    candidate = candidate_results[0]
+    assert isinstance(candidate, MemoryCandidate)
+    assert all(item is candidate for item in candidate_results)
+
+    history._revision_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    history._revision_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    revision_proposal = make_revision_proposal(candidate_id=candidate.candidate_id)
+
+    revision_results = run_race(
+        (revision_proposal,) * RACE_SIZE,
+        history.append_revision,
+    )
+
+    revision = revision_results[0]
+    assert isinstance(revision, MemoryRevision)
+    assert all(item is revision for item in revision_results)
+    assert history.list_candidates(make_scope()) == (candidate,)
+    assert history.list_revisions(make_scope()) == (revision,)
+
+
+def test_concurrent_candidate_idempotency_conflicts_have_one_winner() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    history._candidate_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    history._candidate_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_candidate_proposal(
+            content=f"candidate-{index}",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="shared-candidate-key",
+        )
+        for index in range(RACE_SIZE)
+    )
+
+    outcomes = run_race(proposals, history.append_candidate)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryCandidate))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, CandidateConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    winner = winners[0]
+    assert history._candidate_by_id == {(make_scope(), winner.candidate_id): winner}
+    assert history._candidate_by_idempotency == {
+        (make_scope(), winner.proposal.idempotency_key): winner
+    }
+    assert history._candidates_by_scope == {make_scope(): [winner]}
+    assert history.list_candidates(make_scope()) == (winner,)
+
+
+def test_concurrent_revision_idempotency_conflicts_leave_loser_candidates_usable() -> (
+    None
+):
+    history, _, candidates = seed_candidates(RACE_SIZE)
+    history._revision_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    history._revision_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            idempotency_key="shared-revision-key",
+        )
+        for candidate in candidates
+    )
+
+    outcomes = run_race(proposals, history.append_revision)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryRevision))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, RevisionConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    winner = winners[0]
+    assert history._revision_by_id == {(make_scope(), winner.revision_id): winner}
+    assert history._revision_by_idempotency == {
+        (make_scope(), winner.proposal.idempotency_key): winner
+    }
+    assert history._revision_by_candidate == {
+        (make_scope(), winner.proposal.candidate_id): winner
+    }
+    assert history._revisions_by_scope == {make_scope(): [winner]}
+    assert history.list_revisions(make_scope()) == (winner,)
+
+    winner_candidate_id = winner.proposal.candidate_id
+    loser = next(
+        item for item in candidates if item.candidate_id != winner_candidate_id
+    )
+    recovered = history.append_revision(
+        make_revision_proposal(
+            candidate_id=loser.candidate_id,
+            idempotency_key="recovered-revision-key",
+        )
+    )
+    assert recovered.proposal.candidate_id == loser.candidate_id
+
+
+def test_concurrent_different_transitions_using_one_candidate_have_one_winner() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    history._revision_by_candidate = YieldingMissingContainsDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            idempotency_key=f"revision-{index}",
+        )
+        for index in range(RACE_SIZE)
+    )
+
+    outcomes = run_race(proposals, history.append_revision)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryRevision))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, RevisionConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    winner = winners[0]
+    assert history._revision_by_id == {(make_scope(), winner.revision_id): winner}
+    assert history._revision_by_idempotency == {
+        (make_scope(), winner.proposal.idempotency_key): winner
+    }
+    assert history._revision_by_candidate == {
+        (make_scope(), candidate.candidate_id): winner
+    }
+    assert history._revisions_by_scope == {make_scope(): [winner]}
+    assert history.list_revisions(make_scope()) == (winner,)
+
+
+def test_concurrent_sibling_revisions_all_survive() -> None:
+    history, _, candidates = seed_candidates(RACE_SIZE + 1)
+    parent = history.append_revision(
+        make_revision_proposal(candidate_id=candidates[0].candidate_id)
+    )
+    proposals = tuple(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=parent.revision_id,
+            idempotency_key=f"sibling-{index}",
+        )
+        for index, candidate in enumerate(candidates[1:])
+    )
+
+    outcomes = run_race(proposals, history.append_revision)
+
+    siblings = tuple(item for item in outcomes if isinstance(item, MemoryRevision))
+    assert len(siblings) == RACE_SIZE
+    assert len({item.revision_id for item in siblings}) == RACE_SIZE
+    assert {item.proposal.candidate_id for item in siblings} == {
+        candidate.candidate_id for candidate in candidates[1:]
+    }
+    assert {item.proposal.parent_revision_id for item in siblings} == {
+        parent.revision_id
+    }
+    assert {item.memory_id for item in siblings} == {parent.memory_id}
+    assert {item.generation for item in siblings} == {parent.generation + 1}
+    stored = history.list_revisions(make_scope())
+    expected_revision_ids = {parent.revision_id} | {
+        item.revision_id for item in siblings
+    }
+    assert len(stored) == RACE_SIZE + 1
+    assert {item.revision_id for item in stored} == expected_revision_ids
+    assert len(history._revision_by_id) == RACE_SIZE + 1
+    assert len(history._revision_by_idempotency) == RACE_SIZE + 1
+    assert len(history._revision_by_candidate) == RACE_SIZE + 1
+    assert set(history._revisions_by_scope) == {make_scope()}
+    assert {
+        item.revision_id for item in history._revisions_by_scope[make_scope()]
+    } == expected_revision_ids
+
+
+@pytest.mark.parametrize("same_full_hash", [True, False], ids=["full", "prefix"])
+def test_concurrent_candidate_collision_is_atomic_and_loser_key_is_reusable(
+    monkeypatch: pytest.MonkeyPatch,
+    same_full_hash: bool,
+) -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    history._candidate_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_candidate_proposal(
+            content=f"collision-{index}",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key=f"collision-{index}",
+        )
+        for index in range(RACE_SIZE)
+    )
+    prefix = "a" * 24
+    digest_by_bytes = {
+        proposal.canonical_bytes(): (
+            prefix + ("b" * 40 if same_full_hash else f"{index:040x}")
+        )
+        for index, proposal in enumerate(proposals)
+    }
+    assert {digest[:24] for digest in digest_by_bytes.values()} == {prefix}
+    assert len(set(digest_by_bytes.values())) == (1 if same_full_hash else RACE_SIZE)
+    install_digest_map(monkeypatch, digest_by_bytes)
+
+    outcomes = run_race(proposals, history.append_candidate)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryCandidate))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, CandidateConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    assert len(history._candidate_by_id) == 1
+    assert len(history._candidate_by_idempotency) == 1
+    assert history._candidates_by_scope == {make_scope(): [winners[0]]}
+    assert history.list_candidates(make_scope()) == winners
+    assert set(history._candidate_by_id) == {(make_scope(), winners[0].candidate_id)}
+    assert set(history._candidate_by_idempotency) == {
+        (make_scope(), winners[0].proposal.idempotency_key)
+    }
+
+    winner_key = winners[0].proposal.idempotency_key
+    loser_proposal = next(
+        proposal for proposal in proposals if proposal.idempotency_key != winner_key
+    )
+    monkeypatch.undo()
+    recovered = history.append_candidate(loser_proposal)
+    assert recovered.proposal.idempotency_key == loser_proposal.idempotency_key
+
+
+@pytest.mark.parametrize("same_full_hash", [True, False], ids=["full", "prefix"])
+def test_concurrent_revision_collision_is_atomic_and_loser_candidate_is_reusable(
+    monkeypatch: pytest.MonkeyPatch,
+    same_full_hash: bool,
+) -> None:
+    history, _, candidates = seed_candidates(RACE_SIZE)
+    history._revision_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    proposals = tuple(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            idempotency_key=f"collision-revision-{index}",
+        )
+        for index, candidate in enumerate(candidates)
+    )
+    prefix = "c" * 24
+    digest_by_bytes = {
+        proposal.canonical_bytes(): (
+            prefix + ("d" * 40 if same_full_hash else f"{index:040x}")
+        )
+        for index, proposal in enumerate(proposals)
+    }
+    assert {digest[:24] for digest in digest_by_bytes.values()} == {prefix}
+    assert len(set(digest_by_bytes.values())) == (1 if same_full_hash else RACE_SIZE)
+    install_digest_map(monkeypatch, digest_by_bytes)
+
+    outcomes = run_race(proposals, history.append_revision)
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryRevision))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, RevisionConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    assert len(history._revision_by_id) == 1
+    assert len(history._revision_by_idempotency) == 1
+    assert len(history._revision_by_candidate) == 1
+    assert history._revisions_by_scope == {make_scope(): [winners[0]]}
+    assert history.list_revisions(make_scope()) == winners
+    assert set(history._revision_by_id) == {(make_scope(), winners[0].revision_id)}
+    assert set(history._revision_by_idempotency) == {
+        (make_scope(), winners[0].proposal.idempotency_key)
+    }
+    assert set(history._revision_by_candidate) == {
+        (make_scope(), winners[0].proposal.candidate_id)
+    }
+
+    winner_candidate_id = winners[0].proposal.candidate_id
+    loser_proposal = next(
+        proposal
+        for proposal in proposals
+        if proposal.candidate_id != winner_candidate_id
+    )
+    monkeypatch.undo()
+    recovered = history.append_revision(loser_proposal)
+    assert recovered.proposal.candidate_id == loser_proposal.candidate_id
+
+
+@pytest.mark.parametrize("same_full_hash", [True, False], ids=["full", "prefix"])
+def test_forced_cross_scope_collisions_coexist_for_candidates_and_revisions(
+    monkeypatch: pytest.MonkeyPatch,
+    same_full_hash: bool,
+) -> None:
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    evidence_store = InMemoryEvidenceStore()
+    first_evidence = evidence_store.append(make_evidence_event(scope=first_scope))
+    second_evidence = evidence_store.append(
+        make_evidence_event(
+            scope=second_scope,
+            idempotency_key="second-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate_proposals = (
+        make_candidate_proposal(
+            scope=first_scope,
+            content="first",
+            evidence_ids=(first_evidence.evidence_id,),
+            idempotency_key="shared-candidate-key",
+        ),
+        make_candidate_proposal(
+            scope=second_scope,
+            content="second",
+            evidence_ids=(second_evidence.evidence_id,),
+            idempotency_key="shared-candidate-key",
+        ),
+    )
+    candidate_prefix = "e" * 24
+    candidate_digests = tuple(
+        candidate_prefix + ("a" * 40 if same_full_hash else f"{index:040x}")
+        for index in range(2)
+    )
+    install_digest_map(
+        monkeypatch,
+        {
+            proposal.canonical_bytes(): digest
+            for proposal, digest in zip(
+                candidate_proposals,
+                candidate_digests,
+                strict=True,
+            )
+        },
+    )
+
+    candidates = tuple(history.append_candidate(item) for item in candidate_proposals)
+
+    assert candidates[0].candidate_id == candidates[1].candidate_id
+    assert (candidates[0].content_hash == candidates[1].content_hash) is same_full_hash
+    assert (
+        history.get_candidate(first_scope, candidates[0].candidate_id) is candidates[0]
+    )
+    assert (
+        history.get_candidate(second_scope, candidates[1].candidate_id) is candidates[1]
+    )
+    assert history.list_candidates(first_scope) == (candidates[0],)
+    assert history.list_candidates(second_scope) == (candidates[1],)
+    assert history.append_candidate(candidate_proposals[0]) is candidates[0]
+    assert history.append_candidate(candidate_proposals[1]) is candidates[1]
+    assert history._candidate_by_id == {
+        (first_scope, candidates[0].candidate_id): candidates[0],
+        (second_scope, candidates[1].candidate_id): candidates[1],
+    }
+    assert history._candidate_by_idempotency == {
+        (first_scope, "shared-candidate-key"): candidates[0],
+        (second_scope, "shared-candidate-key"): candidates[1],
+    }
+    assert history._candidates_by_scope == {
+        first_scope: [candidates[0]],
+        second_scope: [candidates[1]],
+    }
+
+    revision_proposals = (
+        make_revision_proposal(
+            scope=first_scope,
+            candidate_id=candidates[0].candidate_id,
+            idempotency_key="shared-revision-key",
+        ),
+        make_revision_proposal(
+            scope=second_scope,
+            candidate_id=candidates[1].candidate_id,
+            idempotency_key="shared-revision-key",
+        ),
+    )
+    revision_prefix = "f" * 24
+    revision_digests = tuple(
+        revision_prefix + ("b" * 40 if same_full_hash else f"{index + 2:040x}")
+        for index in range(2)
+    )
+    install_digest_map(
+        monkeypatch,
+        {
+            proposal.canonical_bytes(): digest
+            for proposal, digest in zip(
+                revision_proposals,
+                revision_digests,
+                strict=True,
+            )
+        },
+    )
+
+    revisions = tuple(history.append_revision(item) for item in revision_proposals)
+
+    assert revisions[0].revision_id == revisions[1].revision_id
+    assert (revisions[0].content_hash == revisions[1].content_hash) is same_full_hash
+    assert history.get_revision(first_scope, revisions[0].revision_id) is revisions[0]
+    assert history.get_revision(second_scope, revisions[1].revision_id) is revisions[1]
+    assert history.list_revisions(first_scope) == (revisions[0],)
+    assert history.list_revisions(second_scope) == (revisions[1],)
+    assert history.append_revision(revision_proposals[0]) is revisions[0]
+    assert history.append_revision(revision_proposals[1]) is revisions[1]
+    assert history._revision_by_id == {
+        (first_scope, revisions[0].revision_id): revisions[0],
+        (second_scope, revisions[1].revision_id): revisions[1],
+    }
+    assert history._revision_by_idempotency == {
+        (first_scope, "shared-revision-key"): revisions[0],
+        (second_scope, "shared-revision-key"): revisions[1],
+    }
+    assert history._revision_by_candidate == {
+        (first_scope, candidates[0].candidate_id): revisions[0],
+        (second_scope, candidates[1].candidate_id): revisions[1],
+    }
+    assert history._revisions_by_scope == {
+        first_scope: [revisions[0]],
+        second_scope: [revisions[1]],
+    }

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the evidence-grounded in-memory history store."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from hashlib import sha256
+
+import pytest
+
+from areal.v2.memory_service.errors import (
+    CandidateConflictError,
+    CandidateNotFoundError,
+    EvidenceNotFoundError,
+    MemoryServiceError,
+)
+from areal.v2.memory_service.history_store import (
+    InMemoryMemoryHistoryStore,
+    MemoryHistoryStore,
+)
+from areal.v2.memory_service.history_types import CandidateProposal
+from areal.v2.memory_service.store import InMemoryEvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+
+class MutableHashStr(str):
+    """String subclass that records unsafe hashing by store queries."""
+
+    hash_calls: int
+    hash_salt: int
+
+    def __new__(cls, value: str) -> MutableHashStr:
+        instance = str.__new__(cls, value)
+        instance.hash_calls = 0
+        instance.hash_salt = 0
+        return instance
+
+    def __hash__(self) -> int:
+        self.hash_calls += 1
+        return str.__hash__(self) + self.hash_salt
+
+
+class MemoryScopeSubclass(MemoryScope):
+    pass
+
+
+class CandidateProposalSubclass(CandidateProposal):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
+UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, tzinfo=UTC)
+
+
+def make_scope(**overrides: str) -> MemoryScope:
+    values = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)
+
+
+def make_candidate_proposal(**overrides: object) -> CandidateProposal:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "content": "remember this",
+        "evidence_ids": ("evd_missing",),
+        "idempotency_key": "candidate-1",
+    }
+    values.update(overrides)
+    return CandidateProposal(**values)  # type: ignore[arg-type]
+
+
+def make_evidence_event(**overrides: object) -> EvidenceEvent:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "sequence_no": 0,
+        "kind": EvidenceKind.USER_MESSAGE,
+        "payload": "remember this",
+        "observed_at": UTC_INSTANT,
+        "idempotency_key": "evidence-1",
+    }
+    values.update(overrides)
+    return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+def seeded_evidence_store() -> tuple[InMemoryEvidenceStore, EvidenceRecord]:
+    evidence_store = InMemoryEvidenceStore()
+    evidence = evidence_store.append(make_evidence_event())
+    return evidence_store, evidence
+
+
+def assert_candidate_indexes_empty(history: InMemoryMemoryHistoryStore) -> None:
+    assert history._candidate_by_id == {}
+    assert history._candidate_by_idempotency == {}
+    assert history._candidates_by_scope == {}
+
+
+def test_history_store_contract_exposes_only_candidate_surface() -> None:
+    public_members = {
+        name for name in MemoryHistoryStore.__dict__ if not name.startswith("_")
+    }
+
+    assert public_members == {
+        "append_candidate",
+        "get_candidate",
+        "get_candidate_evidence",
+        "list_candidates",
+    }
+
+
+def test_candidate_error_types_share_memory_service_base_error() -> None:
+    assert issubclass(CandidateNotFoundError, MemoryServiceError)
+    assert issubclass(CandidateConflictError, MemoryServiceError)
+
+
+def test_append_candidate_requires_existing_evidence_in_same_scope() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+
+    candidate = history.append_candidate(proposal)
+
+    assert candidate.proposal is proposal
+    assert candidate.proposal.evidence_ids == (evidence.evidence_id,)
+    assert history.get_candidate(proposal.scope, candidate.candidate_id) is candidate
+    assert history.get_candidate_evidence(proposal.scope, candidate.candidate_id) == (
+        evidence,
+    )
+
+
+def test_append_candidate_rejects_proposal_subclass_before_any_write() -> None:
+    proposal = CandidateProposalSubclass(
+        make_scope(), "remember this", ("evd_missing",), "candidate-1"
+    )
+    history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+
+    with pytest.raises(TypeError, match="CandidateProposal"):
+        history.append_candidate(proposal)
+
+    assert_candidate_indexes_empty(history)
+
+
+def test_first_missing_evidence_leaves_every_candidate_index_empty() -> None:
+    history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+    proposal = make_candidate_proposal(evidence_ids=("evd_missing",))
+
+    with pytest.raises(EvidenceNotFoundError):
+        history.append_candidate(proposal)
+
+    assert_candidate_indexes_empty(history)
+    assert history.list_candidates(proposal.scope) == ()
+
+
+def test_late_missing_evidence_leaves_every_candidate_index_empty() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    proposal = make_candidate_proposal(
+        evidence_ids=(evidence.evidence_id, "evd_missing")
+    )
+
+    with pytest.raises(EvidenceNotFoundError):
+        history.append_candidate(proposal)
+
+    assert_candidate_indexes_empty(history)
+
+
+def test_candidate_evidence_preserves_proposal_order() -> None:
+    evidence_store, first = seeded_evidence_store()
+    second = evidence_store.append(
+        make_evidence_event(
+            sequence_no=1,
+            payload="second",
+            idempotency_key="evidence-2",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(second.evidence_id, first.evidence_id))
+    )
+
+    assert history.get_candidate_evidence(
+        candidate.proposal.scope, candidate.candidate_id
+    ) == (second, first)
+
+
+def test_foreign_scope_evidence_is_indistinguishable_from_missing() -> None:
+    evidence_store = InMemoryEvidenceStore()
+    foreign = evidence_store.append(
+        make_evidence_event(scope=make_scope(subject_id="user-2"))
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    missing_history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+    proposal = make_candidate_proposal(evidence_ids=(foreign.evidence_id,))
+
+    with pytest.raises(EvidenceNotFoundError) as foreign_error:
+        history.append_candidate(proposal)
+    with pytest.raises(EvidenceNotFoundError) as missing_error:
+        missing_history.append_candidate(proposal)
+
+    assert type(foreign_error.value) is EvidenceNotFoundError
+    assert str(foreign_error.value) == str(missing_error.value)
+    assert_candidate_indexes_empty(history)
+
+
+def test_identical_candidate_retry_returns_original_record() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+
+    first = history.append_candidate(proposal)
+    retry = history.append_candidate(
+        CandidateProposal(
+            scope=proposal.scope,
+            content=proposal.content,
+            evidence_ids=proposal.evidence_ids,
+            idempotency_key=proposal.idempotency_key,
+        )
+    )
+
+    assert retry is first
+    assert history.list_candidates(proposal.scope) == (first,)
+    assert len(history._candidate_by_id) == 1
+    assert len(history._candidate_by_idempotency) == 1
+
+
+def test_changed_candidate_idempotency_key_reuse_conflicts_without_partial_write() -> (
+    None
+):
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+
+    with pytest.raises(CandidateConflictError, match="idempotency"):
+        history.append_candidate(
+            make_candidate_proposal(
+                content="changed",
+                evidence_ids=(evidence.evidence_id,),
+            )
+        )
+
+    assert history.list_candidates(first.proposal.scope) == (first,)
+    assert tuple(history._candidate_by_id.values()) == (first,)
+    assert tuple(history._candidate_by_idempotency.values()) == (first,)
+
+
+def test_committed_idempotency_conflict_precedes_missing_or_foreign_evidence() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    foreign = evidence_store.append(
+        make_evidence_event(
+            scope=make_scope(subject_id="user-2"),
+            idempotency_key="foreign-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+
+    for invalid_evidence_id in ("evd_missing", foreign.evidence_id):
+        with pytest.raises(CandidateConflictError, match="idempotency"):
+            history.append_candidate(
+                make_candidate_proposal(
+                    content="changed",
+                    evidence_ids=(invalid_evidence_id,),
+                )
+            )
+
+    assert history.list_candidates(first.proposal.scope) == (first,)
+    assert tuple(history._candidate_by_id.values()) == (first,)
+    assert tuple(history._candidate_by_idempotency.values()) == (first,)
+
+
+def test_candidate_uses_full_sha256_truncated_identifier_and_utc_timestamp() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    expected_hash = sha256(proposal.canonical_bytes()).hexdigest()
+
+    candidate = history.append_candidate(proposal)
+
+    assert candidate.content_hash == expected_hash
+    assert re.fullmatch(r"[0-9a-f]{64}", candidate.content_hash)
+    assert candidate.candidate_id == f"cand_{expected_hash[:24]}"
+    assert re.fullmatch(r"cand_[0-9a-f]{24}", candidate.candidate_id)
+    assert candidate.created_at.tzinfo is UTC
+
+
+def test_candidate_lookup_and_lists_are_scope_isolated_and_deterministic() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    other_scope = make_scope(subject_id="user-2")
+    other_evidence = evidence_store.append(
+        make_evidence_event(
+            scope=other_scope,
+            payload="other",
+            idempotency_key="other-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    right = history.append_candidate(
+        make_candidate_proposal(
+            content="right",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="right",
+        )
+    )
+    left = history.append_candidate(
+        make_candidate_proposal(
+            content="left",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="left",
+        )
+    )
+    other = history.append_candidate(
+        make_candidate_proposal(
+            scope=other_scope,
+            content="other",
+            evidence_ids=(other_evidence.evidence_id,),
+            idempotency_key="other",
+        )
+    )
+    expected = tuple(sorted((left, right), key=lambda item: item.candidate_id))
+
+    assert (right, left) != expected
+    assert history.list_candidates(make_scope()) == expected
+    assert history.list_candidates(other_scope) == (other,)
+    assert history.get_candidate(make_scope(), left.candidate_id) is left
+    with pytest.raises(CandidateNotFoundError):
+        history.get_candidate(other_scope, left.candidate_id)
+
+
+def test_equal_candidate_content_under_new_attempt_is_not_semantically_deduplicated() -> (
+    None
+):
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first = history.append_candidate(
+        make_candidate_proposal(
+            evidence_ids=(evidence.evidence_id,), idempotency_key="attempt-a"
+        )
+    )
+    second = history.append_candidate(
+        make_candidate_proposal(
+            evidence_ids=(evidence.evidence_id,), idempotency_key="attempt-b"
+        )
+    )
+
+    assert first.candidate_id != second.candidate_id
+    assert history.list_candidates(make_scope()) == tuple(
+        sorted((first, second), key=lambda item: item.candidate_id)
+    )
+
+
+def test_candidate_list_snapshot_does_not_change_after_later_append() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    snapshot = history.list_candidates(make_scope())
+
+    history.append_candidate(
+        make_candidate_proposal(
+            content="later",
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="later",
+        )
+    )
+
+    assert snapshot == (first,)
+
+
+def test_candidate_queries_snapshot_ids_and_reject_scope_subclasses() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    query_id = MutableHashStr(candidate.candidate_id)
+    query_id.hash_salt = 1_000_003
+
+    assert history.get_candidate(make_scope(), query_id) is candidate
+    assert history.get_candidate_evidence(make_scope(), query_id) == (evidence,)
+    assert query_id.hash_calls == 0
+    invalid_scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+    with pytest.raises(TypeError, match="scope"):
+        history.get_candidate(invalid_scope, candidate.candidate_id)
+    with pytest.raises(TypeError, match="scope"):
+        history.list_candidates(invalid_scope)
+
+
+def test_foreign_candidate_error_matches_genuinely_missing_error() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    empty_history = InMemoryMemoryHistoryStore(evidence_store)
+
+    with pytest.raises(CandidateNotFoundError) as foreign:
+        history.get_candidate(make_scope(subject_id="user-2"), candidate.candidate_id)
+    with pytest.raises(CandidateNotFoundError) as missing:
+        empty_history.get_candidate(make_scope(), candidate.candidate_id)
+
+    assert str(foreign.value) == str(missing.value)

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -7,20 +7,30 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 from hashlib import sha256
+from threading import RLock
 
 import pytest
 
+from areal.v2.memory_service import history_store as history_store_module
 from areal.v2.memory_service.errors import (
     CandidateConflictError,
     CandidateNotFoundError,
     EvidenceNotFoundError,
     MemoryServiceError,
+    RevisionConflictError,
+    RevisionNotFoundError,
 )
 from areal.v2.memory_service.history_store import (
     InMemoryMemoryHistoryStore,
     MemoryHistoryStore,
 )
-from areal.v2.memory_service.history_types import CandidateProposal
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
+)
 from areal.v2.memory_service.store import InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
     EvidenceEvent,
@@ -47,11 +57,33 @@ class MutableHashStr(str):
         return str.__hash__(self) + self.hash_salt
 
 
+class AlwaysEqualStr(str):
+    """String subclass that records unsafe equality by store queries."""
+
+    equality_calls: int
+
+    def __new__(cls, value: str) -> AlwaysEqualStr:
+        instance = str.__new__(cls, value)
+        instance.equality_calls = 0
+        return instance
+
+    def __eq__(self, other: object) -> bool:
+        self.equality_calls += 1
+        return True
+
+    __hash__ = str.__hash__
+
+
 class MemoryScopeSubclass(MemoryScope):
     pass
 
 
 class CandidateProposalSubclass(CandidateProposal):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
+class RevisionProposalSubclass(RevisionProposal):
     def canonical_bytes(self) -> bytes:
         return b"overridden"
 
@@ -78,6 +110,18 @@ def make_candidate_proposal(**overrides: object) -> CandidateProposal:
     }
     values.update(overrides)
     return CandidateProposal(**values)  # type: ignore[arg-type]
+
+
+def make_revision_proposal(**overrides: object) -> RevisionProposal:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "candidate_id": "cand_missing",
+        "operation": RevisionOperation.ADD,
+        "parent_revision_id": None,
+        "idempotency_key": "revision-1",
+    }
+    values.update(overrides)
+    return RevisionProposal(**values)  # type: ignore[arg-type]
 
 
 def make_evidence_event(**overrides: object) -> EvidenceEvent:
@@ -107,7 +151,7 @@ def assert_candidate_indexes_empty(history: InMemoryMemoryHistoryStore) -> None:
     assert history._candidates_by_scope == {}
 
 
-def test_history_store_contract_exposes_only_candidate_surface() -> None:
+def test_history_store_contract_exposes_only_candidate_and_revision_surface() -> None:
     public_members = {
         name for name in MemoryHistoryStore.__dict__ if not name.startswith("_")
     }
@@ -117,12 +161,17 @@ def test_history_store_contract_exposes_only_candidate_surface() -> None:
         "get_candidate",
         "get_candidate_evidence",
         "list_candidates",
+        "append_revision",
+        "get_revision",
+        "list_revisions",
     }
 
 
-def test_candidate_error_types_share_memory_service_base_error() -> None:
+def test_history_errors_share_memory_service_base() -> None:
     assert issubclass(CandidateNotFoundError, MemoryServiceError)
     assert issubclass(CandidateConflictError, MemoryServiceError)
+    assert issubclass(RevisionNotFoundError, MemoryServiceError)
+    assert issubclass(RevisionConflictError, MemoryServiceError)
 
 
 def test_append_candidate_requires_existing_evidence_in_same_scope() -> None:
@@ -416,3 +465,801 @@ def test_foreign_candidate_error_matches_genuinely_missing_error() -> None:
         empty_history.get_candidate(make_scope(), candidate.candidate_id)
 
     assert str(foreign.value) == str(missing.value)
+
+
+def append_candidate(
+    history: InMemoryMemoryHistoryStore,
+    evidence_store: InMemoryEvidenceStore,
+    *,
+    candidate_key: str,
+    evidence_key: str,
+) -> MemoryCandidate:
+    evidence = evidence_store.append(
+        make_evidence_event(
+            sequence_no=len(evidence_store.list(make_scope())),
+            payload=candidate_key,
+            idempotency_key=evidence_key,
+        )
+    )
+    return history.append_candidate(
+        make_candidate_proposal(
+            content=candidate_key,
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key=candidate_key,
+        )
+    )
+
+
+def seeded_history_candidate() -> tuple[
+    InMemoryMemoryHistoryStore, MemoryCandidate, EvidenceRecord
+]:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    return history, candidate, evidence
+
+
+def seeded_parent_and_candidate() -> tuple[
+    InMemoryMemoryHistoryStore, MemoryRevision, MemoryCandidate
+]:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    root_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    parent = history.append_revision(
+        make_revision_proposal(candidate_id=root_candidate.candidate_id)
+    )
+    child_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="child-candidate",
+        evidence_key="child-evidence",
+    )
+    return history, parent, child_candidate
+
+
+def seeded_parent_and_two_candidates() -> tuple[
+    InMemoryMemoryHistoryStore,
+    MemoryRevision,
+    MemoryCandidate,
+    MemoryCandidate,
+]:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    root_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    parent = history.append_revision(
+        make_revision_proposal(candidate_id=root_candidate.candidate_id)
+    )
+    left = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="left-candidate",
+        evidence_key="left-evidence",
+    )
+    right = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="right-candidate",
+        evidence_key="right-evidence",
+    )
+    return history, parent, left, right
+
+
+def test_add_creates_generation_zero_logical_memory() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    revision = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+
+    assert revision.proposal.operation is RevisionOperation.ADD
+    assert revision.proposal.parent_revision_id is None
+    assert revision.generation == 0
+    assert revision.memory_id == "mem_" + revision.content_hash[:24]
+
+
+def test_append_revision_rejects_proposal_subclass_before_any_write() -> None:
+    proposal = RevisionProposalSubclass(
+        make_scope(), "cand_missing", RevisionOperation.ADD, None, "revision-1"
+    )
+    history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+
+    with pytest.raises(TypeError, match="RevisionProposal"):
+        history.append_revision(proposal)
+
+    assert history._revision_by_id == {}
+    assert history._revision_by_idempotency == {}
+    assert history._revision_by_candidate == {}
+    assert history._revisions_by_scope == {}
+
+
+def test_revision_identity_is_derived_before_history_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history, candidate, _ = seeded_history_candidate()
+    proposal = make_revision_proposal(candidate_id=candidate.candidate_id)
+    expected_hash = sha256(proposal.canonical_bytes()).hexdigest()
+    events: list[str] = []
+
+    class ProbeLock:
+        def __init__(self) -> None:
+            self._lock = RLock()
+            self.held = False
+
+        def __enter__(self) -> ProbeLock:
+            assert events == ["canonical", "sha256", "hexdigest", "revision-id"]
+            self._lock.acquire()
+            self.held = True
+            return self
+
+        def __exit__(
+            self,
+            exc_type: object,
+            exc_value: object,
+            traceback: object,
+        ) -> None:
+            self.held = False
+            self._lock.release()
+
+    probe_lock = ProbeLock()
+    history._lock = probe_lock  # type: ignore[assignment]
+    original_canonical_bytes = RevisionProposal.canonical_bytes
+    original_sha256 = history_store_module.hashlib.sha256
+
+    def observed_canonical_bytes(value: RevisionProposal) -> bytes:
+        assert not probe_lock.held
+        events.append("canonical")
+        return original_canonical_bytes(value)
+
+    class ObservedHexDigest(str):
+        slice_count: int
+
+        def __new__(cls, value: str) -> ObservedHexDigest:
+            instance = str.__new__(cls, value)
+            instance.slice_count = 0
+            return instance
+
+        def __getitem__(self, key: object) -> str:
+            self.slice_count += 1
+            if self.slice_count == 1:
+                assert not probe_lock.held
+                events.append("revision-id")
+            return str.__getitem__(self, key)  # type: ignore[index]
+
+    class ObservedHash:
+        def __init__(self, canonical_bytes: bytes) -> None:
+            self._hash = original_sha256(canonical_bytes)
+
+        def hexdigest(self) -> ObservedHexDigest:
+            assert not probe_lock.held
+            events.append("hexdigest")
+            return ObservedHexDigest(self._hash.hexdigest())
+
+    def observed_sha256(canonical_bytes: bytes) -> ObservedHash:
+        assert not probe_lock.held
+        events.append("sha256")
+        return ObservedHash(canonical_bytes)
+
+    monkeypatch.setattr(RevisionProposal, "canonical_bytes", observed_canonical_bytes)
+    monkeypatch.setattr(history_store_module.hashlib, "sha256", observed_sha256)
+
+    revision = history.append_revision(proposal)
+
+    assert revision.content_hash == expected_hash
+    assert revision.revision_id == f"rev_{expected_hash[:24]}"
+    assert events == ["canonical", "sha256", "hexdigest", "revision-id"]
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        RevisionOperation.REFINE,
+        RevisionOperation.SUPERSEDE,
+        RevisionOperation.CONTRADICT,
+    ],
+)
+def test_child_transition_inherits_memory_and_preserves_parent(
+    operation: RevisionOperation,
+) -> None:
+    history, parent, child_candidate = seeded_parent_and_candidate()
+    parent_bytes = parent.proposal.canonical_bytes()
+
+    child = history.append_revision(
+        make_revision_proposal(
+            candidate_id=child_candidate.candidate_id,
+            operation=operation,
+            parent_revision_id=parent.revision_id,
+            idempotency_key=f"{operation.value}-1",
+        )
+    )
+
+    assert child.memory_id == parent.memory_id
+    assert child.generation == parent.generation + 1
+    assert parent.proposal.canonical_bytes() == parent_bytes
+    assert history.get_revision(parent.proposal.scope, parent.revision_id) is parent
+
+
+def test_different_candidates_from_one_parent_survive_as_siblings() -> None:
+    history, parent, left_candidate, right_candidate = (
+        seeded_parent_and_two_candidates()
+    )
+    left = history.append_revision(
+        make_revision_proposal(
+            candidate_id=left_candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=parent.revision_id,
+            idempotency_key="left",
+        )
+    )
+    right = history.append_revision(
+        make_revision_proposal(
+            candidate_id=right_candidate.candidate_id,
+            operation=RevisionOperation.CONTRADICT,
+            parent_revision_id=parent.revision_id,
+            idempotency_key="right",
+        )
+    )
+
+    assert left.memory_id == right.memory_id == parent.memory_id
+    assert left.generation == right.generation == 1
+    assert set(history.list_revisions(parent.proposal.scope)) == {parent, left, right}
+
+
+def test_missing_parent_does_not_consume_candidate() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    invalid = make_revision_proposal(
+        candidate_id=candidate.candidate_id,
+        operation=RevisionOperation.REFINE,
+        parent_revision_id="rev_missing",
+    )
+    with pytest.raises(RevisionNotFoundError):
+        history.append_revision(invalid)
+
+    valid = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+    assert valid.generation == 0
+
+
+def test_foreign_candidate_and_parent_are_hidden_as_missing() -> None:
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    evidence_store = InMemoryEvidenceStore()
+    first_evidence = evidence_store.append(make_evidence_event(scope=first_scope))
+    second_evidence = evidence_store.append(
+        make_evidence_event(
+            scope=second_scope,
+            idempotency_key="second-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first_candidate = history.append_candidate(
+        make_candidate_proposal(
+            scope=first_scope,
+            evidence_ids=(first_evidence.evidence_id,),
+            idempotency_key="first-candidate",
+        )
+    )
+    second_candidate = history.append_candidate(
+        make_candidate_proposal(
+            scope=second_scope,
+            evidence_ids=(second_evidence.evidence_id,),
+            idempotency_key="second-candidate",
+        )
+    )
+    foreign_parent = history.append_revision(
+        make_revision_proposal(
+            scope=second_scope,
+            candidate_id=second_candidate.candidate_id,
+            idempotency_key="foreign-parent",
+        )
+    )
+
+    with pytest.raises(CandidateNotFoundError):
+        history.append_revision(
+            make_revision_proposal(candidate_id=second_candidate.candidate_id)
+        )
+    with pytest.raises(RevisionNotFoundError):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id=first_candidate.candidate_id,
+                operation=RevisionOperation.REFINE,
+                parent_revision_id=foreign_parent.revision_id,
+            )
+        )
+
+
+def test_revision_idempotency_and_lists_are_scope_isolated() -> None:
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    evidence_store = InMemoryEvidenceStore()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+
+    def append_root(scope: MemoryScope) -> MemoryRevision:
+        evidence = evidence_store.append(
+            make_evidence_event(
+                scope=scope,
+                idempotency_key="shared-evidence",
+            )
+        )
+        candidate = history.append_candidate(
+            make_candidate_proposal(
+                scope=scope,
+                evidence_ids=(evidence.evidence_id,),
+                idempotency_key="shared-candidate",
+            )
+        )
+        return history.append_revision(
+            make_revision_proposal(
+                scope=scope,
+                candidate_id=candidate.candidate_id,
+                idempotency_key="shared-revision",
+            )
+        )
+
+    first = append_root(first_scope)
+    second = append_root(second_scope)
+
+    assert first is not second
+    assert history.list_revisions(first_scope) == (first,)
+    assert history.list_revisions(second_scope) == (second,)
+
+
+def test_revision_retry_and_conflicting_idempotency_are_atomic() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    parent_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    proposal = make_revision_proposal(candidate_id=parent_candidate.candidate_id)
+    first = history.append_revision(proposal)
+    retry = history.append_revision(
+        RevisionProposal(
+            scope=proposal.scope,
+            candidate_id=proposal.candidate_id,
+            operation=proposal.operation,
+            parent_revision_id=proposal.parent_revision_id,
+            idempotency_key=proposal.idempotency_key,
+        )
+    )
+    assert retry is first
+
+    other_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="other-candidate",
+        evidence_key="other-evidence",
+    )
+    before = (
+        dict(history._revision_by_id),
+        dict(history._revision_by_idempotency),
+        dict(history._revision_by_candidate),
+        {scope: list(items) for scope, items in history._revisions_by_scope.items()},
+    )
+    with pytest.raises(RevisionConflictError, match="idempotency"):
+        history.append_revision(
+            make_revision_proposal(candidate_id=other_candidate.candidate_id)
+        )
+    assert (
+        history._revision_by_id,
+        history._revision_by_idempotency,
+        history._revision_by_candidate,
+        history._revisions_by_scope,
+    ) == before
+
+    recovered = history.append_revision(
+        make_revision_proposal(
+            candidate_id=other_candidate.candidate_id,
+            idempotency_key="other-revision",
+        )
+    )
+    assert recovered.proposal.candidate_id == other_candidate.candidate_id
+
+
+def test_revision_error_precedence_and_id_collision_are_atomic() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    first = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+
+    def revision_indexes() -> tuple[object, ...]:
+        return (
+            dict(history._revision_by_id),
+            dict(history._revision_by_idempotency),
+            dict(history._revision_by_candidate),
+            {
+                scope: list(revisions)
+                for scope, revisions in history._revisions_by_scope.items()
+            },
+        )
+
+    idempotency_attempt = make_revision_proposal(
+        candidate_id="cand_missing",
+        operation=RevisionOperation.REFINE,
+        parent_revision_id="rev_missing",
+    )
+    idempotency_hash = sha256(idempotency_attempt.canonical_bytes()).hexdigest()
+    idempotency_index = (
+        idempotency_attempt.scope,
+        f"rev_{idempotency_hash[:24]}",
+    )
+    history._revision_by_id[idempotency_index] = first
+    before = revision_indexes()
+    with pytest.raises(RevisionConflictError, match="idempotency"):
+        history.append_revision(idempotency_attempt)
+    assert revision_indexes() == before
+    del history._revision_by_id[idempotency_index]
+
+    collision_attempt = make_revision_proposal(
+        candidate_id="cand_missing",
+        operation=RevisionOperation.REFINE,
+        parent_revision_id="rev_missing",
+        idempotency_key="collision-attempt",
+    )
+    collision_hash = sha256(collision_attempt.canonical_bytes()).hexdigest()
+    collision_index = (
+        collision_attempt.scope,
+        f"rev_{collision_hash[:24]}",
+    )
+    history._revision_by_id[collision_index] = first
+    before = revision_indexes()
+    with pytest.raises(RevisionConflictError, match="collision"):
+        history.append_revision(collision_attempt)
+    assert revision_indexes() == before
+    del history._revision_by_id[collision_index]
+
+    with pytest.raises(CandidateNotFoundError):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id="cand_missing",
+                operation=RevisionOperation.REFINE,
+                parent_revision_id="rev_missing",
+                idempotency_key="missing-relationships",
+            )
+        )
+    with pytest.raises(RevisionConflictError, match="candidate"):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id=candidate.candidate_id,
+                operation=RevisionOperation.REFINE,
+                parent_revision_id="rev_missing",
+                idempotency_key="used-candidate",
+            )
+        )
+
+
+def test_one_candidate_can_back_only_one_revision() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    history.append_revision(make_revision_proposal(candidate_id=candidate.candidate_id))
+
+    with pytest.raises(RevisionConflictError, match="candidate"):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id=candidate.candidate_id,
+                idempotency_key="second-use",
+            )
+        )
+
+
+def test_revision_relationship_checks_and_writes_share_one_lock_epoch() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    records: list[tuple[str, int]] = []
+
+    class EpochLock:
+        def __init__(self) -> None:
+            self._lock = RLock()
+            self.held = False
+            self.epoch = 0
+            self.enter_count = 0
+
+        def __enter__(self) -> EpochLock:
+            self._lock.acquire()
+            assert not self.held
+            self.held = True
+            self.epoch += 1
+            self.enter_count += 1
+            return self
+
+        def __exit__(
+            self,
+            exc_type: object,
+            exc_value: object,
+            traceback: object,
+        ) -> None:
+            self.held = False
+            self._lock.release()
+
+        def current_epoch(self) -> int:
+            assert self.held, "revision index accessed outside history lock"
+            return self.epoch
+
+    epoch_lock = EpochLock()
+
+    def record(event: str) -> None:
+        records.append((event, epoch_lock.current_epoch()))
+
+    class RecordingList(list[object]):
+        def append(self, item: object) -> None:
+            record("scope:append")
+            super().append(item)
+
+    class RecordingDict(dict[object, object]):
+        def __init__(self, values: dict[object, object], name: str) -> None:
+            super().__init__(values)
+            self._name = name
+
+        def get(self, key: object, default: object = None) -> object:
+            record(f"{self._name}:get")
+            return super().get(key, default)
+
+        def __contains__(self, key: object) -> bool:
+            record(f"{self._name}:contains")
+            return super().__contains__(key)
+
+        def __setitem__(self, key: object, value: object) -> None:
+            record(f"{self._name}:set")
+            super().__setitem__(key, value)
+
+        def setdefault(self, key: object, default: object = None) -> object:
+            record(f"{self._name}:setdefault")
+            if not dict.__contains__(self, key):
+                default = RecordingList(default or ())
+            return super().setdefault(key, default)
+
+    history._lock = epoch_lock  # type: ignore[assignment]
+    history._candidate_by_id = RecordingDict(  # type: ignore[assignment]
+        history._candidate_by_id,
+        "candidate",
+    )
+    history._revision_by_id = RecordingDict(  # type: ignore[assignment]
+        history._revision_by_id,
+        "revision",
+    )
+    history._revision_by_idempotency = RecordingDict(  # type: ignore[assignment]
+        history._revision_by_idempotency,
+        "idempotency",
+    )
+    history._revision_by_candidate = RecordingDict(  # type: ignore[assignment]
+        history._revision_by_candidate,
+        "candidate-revision",
+    )
+    history._revisions_by_scope = RecordingDict(  # type: ignore[assignment]
+        history._revisions_by_scope,
+        "scope",
+    )
+    revision = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+
+    assert epoch_lock.enter_count == 1
+    assert {epoch for _, epoch in records} == {1}
+    assert [event for event, _ in records] == [
+        "idempotency:get",
+        "revision:get",
+        "candidate:get",
+        "candidate-revision:contains",
+        "revision:set",
+        "idempotency:set",
+        "candidate-revision:set",
+        "scope:setdefault",
+        "scope:append",
+    ]
+    assert tuple(history._revision_by_id.values()) == (revision,)
+    assert tuple(history._revision_by_idempotency.values()) == (revision,)
+    assert tuple(history._revision_by_candidate.values()) == (revision,)
+    assert tuple(history._revisions_by_scope.values()) == ([revision],)
+
+
+def test_revision_identity_order_filter_and_public_provenance() -> None:
+    history, parent, child_candidate = seeded_parent_and_candidate()
+    child = history.append_revision(
+        make_revision_proposal(
+            candidate_id=child_candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=parent.revision_id,
+            idempotency_key="child-revision",
+        )
+    )
+    expected_hash = sha256(child.proposal.canonical_bytes()).hexdigest()
+
+    assert child.content_hash == expected_hash
+    assert re.fullmatch(r"[0-9a-f]{64}", child.content_hash)
+    assert child.revision_id == f"rev_{expected_hash[:24]}"
+    assert re.fullmatch(r"rev_[0-9a-f]{24}", child.revision_id)
+    assert history.list_revisions(parent.proposal.scope) == (parent, child)
+    assert history.list_revisions(
+        parent.proposal.scope, memory_id=parent.memory_id
+    ) == (parent, child)
+    assert history.list_revisions(parent.proposal.scope, memory_id="mem_missing") == ()
+    resolved = history.get_revision(child.proposal.scope, child.revision_id)
+    candidate = history.get_candidate(
+        resolved.proposal.scope, resolved.proposal.candidate_id
+    )
+    assert history.get_candidate_evidence(
+        candidate.proposal.scope, candidate.candidate_id
+    )
+    with pytest.raises(RevisionNotFoundError):
+        history.get_revision(make_scope(subject_id="user-2"), child.revision_id)
+
+
+def test_candidate_and_revision_idempotency_domains_are_independent() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    candidate = history.append_candidate(
+        make_candidate_proposal(
+            evidence_ids=(evidence.evidence_id,),
+            idempotency_key="shared-key",
+        )
+    )
+    revision = history.append_revision(
+        make_revision_proposal(
+            candidate_id=candidate.candidate_id,
+            idempotency_key="shared-key",
+        )
+    )
+    assert revision.proposal.candidate_id == candidate.candidate_id
+
+
+def test_revision_queries_snapshot_strings_and_hide_scope_occupancy() -> None:
+    history, candidate, _ = seeded_history_candidate()
+    revision = history.append_revision(
+        make_revision_proposal(candidate_id=candidate.candidate_id)
+    )
+    query_id = MutableHashStr(revision.revision_id)
+    query_id.hash_salt = 1_000_003
+    false_filter = AlwaysEqualStr("mem_missing")
+
+    assert history.get_revision(make_scope(), query_id) is revision
+    assert query_id.hash_calls == 0
+    assert history.list_revisions(make_scope(), memory_id=false_filter) == ()
+    assert false_filter.equality_calls == 0
+    invalid_scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+    with pytest.raises(TypeError, match="scope"):
+        history.get_revision(invalid_scope, revision.revision_id)
+    with pytest.raises(TypeError, match="scope"):
+        history.list_revisions(invalid_scope)
+
+    empty_history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+    with pytest.raises(RevisionNotFoundError) as foreign:
+        history.get_revision(make_scope(subject_id="user-2"), revision.revision_id)
+    with pytest.raises(RevisionNotFoundError) as missing:
+        empty_history.get_revision(make_scope(), revision.revision_id)
+    assert str(foreign.value) == str(missing.value)
+
+
+def test_revision_order_and_returned_snapshot_cover_roots_and_siblings() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    first_root_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    first_root = history.append_revision(
+        make_revision_proposal(candidate_id=first_root_candidate.candidate_id)
+    )
+    left_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="left",
+        evidence_key="left-evidence",
+    )
+    right_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="right",
+        evidence_key="right-evidence",
+    )
+    right = history.append_revision(
+        make_revision_proposal(
+            candidate_id=right_candidate.candidate_id,
+            operation=RevisionOperation.CONTRADICT,
+            parent_revision_id=first_root.revision_id,
+            idempotency_key="right-revision",
+        )
+    )
+    left = history.append_revision(
+        make_revision_proposal(
+            candidate_id=left_candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=first_root.revision_id,
+            idempotency_key="left-revision",
+        )
+    )
+    second_root_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="second-root",
+        evidence_key="second-root-evidence",
+    )
+    second_root = history.append_revision(
+        make_revision_proposal(
+            candidate_id=second_root_candidate.candidate_id,
+            idempotency_key="second-root-revision",
+        )
+    )
+    expected = tuple(
+        sorted(
+            (first_root, left, right, second_root),
+            key=lambda item: (item.memory_id, item.generation, item.revision_id),
+        )
+    )
+    snapshot = history.list_revisions(make_scope())
+    assert snapshot == expected
+
+    later_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="later",
+        evidence_key="later-evidence",
+    )
+    history.append_revision(
+        make_revision_proposal(
+            candidate_id=later_candidate.candidate_id,
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=first_root.revision_id,
+            idempotency_key="later-revision",
+        )
+    )
+    assert snapshot == expected
+
+
+def test_generation_overflow_leaves_all_revision_indexes_unchanged() -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    parent_candidate = history.append_candidate(
+        make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+    )
+    parent_proposal = make_revision_proposal(
+        candidate_id=parent_candidate.candidate_id,
+        idempotency_key="max-parent",
+    )
+    parent = MemoryRevision(
+        revision_id="rev_max",
+        memory_id="mem_max",
+        generation=2**63 - 1,
+        proposal=parent_proposal,
+        content_hash="a" * 64,
+        created_at=datetime.now(UTC),
+    )
+    history._revision_by_id[(make_scope(), parent.revision_id)] = parent
+    history._revision_by_idempotency[(make_scope(), "max-parent")] = parent
+    history._revision_by_candidate[
+        (
+            make_scope(),
+            parent_candidate.candidate_id,
+        )
+    ] = parent
+    history._revisions_by_scope[make_scope()] = [parent]
+    child_candidate = append_candidate(
+        history,
+        evidence_store,
+        candidate_key="overflow-child",
+        evidence_key="overflow-evidence",
+    )
+    before = (
+        dict(history._revision_by_id),
+        dict(history._revision_by_idempotency),
+        dict(history._revision_by_candidate),
+        {scope: list(items) for scope, items in history._revisions_by_scope.items()},
+    )
+
+    with pytest.raises(RevisionConflictError, match="generation"):
+        history.append_revision(
+            make_revision_proposal(
+                candidate_id=child_candidate.candidate_id,
+                operation=RevisionOperation.REFINE,
+                parent_revision_id=parent.revision_id,
+                idempotency_key="overflow-child-revision",
+            )
+        )
+
+    after = (
+        history._revision_by_id,
+        history._revision_by_idempotency,
+        history._revision_by_candidate,
+        history._revisions_by_scope,
+    )
+    assert after == before

--- a/tests/v2/memory_service/test_history_store.py
+++ b/tests/v2/memory_service/test_history_store.py
@@ -121,6 +121,20 @@ class YieldingMissingContainsDict(dict[object, object]):
         return exists
 
 
+class SetThenInterruptDict(dict[object, object]):
+    """Mutate once before raising to exercise BaseException rollback."""
+
+    def __init__(self, values: dict[object, object] | None = None) -> None:
+        super().__init__({} if values is None else values)
+        self.should_interrupt = True
+
+    def __setitem__(self, key: object, value: object) -> None:
+        super().__setitem__(key, value)
+        if self.should_interrupt:
+            self.should_interrupt = False
+            raise KeyboardInterrupt("injected publication interruption")
+
+
 class StubHash:
     """Return one test-controlled hexadecimal digest."""
 
@@ -408,6 +422,27 @@ def test_append_candidate_requires_existing_evidence_in_same_scope() -> None:
     assert history.get_candidate_evidence(proposal.scope, candidate.candidate_id) == (
         evidence,
     )
+
+
+@pytest.mark.parametrize(
+    "failing_index",
+    ("_candidate_by_idempotency", "_candidates_by_scope"),
+)
+def test_candidate_publication_rolls_back_every_index_after_base_exception(
+    failing_index: str,
+) -> None:
+    evidence_store, evidence = seeded_evidence_store()
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    setattr(history, failing_index, SetThenInterruptDict())
+    proposal = make_candidate_proposal(evidence_ids=(evidence.evidence_id,))
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        history.append_candidate(proposal)
+
+    assert_candidate_indexes_empty(history)
+    candidate = history.append_candidate(proposal)
+    assert history.get_candidate(proposal.scope, candidate.candidate_id) == candidate
+    assert history.list_candidates(proposal.scope) == (candidate,)
 
 
 def test_append_candidate_rejects_proposal_subclass_before_any_write() -> None:
@@ -781,6 +816,33 @@ def test_add_creates_generation_zero_logical_memory() -> None:
     assert revision.proposal.parent_revision_id is None
     assert revision.generation == 0
     assert revision.memory_id == "mem_" + revision.content_hash[:24]
+
+
+@pytest.mark.parametrize(
+    "failing_index",
+    (
+        "_revision_by_idempotency",
+        "_revision_by_candidate",
+        "_revisions_by_scope",
+    ),
+)
+def test_revision_publication_rolls_back_every_index_after_base_exception(
+    failing_index: str,
+) -> None:
+    history, candidate, _evidence = seeded_history_candidate()
+    setattr(history, failing_index, SetThenInterruptDict())
+    proposal = make_revision_proposal(candidate_id=candidate.candidate_id)
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        history.append_revision(proposal)
+
+    assert history._revision_by_id == {}
+    assert history._revision_by_idempotency == {}
+    assert history._revision_by_candidate == {}
+    assert history._revisions_by_scope == {}
+    revision = history.append_revision(proposal)
+    assert history.get_revision(proposal.scope, revision.revision_id) == revision
+    assert history.list_revisions(proposal.scope) == (revision,)
 
 
 def test_append_revision_rejects_proposal_subclass_before_any_write() -> None:
@@ -1263,11 +1325,14 @@ def test_revision_relationship_checks_and_writes_share_one_lock_epoch() -> None:
         "revision:get",
         "candidate:get",
         "candidate-revision:contains",
+        "revision:get",
         "revision:set",
+        "idempotency:get",
         "idempotency:set",
+        "candidate-revision:get",
         "candidate-revision:set",
-        "scope:setdefault",
-        "scope:append",
+        "scope:get",
+        "scope:set",
     ]
     assert tuple(history._revision_by_id.values()) == (revision,)
     assert tuple(history._revision_by_idempotency.values()) == (revision,)

--- a/tests/v2/memory_service/test_history_types.py
+++ b/tests/v2/memory_service/test_history_types.py
@@ -254,6 +254,13 @@ def test_proposals_require_exact_scope_and_revision_operation() -> None:
         make_revision_proposal(operation="add")
 
 
+def test_revision_proposal_requires_exact_scope() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope"):
+        make_revision_proposal(scope=scope)
+
+
 def test_persisted_records_reject_proposal_subclasses() -> None:
     candidate_proposal = CandidateProposalSubclass(
         make_scope(), "remember this", ("evd_a",), "candidate-1"

--- a/tests/v2/memory_service/test_history_types.py
+++ b/tests/v2/memory_service/test_history_types.py
@@ -1,0 +1,481 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for immutable Memory Service candidate and revision values."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError, fields
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
+
+import pytest
+
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
+)
+from areal.v2.memory_service.types import MemoryScope
+
+
+class StringSubclass(str):
+    pass
+
+
+class TupleSubclass(tuple[str, ...]):
+    def __iter__(self):
+        return iter(("overridden",))
+
+
+class IntSubclass(int):
+    pass
+
+
+class MemoryScopeSubclass(MemoryScope):
+    pass
+
+
+class CandidateProposalSubclass(CandidateProposal):
+    pass
+
+
+class RevisionProposalSubclass(RevisionProposal):
+    pass
+
+
+class MutableTimezone(tzinfo):
+    def __init__(self) -> None:
+        self.offset = timedelta(hours=1)
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        return self.offset
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(0)
+
+    def tzname(self, value: datetime | None) -> str:
+        return "MUTABLE"
+
+
+class StatefulDatetime(datetime):
+    def astimezone(self, timezone: tzinfo | None = None) -> StatefulDatetime:
+        return self
+
+
+LONE_SURROGATE = "\ud800"
+
+
+def make_scope(**overrides: str) -> MemoryScope:
+    values = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)
+
+
+def make_candidate_proposal(**overrides: object) -> CandidateProposal:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "content": "remember this",
+        "evidence_ids": ("evd_a",),
+        "idempotency_key": "candidate-1",
+    }
+    values.update(overrides)
+    return CandidateProposal(**values)  # type: ignore[arg-type]
+
+
+def make_revision_proposal(**overrides: object) -> RevisionProposal:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "candidate_id": "cand_a",
+        "operation": RevisionOperation.ADD,
+        "parent_revision_id": None,
+        "idempotency_key": "revision-1",
+    }
+    values.update(overrides)
+    return RevisionProposal(**values)  # type: ignore[arg-type]
+
+
+def test_revision_operation_wire_values_are_stable() -> None:
+    assert {item.name: item.value for item in RevisionOperation} == {
+        "ADD": "add",
+        "REFINE": "refine",
+        "SUPERSEDE": "supersede",
+        "CONTRADICT": "contradict",
+    }
+
+
+def test_candidate_proposal_canonical_schema_v1_is_frozen() -> None:
+    proposal = CandidateProposal(
+        scope=make_scope(),
+        content="remember this",
+        evidence_ids=("evd_a", "evd_b"),
+        idempotency_key="candidate-1",
+    )
+    assert proposal.canonical_bytes() == (
+        b'{"content":"remember this","evidence_ids":["evd_a","evd_b"],'
+        b'"idempotency_key":"candidate-1","schema_version":1,'
+        b'"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        b'"tenant_id":"tenant-1"}}'
+    )
+
+
+def test_candidate_proposal_canonical_schema_preserves_literal_utf8() -> None:
+    proposal = CandidateProposal(
+        scope=make_scope(),
+        content="记住🙂",
+        evidence_ids=("evd_a",),
+        idempotency_key="candidate-1",
+    )
+
+    canonical_bytes = proposal.canonical_bytes()
+    expected = (
+        '{"content":"记住🙂","evidence_ids":["evd_a"],'
+        '"idempotency_key":"candidate-1","schema_version":1,'
+        '"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        '"tenant_id":"tenant-1"}}'
+    ).encode()
+
+    assert canonical_bytes == expected
+    assert b"\\u" not in canonical_bytes
+
+
+def test_revision_proposal_canonical_schema_v1_is_frozen() -> None:
+    proposal = RevisionProposal(
+        scope=make_scope(),
+        candidate_id="cand_a",
+        operation=RevisionOperation.ADD,
+        parent_revision_id=None,
+        idempotency_key="revision-1",
+    )
+    assert proposal.canonical_bytes() == (
+        b'{"candidate_id":"cand_a","idempotency_key":"revision-1",'
+        b'"operation":"add","parent_revision_id":null,"schema_version":1,'
+        b'"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        b'"tenant_id":"tenant-1"}}'
+    )
+
+
+def test_non_add_canonical_schema_serializes_parent_as_exact_string() -> None:
+    proposal = make_revision_proposal(
+        operation=RevisionOperation.REFINE,
+        parent_revision_id=StringSubclass("rev_parent"),
+    )
+    value = json.loads(proposal.canonical_bytes())
+
+    assert type(proposal.parent_revision_id) is str
+    assert value["parent_revision_id"] == "rev_parent"
+    assert type(value["parent_revision_id"]) is str
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        RevisionOperation.REFINE,
+        RevisionOperation.SUPERSEDE,
+        RevisionOperation.CONTRADICT,
+    ],
+)
+def test_non_add_revision_requires_one_parent(operation: RevisionOperation) -> None:
+    with pytest.raises(ValueError, match="parent_revision_id"):
+        make_revision_proposal(operation=operation, parent_revision_id=None)
+
+
+def test_add_revision_rejects_parent() -> None:
+    with pytest.raises(ValueError, match="parent_revision_id"):
+        make_revision_proposal(
+            operation=RevisionOperation.ADD,
+            parent_revision_id="rev_parent",
+        )
+
+
+def test_candidate_proposal_snapshots_tuple_and_string_subclasses() -> None:
+    proposal = make_candidate_proposal(
+        content=StringSubclass(" remember this "),
+        evidence_ids=TupleSubclass((StringSubclass("evd_a"), StringSubclass("evd_b"))),
+        idempotency_key=StringSubclass(" candidate-1 "),
+    )
+
+    assert type(proposal.content) is str
+    assert proposal.content == " remember this "
+    assert type(proposal.evidence_ids) is tuple
+    assert proposal.evidence_ids == ("evd_a", "evd_b")
+    assert all(type(item) is str for item in proposal.evidence_ids)
+    assert type(proposal.idempotency_key) is str
+    assert proposal.idempotency_key == " candidate-1 "
+
+
+def test_revision_proposal_snapshots_string_subclasses() -> None:
+    proposal = make_revision_proposal(
+        candidate_id=StringSubclass(" cand_a "),
+        operation=RevisionOperation.REFINE,
+        parent_revision_id=StringSubclass(" rev_parent "),
+        idempotency_key=StringSubclass(" revision-1 "),
+    )
+
+    assert type(proposal.candidate_id) is str
+    assert proposal.candidate_id == " cand_a "
+    assert type(proposal.parent_revision_id) is str
+    assert proposal.parent_revision_id == " rev_parent "
+    assert type(proposal.idempotency_key) is str
+    assert proposal.idempotency_key == " revision-1 "
+
+
+@pytest.mark.parametrize("evidence_ids", [(), ("evd_a", "evd_a")])
+def test_candidate_proposal_rejects_empty_or_duplicate_evidence(
+    evidence_ids: tuple[str, ...],
+) -> None:
+    with pytest.raises(ValueError, match="evidence_ids"):
+        make_candidate_proposal(evidence_ids=evidence_ids)
+
+
+@pytest.mark.parametrize("evidence_ids", [["evd_a"], {"evd_a"}])
+def test_candidate_proposal_rejects_non_tuple_evidence(evidence_ids: object) -> None:
+    with pytest.raises(TypeError, match="evidence_ids"):
+        make_candidate_proposal(evidence_ids=evidence_ids)
+
+
+def test_candidate_proposal_rejects_blank_content_and_evidence_id() -> None:
+    with pytest.raises(ValueError, match="content"):
+        make_candidate_proposal(content=" \t\n")
+    with pytest.raises(ValueError, match="evidence_ids"):
+        make_candidate_proposal(evidence_ids=(" ",))
+
+
+def test_proposals_require_exact_scope_and_revision_operation() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+    with pytest.raises(TypeError, match="scope"):
+        make_candidate_proposal(scope=scope)
+    with pytest.raises(TypeError, match="operation"):
+        make_revision_proposal(operation="add")
+
+
+def test_persisted_records_reject_proposal_subclasses() -> None:
+    candidate_proposal = CandidateProposalSubclass(
+        make_scope(), "remember this", ("evd_a",), "candidate-1"
+    )
+    revision_proposal = RevisionProposalSubclass(
+        make_scope(), "cand_a", RevisionOperation.ADD, None, "revision-1"
+    )
+    with pytest.raises(TypeError, match="CandidateProposal"):
+        MemoryCandidate("cand_a", candidate_proposal, "a" * 64, datetime.now(UTC))
+    with pytest.raises(TypeError, match="RevisionProposal"):
+        MemoryRevision(
+            "rev_a",
+            "mem_a",
+            0,
+            revision_proposal,
+            "b" * 64,
+            datetime.now(UTC),
+        )
+
+
+def test_all_proposal_text_rejects_lone_surrogates() -> None:
+    with pytest.raises(ValueError, match="content"):
+        make_candidate_proposal(content=LONE_SURROGATE)
+    with pytest.raises(ValueError, match="evidence_ids"):
+        make_candidate_proposal(evidence_ids=(LONE_SURROGATE,))
+    with pytest.raises(ValueError, match="idempotency_key"):
+        make_candidate_proposal(idempotency_key=LONE_SURROGATE)
+    with pytest.raises(ValueError, match="candidate_id"):
+        make_revision_proposal(candidate_id=LONE_SURROGATE)
+    with pytest.raises(ValueError, match="parent_revision_id"):
+        make_revision_proposal(
+            operation=RevisionOperation.REFINE,
+            parent_revision_id=LONE_SURROGATE,
+        )
+    with pytest.raises(ValueError, match="idempotency_key"):
+        make_revision_proposal(idempotency_key=LONE_SURROGATE)
+
+
+@pytest.mark.parametrize("field", ["candidate_id", "content_hash"])
+def test_memory_candidate_rejects_lone_surrogate_persisted_text(field: str) -> None:
+    values: dict[str, object] = {
+        "candidate_id": "cand_a",
+        "proposal": make_candidate_proposal(),
+        "content_hash": "a" * 64,
+        "created_at": datetime.now(UTC),
+    }
+    values[field] = LONE_SURROGATE
+
+    with pytest.raises(ValueError, match=rf"^{field} must be valid UTF-8$"):
+        MemoryCandidate(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", ["revision_id", "memory_id", "content_hash"])
+def test_memory_revision_rejects_lone_surrogate_persisted_text(field: str) -> None:
+    values: dict[str, object] = {
+        "revision_id": "rev_a",
+        "memory_id": "mem_a",
+        "generation": 0,
+        "proposal": make_revision_proposal(),
+        "content_hash": "b" * 64,
+        "created_at": datetime.now(UTC),
+    }
+    values[field] = LONE_SURROGATE
+
+    with pytest.raises(ValueError, match=rf"^{field} must be valid UTF-8$"):
+        MemoryRevision(**values)  # type: ignore[arg-type]
+
+
+def test_persisted_records_snapshot_identifiers_and_utc_datetime() -> None:
+    created_at = datetime(2026, 7, 7, 12, tzinfo=timezone(timedelta(hours=8)))
+    candidate = MemoryCandidate(
+        candidate_id=StringSubclass("cand_a"),
+        proposal=make_candidate_proposal(),
+        content_hash=StringSubclass("a" * 64),
+        created_at=created_at,
+    )
+    revision = MemoryRevision(
+        revision_id=StringSubclass("rev_a"),
+        memory_id=StringSubclass("mem_a"),
+        generation=0,
+        proposal=make_revision_proposal(),
+        content_hash=StringSubclass("b" * 64),
+        created_at=created_at,
+    )
+
+    assert type(candidate.candidate_id) is str
+    assert type(candidate.content_hash) is str
+    assert type(candidate.created_at) is datetime
+    assert candidate.created_at == datetime(2026, 7, 7, 4, tzinfo=UTC)
+    assert type(revision.revision_id) is str
+    assert type(revision.memory_id) is str
+    assert type(revision.content_hash) is str
+    assert type(revision.created_at) is datetime
+    assert revision.created_at.tzinfo is UTC
+
+
+def test_persisted_records_detach_mutable_timezone_and_datetime_subclass() -> None:
+    mutable_timezone = MutableTimezone()
+    source = datetime(2026, 7, 7, 5, tzinfo=mutable_timezone)
+    candidate = MemoryCandidate("cand_a", make_candidate_proposal(), "a" * 64, source)
+    subclass_source = StatefulDatetime(2026, 7, 7, 4, tzinfo=UTC)
+    revision = MemoryRevision(
+        "rev_a",
+        "mem_a",
+        0,
+        make_revision_proposal(),
+        "b" * 64,
+        subclass_source,
+    )
+    mutable_timezone.offset = timedelta(hours=2)
+
+    assert type(candidate.created_at) is datetime
+    assert candidate.created_at == datetime(2026, 7, 7, 4, tzinfo=UTC)
+    assert type(revision.created_at) is datetime
+    assert revision.created_at == datetime(2026, 7, 7, 4, tzinfo=UTC)
+
+
+def test_persisted_records_reject_naive_or_non_normalizable_datetime() -> None:
+    with pytest.raises(ValueError, match="created_at"):
+        MemoryCandidate(
+            "cand_a",
+            make_candidate_proposal(),
+            "a" * 64,
+            datetime(2026, 7, 7),
+        )
+    with pytest.raises(ValueError, match="created_at"):
+        MemoryRevision(
+            "rev_a",
+            "mem_a",
+            0,
+            make_revision_proposal(),
+            "b" * 64,
+            datetime.min.replace(tzinfo=timezone(timedelta(hours=1))),
+        )
+
+
+@pytest.mark.parametrize("generation", [True, IntSubclass(1), -1, 2**63])
+def test_revision_rejects_invalid_generation(generation: object) -> None:
+    with pytest.raises((TypeError, ValueError), match="generation"):
+        MemoryRevision(
+            revision_id="rev_a",
+            memory_id="mem_a",
+            generation=generation,  # type: ignore[arg-type]
+            proposal=make_revision_proposal(),
+            content_hash="a" * 64,
+            created_at=datetime.now(UTC),
+        )
+
+
+@pytest.mark.parametrize("generation", [0, 2**63 - 1])
+def test_revision_accepts_generation_boundaries(generation: int) -> None:
+    revision = MemoryRevision(
+        "rev_a",
+        "mem_a",
+        generation,
+        make_revision_proposal(),
+        "a" * 64,
+        datetime.now(UTC),
+    )
+    assert revision.generation == generation
+
+
+def test_values_are_frozen_and_slotted() -> None:
+    values_and_fields = (
+        (make_candidate_proposal(), "content"),
+        (
+            MemoryCandidate(
+                "cand_a", make_candidate_proposal(), "a" * 64, datetime.now(UTC)
+            ),
+            "candidate_id",
+        ),
+        (make_revision_proposal(), "candidate_id"),
+        (
+            MemoryRevision(
+                "rev_a",
+                "mem_a",
+                0,
+                make_revision_proposal(),
+                "b" * 64,
+                datetime.now(UTC),
+            ),
+            "revision_id",
+        ),
+    )
+
+    for value, field_name in values_and_fields:
+        assert not hasattr(value, "__dict__")
+        with pytest.raises(FrozenInstanceError):
+            setattr(value, field_name, "changed")
+
+
+def test_idempotency_key_is_part_of_candidate_identity() -> None:
+    left = make_candidate_proposal(idempotency_key="attempt-a")
+    right = make_candidate_proposal(idempotency_key="attempt-b")
+    assert left.canonical_bytes() != right.canonical_bytes()
+
+
+def test_exact_field_order_excludes_status_metadata_and_duplicated_evidence() -> None:
+    assert tuple(field.name for field in fields(CandidateProposal)) == (
+        "scope",
+        "content",
+        "evidence_ids",
+        "idempotency_key",
+    )
+    assert tuple(field.name for field in fields(MemoryCandidate)) == (
+        "candidate_id",
+        "proposal",
+        "content_hash",
+        "created_at",
+    )
+    assert tuple(field.name for field in fields(RevisionProposal)) == (
+        "scope",
+        "candidate_id",
+        "operation",
+        "parent_revision_id",
+        "idempotency_key",
+    )
+    assert tuple(field.name for field in fields(MemoryRevision)) == (
+        "revision_id",
+        "memory_id",
+        "generation",
+        "proposal",
+        "content_hash",
+        "created_at",
+    )

--- a/tests/v2/memory_service/test_release_store.py
+++ b/tests/v2/memory_service/test_release_store.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 
 import faulthandler
 import inspect
+import json
 import re
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from datetime import UTC, datetime
 from hashlib import sha256
 from threading import Barrier, Event, RLock
@@ -18,6 +20,7 @@ from typing import TypeVar
 import pytest
 
 import areal.v2.memory_service.release_store as release_store_module
+import areal.v2.memory_service.release_types as release_types_module
 from areal.v2.memory_service.errors import (
     MemoryServiceError,
     ReleaseConflictError,
@@ -35,7 +38,11 @@ from areal.v2.memory_service.release_store import (
     InMemoryMemoryReleaseStore,
     MemoryReleaseStore,
 )
-from areal.v2.memory_service.release_types import MemoryRelease, ReleaseManifest
+from areal.v2.memory_service.release_types import (
+    MemoryRelease,
+    ReleaseManifest,
+    _release_commitment_bytes,
+)
 from areal.v2.memory_service.store import InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
     EvidenceEvent,
@@ -141,9 +148,23 @@ def install_digest_map(
     """Install deterministic release digests for pre-seeded manifests."""
 
     def fake_sha256(canonical_bytes: bytes) -> StubHash:
-        return StubHash(digest_by_bytes[canonical_bytes])
+        return StubHash(
+            digest_by_bytes.get(canonical_bytes, sha256(canonical_bytes).hexdigest())
+        )
 
     monkeypatch.setattr(release_store_module, "sha256", fake_sha256)
+    monkeypatch.setattr(release_types_module, "sha256", fake_sha256)
+
+
+def release_commitment_for(
+    store: InMemoryMemoryReleaseStore,
+    manifest: ReleaseManifest,
+) -> bytes:
+    graph_bytes, _ = store._derive_release_graph(manifest)
+    return _release_commitment_bytes(
+        sha256(manifest.canonical_bytes()).hexdigest(),
+        sha256(graph_bytes).hexdigest(),
+    )
 
 
 def test_run_race_waits_for_workers_before_cancelling_watchdog(
@@ -580,13 +601,32 @@ def test_empty_manifest_is_a_stable_memory_off_release_without_lookup() -> None:
     history = NoLookupHistory()
     store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
     manifest = ReleaseManifest(make_scope(), ())
-    expected_hash = sha256(manifest.canonical_bytes()).hexdigest()
+    expected_graph_bytes = (
+        b'{"ancestry_order":"selected_to_add_root",'
+        b'"record_kind":"memory_release_graph","schema_version":1,'
+        b'"selected_revisions":[]}'
+    )
+    expected_graph_hash = sha256(expected_graph_bytes).hexdigest()
+    expected_commitment = _release_commitment_bytes(
+        sha256(manifest.canonical_bytes()).hexdigest(),
+        expected_graph_hash,
+    )
+    expected_hash = sha256(expected_commitment).hexdigest()
 
     release = store.append_release(manifest, idempotency_key="memory-off")
 
     assert history.lookup_count == 0
     assert release.release_id == f"rel_{expected_hash[:24]}"
     assert release.content_hash == expected_hash
+    assert release.release_graph_sha256 == expected_graph_hash
+    assert release.commitment_bytes() == expected_commitment
+    assert release.release_graph_sha256 == (
+        "f1581b6dd2fc67d76188af8902552c835ec99debd31ec9f1f5f26b8f1e0a81a9"
+    )
+    assert release.content_hash == (
+        "db06eccca5cebc8730e6cf2562fc9f2487a69add6a4ec4486cb96bab7ef1b0a4"
+    )
+    assert release.release_id == "rel_db06eccca5cebc8730e6cf25"
     assert store.get_release_revisions(manifest.scope, release.release_id) == ()
     assert history.lookup_count == 0
     assert store.list_releases(manifest.scope) == (release,)
@@ -787,16 +827,17 @@ def test_changed_same_key_conflicts_before_missing_member_lookup() -> None:
     assert len(store._release_by_idempotency) == 1
 
 
-def test_release_hash_and_identifier_depend_only_on_manifest() -> None:
+def test_release_hash_and_identifier_commit_to_manifest_and_derived_graph() -> None:
     history, _, (root, _, _) = seeded_history()
     manifest = ReleaseManifest(make_scope(), (root.revision_id,))
-    expected_hash = sha256(manifest.canonical_bytes()).hexdigest()
     first_store = InMemoryMemoryReleaseStore(history)
     second_store = InMemoryMemoryReleaseStore(history)
 
     first = first_store.append_release(manifest, idempotency_key="first-key")
     second = second_store.append_release(manifest, idempotency_key="other-key")
 
+    expected_hash = sha256(first.commitment_bytes()).hexdigest()
+    assert first.release_graph_sha256 == second.release_graph_sha256
     assert first.content_hash == second.content_hash == expected_hash
     assert first.release_id == second.release_id == f"rel_{expected_hash[:24]}"
     assert re.fullmatch(r"rel_[0-9a-f]{24}", first.release_id)
@@ -806,21 +847,28 @@ def test_append_release_uses_module_level_sha256(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manifest = ReleaseManifest(make_scope(), ())
-    digest = "a" * 64
     observed_bytes: list[bytes] = []
+    real_sha256 = release_store_module.sha256
 
     def fake_sha256(canonical_bytes: bytes) -> StubHash:
         observed_bytes.append(canonical_bytes)
-        return StubHash(digest)
+        return StubHash(real_sha256(canonical_bytes).hexdigest())
 
     monkeypatch.setattr(release_store_module, "sha256", fake_sha256)
     store = InMemoryMemoryReleaseStore(NoLookupHistory())  # type: ignore[arg-type]
 
     release = store.append_release(manifest, idempotency_key="release-1")
 
-    assert observed_bytes == [manifest.canonical_bytes()]
-    assert release.content_hash == digest
-    assert release.release_id == f"rel_{digest[:24]}"
+    assert observed_bytes == [
+        manifest.canonical_bytes(),
+        (
+            b'{"ancestry_order":"selected_to_add_root",'
+            b'"record_kind":"memory_release_graph","schema_version":1,'
+            b'"selected_revisions":[]}'
+        ),
+        release.commitment_bytes(),
+    ]
+    assert release.content_hash == sha256(release.commitment_bytes()).hexdigest()
 
 
 def test_release_validation_and_commit_obey_exact_lock_epochs(
@@ -898,6 +946,14 @@ def test_release_validation_and_commit_obey_exact_lock_epochs(
             epoch_lock.record_unlocked("history:get")
             return history.get_revision(scope, revision_id)
 
+        def get_candidate(self, scope: MemoryScope, candidate_id: str):
+            epoch_lock.record_unlocked("history:get_candidate")
+            return history.get_candidate(scope, candidate_id)
+
+        def get_candidate_evidence(self, scope: MemoryScope, candidate_id: str):
+            epoch_lock.record_unlocked("history:get_candidate_evidence")
+            return history.get_candidate_evidence(scope, candidate_id)
+
     original_sha256 = release_store_module.sha256
 
     def observed_sha256(canonical_bytes: bytes) -> object:
@@ -917,21 +973,23 @@ def test_release_validation_and_commit_obey_exact_lock_epochs(
     release = store.append_release(manifest, idempotency_key="release-1")
 
     assert epoch_lock.enter_count == 2
-    assert records == [
-        ("sha256", 0),
-        ("lock:enter", 1),
-        ("idempotency:get", 1),
-        ("lock:exit", 1),
-        ("history:get", 1),
-        ("lock:enter", 2),
-        ("idempotency:get", 2),
-        ("release:get", 2),
-        ("release:set", 2),
-        ("idempotency:set", 2),
-        ("scope:setdefault", 2),
-        ("scope:append", 2),
-        ("lock:exit", 2),
-    ]
+    assert records[0] == ("sha256", 0)
+    assert records.count(("lock:enter", 1)) == 1
+    assert records.count(("lock:enter", 2)) == 1
+    assert ("release:set", 2) in records
+    assert ("idempotency:set", 2) in records
+    assert ("scope:set", 2) in records
+    assert all(
+        event
+        not in {
+            "history:get",
+            "history:get_candidate",
+            "history:get_candidate_evidence",
+            "sha256",
+        }
+        or epoch in {0, 1}
+        for event, epoch in records
+    )
 
     records.clear()
     epoch_lock.epoch = 0
@@ -940,18 +998,11 @@ def test_release_validation_and_commit_obey_exact_lock_epochs(
 
     assert alias is release
     assert epoch_lock.enter_count == 2
-    assert records == [
-        ("sha256", 0),
-        ("lock:enter", 1),
-        ("idempotency:get", 1),
-        ("lock:exit", 1),
-        ("history:get", 1),
-        ("lock:enter", 2),
-        ("idempotency:get", 2),
-        ("release:get", 2),
-        ("idempotency:set", 2),
-        ("lock:exit", 2),
-    ]
+    assert records[0] == ("sha256", 0)
+    assert records.count(("lock:enter", 1)) == 1
+    assert records.count(("lock:enter", 2)) == 1
+    assert ("idempotency:set", 2) in records
+    assert ("release:set", 2) not in records
 
 
 def test_get_release_snapshots_identifier_subclass_before_lookup() -> None:
@@ -1044,6 +1095,16 @@ def test_missing_member_error_is_not_rewritten_by_same_key_winner() -> None:
                 missing_lookup_started.set()
                 assert allow_missing_lookup.wait(timeout=RACE_TIMEOUT_SECONDS)
             return history.get_revision(requested_scope, revision_id)
+
+        def get_candidate(self, requested_scope: MemoryScope, candidate_id: str):
+            return history.get_candidate(requested_scope, candidate_id)
+
+        def get_candidate_evidence(
+            self,
+            requested_scope: MemoryScope,
+            candidate_id: str,
+        ):
+            return history.get_candidate_evidence(requested_scope, candidate_id)
 
     store = InMemoryMemoryReleaseStore(BlockingMissingHistory())  # type: ignore[arg-type]
     invalid_manifest = ReleaseManifest(scope, ("rev_missing",))
@@ -1225,7 +1286,7 @@ def test_concurrent_release_collision_is_atomic_and_all_losers_recover(
     keys = tuple(f"collision-release-{index}" for index in range(RACE_SIZE))
     prefix = "a" * 24
     digest_by_bytes = {
-        manifest.canonical_bytes(): (
+        release_commitment_for(store, manifest): (
             prefix + ("b" * 40 if same_full_hash else f"{index:040x}")
         )
         for index, manifest in enumerate(manifests)
@@ -1297,15 +1358,15 @@ def test_forced_release_id_collision_is_isolated_across_scopes(
     digests = tuple(
         prefix + ("d" * 40 if same_full_hash else f"{index:040x}") for index in range(2)
     )
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
     install_digest_map(
         monkeypatch,
         {
-            manifest.canonical_bytes(): digest
+            release_commitment_for(store, manifest): digest
             for manifest, digest in zip(manifests, digests, strict=True)
         },
     )
-    history = NoLookupHistory()
-    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
     store._release_by_id = YieldingMissingDict()  # type: ignore[assignment]
     store._release_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
 
@@ -1351,3 +1412,386 @@ def test_forced_release_id_collision_is_isolated_across_scopes(
         second_scope: [second],
     }
     assert history.lookup_count == 0
+
+
+def make_colliding_root_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    root: MemoryRevision,
+    alternate_candidate_id: str,
+) -> MemoryRevision:
+    """Build a valid alternate full hash behind the same 96-bit address."""
+
+    proposal = RevisionProposal(
+        scope=root.proposal.scope,
+        candidate_id=alternate_candidate_id,
+        operation=RevisionOperation.ADD,
+        parent_revision_id=None,
+        idempotency_key="revision-collision-alternate",
+    )
+    prefix = root.revision_id.removeprefix("rev_")
+    content_hash = prefix + "f" * 40
+    assert content_hash != root.content_hash
+    install_digest_map(monkeypatch, {proposal.canonical_bytes(): content_hash})
+    return MemoryRevision(
+        revision_id=root.revision_id,
+        memory_id=f"mem_{prefix}",
+        generation=0,
+        proposal=proposal,
+        content_hash=content_hash,
+        created_at=UTC_INSTANT,
+    )
+
+
+def test_same_manifest_over_different_valid_full_graphs_has_distinct_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history, _, (root, _, other) = seeded_history()
+    alternate = make_colliding_root_revision(
+        monkeypatch,
+        root=root,
+        alternate_candidate_id=other.proposal.candidate_id,
+    )
+
+    class AlternateHistory:
+        def get_revision(self, scope: MemoryScope, revision_id: str):
+            if revision_id == root.revision_id:
+                return alternate
+            return history.get_revision(scope, revision_id)
+
+        def get_candidate(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate(scope, candidate_id)
+
+        def get_candidate_evidence(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate_evidence(scope, candidate_id)
+
+    manifest = ReleaseManifest(make_scope(), (root.revision_id,))
+    original = InMemoryMemoryReleaseStore(history).append_release(
+        manifest,
+        idempotency_key="original",
+    )
+    collided = InMemoryMemoryReleaseStore(AlternateHistory()).append_release(
+        manifest,
+        idempotency_key="alternate",
+    )
+
+    assert original.manifest == collided.manifest == manifest
+    assert root.revision_id == alternate.revision_id
+    assert root.content_hash != alternate.content_hash
+    assert original.release_graph_sha256 != collided.release_graph_sha256
+    assert original.content_hash != collided.content_hash
+    assert original.release_id != collided.release_id
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("wrong_type", "non-MemoryRevision"),
+        ("wrong_scope", "requested scope"),
+        ("wrong_address", "address"),
+        ("wrong_hash", "canonical commitment"),
+    ],
+)
+def test_append_release_rejects_malicious_revision_values(
+    mutation: str,
+    message: str,
+) -> None:
+    history, _, (root, _, _) = seeded_history()
+    foreign_proposal = RevisionProposal(
+        scope=make_scope(subject_id="attacker"),
+        candidate_id=root.proposal.candidate_id,
+        operation=RevisionOperation.ADD,
+        parent_revision_id=None,
+        idempotency_key="foreign",
+    )
+
+    class MaliciousHistory:
+        def get_revision(self, scope: MemoryScope, revision_id: str):
+            if mutation == "wrong_type":
+                return object()
+            if mutation == "wrong_scope":
+                return replace(root, proposal=foreign_proposal)
+            if mutation == "wrong_address":
+                return replace(root, revision_id="rev_other")
+            return replace(root, content_hash="0" * 64)
+
+        def get_candidate(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate(scope, candidate_id)
+
+        def get_candidate_evidence(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate_evidence(scope, candidate_id)
+
+    store = InMemoryMemoryReleaseStore(MaliciousHistory())  # type: ignore[arg-type]
+    with pytest.raises(ReleaseConflictError, match=message):
+        store.append_release(
+            ReleaseManifest(make_scope(), (root.revision_id,)),
+            idempotency_key="malicious",
+        )
+    assert_release_indexes_empty(store)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("candidate_type", "non-MemoryCandidate"),
+        ("candidate_address", "candidate address"),
+        ("candidate_hash", "candidate canonical commitment"),
+        ("evidence_order", "evidence addresses"),
+        ("evidence_hash", "evidence canonical commitment"),
+    ],
+)
+def test_append_release_rejects_candidate_and_evidence_mutation(
+    mutation: str,
+    message: str,
+) -> None:
+    history, _, (root, _, _) = seeded_history()
+    candidate = history.get_candidate(make_scope(), root.proposal.candidate_id)
+    evidence = history.get_candidate_evidence(make_scope(), candidate.candidate_id)
+
+    class MaliciousHistory:
+        def get_revision(self, scope: MemoryScope, revision_id: str):
+            return history.get_revision(scope, revision_id)
+
+        def get_candidate(self, scope: MemoryScope, candidate_id: str):
+            if mutation == "candidate_type":
+                return object()
+            if mutation == "candidate_address":
+                return replace(candidate, candidate_id="cand_other")
+            if mutation == "candidate_hash":
+                return replace(candidate, content_hash="0" * 64)
+            return history.get_candidate(scope, candidate_id)
+
+        def get_candidate_evidence(self, scope: MemoryScope, candidate_id: str):
+            if mutation == "evidence_order":
+                return tuple(reversed(evidence))
+            if mutation == "evidence_hash":
+                return (replace(evidence[0], content_hash="0" * 64), evidence[1])
+            return history.get_candidate_evidence(scope, candidate_id)
+
+    store = InMemoryMemoryReleaseStore(MaliciousHistory())  # type: ignore[arg-type]
+    with pytest.raises(ReleaseConflictError, match=message):
+        store.append_release(
+            ReleaseManifest(make_scope(), (root.revision_id,)),
+            idempotency_key="malicious-source",
+        )
+    assert_release_indexes_empty(store)
+
+
+def test_release_graph_records_selected_to_add_root_and_excludes_other_branch() -> None:
+    history, left, right = seeded_sibling_revisions()
+    root_id = left.proposal.parent_revision_id
+    assert root_id is not None
+    store = InMemoryMemoryReleaseStore(history)
+    left_manifest = ReleaseManifest(make_scope(), (left.revision_id,))
+    right_manifest = ReleaseManifest(make_scope(), (right.revision_id,))
+
+    left_graph_bytes, _ = store._derive_release_graph(left_manifest)
+    right_graph_bytes, _ = store._derive_release_graph(right_manifest)
+    left_graph = json.loads(left_graph_bytes)
+    ancestry = left_graph["selected_revisions"][0]["ancestry"]
+
+    assert left_graph["ancestry_order"] == "selected_to_add_root"
+    assert [node["revision_id"] for node in ancestry] == [left.revision_id, root_id]
+    assert right.revision_id not in {node["revision_id"] for node in ancestry}
+    assert set(ancestry[0]) == {
+        "candidate",
+        "generation",
+        "memory_id",
+        "revision_id",
+        "revision_sha256",
+    }
+    assert set(ancestry[0]["candidate"]) == {
+        "candidate_id",
+        "candidate_sha256",
+        "evidence",
+    }
+    assert all(
+        set(reference) == {"evidence_id", "evidence_sha256"}
+        for node in ancestry
+        for reference in node["candidate"]["evidence"]
+    )
+    assert b"root memory" not in left_graph_bytes
+    assert b"left sibling" not in left_graph_bytes
+    left_release = store.append_release(left_manifest, idempotency_key="left")
+    right_release = store.append_release(right_manifest, idempotency_key="right")
+    assert left_graph_bytes != right_graph_bytes
+    assert left_release.release_graph_sha256 != right_release.release_graph_sha256
+
+
+def test_deep_release_lineage_is_validated_iteratively() -> None:
+    scope = make_scope()
+    evidence_store = InMemoryEvidenceStore()
+    evidence = evidence_store.append(
+        make_event(
+            scope=scope,
+            sequence_no=0,
+            payload="deep lineage",
+            idempotency_key="deep-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    parent: MemoryRevision | None = None
+    for generation in range(1050):
+        candidate = append_candidate(
+            history,
+            scope=scope,
+            evidence_ids=(evidence.evidence_id,),
+            content=f"memory generation {generation}",
+            idempotency_key=f"deep-candidate-{generation}",
+        )
+        parent = append_revision(
+            history,
+            scope=scope,
+            candidate_id=candidate.candidate_id,
+            operation=(
+                RevisionOperation.ADD if parent is None else RevisionOperation.REFINE
+            ),
+            parent_revision_id=None if parent is None else parent.revision_id,
+            idempotency_key=f"deep-revision-{generation}",
+        )
+    assert parent is not None
+    store = InMemoryMemoryReleaseStore(history)
+    release = store.append_release(
+        ReleaseManifest(scope, (parent.revision_id,)),
+        idempotency_key="deep-release",
+    )
+    assert store.get_release_revisions(scope, release.release_id) == (parent,)
+
+
+def test_append_release_rejects_iterative_ancestry_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history, _, (_, child, _) = seeded_history()
+    cyclic_proposal = RevisionProposal(
+        scope=make_scope(),
+        candidate_id=child.proposal.candidate_id,
+        operation=RevisionOperation.REFINE,
+        parent_revision_id=child.revision_id,
+        idempotency_key="cyclic-revision",
+    )
+    prefix = child.revision_id.removeprefix("rev_")
+    cyclic_hash = prefix + "e" * 40
+    install_digest_map(monkeypatch, {cyclic_proposal.canonical_bytes(): cyclic_hash})
+    cyclic = replace(child, proposal=cyclic_proposal, content_hash=cyclic_hash)
+
+    class CyclicHistory:
+        def get_revision(self, scope: MemoryScope, revision_id: str):
+            return cyclic
+
+        def get_candidate(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate(scope, candidate_id)
+
+        def get_candidate_evidence(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate_evidence(scope, candidate_id)
+
+    store = InMemoryMemoryReleaseStore(CyclicHistory())  # type: ignore[arg-type]
+    with pytest.raises(ReleaseConflictError, match="cycle"):
+        store.append_release(
+            ReleaseManifest(make_scope(), (child.revision_id,)),
+            idempotency_key="cycle",
+        )
+    assert_release_indexes_empty(store)
+
+
+def test_final_graph_recheck_rejects_valid_toctou_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history, _, (root, _, other) = seeded_history()
+    alternate = make_colliding_root_revision(
+        monkeypatch,
+        root=root,
+        alternate_candidate_id=other.proposal.candidate_id,
+    )
+
+    class DriftingHistory:
+        selected_reads = 0
+
+        def get_revision(self, scope: MemoryScope, revision_id: str):
+            self.selected_reads += 1
+            return root if self.selected_reads == 1 else alternate
+
+        def get_candidate(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate(scope, candidate_id)
+
+        def get_candidate_evidence(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate_evidence(scope, candidate_id)
+
+    store = InMemoryMemoryReleaseStore(DriftingHistory())  # type: ignore[arg-type]
+    with pytest.raises(ReleaseConflictError, match="final graph recheck"):
+        store.append_release(
+            ReleaseManifest(make_scope(), (root.revision_id,)),
+            idempotency_key="toctou",
+        )
+    assert_release_indexes_empty(store)
+
+
+def test_get_release_revisions_rejects_valid_committed_graph_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history, _, (root, _, other) = seeded_history()
+    alternate = make_colliding_root_revision(
+        monkeypatch,
+        root=root,
+        alternate_candidate_id=other.proposal.candidate_id,
+    )
+
+    class MutableHistory:
+        drift = False
+
+        def get_revision(self, scope: MemoryScope, revision_id: str):
+            if self.drift and revision_id == root.revision_id:
+                return alternate
+            return history.get_revision(scope, revision_id)
+
+        def get_candidate(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate(scope, candidate_id)
+
+        def get_candidate_evidence(self, scope: MemoryScope, candidate_id: str):
+            return history.get_candidate_evidence(scope, candidate_id)
+
+    mutable_history = MutableHistory()
+    store = InMemoryMemoryReleaseStore(mutable_history)  # type: ignore[arg-type]
+    release = store.append_release(
+        ReleaseManifest(make_scope(), (root.revision_id,)),
+        idempotency_key="stable",
+    )
+    mutable_history.drift = True
+
+    with pytest.raises(ReleaseConflictError, match="committed release identity"):
+        store.get_release_revisions(make_scope(), release.release_id)
+
+
+class PublicationInterrupted(BaseException):
+    pass
+
+
+class SetThenInterruptDict(dict[object, object]):
+    def __setitem__(self, key: object, value: object) -> None:
+        super().__setitem__(key, value)
+        raise PublicationInterrupted
+
+
+def test_interrupted_second_release_index_rolls_back_every_write() -> None:
+    store = InMemoryMemoryReleaseStore(NoLookupHistory())  # type: ignore[arg-type]
+    store._release_by_idempotency = SetThenInterruptDict()  # type: ignore[assignment]
+
+    with pytest.raises(PublicationInterrupted):
+        store.append_release(
+            ReleaseManifest(make_scope(), ()),
+            idempotency_key="interrupt-second",
+        )
+
+    assert_release_indexes_empty(store)
+
+
+def test_interrupted_third_release_index_rolls_back_every_write() -> None:
+    store = InMemoryMemoryReleaseStore(NoLookupHistory())  # type: ignore[arg-type]
+    store._releases_by_scope = SetThenInterruptDict()  # type: ignore[assignment]
+
+    with pytest.raises(PublicationInterrupted):
+        store.append_release(
+            ReleaseManifest(make_scope(), ()),
+            idempotency_key="interrupt-third",
+        )
+
+    assert_release_indexes_empty(store)

--- a/tests/v2/memory_service/test_release_store.py
+++ b/tests/v2/memory_service/test_release_store.py
@@ -229,6 +229,43 @@ def seeded_history(
     return history, (first_evidence, second_evidence), (root, child, other)
 
 
+def seeded_sibling_revisions() -> tuple[
+    InMemoryMemoryHistoryStore,
+    MemoryRevision,
+    MemoryRevision,
+]:
+    history, _, (root, _, _) = seeded_history()
+    scope = root.proposal.scope
+    root_evidence_id = history.get_candidate(
+        scope, root.proposal.candidate_id
+    ).proposal.evidence_ids[0]
+    siblings = []
+    for side, operation in (
+        ("left", RevisionOperation.REFINE),
+        ("right", RevisionOperation.CONTRADICT),
+    ):
+        candidate = append_candidate(
+            history,
+            scope=scope,
+            evidence_ids=(root_evidence_id,),
+            content=f"{side} sibling",
+            idempotency_key=f"candidate-{side}",
+        )
+        siblings.append(
+            append_revision(
+                history,
+                scope=scope,
+                candidate_id=candidate.candidate_id,
+                operation=operation,
+                parent_revision_id=root.revision_id,
+                idempotency_key=f"revision-{side}",
+            )
+        )
+    left, right = siblings
+    assert left.memory_id == right.memory_id == root.memory_id
+    return history, left, right
+
+
 def assert_release_indexes_empty(store: InMemoryMemoryReleaseStore) -> None:
     assert store._release_by_id == {}
     assert store._release_by_idempotency == {}
@@ -399,43 +436,8 @@ def test_foreign_revision_is_indistinguishable_from_missing() -> None:
 
 
 def test_sibling_revisions_conflict_in_one_manifest_but_release_separately() -> None:
-    history, _, (root, _, _) = seeded_history()
-    scope = make_scope()
-    # Reuse a real evidence identifier from the existing root candidate.
-    root_evidence_id = history.get_candidate(
-        scope, root.proposal.candidate_id
-    ).proposal.evidence_ids[0]
-    left_candidate = append_candidate(
-        history,
-        scope=scope,
-        evidence_ids=(root_evidence_id,),
-        content="left sibling",
-        idempotency_key="candidate-left",
-    )
-    right_candidate = append_candidate(
-        history,
-        scope=scope,
-        evidence_ids=(root_evidence_id,),
-        content="right sibling",
-        idempotency_key="candidate-right",
-    )
-    left = append_revision(
-        history,
-        scope=scope,
-        candidate_id=left_candidate.candidate_id,
-        operation=RevisionOperation.REFINE,
-        parent_revision_id=root.revision_id,
-        idempotency_key="revision-left",
-    )
-    right = append_revision(
-        history,
-        scope=scope,
-        candidate_id=right_candidate.candidate_id,
-        operation=RevisionOperation.CONTRADICT,
-        parent_revision_id=root.revision_id,
-        idempotency_key="revision-right",
-    )
-    assert left.memory_id == right.memory_id
+    history, left, right = seeded_sibling_revisions()
+    scope = left.proposal.scope
     store = InMemoryMemoryReleaseStore(history)
 
     with pytest.raises(ReleaseConflictError, match="memory_id"):
@@ -452,6 +454,20 @@ def test_sibling_revisions_conflict_in_one_manifest_but_release_separately() -> 
         ReleaseManifest(scope, (right.revision_id,)), idempotency_key="release-right"
     )
     assert set(store.list_releases(scope)) == {left_release, right_release}
+
+
+def test_missing_member_precedes_duplicate_memory_conflict() -> None:
+    history, left, right = seeded_sibling_revisions()
+    store = InMemoryMemoryReleaseStore(history)
+    manifest = ReleaseManifest(
+        left.proposal.scope,
+        (left.revision_id, right.revision_id, "rev_missing"),
+    )
+
+    with pytest.raises(RevisionNotFoundError, match="rev_missing"):
+        store.append_release(manifest, idempotency_key="release-invalid")
+
+    assert_release_indexes_empty(store)
 
 
 def test_same_key_retry_returns_original_release() -> None:

--- a/tests/v2/memory_service/test_release_store.py
+++ b/tests/v2/memory_service/test_release_store.py
@@ -11,6 +11,7 @@ from hashlib import sha256
 
 import pytest
 
+from areal.v2.memory_service import release_store as release_store_module
 from areal.v2.memory_service.errors import (
     MemoryServiceError,
     ReleaseConflictError,
@@ -70,6 +71,16 @@ class NoLookupHistory:
     def get_revision(self, scope: MemoryScope, revision_id: str) -> MemoryRevision:
         self.lookup_count += 1
         raise AssertionError("release unexpectedly looked up a revision")
+
+
+class StubHash:
+    """Return one test-controlled hexadecimal digest."""
+
+    def __init__(self, digest: str) -> None:
+        self._digest = digest
+
+    def hexdigest(self) -> str:
+        return self._digest
 
 
 UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, tzinfo=UTC)
@@ -521,6 +532,27 @@ def test_release_hash_and_identifier_depend_only_on_manifest() -> None:
     assert first.content_hash == second.content_hash == expected_hash
     assert first.release_id == second.release_id == f"rel_{expected_hash[:24]}"
     assert re.fullmatch(r"rel_[0-9a-f]{24}", first.release_id)
+
+
+def test_append_release_uses_module_level_sha256(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = ReleaseManifest(make_scope(), ())
+    digest = "a" * 64
+    observed_bytes: list[bytes] = []
+
+    def fake_sha256(canonical_bytes: bytes) -> StubHash:
+        observed_bytes.append(canonical_bytes)
+        return StubHash(digest)
+
+    monkeypatch.setattr(release_store_module, "sha256", fake_sha256)
+    store = InMemoryMemoryReleaseStore(NoLookupHistory())  # type: ignore[arg-type]
+
+    release = store.append_release(manifest, idempotency_key="release-1")
+
+    assert observed_bytes == [manifest.canonical_bytes()]
+    assert release.content_hash == digest
+    assert release.release_id == f"rel_{digest[:24]}"
 
 
 def test_get_release_snapshots_identifier_subclass_before_lookup() -> None:

--- a/tests/v2/memory_service/test_release_store.py
+++ b/tests/v2/memory_service/test_release_store.py
@@ -1,0 +1,597 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for immutable Memory Service release manifests."""
+
+from __future__ import annotations
+
+import inspect
+import re
+from datetime import UTC, datetime
+from hashlib import sha256
+
+import pytest
+
+from areal.v2.memory_service.errors import (
+    MemoryServiceError,
+    ReleaseConflictError,
+    ReleaseNotFoundError,
+    RevisionNotFoundError,
+)
+from areal.v2.memory_service.history_store import InMemoryMemoryHistoryStore
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
+)
+from areal.v2.memory_service.release_store import (
+    InMemoryMemoryReleaseStore,
+    MemoryReleaseStore,
+)
+from areal.v2.memory_service.release_types import ReleaseManifest
+from areal.v2.memory_service.store import InMemoryEvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+
+class MutableHashStr(str):
+    """A string subclass that exposes unsafe hashing before snapshotting."""
+
+    hash_calls: int
+
+    def __new__(cls, value: str) -> MutableHashStr:
+        instance = str.__new__(cls, value)
+        instance.hash_calls = 0
+        return instance
+
+    def __hash__(self) -> int:
+        self.hash_calls += 1
+        return str.__hash__(self) + self.hash_calls
+
+
+class MemoryScopeSubclass(MemoryScope):
+    pass
+
+
+class ReleaseManifestSubclass(ReleaseManifest):
+    pass
+
+
+class NoLookupHistory:
+    """History stub that fails if an empty release performs member lookup."""
+
+    def __init__(self) -> None:
+        self.lookup_count = 0
+
+    def get_revision(self, scope: MemoryScope, revision_id: str) -> MemoryRevision:
+        self.lookup_count += 1
+        raise AssertionError("release unexpectedly looked up a revision")
+
+
+UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, tzinfo=UTC)
+LONE_SURROGATE = "\ud800"
+
+
+def make_scope(**overrides: str) -> MemoryScope:
+    values = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)
+
+
+def make_event(
+    *,
+    scope: MemoryScope,
+    sequence_no: int,
+    payload: str,
+    idempotency_key: str,
+) -> EvidenceEvent:
+    return EvidenceEvent(
+        scope=scope,
+        session_id="session-1",
+        run_id="run-1",
+        sequence_no=sequence_no,
+        kind=EvidenceKind.USER_MESSAGE,
+        payload=payload,
+        observed_at=UTC_INSTANT,
+        idempotency_key=idempotency_key,
+    )
+
+
+def append_candidate(
+    history: InMemoryMemoryHistoryStore,
+    *,
+    scope: MemoryScope,
+    evidence_ids: tuple[str, ...],
+    content: str,
+    idempotency_key: str,
+):
+    return history.append_candidate(
+        CandidateProposal(
+            scope=scope,
+            content=content,
+            evidence_ids=evidence_ids,
+            idempotency_key=idempotency_key,
+        )
+    )
+
+
+def append_revision(
+    history: InMemoryMemoryHistoryStore,
+    *,
+    scope: MemoryScope,
+    candidate_id: str,
+    operation: RevisionOperation,
+    parent_revision_id: str | None,
+    idempotency_key: str,
+) -> MemoryRevision:
+    return history.append_revision(
+        RevisionProposal(
+            scope=scope,
+            candidate_id=candidate_id,
+            operation=operation,
+            parent_revision_id=parent_revision_id,
+            idempotency_key=idempotency_key,
+        )
+    )
+
+
+def seeded_history(
+    *,
+    scope: MemoryScope | None = None,
+) -> tuple[
+    InMemoryMemoryHistoryStore,
+    tuple[EvidenceRecord, EvidenceRecord],
+    tuple[MemoryRevision, MemoryRevision, MemoryRevision],
+]:
+    scope = scope or make_scope()
+    evidence_store = InMemoryEvidenceStore()
+    first_evidence = evidence_store.append(
+        make_event(
+            scope=scope,
+            sequence_no=0,
+            payload="first observation",
+            idempotency_key="evidence-1",
+        )
+    )
+    second_evidence = evidence_store.append(
+        make_event(
+            scope=scope,
+            sequence_no=1,
+            payload="second observation",
+            idempotency_key="evidence-2",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+    root_candidate = append_candidate(
+        history,
+        scope=scope,
+        evidence_ids=(second_evidence.evidence_id, first_evidence.evidence_id),
+        content="root memory",
+        idempotency_key="candidate-root",
+    )
+    root = append_revision(
+        history,
+        scope=scope,
+        candidate_id=root_candidate.candidate_id,
+        operation=RevisionOperation.ADD,
+        parent_revision_id=None,
+        idempotency_key="revision-root",
+    )
+    child_candidate = append_candidate(
+        history,
+        scope=scope,
+        evidence_ids=(first_evidence.evidence_id,),
+        content="refined memory",
+        idempotency_key="candidate-child",
+    )
+    child = append_revision(
+        history,
+        scope=scope,
+        candidate_id=child_candidate.candidate_id,
+        operation=RevisionOperation.REFINE,
+        parent_revision_id=root.revision_id,
+        idempotency_key="revision-child",
+    )
+    other_candidate = append_candidate(
+        history,
+        scope=scope,
+        evidence_ids=(second_evidence.evidence_id,),
+        content="independent memory",
+        idempotency_key="candidate-other",
+    )
+    other = append_revision(
+        history,
+        scope=scope,
+        candidate_id=other_candidate.candidate_id,
+        operation=RevisionOperation.ADD,
+        parent_revision_id=None,
+        idempotency_key="revision-other",
+    )
+    return history, (first_evidence, second_evidence), (root, child, other)
+
+
+def assert_release_indexes_empty(store: InMemoryMemoryReleaseStore) -> None:
+    assert store._release_by_id == {}
+    assert store._release_by_idempotency == {}
+    assert store._releases_by_scope == {}
+
+
+def test_release_contract_exposes_only_immutable_manifest_api() -> None:
+    expected = {
+        "append_release",
+        "get_release",
+        "get_release_revisions",
+        "list_releases",
+    }
+    protocol_methods = {
+        name
+        for name, value in inspect.getmembers(MemoryReleaseStore)
+        if not name.startswith("_") and callable(value)
+    }
+    implementation_methods = {
+        name
+        for name, value in inspect.getmembers(InMemoryMemoryReleaseStore)
+        if not name.startswith("_") and callable(value)
+    }
+
+    assert protocol_methods == expected
+    assert implementation_methods == expected
+
+
+def test_release_errors_share_memory_service_base() -> None:
+    assert issubclass(ReleaseNotFoundError, MemoryServiceError)
+    assert issubclass(ReleaseConflictError, MemoryServiceError)
+
+
+def test_release_resolves_revisions_in_manifest_order_with_evidence_provenance() -> (
+    None
+):
+    history, (first_evidence, second_evidence), (root, child, other) = seeded_history()
+    store = InMemoryMemoryReleaseStore(history)
+    manifest = ReleaseManifest(
+        scope=make_scope(),
+        revision_ids=(other.revision_id, child.revision_id),
+    )
+
+    release = store.append_release(manifest, idempotency_key="release-1")
+
+    assert release.manifest is manifest
+    assert store.get_release_revisions(manifest.scope, release.release_id) == (
+        other,
+        child,
+    )
+    assert history.get_candidate_evidence(
+        manifest.scope, root.proposal.candidate_id
+    ) == (second_evidence, first_evidence)
+    assert history.get_candidate_evidence(
+        manifest.scope, child.proposal.candidate_id
+    ) == (first_evidence,)
+
+
+def test_empty_manifest_is_a_stable_memory_off_release_without_lookup() -> None:
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+    manifest = ReleaseManifest(make_scope(), ())
+    expected_hash = sha256(manifest.canonical_bytes()).hexdigest()
+
+    release = store.append_release(manifest, idempotency_key="memory-off")
+
+    assert history.lookup_count == 0
+    assert release.release_id == f"rel_{expected_hash[:24]}"
+    assert release.content_hash == expected_hash
+    assert store.get_release_revisions(manifest.scope, release.release_id) == ()
+    assert history.lookup_count == 0
+    assert store.list_releases(manifest.scope) == (release,)
+
+
+def test_append_release_requires_exact_manifest_before_any_write_or_lookup() -> None:
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+    subclass = ReleaseManifestSubclass(make_scope(), ())
+
+    with pytest.raises(TypeError, match="manifest must be a ReleaseManifest"):
+        store.append_release(subclass, idempotency_key="release-1")
+    with pytest.raises(TypeError, match="manifest must be a ReleaseManifest"):
+        store.append_release(object(), idempotency_key="release-2")  # type: ignore[arg-type]
+
+    assert history.lookup_count == 0
+    assert_release_indexes_empty(store)
+
+
+@pytest.mark.parametrize("idempotency_key", [None, 7, b"key"])
+def test_append_release_rejects_non_string_idempotency_key(
+    idempotency_key: object,
+) -> None:
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="idempotency_key"):
+        store.append_release(
+            ReleaseManifest(make_scope(), ()),
+            idempotency_key=idempotency_key,  # type: ignore[arg-type]
+        )
+
+    assert history.lookup_count == 0
+    assert_release_indexes_empty(store)
+
+
+@pytest.mark.parametrize("idempotency_key", ["", " \t\n", LONE_SURROGATE])
+def test_append_release_rejects_blank_or_non_utf8_idempotency_key(
+    idempotency_key: str,
+) -> None:
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="idempotency_key"):
+        store.append_release(
+            ReleaseManifest(make_scope(), ()),
+            idempotency_key=idempotency_key,
+        )
+
+    assert history.lookup_count == 0
+    assert_release_indexes_empty(store)
+
+
+def test_append_release_snapshots_idempotency_key_before_indexing() -> None:
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+    key = MutableHashStr("release-1")
+
+    release = store.append_release(
+        ReleaseManifest(make_scope(), ()), idempotency_key=key
+    )
+
+    assert key.hash_calls == 0
+    stored_scope, stored_key = next(iter(store._release_by_idempotency))
+    assert stored_scope == make_scope()
+    assert type(stored_key) is str
+    assert stored_key == "release-1"
+    assert store._release_by_idempotency[(make_scope(), "release-1")] is release
+
+
+def test_missing_revision_leaves_all_release_indexes_empty() -> None:
+    history = InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+    store = InMemoryMemoryReleaseStore(history)
+    manifest = ReleaseManifest(make_scope(), ("rev_missing",))
+
+    with pytest.raises(RevisionNotFoundError, match="rev_missing"):
+        store.append_release(manifest, idempotency_key="release-1")
+
+    assert_release_indexes_empty(store)
+
+
+def test_foreign_revision_is_indistinguishable_from_missing() -> None:
+    foreign_scope = make_scope(subject_id="user-2")
+    foreign_history, _, (foreign_revision, _, _) = seeded_history(scope=foreign_scope)
+    foreign_store = InMemoryMemoryReleaseStore(foreign_history)
+    missing_store = InMemoryMemoryReleaseStore(
+        InMemoryMemoryHistoryStore(InMemoryEvidenceStore())
+    )
+    manifest = ReleaseManifest(make_scope(), (foreign_revision.revision_id,))
+
+    with pytest.raises(RevisionNotFoundError) as foreign_error:
+        foreign_store.append_release(manifest, idempotency_key="release-1")
+    with pytest.raises(RevisionNotFoundError) as missing_error:
+        missing_store.append_release(manifest, idempotency_key="release-1")
+
+    assert type(foreign_error.value) is RevisionNotFoundError
+    assert str(foreign_error.value) == str(missing_error.value)
+    assert_release_indexes_empty(foreign_store)
+
+
+def test_sibling_revisions_conflict_in_one_manifest_but_release_separately() -> None:
+    history, _, (root, _, _) = seeded_history()
+    scope = make_scope()
+    # Reuse a real evidence identifier from the existing root candidate.
+    root_evidence_id = history.get_candidate(
+        scope, root.proposal.candidate_id
+    ).proposal.evidence_ids[0]
+    left_candidate = append_candidate(
+        history,
+        scope=scope,
+        evidence_ids=(root_evidence_id,),
+        content="left sibling",
+        idempotency_key="candidate-left",
+    )
+    right_candidate = append_candidate(
+        history,
+        scope=scope,
+        evidence_ids=(root_evidence_id,),
+        content="right sibling",
+        idempotency_key="candidate-right",
+    )
+    left = append_revision(
+        history,
+        scope=scope,
+        candidate_id=left_candidate.candidate_id,
+        operation=RevisionOperation.REFINE,
+        parent_revision_id=root.revision_id,
+        idempotency_key="revision-left",
+    )
+    right = append_revision(
+        history,
+        scope=scope,
+        candidate_id=right_candidate.candidate_id,
+        operation=RevisionOperation.CONTRADICT,
+        parent_revision_id=root.revision_id,
+        idempotency_key="revision-right",
+    )
+    assert left.memory_id == right.memory_id
+    store = InMemoryMemoryReleaseStore(history)
+
+    with pytest.raises(ReleaseConflictError, match="memory_id"):
+        store.append_release(
+            ReleaseManifest(scope, (left.revision_id, right.revision_id)),
+            idempotency_key="release-both",
+        )
+    assert_release_indexes_empty(store)
+
+    left_release = store.append_release(
+        ReleaseManifest(scope, (left.revision_id,)), idempotency_key="release-left"
+    )
+    right_release = store.append_release(
+        ReleaseManifest(scope, (right.revision_id,)), idempotency_key="release-right"
+    )
+    assert set(store.list_releases(scope)) == {left_release, right_release}
+
+
+def test_same_key_retry_returns_original_release() -> None:
+    history, _, (root, _, _) = seeded_history()
+    store = InMemoryMemoryReleaseStore(history)
+    manifest = ReleaseManifest(make_scope(), (root.revision_id,))
+
+    first = store.append_release(manifest, idempotency_key="release-1")
+    retry = store.append_release(
+        ReleaseManifest(manifest.scope, manifest.revision_ids),
+        idempotency_key="release-1",
+    )
+
+    assert retry is first
+    assert store.list_releases(manifest.scope) == (first,)
+    assert len(store._release_by_id) == 1
+    assert len(store._release_by_idempotency) == 1
+
+
+def test_new_key_aliases_existing_release_without_duplicate_list_entry() -> None:
+    history, _, (root, _, _) = seeded_history()
+    store = InMemoryMemoryReleaseStore(history)
+    manifest = ReleaseManifest(make_scope(), (root.revision_id,))
+
+    first = store.append_release(manifest, idempotency_key="release-1")
+    alias = store.append_release(manifest, idempotency_key="release-2")
+
+    assert alias is first
+    assert store.list_releases(manifest.scope) == (first,)
+    assert len(store._release_by_id) == 1
+    assert len(store._release_by_idempotency) == 2
+
+
+def test_empty_control_aliases_across_keys_without_history_lookup() -> None:
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+    manifest = ReleaseManifest(make_scope(), ())
+
+    first = store.append_release(manifest, idempotency_key="memory-off-1")
+    alias = store.append_release(manifest, idempotency_key="memory-off-2")
+
+    assert alias is first
+    assert history.lookup_count == 0
+    assert store.list_releases(manifest.scope) == (first,)
+    assert len(store._release_by_idempotency) == 2
+
+
+def test_changed_same_key_conflicts_before_missing_member_lookup() -> None:
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+    scope = make_scope()
+    first = store.append_release(
+        ReleaseManifest(scope, ()), idempotency_key="release-1"
+    )
+
+    with pytest.raises(ReleaseConflictError, match="idempotency"):
+        store.append_release(
+            ReleaseManifest(scope, ("rev_missing",)),
+            idempotency_key="release-1",
+        )
+
+    assert history.lookup_count == 0
+    assert store.list_releases(scope) == (first,)
+    assert len(store._release_by_id) == 1
+    assert len(store._release_by_idempotency) == 1
+
+
+def test_release_hash_and_identifier_depend_only_on_manifest() -> None:
+    history, _, (root, _, _) = seeded_history()
+    manifest = ReleaseManifest(make_scope(), (root.revision_id,))
+    expected_hash = sha256(manifest.canonical_bytes()).hexdigest()
+    first_store = InMemoryMemoryReleaseStore(history)
+    second_store = InMemoryMemoryReleaseStore(history)
+
+    first = first_store.append_release(manifest, idempotency_key="first-key")
+    second = second_store.append_release(manifest, idempotency_key="other-key")
+
+    assert first.content_hash == second.content_hash == expected_hash
+    assert first.release_id == second.release_id == f"rel_{expected_hash[:24]}"
+    assert re.fullmatch(r"rel_[0-9a-f]{24}", first.release_id)
+
+
+def test_get_release_snapshots_identifier_subclass_before_lookup() -> None:
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+    release = store.append_release(
+        ReleaseManifest(make_scope(), ()), idempotency_key="release-1"
+    )
+    release_id = MutableHashStr(release.release_id)
+
+    assert store.get_release(make_scope(), release_id) is release
+    assert release_id.hash_calls == 0
+
+
+@pytest.mark.parametrize("release_id", ["", " \t\n"])
+def test_blank_release_identifier_is_reported_as_not_found(release_id: str) -> None:
+    store = InMemoryMemoryReleaseStore(NoLookupHistory())  # type: ignore[arg-type]
+
+    with pytest.raises(ReleaseNotFoundError):
+        store.get_release(make_scope(), release_id)
+
+
+def test_release_queries_require_exact_scope() -> None:
+    store = InMemoryMemoryReleaseStore(NoLookupHistory())  # type: ignore[arg-type]
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        store.get_release(scope, "rel_missing")
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        store.get_release_revisions(scope, "rel_missing")
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        store.list_releases(scope)
+
+
+def test_foreign_release_is_indistinguishable_from_missing() -> None:
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+    foreign_scope = make_scope(subject_id="user-2")
+    release = store.append_release(
+        ReleaseManifest(foreign_scope, ()), idempotency_key="release-1"
+    )
+
+    with pytest.raises(ReleaseNotFoundError) as foreign_error:
+        store.get_release(make_scope(), release.release_id)
+    with pytest.raises(ReleaseNotFoundError) as missing_error:
+        InMemoryMemoryReleaseStore(history).get_release(
+            make_scope(), release.release_id
+        )
+
+    assert type(foreign_error.value) is ReleaseNotFoundError
+    assert str(foreign_error.value) == str(missing_error.value)
+
+
+def test_list_releases_is_sorted_and_previous_tuple_stays_stable() -> None:
+    history, _, (root, child, other) = seeded_history()
+    store = InMemoryMemoryReleaseStore(history)
+    scope = make_scope()
+    first = store.append_release(
+        ReleaseManifest(scope, (root.revision_id,)), idempotency_key="release-root"
+    )
+    second = store.append_release(
+        ReleaseManifest(scope, (other.revision_id,)), idempotency_key="release-other"
+    )
+    snapshot = store.list_releases(scope)
+
+    third = store.append_release(
+        ReleaseManifest(scope, (child.revision_id,)), idempotency_key="release-child"
+    )
+
+    assert snapshot == tuple(sorted((first, second), key=lambda item: item.release_id))
+    assert third not in snapshot
+    assert store.list_releases(scope) == tuple(
+        sorted((first, second, third), key=lambda item: item.release_id)
+    )

--- a/tests/v2/memory_service/test_release_store.py
+++ b/tests/v2/memory_service/test_release_store.py
@@ -168,25 +168,70 @@ def test_run_race_waits_for_workers_before_cancelling_watchdog(
         ("cancel",),
     ]
 
+    real_executor = ThreadPoolExecutor
+    slow_workers_ready = Event()
+    ready_count = 0
+    ready_lock = RLock()
+    shutdown_started = Event()
+    shutdown_finished = Event()
     finished: set[int] = set()
     finished_lock = RLock()
 
+    class ObservedExecutor(real_executor):
+        def shutdown(
+            self,
+            wait: bool = True,
+            *,
+            cancel_futures: bool = False,
+        ) -> None:
+            assert wait is True
+            shutdown_started.set()
+            events.append(("shutdown:start", wait, cancel_futures))
+            super().shutdown(wait=True, cancel_futures=cancel_futures)
+            shutdown_finished.set()
+            events.append(("shutdown:finish",))
+
+    def record_cancel_after_shutdown() -> None:
+        with finished_lock:
+            assert finished == set(range(1, RACE_SIZE))
+        assert shutdown_finished.is_set()
+        events.append(("cancel",))
+
     def fail_or_finish(item: int) -> object:
         if item == 0:
+            assert slow_workers_ready.wait(timeout=RACE_TIMEOUT_SECONDS)
             raise RuntimeError("worker failed")
-        sleep(0.15)
+        nonlocal ready_count
+        with ready_lock:
+            ready_count += 1
+            if ready_count == RACE_SIZE - 1:
+                slow_workers_ready.set()
+        assert shutdown_started.wait(timeout=RACE_TIMEOUT_SECONDS)
         with finished_lock:
             finished.add(item)
         return item
 
     events.clear()
-    started_at = monotonic()
+    monkeypatch.setattr(
+        faulthandler,
+        "cancel_dump_traceback_later",
+        record_cancel_after_shutdown,
+    )
+    monkeypatch.setitem(
+        run_race.__globals__,
+        "ThreadPoolExecutor",
+        ObservedExecutor,
+    )
     with pytest.raises(RuntimeError, match="worker failed"):
         run_race(tuple(range(RACE_SIZE)), fail_or_finish)
-    assert monotonic() - started_at >= 0.1
+    assert slow_workers_ready.is_set()
+    assert shutdown_started.is_set()
+    assert shutdown_finished.is_set()
     assert finished == set(range(1, RACE_SIZE))
     assert events == [
         ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("shutdown:start", True, False),
+        ("shutdown:finish",),
         ("cancel",),
     ]
 

--- a/tests/v2/memory_service/test_release_store.py
+++ b/tests/v2/memory_service/test_release_store.py
@@ -4,14 +4,20 @@
 
 from __future__ import annotations
 
+import faulthandler
 import inspect
 import re
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from hashlib import sha256
+from threading import Barrier, Event, RLock
+from time import monotonic, sleep
+from typing import TypeVar
 
 import pytest
 
-from areal.v2.memory_service import release_store as release_store_module
+import areal.v2.memory_service.release_store as release_store_module
 from areal.v2.memory_service.errors import (
     MemoryServiceError,
     ReleaseConflictError,
@@ -29,7 +35,7 @@ from areal.v2.memory_service.release_store import (
     InMemoryMemoryReleaseStore,
     MemoryReleaseStore,
 )
-from areal.v2.memory_service.release_types import ReleaseManifest
+from areal.v2.memory_service.release_types import MemoryRelease, ReleaseManifest
 from areal.v2.memory_service.store import InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
     EvidenceEvent,
@@ -73,6 +79,16 @@ class NoLookupHistory:
         raise AssertionError("release unexpectedly looked up a revision")
 
 
+class YieldingMissingDict(dict[object, object]):
+    """Yield after a missing lookup to expose an unprotected check/write race."""
+
+    def get(self, key: object, default: object = None) -> object:
+        value = super().get(key, default)
+        if value is default:
+            sleep(0.02)
+        return value
+
+
 class StubHash:
     """Return one test-controlled hexadecimal digest."""
 
@@ -85,6 +101,151 @@ class StubHash:
 
 UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, tzinfo=UTC)
 LONE_SURROGATE = "\ud800"
+RACE_SIZE = 16
+RACE_TIMEOUT_SECONDS = 10.0
+HARD_RACE_TIMEOUT_SECONDS = 15.0
+T = TypeVar("T")
+
+
+def run_race(
+    items: tuple[T, ...], operation: Callable[[T], object]
+) -> tuple[object, ...]:
+    """Release callers together and apply one deadline to result collection."""
+
+    barrier = Barrier(len(items), timeout=RACE_TIMEOUT_SECONDS)
+
+    def worker(item: T) -> object:
+        barrier.wait()
+        try:
+            return operation(item)
+        except MemoryServiceError as error:
+            return error
+
+    faulthandler.dump_traceback_later(HARD_RACE_TIMEOUT_SECONDS, exit=True)
+    try:
+        with ThreadPoolExecutor(max_workers=len(items)) as executor:
+            futures = tuple(executor.submit(worker, item) for item in items)
+            deadline = monotonic() + RACE_TIMEOUT_SECONDS
+            return tuple(
+                future.result(timeout=max(0.0, deadline - monotonic()))
+                for future in futures
+            )
+    finally:
+        faulthandler.cancel_dump_traceback_later()
+
+
+def install_digest_map(
+    monkeypatch: pytest.MonkeyPatch,
+    digest_by_bytes: dict[bytes, str],
+) -> None:
+    """Install deterministic release digests for pre-seeded manifests."""
+
+    def fake_sha256(canonical_bytes: bytes) -> StubHash:
+        return StubHash(digest_by_bytes[canonical_bytes])
+
+    monkeypatch.setattr(release_store_module, "sha256", fake_sha256)
+
+
+def test_run_race_waits_for_workers_before_cancelling_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[object, ...]] = []
+
+    def record_arm(timeout: float, *, exit: bool) -> None:
+        events.append(("arm", timeout, exit))
+
+    def record_cancel() -> None:
+        events.append(("cancel",))
+
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", record_arm)
+    monkeypatch.setattr(faulthandler, "cancel_dump_traceback_later", record_cancel)
+
+    assert run_race(tuple(range(RACE_SIZE)), lambda item: item) == tuple(
+        range(RACE_SIZE)
+    )
+    assert events == [
+        ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("cancel",),
+    ]
+
+    finished: set[int] = set()
+    finished_lock = RLock()
+
+    def fail_or_finish(item: int) -> object:
+        if item == 0:
+            raise RuntimeError("worker failed")
+        sleep(0.15)
+        with finished_lock:
+            finished.add(item)
+        return item
+
+    events.clear()
+    started_at = monotonic()
+    with pytest.raises(RuntimeError, match="worker failed"):
+        run_race(tuple(range(RACE_SIZE)), fail_or_finish)
+    assert monotonic() - started_at >= 0.1
+    assert finished == set(range(1, RACE_SIZE))
+    assert events == [
+        ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("cancel",),
+    ]
+
+
+def test_run_race_watchdog_wraps_executor_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[object, ...]] = []
+
+    def record_arm(timeout: float, *, exit: bool) -> None:
+        events.append(("arm", timeout, exit))
+
+    def record_cancel() -> None:
+        events.append(("cancel",))
+
+    class FailingFuture:
+        def result(self, timeout: float) -> object:
+            events.append(("result",))
+            raise RuntimeError("worker failed")
+
+    class StubExecutor:
+        def __init__(self, *, max_workers: int) -> None:
+            events.append(("executor:init", max_workers))
+
+        def __enter__(self) -> StubExecutor:
+            events.append(("executor:enter",))
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: object,
+        ) -> None:
+            events.append(("executor:exit", exc_type))
+
+        def submit(
+            self,
+            operation: Callable[[int], object],
+            item: int,
+        ) -> FailingFuture:
+            events.append(("submit", item))
+            return FailingFuture()
+
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", record_arm)
+    monkeypatch.setattr(faulthandler, "cancel_dump_traceback_later", record_cancel)
+    monkeypatch.setitem(run_race.__globals__, "ThreadPoolExecutor", StubExecutor)
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        run_race((0,), lambda item: item)
+    assert events == [
+        ("arm", HARD_RACE_TIMEOUT_SECONDS, True),
+        ("executor:init", 1),
+        ("executor:enter",),
+        ("submit", 0),
+        ("result",),
+        ("executor:exit", RuntimeError),
+        ("cancel",),
+    ]
 
 
 def make_scope(**overrides: str) -> MemoryScope:
@@ -227,6 +388,52 @@ def seeded_history(
         idempotency_key="revision-other",
     )
     return history, (first_evidence, second_evidence), (root, child, other)
+
+
+def seed_revisions(
+    count: int = RACE_SIZE,
+    *,
+    siblings: bool = False,
+    scope: MemoryScope | None = None,
+) -> tuple[InMemoryMemoryHistoryStore, tuple[MemoryRevision, ...]]:
+    """Seed independent roots or same-memory siblings for release races."""
+
+    scope = scope or make_scope()
+    evidence_store = InMemoryEvidenceStore()
+    evidence = evidence_store.append(
+        make_event(
+            scope=scope,
+            sequence_no=0,
+            payload="race evidence",
+            idempotency_key="race-evidence",
+        )
+    )
+    history = InMemoryMemoryHistoryStore(evidence_store)
+
+    def make_revision(index: int, parent: MemoryRevision | None) -> MemoryRevision:
+        candidate = append_candidate(
+            history,
+            scope=scope,
+            evidence_ids=(evidence.evidence_id,),
+            content=f"race memory {index}",
+            idempotency_key=f"race-candidate-{index}",
+        )
+        return append_revision(
+            history,
+            scope=scope,
+            candidate_id=candidate.candidate_id,
+            operation=(
+                RevisionOperation.ADD if parent is None else RevisionOperation.REFINE
+            ),
+            parent_revision_id=None if parent is None else parent.revision_id,
+            idempotency_key=f"race-revision-{index}",
+        )
+
+    if not siblings:
+        return history, tuple(make_revision(index, None) for index in range(count))
+
+    parent = make_revision(-1, None)
+    return history, tuple(make_revision(index, parent) for index in range(count))
 
 
 def seeded_sibling_revisions() -> tuple[
@@ -571,6 +778,137 @@ def test_append_release_uses_module_level_sha256(
     assert release.release_id == f"rel_{digest[:24]}"
 
 
+def test_release_validation_and_commit_obey_exact_lock_epochs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history, _, (root, _, _) = seeded_history()
+    records: list[tuple[str, int]] = []
+
+    class EpochLock:
+        def __init__(self) -> None:
+            self._lock = RLock()
+            self.held = False
+            self.epoch = 0
+            self.enter_count = 0
+
+        def __enter__(self) -> EpochLock:
+            self._lock.acquire()
+            assert not self.held
+            self.held = True
+            self.epoch += 1
+            self.enter_count += 1
+            records.append(("lock:enter", self.epoch))
+            return self
+
+        def __exit__(
+            self,
+            exc_type: object,
+            exc_value: object,
+            traceback: object,
+        ) -> None:
+            records.append(("lock:exit", self.epoch))
+            self.held = False
+            self._lock.release()
+
+        def record_locked(self, event: str) -> None:
+            assert self.held, f"{event} accessed outside release lock"
+            records.append((event, self.epoch))
+
+        def record_unlocked(self, event: str) -> None:
+            assert not self.held, f"{event} ran inside release lock"
+            records.append((event, self.epoch))
+
+    epoch_lock = EpochLock()
+
+    class RecordingList(list[object]):
+        def append(self, item: object) -> None:
+            epoch_lock.record_locked("scope:append")
+            super().append(item)
+
+    class RecordingDict(dict[object, object]):
+        def __init__(self, name: str) -> None:
+            super().__init__()
+            self._name = name
+
+        def get(self, key: object, default: object = None) -> object:
+            epoch_lock.record_locked(f"{self._name}:get")
+            return super().get(key, default)
+
+        def __setitem__(self, key: object, value: object) -> None:
+            epoch_lock.record_locked(f"{self._name}:set")
+            super().__setitem__(key, value)
+
+        def setdefault(self, key: object, default: object = None) -> object:
+            epoch_lock.record_locked(f"{self._name}:setdefault")
+            if not dict.__contains__(self, key):
+                default = RecordingList(default or ())
+            return super().setdefault(key, default)
+
+    class ObservedHistory:
+        def get_revision(
+            self,
+            scope: MemoryScope,
+            revision_id: str,
+        ) -> MemoryRevision:
+            epoch_lock.record_unlocked("history:get")
+            return history.get_revision(scope, revision_id)
+
+    original_sha256 = release_store_module.sha256
+
+    def observed_sha256(canonical_bytes: bytes) -> object:
+        epoch_lock.record_unlocked("sha256")
+        return original_sha256(canonical_bytes)
+
+    monkeypatch.setattr(release_store_module, "sha256", observed_sha256)
+    store = InMemoryMemoryReleaseStore(ObservedHistory())  # type: ignore[arg-type]
+    store._lock = epoch_lock  # type: ignore[assignment]
+    store._release_by_id = RecordingDict("release")  # type: ignore[assignment]
+    store._release_by_idempotency = RecordingDict(  # type: ignore[assignment]
+        "idempotency"
+    )
+    store._releases_by_scope = RecordingDict("scope")  # type: ignore[assignment]
+    manifest = ReleaseManifest(make_scope(), (root.revision_id,))
+
+    release = store.append_release(manifest, idempotency_key="release-1")
+
+    assert epoch_lock.enter_count == 2
+    assert records == [
+        ("sha256", 0),
+        ("lock:enter", 1),
+        ("idempotency:get", 1),
+        ("lock:exit", 1),
+        ("history:get", 1),
+        ("lock:enter", 2),
+        ("idempotency:get", 2),
+        ("release:get", 2),
+        ("release:set", 2),
+        ("idempotency:set", 2),
+        ("scope:setdefault", 2),
+        ("scope:append", 2),
+        ("lock:exit", 2),
+    ]
+
+    records.clear()
+    epoch_lock.epoch = 0
+    epoch_lock.enter_count = 0
+    alias = store.append_release(manifest, idempotency_key="release-alias")
+
+    assert alias is release
+    assert epoch_lock.enter_count == 2
+    assert records == [
+        ("sha256", 0),
+        ("lock:enter", 1),
+        ("idempotency:get", 1),
+        ("lock:exit", 1),
+        ("history:get", 1),
+        ("lock:enter", 2),
+        ("idempotency:get", 2),
+        ("release:get", 2),
+        ("idempotency:set", 2),
+        ("lock:exit", 2),
+    ]
+
+
 def test_get_release_snapshots_identifier_subclass_before_lookup() -> None:
     history = NoLookupHistory()
     store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
@@ -643,3 +981,328 @@ def test_list_releases_is_sorted_and_previous_tuple_stays_stable() -> None:
     assert store.list_releases(scope) == tuple(
         sorted((first, second, third), key=lambda item: item.release_id)
     )
+
+
+def test_missing_member_error_is_not_rewritten_by_same_key_winner() -> None:
+    history, revisions = seed_revisions(1)
+    scope = make_scope()
+    missing_lookup_started = Event()
+    allow_missing_lookup = Event()
+
+    class BlockingMissingHistory:
+        def get_revision(
+            self,
+            requested_scope: MemoryScope,
+            revision_id: str,
+        ) -> MemoryRevision:
+            if revision_id == "rev_missing":
+                missing_lookup_started.set()
+                assert allow_missing_lookup.wait(timeout=RACE_TIMEOUT_SECONDS)
+            return history.get_revision(requested_scope, revision_id)
+
+    store = InMemoryMemoryReleaseStore(BlockingMissingHistory())  # type: ignore[arg-type]
+    invalid_manifest = ReleaseManifest(scope, ("rev_missing",))
+    valid_manifest = ReleaseManifest(scope, (revisions[0].revision_id,))
+    winner: MemoryRelease | None = None
+    invalid_error: RevisionNotFoundError | None = None
+
+    faulthandler.dump_traceback_later(HARD_RACE_TIMEOUT_SECONDS, exit=True)
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            invalid_future = executor.submit(
+                store.append_release,
+                invalid_manifest,
+                idempotency_key="shared-release-key",
+            )
+            try:
+                assert missing_lookup_started.wait(timeout=RACE_TIMEOUT_SECONDS)
+                valid_future = executor.submit(
+                    store.append_release,
+                    valid_manifest,
+                    idempotency_key="shared-release-key",
+                )
+                winner = valid_future.result(timeout=RACE_TIMEOUT_SECONDS)
+            finally:
+                allow_missing_lookup.set()
+
+            with pytest.raises(RevisionNotFoundError, match="rev_missing") as raised:
+                invalid_future.result(timeout=RACE_TIMEOUT_SECONDS)
+            invalid_error = raised.value
+    finally:
+        faulthandler.cancel_dump_traceback_later()
+
+    assert type(invalid_error) is RevisionNotFoundError
+    assert winner is not None
+    assert winner.manifest is valid_manifest
+    assert store._release_by_id == {(scope, winner.release_id): winner}
+    assert store._release_by_idempotency == {(scope, "shared-release-key"): winner}
+    assert store._releases_by_scope == {scope: [winner]}
+
+
+def test_concurrent_same_key_and_manifest_converge_to_one_release() -> None:
+    history, revisions = seed_revisions(1)
+    store = InMemoryMemoryReleaseStore(history)
+    store._release_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    store._release_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    manifest = ReleaseManifest(make_scope(), (revisions[0].revision_id,))
+
+    outcomes = run_race(
+        (manifest,) * RACE_SIZE,
+        lambda item: store.append_release(item, idempotency_key="shared-key"),
+    )
+
+    release = outcomes[0]
+    assert isinstance(release, MemoryRelease)
+    assert all(item is release for item in outcomes)
+    assert store._release_by_id == {(manifest.scope, release.release_id): release}
+    assert store._release_by_idempotency == {(manifest.scope, "shared-key"): release}
+    assert store._releases_by_scope == {manifest.scope: [release]}
+
+
+def test_concurrent_keys_for_same_manifest_all_alias_one_release() -> None:
+    history, revisions = seed_revisions(1)
+    store = InMemoryMemoryReleaseStore(history)
+    store._release_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    store._release_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    manifest = ReleaseManifest(make_scope(), (revisions[0].revision_id,))
+    keys = tuple(f"release-key-{index}" for index in range(RACE_SIZE))
+
+    outcomes = run_race(
+        keys,
+        lambda key: store.append_release(manifest, idempotency_key=key),
+    )
+
+    release = outcomes[0]
+    assert isinstance(release, MemoryRelease)
+    assert all(item is release for item in outcomes)
+    assert store._release_by_id == {(manifest.scope, release.release_id): release}
+    assert store._release_by_idempotency == {
+        (manifest.scope, key): release for key in keys
+    }
+    assert store._releases_by_scope == {manifest.scope: [release]}
+
+
+def test_concurrent_manifests_for_shared_key_leave_losers_recoverable() -> None:
+    history, revisions = seed_revisions()
+    store = InMemoryMemoryReleaseStore(history)
+    store._release_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    store._release_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    manifests = tuple(
+        ReleaseManifest(make_scope(), (revision.revision_id,)) for revision in revisions
+    )
+
+    outcomes = run_race(
+        manifests,
+        lambda manifest: store.append_release(
+            manifest,
+            idempotency_key="shared-release-key",
+        ),
+    )
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryRelease))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, ReleaseConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    winner = winners[0]
+    assert store._release_by_id == {(winner.manifest.scope, winner.release_id): winner}
+    assert store._release_by_idempotency == {
+        (winner.manifest.scope, "shared-release-key"): winner
+    }
+    assert store._releases_by_scope == {winner.manifest.scope: [winner]}
+
+    loser_manifests = tuple(
+        manifest for manifest in manifests if manifest is not winner.manifest
+    )
+    recovered = tuple(
+        store.append_release(
+            manifest,
+            idempotency_key=f"recovered-release-{index}",
+        )
+        for index, manifest in enumerate(loser_manifests)
+    )
+    releases = store.list_releases(make_scope())
+    assert len(recovered) == RACE_SIZE - 1
+    assert len(releases) == RACE_SIZE
+    assert len(store._release_by_id) == RACE_SIZE
+    assert len(store._release_by_idempotency) == RACE_SIZE
+    assert len(store._releases_by_scope[make_scope()]) == RACE_SIZE
+    assert set(store._release_by_id.values()) == set(releases)
+    assert set(store._release_by_idempotency.values()) == set(releases)
+    assert set(store._releases_by_scope[make_scope()]) == set(releases)
+
+
+def test_same_memory_siblings_survive_in_separate_concurrent_releases() -> None:
+    history, siblings = seed_revisions(siblings=True)
+    assert len({revision.memory_id for revision in siblings}) == 1
+    store = InMemoryMemoryReleaseStore(history)
+    store._release_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    store._release_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    requests = tuple(
+        (
+            ReleaseManifest(make_scope(), (revision.revision_id,)),
+            f"sibling-release-{index}",
+        )
+        for index, revision in enumerate(siblings)
+    )
+
+    outcomes = run_race(
+        requests,
+        lambda item: store.append_release(item[0], idempotency_key=item[1]),
+    )
+
+    releases = tuple(item for item in outcomes if isinstance(item, MemoryRelease))
+    assert len(releases) == RACE_SIZE
+    assert len({release.release_id for release in releases}) == RACE_SIZE
+    assert {release.manifest.revision_ids[0] for release in releases} == {
+        revision.revision_id for revision in siblings
+    }
+    assert set(store.list_releases(make_scope())) == set(releases)
+    assert len(store._release_by_id) == RACE_SIZE
+    assert len(store._release_by_idempotency) == RACE_SIZE
+    assert len(store._releases_by_scope[make_scope()]) == RACE_SIZE
+
+
+@pytest.mark.parametrize("same_full_hash", [True, False], ids=["full", "prefix"])
+def test_concurrent_release_collision_is_atomic_and_all_losers_recover(
+    monkeypatch: pytest.MonkeyPatch,
+    same_full_hash: bool,
+) -> None:
+    history, revisions = seed_revisions()
+    scope = make_scope()
+    store = InMemoryMemoryReleaseStore(history)
+    store._release_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    store._release_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+    manifests = tuple(
+        ReleaseManifest(scope, (revision.revision_id,)) for revision in revisions
+    )
+    keys = tuple(f"collision-release-{index}" for index in range(RACE_SIZE))
+    prefix = "a" * 24
+    digest_by_bytes = {
+        manifest.canonical_bytes(): (
+            prefix + ("b" * 40 if same_full_hash else f"{index:040x}")
+        )
+        for index, manifest in enumerate(manifests)
+    }
+    assert {digest[:24] for digest in digest_by_bytes.values()} == {prefix}
+    assert len(set(digest_by_bytes.values())) == (1 if same_full_hash else RACE_SIZE)
+    install_digest_map(monkeypatch, digest_by_bytes)
+
+    outcomes = run_race(
+        tuple(zip(manifests, keys, strict=True)),
+        lambda item: store.append_release(item[0], idempotency_key=item[1]),
+    )
+
+    winners = tuple(item for item in outcomes if isinstance(item, MemoryRelease))
+    conflicts = tuple(
+        item for item in outcomes if isinstance(item, ReleaseConflictError)
+    )
+    assert len(winners) == 1
+    assert len(conflicts) == RACE_SIZE - 1
+    winner = winners[0]
+    winner_index = next(
+        index
+        for index, outcome in enumerate(outcomes)
+        if isinstance(outcome, MemoryRelease)
+    )
+    winner_key = keys[winner_index]
+    loser_indexes = tuple(index for index in range(RACE_SIZE) if index != winner_index)
+    assert store._release_by_id == {(scope, winner.release_id): winner}
+    assert store._release_by_idempotency == {(scope, winner_key): winner}
+    assert store._releases_by_scope == {scope: [winner]}
+    assert all(
+        (scope, keys[index]) not in store._release_by_idempotency
+        for index in loser_indexes
+    )
+
+    monkeypatch.undo()
+    recovered = tuple(
+        store.append_release(
+            manifests[index],
+            idempotency_key=keys[index],
+        )
+        for index in loser_indexes
+    )
+
+    releases = store.list_releases(scope)
+    assert len(recovered) == RACE_SIZE - 1
+    assert len(releases) == RACE_SIZE
+    assert len(store._release_by_id) == RACE_SIZE
+    assert len(store._release_by_idempotency) == RACE_SIZE
+    assert len(store._releases_by_scope[scope]) == RACE_SIZE
+    assert set(store._release_by_id.values()) == set(releases)
+    assert set(store._release_by_idempotency.values()) == set(releases)
+    assert set(store._releases_by_scope[scope]) == set(releases)
+    assert {release.manifest for release in releases} == set(manifests)
+
+
+@pytest.mark.parametrize("same_full_hash", [True, False], ids=["full", "prefix"])
+def test_forced_release_id_collision_is_isolated_across_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+    same_full_hash: bool,
+) -> None:
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    manifests = (
+        ReleaseManifest(first_scope, ()),
+        ReleaseManifest(second_scope, ()),
+    )
+    prefix = "c" * 24
+    digests = tuple(
+        prefix + ("d" * 40 if same_full_hash else f"{index:040x}") for index in range(2)
+    )
+    install_digest_map(
+        monkeypatch,
+        {
+            manifest.canonical_bytes(): digest
+            for manifest, digest in zip(manifests, digests, strict=True)
+        },
+    )
+    history = NoLookupHistory()
+    store = InMemoryMemoryReleaseStore(history)  # type: ignore[arg-type]
+    store._release_by_id = YieldingMissingDict()  # type: ignore[assignment]
+    store._release_by_idempotency = YieldingMissingDict()  # type: ignore[assignment]
+
+    outcomes = run_race(
+        manifests,
+        lambda manifest: store.append_release(
+            manifest,
+            idempotency_key="shared-scoped-key",
+        ),
+    )
+    aliases = run_race(
+        manifests,
+        lambda manifest: store.append_release(
+            manifest,
+            idempotency_key="shared-scoped-alias",
+        ),
+    )
+
+    first, second = outcomes
+    assert isinstance(first, MemoryRelease)
+    assert isinstance(second, MemoryRelease)
+    assert first is not second
+    assert first.release_id == second.release_id == f"rel_{prefix}"
+    assert (first.content_hash == second.content_hash) is same_full_hash
+    assert aliases[0] is first
+    assert aliases[1] is second
+    assert store.get_release(first_scope, first.release_id) is first
+    assert store.get_release(second_scope, second.release_id) is second
+    assert store.list_releases(first_scope) == (first,)
+    assert store.list_releases(second_scope) == (second,)
+    assert store._release_by_id == {
+        (first_scope, first.release_id): first,
+        (second_scope, second.release_id): second,
+    }
+    assert store._release_by_idempotency == {
+        (first_scope, "shared-scoped-key"): first,
+        (second_scope, "shared-scoped-key"): second,
+        (first_scope, "shared-scoped-alias"): first,
+        (second_scope, "shared-scoped-alias"): second,
+    }
+    assert store._releases_by_scope == {
+        first_scope: [first],
+        second_scope: [second],
+    }
+    assert history.lookup_count == 0

--- a/tests/v2/memory_service/test_release_types.py
+++ b/tests/v2/memory_service/test_release_types.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for immutable Memory Service release values."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError, fields
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
+
+import pytest
+
+from areal.v2.memory_service.release_types import MemoryRelease, ReleaseManifest
+from areal.v2.memory_service.types import MemoryScope
+
+
+class StringSubclass(str):
+    pass
+
+
+class TupleSubclass(tuple[str, ...]):
+    def __iter__(self):
+        return iter(("overridden",))
+
+
+class MemoryScopeSubclass(MemoryScope):
+    pass
+
+
+class ReleaseManifestSubclass(ReleaseManifest):
+    pass
+
+
+class MutableTimezone(tzinfo):
+    def __init__(self) -> None:
+        self.offset = timedelta(hours=1)
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        return self.offset
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(0)
+
+    def tzname(self, value: datetime | None) -> str:
+        return "MUTABLE"
+
+
+class StatefulDatetime(datetime):
+    def astimezone(self, timezone: tzinfo | None = None) -> StatefulDatetime:
+        return self
+
+
+LONE_SURROGATE = "\ud800"
+
+
+def make_scope(**overrides: str) -> MemoryScope:
+    values = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)
+
+
+def make_manifest(**overrides: object) -> ReleaseManifest:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "revision_ids": ("rev_a", "rev_b"),
+    }
+    values.update(overrides)
+    return ReleaseManifest(**values)  # type: ignore[arg-type]
+
+
+def test_release_manifest_canonical_schema_v1_is_frozen() -> None:
+    manifest = make_manifest()
+
+    assert manifest.canonical_bytes() == (
+        b'{"revision_ids":["rev_a","rev_b"],"schema_version":1,'
+        b'"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        b'"tenant_id":"tenant-1"}}'
+    )
+    value = json.loads(manifest.canonical_bytes())
+    assert tuple(value) == ("revision_ids", "schema_version", "scope")
+    assert "idempotency_key" not in value
+
+
+def test_empty_release_manifest_has_stable_memory_off_wire_value() -> None:
+    manifest = make_manifest(revision_ids=())
+
+    assert manifest.revision_ids == ()
+    assert manifest.canonical_bytes() == (
+        b'{"revision_ids":[],"schema_version":1,'
+        b'"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        b'"tenant_id":"tenant-1"}}'
+    )
+
+
+def test_release_manifest_canonical_schema_preserves_literal_utf8() -> None:
+    manifest = ReleaseManifest(
+        scope=make_scope(
+            tenant_id="租户一",
+            namespace="智能体记忆",
+            subject_id="用户🙂",
+        ),
+        revision_ids=("修订一", "rev_🙂"),
+    )
+
+    canonical_bytes = manifest.canonical_bytes()
+    expected = (
+        '{"revision_ids":["修订一","rev_🙂"],"schema_version":1,'
+        '"scope":{"namespace":"智能体记忆","subject_id":"用户🙂",'
+        '"tenant_id":"租户一"}}'
+    ).encode()
+
+    assert canonical_bytes == expected
+    assert b"\\u" not in canonical_bytes
+
+
+def test_release_manifest_snapshots_tuple_and_string_subclasses() -> None:
+    manifest = make_manifest(
+        revision_ids=TupleSubclass(
+            (StringSubclass(" rev_a "), StringSubclass(" rev_b "))
+        )
+    )
+
+    assert type(manifest.revision_ids) is tuple
+    assert manifest.revision_ids == (" rev_a ", " rev_b ")
+    assert all(type(item) is str for item in manifest.revision_ids)
+
+
+@pytest.mark.parametrize("revision_ids", [["rev_a"], {"rev_a"}, object()])
+def test_release_manifest_rejects_non_tuple_revision_ids(
+    revision_ids: object,
+) -> None:
+    with pytest.raises(TypeError, match="revision_ids"):
+        make_manifest(revision_ids=revision_ids)
+
+
+def test_release_manifest_rejects_duplicate_revision_ids() -> None:
+    with pytest.raises(ValueError, match="revision_ids"):
+        make_manifest(revision_ids=("rev_a", "rev_a"))
+
+
+@pytest.mark.parametrize("revision_id", ["", " \t\n", LONE_SURROGATE])
+def test_release_manifest_rejects_invalid_revision_id(revision_id: str) -> None:
+    with pytest.raises(ValueError, match="revision_ids"):
+        make_manifest(revision_ids=(revision_id,))
+
+
+@pytest.mark.parametrize("revision_id", [None, 7, b"rev_a"])
+def test_release_manifest_rejects_non_string_revision_id(
+    revision_id: object,
+) -> None:
+    with pytest.raises(TypeError, match="revision_ids"):
+        make_manifest(revision_ids=(revision_id,))
+
+
+def test_release_manifest_uses_base_tuple_iterator_before_duplicate_check() -> None:
+    with pytest.raises(ValueError, match="revision_ids"):
+        make_manifest(revision_ids=TupleSubclass(("rev_a", "rev_a")))
+
+
+@pytest.mark.parametrize("scope", [object(), None])
+def test_release_manifest_requires_memory_scope(scope: object) -> None:
+    with pytest.raises(TypeError, match="scope"):
+        make_manifest(scope=scope)
+
+
+def test_release_manifest_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        make_manifest(scope=scope)
+
+
+def test_memory_release_snapshots_identifiers_and_utc_datetime() -> None:
+    release = MemoryRelease(
+        release_id=StringSubclass(" rel_a "),
+        manifest=make_manifest(),
+        content_hash=StringSubclass(" hash_a "),
+        created_at=datetime(
+            2026,
+            7,
+            7,
+            12,
+            5,
+            6,
+            789000,
+            tzinfo=timezone(timedelta(hours=8)),
+        ),
+    )
+
+    assert type(release.release_id) is str
+    assert release.release_id == " rel_a "
+    assert type(release.content_hash) is str
+    assert release.content_hash == " hash_a "
+    assert type(release.created_at) is datetime
+    assert release.created_at == datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
+    assert release.created_at.tzinfo is UTC
+
+
+def test_memory_release_detaches_mutable_timezone_and_datetime_subclass() -> None:
+    mutable_timezone = MutableTimezone()
+    mutable_source = datetime(2026, 7, 7, 5, tzinfo=mutable_timezone)
+    mutable_release = MemoryRelease(
+        "rel_a",
+        make_manifest(),
+        "a" * 64,
+        mutable_source,
+    )
+    subclass_source = StatefulDatetime(2026, 7, 7, 4, tzinfo=UTC)
+    subclass_release = MemoryRelease(
+        "rel_b",
+        make_manifest(),
+        "b" * 64,
+        subclass_source,
+    )
+    mutable_timezone.offset = timedelta(hours=2)
+
+    assert type(mutable_release.created_at) is datetime
+    assert mutable_release.created_at == datetime(2026, 7, 7, 4, tzinfo=UTC)
+    assert type(subclass_release.created_at) is datetime
+    assert subclass_release.created_at == datetime(2026, 7, 7, 4, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    [
+        datetime(2026, 7, 7),
+        datetime.min.replace(tzinfo=timezone(timedelta(hours=1))),
+    ],
+)
+def test_memory_release_rejects_naive_or_non_normalizable_datetime(
+    created_at: datetime,
+) -> None:
+    with pytest.raises(ValueError, match="created_at"):
+        MemoryRelease("rel_a", make_manifest(), "a" * 64, created_at)
+
+
+def test_memory_release_requires_exact_manifest() -> None:
+    manifest_subclass = ReleaseManifestSubclass(make_scope(), ("rev_a",))
+
+    with pytest.raises(TypeError, match="manifest must be a ReleaseManifest"):
+        MemoryRelease(
+            "rel_a",
+            manifest_subclass,
+            "a" * 64,
+            datetime.now(UTC),
+        )
+    with pytest.raises(TypeError, match="manifest must be a ReleaseManifest"):
+        MemoryRelease(
+            "rel_a",
+            object(),  # type: ignore[arg-type]
+            "a" * 64,
+            datetime.now(UTC),
+        )
+
+
+@pytest.mark.parametrize("field", ["release_id", "content_hash"])
+@pytest.mark.parametrize("value", ["", " \t\n", LONE_SURROGATE])
+def test_memory_release_rejects_invalid_text(field: str, value: str) -> None:
+    values: dict[str, object] = {
+        "release_id": "rel_a",
+        "manifest": make_manifest(),
+        "content_hash": "a" * 64,
+        "created_at": datetime.now(UTC),
+    }
+    values[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        MemoryRelease(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", ["release_id", "content_hash"])
+@pytest.mark.parametrize("value", [None, 7, b"value"])
+def test_memory_release_rejects_non_string_text(field: str, value: object) -> None:
+    values: dict[str, object] = {
+        "release_id": "rel_a",
+        "manifest": make_manifest(),
+        "content_hash": "a" * 64,
+        "created_at": datetime.now(UTC),
+    }
+    values[field] = value
+
+    with pytest.raises(TypeError, match=field):
+        MemoryRelease(**values)  # type: ignore[arg-type]
+
+
+def test_release_values_are_frozen_slotted_and_have_exact_fields() -> None:
+    manifest = make_manifest()
+    release = MemoryRelease(
+        "rel_a",
+        manifest,
+        "a" * 64,
+        datetime.now(UTC),
+    )
+
+    assert tuple(field.name for field in fields(ReleaseManifest)) == (
+        "scope",
+        "revision_ids",
+    )
+    assert tuple(field.name for field in fields(MemoryRelease)) == (
+        "release_id",
+        "manifest",
+        "content_hash",
+        "created_at",
+    )
+    assert not hasattr(manifest, "__dict__")
+    assert not hasattr(release, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        manifest.revision_ids = ()
+    with pytest.raises(FrozenInstanceError):
+        release.release_id = "rel_changed"

--- a/tests/v2/memory_service/test_release_types.py
+++ b/tests/v2/memory_service/test_release_types.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 from dataclasses import FrozenInstanceError, fields
 from datetime import UTC, datetime, timedelta, timezone, tzinfo
+from hashlib import sha256
 
 import pytest
 
@@ -70,6 +71,43 @@ def make_manifest(**overrides: object) -> ReleaseManifest:
     }
     values.update(overrides)
     return ReleaseManifest(**values)  # type: ignore[arg-type]
+
+
+def release_identity(
+    manifest: ReleaseManifest,
+    release_graph_sha256: str = "b" * 64,
+) -> tuple[str, str, bytes]:
+    manifest_sha256 = sha256(manifest.canonical_bytes()).hexdigest()
+    commitment_bytes = json.dumps(
+        {
+            "manifest_sha256": manifest_sha256,
+            "record_kind": "memory_release_commitment",
+            "release_graph_sha256": release_graph_sha256,
+            "schema_version": 1,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    content_hash = sha256(commitment_bytes).hexdigest()
+    return f"rel_{content_hash[:24]}", content_hash, commitment_bytes
+
+
+def make_release(**overrides: object) -> MemoryRelease:
+    manifest = overrides.pop("manifest", make_manifest())
+    assert isinstance(manifest, ReleaseManifest)
+    graph_hash = overrides.pop("release_graph_sha256", "b" * 64)
+    assert isinstance(graph_hash, str)
+    release_id, content_hash, _ = release_identity(manifest, graph_hash)
+    values: dict[str, object] = {
+        "release_id": release_id,
+        "manifest": manifest,
+        "content_hash": content_hash,
+        "release_graph_sha256": graph_hash,
+        "created_at": datetime.now(UTC),
+    }
+    values.update(overrides)
+    return MemoryRelease(**values)  # type: ignore[arg-type]
 
 
 def test_release_manifest_canonical_schema_v1_is_frozen() -> None:
@@ -175,10 +213,13 @@ def test_release_manifest_rejects_memory_scope_subclass() -> None:
 
 
 def test_memory_release_snapshots_identifiers_and_utc_datetime() -> None:
+    manifest = make_manifest()
+    release_id, content_hash, _ = release_identity(manifest)
     release = MemoryRelease(
-        release_id=StringSubclass(" rel_a "),
-        manifest=make_manifest(),
-        content_hash=StringSubclass(" hash_a "),
+        release_id=StringSubclass(release_id),
+        manifest=manifest,
+        content_hash=StringSubclass(content_hash),
+        release_graph_sha256=StringSubclass("b" * 64),
         created_at=datetime(
             2026,
             7,
@@ -192,9 +233,11 @@ def test_memory_release_snapshots_identifiers_and_utc_datetime() -> None:
     )
 
     assert type(release.release_id) is str
-    assert release.release_id == " rel_a "
+    assert release.release_id == release_id
     assert type(release.content_hash) is str
-    assert release.content_hash == " hash_a "
+    assert release.content_hash == content_hash
+    assert type(release.release_graph_sha256) is str
+    assert release.release_graph_sha256 == "b" * 64
     assert type(release.created_at) is datetime
     assert release.created_at == datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
     assert release.created_at.tzinfo is UTC
@@ -203,18 +246,11 @@ def test_memory_release_snapshots_identifiers_and_utc_datetime() -> None:
 def test_memory_release_detaches_mutable_timezone_and_datetime_subclass() -> None:
     mutable_timezone = MutableTimezone()
     mutable_source = datetime(2026, 7, 7, 5, tzinfo=mutable_timezone)
-    mutable_release = MemoryRelease(
-        "rel_a",
-        make_manifest(),
-        "a" * 64,
-        mutable_source,
-    )
+    mutable_release = make_release(created_at=mutable_source)
     subclass_source = StatefulDatetime(2026, 7, 7, 4, tzinfo=UTC)
-    subclass_release = MemoryRelease(
-        "rel_b",
-        make_manifest(),
-        "b" * 64,
-        subclass_source,
+    subclass_release = make_release(
+        manifest=make_manifest(revision_ids=("rev_c",)),
+        created_at=subclass_source,
     )
     mutable_timezone.offset = timedelta(hours=2)
 
@@ -235,7 +271,7 @@ def test_memory_release_rejects_naive_or_non_normalizable_datetime(
     created_at: datetime,
 ) -> None:
     with pytest.raises(ValueError, match="created_at"):
-        MemoryRelease("rel_a", make_manifest(), "a" * 64, created_at)
+        make_release(created_at=created_at)
 
 
 def test_memory_release_requires_exact_manifest() -> None:
@@ -246,6 +282,7 @@ def test_memory_release_requires_exact_manifest() -> None:
             "rel_a",
             manifest_subclass,
             "a" * 64,
+            "b" * 64,
             datetime.now(UTC),
         )
     with pytest.raises(TypeError, match="manifest must be a ReleaseManifest"):
@@ -253,17 +290,23 @@ def test_memory_release_requires_exact_manifest() -> None:
             "rel_a",
             object(),  # type: ignore[arg-type]
             "a" * 64,
+            "b" * 64,
             datetime.now(UTC),
         )
 
 
-@pytest.mark.parametrize("field", ["release_id", "content_hash"])
+@pytest.mark.parametrize(
+    "field", ["release_id", "content_hash", "release_graph_sha256"]
+)
 @pytest.mark.parametrize("value", ["", " \t\n", LONE_SURROGATE])
 def test_memory_release_rejects_invalid_text(field: str, value: str) -> None:
+    manifest = make_manifest()
+    release_id, content_hash, _ = release_identity(manifest)
     values: dict[str, object] = {
-        "release_id": "rel_a",
-        "manifest": make_manifest(),
-        "content_hash": "a" * 64,
+        "release_id": release_id,
+        "manifest": manifest,
+        "content_hash": content_hash,
+        "release_graph_sha256": "b" * 64,
         "created_at": datetime.now(UTC),
     }
     values[field] = value
@@ -272,13 +315,18 @@ def test_memory_release_rejects_invalid_text(field: str, value: str) -> None:
         MemoryRelease(**values)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("field", ["release_id", "content_hash"])
+@pytest.mark.parametrize(
+    "field", ["release_id", "content_hash", "release_graph_sha256"]
+)
 @pytest.mark.parametrize("value", [None, 7, b"value"])
 def test_memory_release_rejects_non_string_text(field: str, value: object) -> None:
+    manifest = make_manifest()
+    release_id, content_hash, _ = release_identity(manifest)
     values: dict[str, object] = {
-        "release_id": "rel_a",
-        "manifest": make_manifest(),
-        "content_hash": "a" * 64,
+        "release_id": release_id,
+        "manifest": manifest,
+        "content_hash": content_hash,
+        "release_graph_sha256": "b" * 64,
         "created_at": datetime.now(UTC),
     }
     values[field] = value
@@ -289,12 +337,7 @@ def test_memory_release_rejects_non_string_text(field: str, value: object) -> No
 
 def test_release_values_are_frozen_slotted_and_have_exact_fields() -> None:
     manifest = make_manifest()
-    release = MemoryRelease(
-        "rel_a",
-        manifest,
-        "a" * 64,
-        datetime.now(UTC),
-    )
+    release = make_release(manifest=manifest)
 
     assert tuple(field.name for field in fields(ReleaseManifest)) == (
         "scope",
@@ -304,6 +347,7 @@ def test_release_values_are_frozen_slotted_and_have_exact_fields() -> None:
         "release_id",
         "manifest",
         "content_hash",
+        "release_graph_sha256",
         "created_at",
     )
     assert not hasattr(manifest, "__dict__")
@@ -312,3 +356,54 @@ def test_release_values_are_frozen_slotted_and_have_exact_fields() -> None:
         manifest.revision_ids = ()
     with pytest.raises(FrozenInstanceError):
         release.release_id = "rel_changed"
+
+
+def test_memory_release_commitment_has_stable_domain_separated_wire_value() -> None:
+    manifest = make_manifest(revision_ids=())
+    release_id, content_hash, expected = release_identity(manifest, "c" * 64)
+    release = MemoryRelease(
+        release_id=release_id,
+        manifest=manifest,
+        content_hash=content_hash,
+        release_graph_sha256="c" * 64,
+        created_at=datetime.now(UTC),
+    )
+
+    assert release.commitment_bytes() == expected
+    assert release.commitment_bytes() == (
+        b'{"manifest_sha256":"b3acef085dae55b17b05e651e1071f20961db204'
+        b'acad245d5285b4f27cf5f5f1","record_kind":"memory_release_commitment",'
+        b'"release_graph_sha256":"cccccccccccccccccccccccccccccccccccccccc'
+        b'cccccccccccccccccccccccc","schema_version":1}'
+    )
+    assert release.content_hash == sha256(expected).hexdigest()
+    assert release.release_id == f"rel_{release.content_hash[:24]}"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("content_hash", "0" * 64, "content_hash"),
+        ("release_id", "rel_" + "0" * 24, "release_id"),
+        ("content_hash", "A" * 64, "lowercase SHA-256"),
+        ("release_graph_sha256", "g" * 64, "lowercase SHA-256"),
+    ],
+)
+def test_memory_release_rejects_incoherent_commitments(
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    manifest = make_manifest()
+    release_id, content_hash, _ = release_identity(manifest)
+    values: dict[str, object] = {
+        "release_id": release_id,
+        "manifest": manifest,
+        "content_hash": content_hash,
+        "release_graph_sha256": "b" * 64,
+        "created_at": datetime.now(UTC),
+    }
+    values[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        MemoryRelease(**values)  # type: ignore[arg-type]

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -176,6 +176,20 @@ class AlwaysEqualStr(str):
     __hash__ = str.__hash__
 
 
+class SetThenInterruptDict(dict[object, object]):
+    """Expose rollback bugs where a mapping mutates before interruption."""
+
+    def __init__(self, values: dict[object, object] | None = None) -> None:
+        super().__init__({} if values is None else values)
+        self.should_interrupt = True
+
+    def __setitem__(self, key: object, value: object) -> None:
+        super().__setitem__(key, value)
+        if self.should_interrupt:
+            self.should_interrupt = False
+            raise KeyboardInterrupt("injected publication interruption")
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -199,6 +213,28 @@ def make_event(**overrides: object) -> EvidenceEvent:
     }
     values.update(overrides)
     return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("failing_index", ("idempotency", "scope"))
+def test_append_rolls_back_every_index_after_base_exception(
+    failing_index: str,
+) -> None:
+    store = InMemoryEvidenceStore()
+    if failing_index == "idempotency":
+        store._by_idempotency_key = SetThenInterruptDict()
+    else:
+        store._by_scope = SetThenInterruptDict()
+    event = make_event()
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        store.append(event)
+
+    assert store._by_evidence_id == {}
+    assert store._by_idempotency_key == {}
+    assert store._by_scope == {}
+    record = store.append(event)
+    assert store.get(event.scope, record.evidence_id) == record
+    assert store.list(event.scope) == (record,)
 
 
 def test_error_types_share_memory_service_base_error() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -25,6 +25,8 @@ from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
     MemoryServiceError,
+    ReleaseConflictError,
+    ReleaseNotFoundError,
     RevisionConflictError,
     RevisionNotFoundError,
 )
@@ -39,6 +41,11 @@ from areal.v2.memory_service.history_types import (
     RevisionOperation,
     RevisionProposal,
 )
+from areal.v2.memory_service.release_store import (
+    InMemoryMemoryReleaseStore,
+    MemoryReleaseStore,
+)
+from areal.v2.memory_service.release_types import MemoryRelease, ReleaseManifest
 from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
     EvidenceEvent,
@@ -300,9 +307,22 @@ def test_error_types_share_memory_service_base_error() -> None:
 
 
 def test_public_module_exports_stable_memory_contracts() -> None:
-    """Expose only the intended immutable evidence and history contracts."""
+    """Expose only the intended immutable evidence, history, and release contracts."""
+    from areal.v2.memory_service import (
+        InMemoryMemoryReleaseStore as PublicInMemoryMemoryReleaseStore,
+    )
+    from areal.v2.memory_service import MemoryRelease as PublicMemoryRelease
+    from areal.v2.memory_service import MemoryReleaseStore as PublicMemoryReleaseStore
+    from areal.v2.memory_service import (
+        ReleaseConflictError as PublicReleaseConflictError,
+    )
+    from areal.v2.memory_service import ReleaseManifest as PublicReleaseManifest
+    from areal.v2.memory_service import (
+        ReleaseNotFoundError as PublicReleaseNotFoundError,
+    )
+
     assert memory_service.__doc__ == (
-        "Public contracts for immutable Memory Service evidence and history."
+        "Public contracts for immutable Memory Service evidence, history, and releases."
     )
     assert memory_service.__all__ == [
         "CandidateConflictError",
@@ -316,11 +336,17 @@ def test_public_module_exports_stable_memory_contracts() -> None:
         "EvidenceStore",
         "InMemoryEvidenceStore",
         "InMemoryMemoryHistoryStore",
+        "InMemoryMemoryReleaseStore",
         "MemoryCandidate",
         "MemoryHistoryStore",
+        "MemoryRelease",
+        "MemoryReleaseStore",
         "MemoryRevision",
         "MemoryScope",
         "MemoryServiceError",
+        "ReleaseConflictError",
+        "ReleaseManifest",
+        "ReleaseNotFoundError",
         "RevisionConflictError",
         "RevisionNotFoundError",
         "RevisionOperation",
@@ -414,6 +440,12 @@ def test_public_module_exports_stable_memory_contracts() -> None:
         strict=True,
     ):
         assert public_symbol is defining_symbol
+    assert PublicInMemoryMemoryReleaseStore is InMemoryMemoryReleaseStore
+    assert PublicMemoryRelease is MemoryRelease
+    assert PublicMemoryReleaseStore is MemoryReleaseStore
+    assert PublicReleaseConflictError is ReleaseConflictError
+    assert PublicReleaseManifest is ReleaseManifest
+    assert PublicReleaseNotFoundError is ReleaseNotFoundError
 
 
 def test_evidence_store_contract_exposes_no_update_or_delete() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -20,9 +20,24 @@ import areal.v2.memory_service as memory_service
 from areal.v2.memory_service import store as store_module
 from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
+    CandidateConflictError,
+    CandidateNotFoundError,
     EvidenceConflictError,
     EvidenceNotFoundError,
     MemoryServiceError,
+    RevisionConflictError,
+    RevisionNotFoundError,
+)
+from areal.v2.memory_service.history_store import (
+    InMemoryMemoryHistoryStore,
+    MemoryHistoryStore,
+)
+from areal.v2.memory_service.history_types import (
+    CandidateProposal,
+    MemoryCandidate,
+    MemoryRevision,
+    RevisionOperation,
+    RevisionProposal,
 )
 from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
@@ -284,8 +299,41 @@ def test_error_types_share_memory_service_base_error() -> None:
     assert issubclass(EvidenceConflictError, MemoryServiceError)
 
 
-def test_public_module_exports_only_stable_evidence_contract() -> None:
-    """Expose only the intended immutable evidence API at package level."""
+def test_public_module_exports_stable_memory_contracts() -> None:
+    """Expose only the intended immutable evidence and history contracts."""
+    assert memory_service.__doc__ == (
+        "Public contracts for immutable Memory Service evidence and history."
+    )
+    assert memory_service.__all__ == [
+        "CandidateConflictError",
+        "CandidateNotFoundError",
+        "CandidateProposal",
+        "EvidenceConflictError",
+        "EvidenceEvent",
+        "EvidenceKind",
+        "EvidenceNotFoundError",
+        "EvidenceRecord",
+        "EvidenceStore",
+        "InMemoryEvidenceStore",
+        "InMemoryMemoryHistoryStore",
+        "MemoryCandidate",
+        "MemoryHistoryStore",
+        "MemoryRevision",
+        "MemoryScope",
+        "MemoryServiceError",
+        "RevisionConflictError",
+        "RevisionNotFoundError",
+        "RevisionOperation",
+        "RevisionProposal",
+    ]
+
+    from areal.v2.memory_service import (
+        CandidateConflictError as PublicCandidateConflictError,
+    )
+    from areal.v2.memory_service import (
+        CandidateNotFoundError as PublicCandidateNotFoundError,
+    )
+    from areal.v2.memory_service import CandidateProposal as PublicCandidateProposal
     from areal.v2.memory_service import (
         EvidenceConflictError as PublicEvidenceConflictError,
     )
@@ -299,21 +347,27 @@ def test_public_module_exports_only_stable_evidence_contract() -> None:
     from areal.v2.memory_service import (
         InMemoryEvidenceStore as PublicInMemoryEvidenceStore,
     )
+    from areal.v2.memory_service import (
+        InMemoryMemoryHistoryStore as PublicInMemoryMemoryHistoryStore,
+    )
+    from areal.v2.memory_service import MemoryCandidate as PublicMemoryCandidate
+    from areal.v2.memory_service import MemoryHistoryStore as PublicMemoryHistoryStore
+    from areal.v2.memory_service import MemoryRevision as PublicMemoryRevision
     from areal.v2.memory_service import MemoryScope as PublicMemoryScope
     from areal.v2.memory_service import MemoryServiceError as PublicMemoryServiceError
+    from areal.v2.memory_service import (
+        RevisionConflictError as PublicRevisionConflictError,
+    )
+    from areal.v2.memory_service import (
+        RevisionNotFoundError as PublicRevisionNotFoundError,
+    )
+    from areal.v2.memory_service import RevisionOperation as PublicRevisionOperation
+    from areal.v2.memory_service import RevisionProposal as PublicRevisionProposal
 
-    assert memory_service.__all__ == [
-        "EvidenceConflictError",
-        "EvidenceEvent",
-        "EvidenceKind",
-        "EvidenceNotFoundError",
-        "EvidenceRecord",
-        "EvidenceStore",
-        "InMemoryEvidenceStore",
-        "MemoryScope",
-        "MemoryServiceError",
-    ]
-    assert (
+    public_symbols = (
+        PublicCandidateConflictError,
+        PublicCandidateNotFoundError,
+        PublicCandidateProposal,
         PublicEvidenceConflictError,
         PublicEvidenceEvent,
         PublicEvidenceKind,
@@ -321,9 +375,21 @@ def test_public_module_exports_only_stable_evidence_contract() -> None:
         PublicEvidenceRecord,
         PublicEvidenceStore,
         PublicInMemoryEvidenceStore,
+        PublicInMemoryMemoryHistoryStore,
+        PublicMemoryCandidate,
+        PublicMemoryHistoryStore,
+        PublicMemoryRevision,
         PublicMemoryScope,
         PublicMemoryServiceError,
-    ) == (
+        PublicRevisionConflictError,
+        PublicRevisionNotFoundError,
+        PublicRevisionOperation,
+        PublicRevisionProposal,
+    )
+    defining_symbols = (
+        CandidateConflictError,
+        CandidateNotFoundError,
+        CandidateProposal,
         EvidenceConflictError,
         EvidenceEvent,
         EvidenceKind,
@@ -331,9 +397,23 @@ def test_public_module_exports_only_stable_evidence_contract() -> None:
         EvidenceRecord,
         EvidenceStore,
         InMemoryEvidenceStore,
+        InMemoryMemoryHistoryStore,
+        MemoryCandidate,
+        MemoryHistoryStore,
+        MemoryRevision,
         MemoryScope,
         MemoryServiceError,
+        RevisionConflictError,
+        RevisionNotFoundError,
+        RevisionOperation,
+        RevisionProposal,
     )
+    for public_symbol, defining_symbol in zip(
+        public_symbols,
+        defining_symbols,
+        strict=True,
+    ):
+        assert public_symbol is defining_symbol
 
 
 def test_evidence_store_contract_exposes_no_update_or_delete() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -55,6 +55,16 @@ class FoldAwareTimezone(tzinfo):
         return "FOLD-DST" if value is not None and value.fold == 0 else "FOLD-STD"
 
 
+class MemoryScopeSubclass(MemoryScope):
+    def __hash__(self) -> int:
+        return 0
+
+
+class EvidenceEventSubclass(EvidenceEvent):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -145,6 +155,37 @@ def test_evidence_store_contract_exposes_no_update_or_delete() -> None:
     assert not hasattr(EvidenceStore, "delete")
     assert not hasattr(store, "update")
     assert not hasattr(store, "delete")
+
+
+def test_append_rejects_evidence_event_subclass() -> None:
+    event = make_event()
+    event_subclass = EvidenceEventSubclass(
+        scope=event.scope,
+        session_id=event.session_id,
+        run_id=event.run_id,
+        sequence_no=event.sequence_no,
+        kind=event.kind,
+        payload=event.payload,
+        observed_at=event.observed_at,
+        idempotency_key=event.idempotency_key,
+    )
+
+    with pytest.raises(TypeError, match="event must be an EvidenceEvent"):
+        InMemoryEvidenceStore().append(event_subclass)
+
+
+def test_get_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        InMemoryEvidenceStore().get(scope, "evd_missing")
+
+
+def test_list_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        InMemoryEvidenceStore().list(scope)
 
 
 def test_append_and_get_round_trip_returns_persisted_record() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -18,6 +18,7 @@ import pytest
 
 import areal.v2.memory_service as memory_service
 from areal.v2.memory_service import store as store_module
+from areal.v2.memory_service._atomic import _atomic_publish
 from areal.v2.memory_service.errors import (
     EvidenceConflictError,
     EvidenceNotFoundError,
@@ -190,6 +191,13 @@ class SetThenInterruptDict(dict[object, object]):
             raise KeyboardInterrupt("injected publication interruption")
 
 
+class InterruptingRollbackDict(SetThenInterruptDict):
+    """Try to interrupt rollback through an overridden mapping method."""
+
+    def pop(self, key: object, default: object = None) -> object:
+        raise KeyboardInterrupt("rollback override must be bypassed")
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -235,6 +243,40 @@ def test_append_rolls_back_every_index_after_base_exception(
     record = store.append(event)
     assert store.get(event.scope, record.evidence_id) == record
     assert store.list(event.scope) == (record,)
+
+
+def test_rollback_bypasses_fault_injection_mapping_overrides() -> None:
+    store = InMemoryEvidenceStore()
+    store._by_idempotency_key = InterruptingRollbackDict()
+    event = make_event()
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        store.append(event)
+
+    assert store._by_evidence_id == {}
+    assert store._by_idempotency_key == {}
+    assert store._by_scope == {}
+    record = store.append(event)
+    assert store.get(event.scope, record.evidence_id) == record
+
+
+def test_atomic_publish_restores_an_existing_scope_list() -> None:
+    old_record = object()
+    new_record = object()
+    scope_index: dict[object, list[object]] = {"scope": [old_record]}
+    failing_index = SetThenInterruptDict()
+
+    with pytest.raises(KeyboardInterrupt, match="publication interruption"):
+        _atomic_publish(
+            mapping_writes=(),
+            sequence_appends=(
+                (scope_index, "scope", new_record),
+                (failing_index, "later-scope", new_record),
+            ),
+        )
+
+    assert scope_index == {"scope": [old_record]}
+    assert failing_index == {}
 
 
 def test_error_types_share_memory_service_base_error() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -546,3 +546,56 @@ def test_hash_prefix_collision_fails_without_overwriting(
     assert original.evidence_id == f"evd_{shared_prefix}"
     assert store.get(original.event.scope, original.evidence_id) is original
     assert store.list(original.event.scope) == (original,)
+
+
+def test_hash_prefix_collision_is_isolated_across_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared_prefix = "a" * 24
+    first_digest = shared_prefix + "b" * 40
+    second_digest = shared_prefix + "c" * 40
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+    missing_scope = make_scope(subject_id="user-3")
+    first_event = make_event(
+        scope=first_scope,
+        payload="first",
+        idempotency_key="shared-key",
+    )
+    second_event = make_event(
+        scope=second_scope,
+        payload="second",
+        idempotency_key="shared-key",
+    )
+    digest_by_canonical_bytes = {
+        first_event.canonical_bytes(): first_digest,
+        second_event.canonical_bytes(): second_digest,
+    }
+
+    class StubHash:
+        def __init__(self, digest: str) -> None:
+            self._digest = digest
+
+        def hexdigest(self) -> str:
+            return self._digest
+
+    def prefix_colliding_sha256(canonical_bytes: bytes) -> StubHash:
+        return StubHash(digest_by_canonical_bytes[canonical_bytes])
+
+    monkeypatch.setattr(store_module.hashlib, "sha256", prefix_colliding_sha256)
+    store = InMemoryEvidenceStore()
+
+    first = store.append(first_event)
+    second = store.append(second_event)
+
+    assert first is not second
+    assert first.evidence_id == second.evidence_id == f"evd_{shared_prefix}"
+    assert first.content_hash == first_digest
+    assert second.content_hash == second_digest
+    assert store.get(first_scope, first.evidence_id) is first
+    assert store.get(second_scope, second.evidence_id) is second
+    with pytest.raises(EvidenceNotFoundError):
+        store.get(missing_scope, first.evidence_id)
+    assert store.list(first_scope) == (first,)
+    assert store.list(second_scope) == (second,)
+    assert store.list(missing_scope) == ()

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import re
 from concurrent.futures import ThreadPoolExecutor
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
 from hashlib import sha256 as calculate_sha256
 from threading import Barrier
 from time import sleep
@@ -40,6 +40,19 @@ class YieldingMissingDict(dict[object, object]):
         if value is default:
             sleep(0.05)
         return value
+
+
+class FoldAwareTimezone(tzinfo):
+    """Minimal repeated-hour timezone independent of the system tz database."""
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        return timedelta(hours=-4 if value is not None and value.fold == 0 else -5)
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(hours=1 if value is not None and value.fold == 0 else 0)
+
+    def tzname(self, value: datetime | None) -> str:
+        return "FOLD-DST" if value is not None and value.fold == 0 else "FOLD-STD"
 
 
 def make_scope(**overrides: str) -> MemoryScope:
@@ -406,6 +419,39 @@ def test_list_returns_deterministic_order_using_normalized_instants() -> None:
         later_run,
         later_session,
     )
+
+
+def test_list_orders_folded_datetimes_by_absolute_instant() -> None:
+    """Normalize before sorting when one repeated wall-clock hour folds backward."""
+    store = InMemoryEvidenceStore()
+    scope = make_scope()
+    fold_timezone = FoldAwareTimezone()
+    earlier_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(2026, 11, 1, 1, 45, tzinfo=fold_timezone, fold=0),
+            idempotency_key="earlier-fold-instant",
+        )
+    )
+    later_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(2026, 11, 1, 1, 15, tzinfo=fold_timezone, fold=1),
+            idempotency_key="later-fold-instant",
+        )
+    )
+
+    assert later_instant.event.observed_at < earlier_instant.event.observed_at
+    assert earlier_instant.event.observed_at.astimezone(
+        UTC
+    ) < later_instant.event.observed_at.astimezone(UTC)
+    assert store.list(scope) == (earlier_instant, later_instant)
 
 
 def test_append_sets_aware_utc_created_at() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -65,6 +65,36 @@ class EvidenceEventSubclass(EvidenceEvent):
         return b"overridden"
 
 
+class MutableHashStr(str):
+    hash_calls: int
+    hash_salt: int
+
+    def __new__(cls, value: str) -> MutableHashStr:
+        instance = str.__new__(cls, value)
+        instance.hash_calls = 0
+        instance.hash_salt = 0
+        return instance
+
+    def __hash__(self) -> int:
+        self.hash_calls += 1
+        return str.__hash__(self) + self.hash_salt
+
+
+class AlwaysEqualStr(str):
+    equality_calls: int
+
+    def __new__(cls, value: str) -> AlwaysEqualStr:
+        instance = str.__new__(cls, value)
+        instance.equality_calls = 0
+        return instance
+
+    def __eq__(self, other: object) -> bool:
+        self.equality_calls += 1
+        return True
+
+    __hash__ = str.__hash__
+
+
 def make_scope(**overrides: str) -> MemoryScope:
     values = {
         "tenant_id": "tenant-1",
@@ -305,6 +335,26 @@ def test_get_missing_evidence_raises_not_found() -> None:
     assert type(error.value) is EvidenceNotFoundError
 
 
+def test_get_snapshots_evidence_id_before_lookup() -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+    query_id = MutableHashStr(record.evidence_id)
+    query_id.hash_salt = 1_000_003
+
+    assert store.get(record.event.scope, query_id) is record
+    assert query_id.hash_calls == 0
+
+
+def test_blank_query_values_remain_no_match() -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+
+    with pytest.raises(EvidenceNotFoundError):
+        store.get(record.event.scope, "")
+    assert store.list(record.event.scope, session_id="") == ()
+    assert store.list(record.event.scope, run_id="") == ()
+
+
 def test_get_hides_record_that_belongs_to_another_scope() -> None:
     store = InMemoryEvidenceStore()
     record = store.append(make_event())
@@ -375,6 +425,16 @@ def test_list_filters_by_scope_session_and_run() -> None:
         session_one_run_two,
     )
     assert store.list(scope, session_id="missing") == ()
+
+
+@pytest.mark.parametrize("field", ["session_id", "run_id"])
+def test_list_snapshots_filter_before_comparison(field: str) -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+    query = AlwaysEqualStr(f"missing-{field}")
+
+    assert store.list(record.event.scope, **{field: query}) == ()
+    assert query.equality_calls == 0
 
 
 def test_list_returns_deterministic_order_using_normalized_instants() -> None:

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the in-memory Memory Service evidence store."""
+
+from __future__ import annotations
+
+import re
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta, timezone
+from hashlib import sha256 as calculate_sha256
+from threading import Barrier
+from time import sleep
+
+import pytest
+
+import areal.v2.memory_service as memory_service
+from areal.v2.memory_service import store as store_module
+from areal.v2.memory_service.errors import (
+    EvidenceConflictError,
+    EvidenceNotFoundError,
+    MemoryServiceError,
+)
+from areal.v2.memory_service.store import EvidenceStore, InMemoryEvidenceStore
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
+CONCURRENCY_TIMEOUT_SECONDS = 10.0
+
+
+class YieldingMissingDict(dict[object, object]):
+    """Yield after a missing lookup to expose an unprotected check/write race."""
+
+    def get(self, key: object, default: object = None) -> object:
+        value = super().get(key, default)
+        if value is default:
+            sleep(0.05)
+        return value
+
+
+def make_scope(**overrides: str) -> MemoryScope:
+    values = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)
+
+
+def make_event(**overrides: object) -> EvidenceEvent:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "sequence_no": 0,
+        "kind": EvidenceKind.USER_MESSAGE,
+        "payload": "hello",
+        "observed_at": UTC_INSTANT,
+        "idempotency_key": "idempotency-1",
+    }
+    values.update(overrides)
+    return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+def test_error_types_share_memory_service_base_error() -> None:
+    assert issubclass(EvidenceNotFoundError, MemoryServiceError)
+    assert issubclass(EvidenceConflictError, MemoryServiceError)
+
+
+def test_public_module_exports_only_stable_evidence_contract() -> None:
+    """Expose only the intended immutable evidence API at package level."""
+    from areal.v2.memory_service import (
+        EvidenceConflictError as PublicEvidenceConflictError,
+    )
+    from areal.v2.memory_service import EvidenceEvent as PublicEvidenceEvent
+    from areal.v2.memory_service import EvidenceKind as PublicEvidenceKind
+    from areal.v2.memory_service import (
+        EvidenceNotFoundError as PublicEvidenceNotFoundError,
+    )
+    from areal.v2.memory_service import EvidenceRecord as PublicEvidenceRecord
+    from areal.v2.memory_service import EvidenceStore as PublicEvidenceStore
+    from areal.v2.memory_service import (
+        InMemoryEvidenceStore as PublicInMemoryEvidenceStore,
+    )
+    from areal.v2.memory_service import MemoryScope as PublicMemoryScope
+    from areal.v2.memory_service import MemoryServiceError as PublicMemoryServiceError
+
+    assert memory_service.__all__ == [
+        "EvidenceConflictError",
+        "EvidenceEvent",
+        "EvidenceKind",
+        "EvidenceNotFoundError",
+        "EvidenceRecord",
+        "EvidenceStore",
+        "InMemoryEvidenceStore",
+        "MemoryScope",
+        "MemoryServiceError",
+    ]
+    assert (
+        PublicEvidenceConflictError,
+        PublicEvidenceEvent,
+        PublicEvidenceKind,
+        PublicEvidenceNotFoundError,
+        PublicEvidenceRecord,
+        PublicEvidenceStore,
+        PublicInMemoryEvidenceStore,
+        PublicMemoryScope,
+        PublicMemoryServiceError,
+    ) == (
+        EvidenceConflictError,
+        EvidenceEvent,
+        EvidenceKind,
+        EvidenceNotFoundError,
+        EvidenceRecord,
+        EvidenceStore,
+        InMemoryEvidenceStore,
+        MemoryScope,
+        MemoryServiceError,
+    )
+
+
+def test_evidence_store_contract_exposes_no_update_or_delete() -> None:
+    """Keep both the protocol and implementation append-only."""
+    store = InMemoryEvidenceStore()
+
+    assert not hasattr(EvidenceStore, "update")
+    assert not hasattr(EvidenceStore, "delete")
+    assert not hasattr(store, "update")
+    assert not hasattr(store, "delete")
+
+
+def test_append_and_get_round_trip_returns_persisted_record() -> None:
+    store = InMemoryEvidenceStore()
+    event = make_event()
+
+    record = store.append(event)
+
+    assert record.event is event
+    assert store.get(event.scope, record.evidence_id) is record
+
+
+def test_append_identical_retry_returns_exact_original_record() -> None:
+    store = InMemoryEvidenceStore()
+    original_event = make_event()
+    equivalent_retry = make_event()
+    assert equivalent_retry is not original_event
+    assert equivalent_retry.canonical_bytes() == original_event.canonical_bytes()
+
+    original_record = store.append(original_event)
+    retry_record = store.append(equivalent_retry)
+
+    assert retry_record is original_record
+    assert retry_record.event is original_event
+    assert store.list(original_event.scope) == (original_record,)
+
+
+def test_concurrent_identical_appends_return_exact_original_record() -> None:
+    """Serialize same-event races into one record without duplicate writes."""
+    store = InMemoryEvidenceStore()
+    store._by_evidence_id = YieldingMissingDict()
+    store._by_idempotency_key = YieldingMissingDict()
+    event = make_event()
+    caller_count = 32
+    start = Barrier(caller_count, timeout=CONCURRENCY_TIMEOUT_SECONDS)
+
+    def append_after_start() -> EvidenceRecord:
+        start.wait()
+        return store.append(event)
+
+    with ThreadPoolExecutor(max_workers=caller_count) as executor:
+        futures = [executor.submit(append_after_start) for _ in range(caller_count)]
+        records = tuple(
+            future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS) for future in futures
+        )
+
+    original = records[0]
+    assert all(record is original for record in records)
+    assert {record.evidence_id for record in records} == {original.evidence_id}
+    assert store.list(event.scope) == (original,)
+
+
+def test_append_rejects_changed_event_with_same_scoped_idempotency_key() -> None:
+    store = InMemoryEvidenceStore()
+    original = store.append(make_event(payload="first"))
+
+    with pytest.raises(EvidenceConflictError, match="idempotency"):
+        store.append(make_event(payload="changed"))
+
+    assert store.get(original.event.scope, original.evidence_id) is original
+    assert store.list(original.event.scope) == (original,)
+
+
+def test_concurrent_scoped_idempotency_conflicts_leave_only_winner_indexed() -> None:
+    """Commit one racing event atomically and reject every conflicting writer."""
+    store = InMemoryEvidenceStore()
+    store._by_evidence_id = YieldingMissingDict()
+    store._by_idempotency_key = YieldingMissingDict()
+    scope = make_scope()
+    events = tuple(
+        make_event(scope=scope, sequence_no=index, payload=f"payload-{index}")
+        for index in range(32)
+    )
+    start = Barrier(len(events), timeout=CONCURRENCY_TIMEOUT_SECONDS)
+
+    def append_after_start(event: EvidenceEvent) -> EvidenceRecord:
+        start.wait()
+        return store.append(event)
+
+    with ThreadPoolExecutor(max_workers=len(events)) as executor:
+        futures = [executor.submit(append_after_start, event) for event in events]
+        winners: list[EvidenceRecord] = []
+        conflicts: list[EvidenceConflictError] = []
+        for future in futures:
+            try:
+                winners.append(future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS))
+            except EvidenceConflictError as error:
+                conflicts.append(error)
+
+    assert len(winners) == 1
+    assert len(conflicts) == len(events) - 1
+    assert {type(error) for error in conflicts} == {EvidenceConflictError}
+
+    winner = winners[0]
+    losers = tuple(event for event in events if event is not winner.event)
+    assert len(losers) == len(events) - 1
+    assert store.list(scope) == (winner,)
+    assert store.get(scope, winner.evidence_id) is winner
+    assert store.append(winner.event) is winner
+
+    for loser in losers:
+        with pytest.raises(EvidenceConflictError, match="idempotency"):
+            store.append(loser)
+        loser_hash = calculate_sha256(loser.canonical_bytes()).hexdigest()
+        with pytest.raises(EvidenceNotFoundError):
+            store.get(scope, f"evd_{loser_hash[:24]}")
+
+    assert store.list(scope) == (winner,)
+
+
+def test_get_missing_evidence_raises_not_found() -> None:
+    store = InMemoryEvidenceStore()
+
+    with pytest.raises(EvidenceNotFoundError) as error:
+        store.get(make_scope(), "evd_missing")
+
+    assert type(error.value) is EvidenceNotFoundError
+
+
+def test_get_hides_record_that_belongs_to_another_scope() -> None:
+    store = InMemoryEvidenceStore()
+    record = store.append(make_event())
+    other_scope = make_scope(subject_id="user-2")
+
+    with pytest.raises(EvidenceNotFoundError) as missing_error:
+        store.get(record.event.scope, "evd_missing")
+    with pytest.raises(EvidenceNotFoundError) as wrong_scope_error:
+        store.get(other_scope, record.evidence_id)
+
+    assert type(wrong_scope_error.value) is EvidenceNotFoundError
+    assert str(wrong_scope_error.value) == str(missing_error.value).replace(
+        "evd_missing", record.evidence_id
+    )
+
+
+def test_list_filters_by_scope_session_and_run() -> None:
+    store = InMemoryEvidenceStore()
+    scope = make_scope()
+    other_scope = make_scope(subject_id="user-2")
+    session_one_run_one = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-1",
+            run_id="run-1",
+            idempotency_key="one-one",
+        )
+    )
+    session_one_run_two = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-1",
+            run_id="run-2",
+            idempotency_key="one-two",
+        )
+    )
+    session_two_run_one = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-2",
+            run_id="run-1",
+            idempotency_key="two-one",
+        )
+    )
+    store.append(
+        make_event(
+            scope=other_scope,
+            session_id="session-1",
+            run_id="run-1",
+            idempotency_key="one-one",
+        )
+    )
+
+    assert store.list(scope) == (
+        session_one_run_one,
+        session_one_run_two,
+        session_two_run_one,
+    )
+    assert store.list(scope, session_id="session-1") == (
+        session_one_run_one,
+        session_one_run_two,
+    )
+    assert store.list(scope, run_id="run-1") == (
+        session_one_run_one,
+        session_two_run_one,
+    )
+    assert store.list(scope, session_id="session-1", run_id="run-2") == (
+        session_one_run_two,
+    )
+    assert store.list(scope, session_id="missing") == ()
+
+
+def test_list_returns_deterministic_order_using_normalized_instants() -> None:
+    store = InMemoryEvidenceStore()
+    scope = make_scope()
+    earlier_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(
+                2026, 7, 7, 12, 0, tzinfo=timezone(timedelta(hours=8))
+            ),
+            idempotency_key="earlier-instant",
+        )
+    )
+    later_instant = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=1,
+            observed_at=datetime(2026, 7, 7, 4, 30, tzinfo=UTC),
+            idempotency_key="later-instant",
+        )
+    )
+    tied_a = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=2,
+            payload="tie-a",
+            idempotency_key="tie-a",
+        )
+    )
+    tied_b = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=2,
+            payload="tie-b",
+            idempotency_key="tie-b",
+        )
+    )
+    later_sequence = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-a",
+            sequence_no=3,
+            observed_at=datetime(2020, 1, 1, tzinfo=UTC),
+            idempotency_key="later-sequence",
+        )
+    )
+    later_run = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-a",
+            run_id="run-b",
+            sequence_no=0,
+            idempotency_key="later-run",
+        )
+    )
+    later_session = store.append(
+        make_event(
+            scope=scope,
+            session_id="session-b",
+            run_id="run-a",
+            sequence_no=0,
+            idempotency_key="later-session",
+        )
+    )
+    tied_by_id = tuple(sorted((tied_a, tied_b), key=lambda item: item.evidence_id))
+
+    assert store.list(scope) == (
+        earlier_instant,
+        later_instant,
+        *tied_by_id,
+        later_sequence,
+        later_run,
+        later_session,
+    )
+
+
+def test_append_sets_aware_utc_created_at() -> None:
+    record = InMemoryEvidenceStore().append(make_event())
+
+    assert record.created_at.tzinfo is UTC
+    assert record.created_at.utcoffset() == timedelta(0)
+
+
+def test_append_uses_sha256_content_hash_and_derived_evidence_id() -> None:
+    event = make_event()
+    expected_hash = calculate_sha256(event.canonical_bytes()).hexdigest()
+
+    record = InMemoryEvidenceStore().append(event)
+
+    assert record.content_hash == expected_hash
+    assert re.fullmatch(r"[0-9a-f]{64}", record.content_hash)
+    assert record.evidence_id == f"evd_{expected_hash[:24]}"
+    assert re.fullmatch(r"evd_[0-9a-f]{24}", record.evidence_id)
+
+
+def test_same_idempotency_key_is_independent_across_scopes() -> None:
+    store = InMemoryEvidenceStore()
+    first_scope = make_scope(subject_id="user-1")
+    second_scope = make_scope(subject_id="user-2")
+
+    first = store.append(make_event(scope=first_scope, payload="first"))
+    second = store.append(make_event(scope=second_scope, payload="second"))
+
+    assert first is not second
+    assert first.evidence_id != second.evidence_id
+    assert store.list(first_scope) == (first,)
+    assert store.list(second_scope) == (second,)
+
+
+def test_full_hash_collision_fails_without_overwriting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ConstantHash:
+        def hexdigest(self) -> str:
+            return "a" * 64
+
+    def constant_sha256(_: bytes) -> ConstantHash:
+        return ConstantHash()
+
+    monkeypatch.setattr(store_module.hashlib, "sha256", constant_sha256)
+    store = InMemoryEvidenceStore()
+    original = store.append(make_event(idempotency_key="first"))
+    colliding_event = make_event(payload="different", idempotency_key="second")
+
+    with pytest.raises(EvidenceConflictError, match="collision"):
+        store.append(colliding_event)
+
+    assert store.get(original.event.scope, original.evidence_id) is original
+    assert store.list(original.event.scope) == (original,)
+
+
+def test_hash_prefix_collision_fails_without_overwriting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject distinct full hashes that derive the same truncated evidence ID."""
+    shared_prefix = "a" * 24
+    original_digest = shared_prefix + "b" * 40
+    colliding_digest = shared_prefix + "c" * 40
+    original_event = make_event(idempotency_key="first")
+    colliding_event = make_event(payload="different", idempotency_key="second")
+    digest_by_canonical_bytes = {
+        original_event.canonical_bytes(): original_digest,
+        colliding_event.canonical_bytes(): colliding_digest,
+    }
+
+    class StubHash:
+        def __init__(self, digest: str) -> None:
+            self._digest = digest
+
+        def hexdigest(self) -> str:
+            return self._digest
+
+    def prefix_colliding_sha256(canonical_bytes: bytes) -> StubHash:
+        return StubHash(digest_by_canonical_bytes[canonical_bytes])
+
+    monkeypatch.setattr(store_module.hashlib, "sha256", prefix_colliding_sha256)
+    store = InMemoryEvidenceStore()
+    original = store.append(original_event)
+
+    with pytest.raises(EvidenceConflictError, match="collision"):
+        store.append(colliding_event)
+
+    assert original.content_hash == original_digest
+    assert original.evidence_id == f"evd_{shared_prefix}"
+    assert store.get(original.event.scope, original.evidence_id) is original
+    assert store.list(original.event.scope) == (original,)

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -4,11 +4,14 @@
 
 from __future__ import annotations
 
+import faulthandler
 import re
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta, timezone, tzinfo
 from hashlib import sha256 as calculate_sha256
-from threading import Barrier
+from threading import Barrier, Event
 from time import sleep
 
 import pytest
@@ -30,6 +33,84 @@ from areal.v2.memory_service.types import (
 
 UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
 CONCURRENCY_TIMEOUT_SECONDS = 10.0
+HARD_CONCURRENCY_TIMEOUT_SECONDS = CONCURRENCY_TIMEOUT_SECONDS + 5.0
+
+
+@contextmanager
+def _hard_bounded_executor(*, max_workers: int) -> Iterator[ThreadPoolExecutor]:
+    faulthandler.dump_traceback_later(
+        HARD_CONCURRENCY_TIMEOUT_SECONDS,
+        exit=True,
+    )
+    try:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            yield executor
+    finally:
+        faulthandler.cancel_dump_traceback_later()
+
+
+def test_hard_bounded_executor_waits_for_workers_before_cancel_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bounded_executor = _hard_bounded_executor
+    watchdog_events: list[object] = []
+    worker_started = Event()
+    shutdown_started = Event()
+    shutdown_finished = Event()
+    worker_finished = Event()
+    shutdown_wait_values: list[bool] = []
+    original_shutdown = ThreadPoolExecutor.shutdown
+    original_error = RuntimeError("body failed")
+
+    def arm_watchdog(timeout: float, *, exit: bool) -> None:
+        watchdog_events.append(("arm", timeout, exit))
+
+    def cancel_watchdog() -> None:
+        watchdog_events.append(
+            (
+                "cancel",
+                worker_finished.is_set(),
+                shutdown_finished.is_set(),
+            )
+        )
+
+    def observe_shutdown(
+        executor: ThreadPoolExecutor,
+        wait: bool = True,
+        *,
+        cancel_futures: bool = False,
+    ) -> None:
+        shutdown_wait_values.append(wait)
+        shutdown_started.set()
+        original_shutdown(
+            executor,
+            wait=wait,
+            cancel_futures=cancel_futures,
+        )
+        shutdown_finished.set()
+
+    def slow_worker() -> None:
+        worker_started.set()
+        assert shutdown_started.wait(timeout=CONCURRENCY_TIMEOUT_SECONDS)
+        worker_finished.set()
+
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", arm_watchdog)
+    monkeypatch.setattr(faulthandler, "cancel_dump_traceback_later", cancel_watchdog)
+    monkeypatch.setattr(ThreadPoolExecutor, "shutdown", observe_shutdown)
+
+    with pytest.raises(RuntimeError) as raised:
+        with bounded_executor(max_workers=1) as executor:
+            future = executor.submit(slow_worker)
+            assert worker_started.wait(timeout=CONCURRENCY_TIMEOUT_SECONDS)
+            raise original_error
+
+    assert raised.value is original_error
+    assert future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS) is None
+    assert watchdog_events == [
+        ("arm", CONCURRENCY_TIMEOUT_SECONDS + 5.0, True),
+        ("cancel", True, True),
+    ]
+    assert shutdown_wait_values == [True]
 
 
 class YieldingMissingDict(dict[object, object]):
@@ -256,7 +337,7 @@ def test_concurrent_identical_appends_return_exact_original_record() -> None:
         start.wait()
         return store.append(event)
 
-    with ThreadPoolExecutor(max_workers=caller_count) as executor:
+    with _hard_bounded_executor(max_workers=caller_count) as executor:
         futures = [executor.submit(append_after_start) for _ in range(caller_count)]
         records = tuple(
             future.result(timeout=CONCURRENCY_TIMEOUT_SECONDS) for future in futures
@@ -295,7 +376,7 @@ def test_concurrent_scoped_idempotency_conflicts_leave_only_winner_indexed() -> 
         start.wait()
         return store.append(event)
 
-    with ThreadPoolExecutor(max_workers=len(events)) as executor:
+    with _hard_bounded_executor(max_workers=len(events)) as executor:
         futures = [executor.submit(append_after_start, event) for event in events]
         winners: list[EvidenceRecord] = []
         conflicts: list[EvidenceConflictError] = []

--- a/tests/v2/memory_service/test_store.py
+++ b/tests/v2/memory_service/test_store.py
@@ -422,17 +422,19 @@ def test_list_returns_deterministic_order_using_normalized_instants() -> None:
 
 
 def test_list_orders_folded_datetimes_by_absolute_instant() -> None:
-    """Normalize before sorting when one repeated wall-clock hour folds backward."""
+    """Snapshot and sort absolute instants when a wall-clock hour folds backward."""
     store = InMemoryEvidenceStore()
     scope = make_scope()
     fold_timezone = FoldAwareTimezone()
+    earlier_source = datetime(2026, 11, 1, 1, 45, tzinfo=fold_timezone, fold=0)
+    later_source = datetime(2026, 11, 1, 1, 15, tzinfo=fold_timezone, fold=1)
     earlier_instant = store.append(
         make_event(
             scope=scope,
             session_id="session-a",
             run_id="run-a",
             sequence_no=1,
-            observed_at=datetime(2026, 11, 1, 1, 45, tzinfo=fold_timezone, fold=0),
+            observed_at=earlier_source,
             idempotency_key="earlier-fold-instant",
         )
     )
@@ -442,15 +444,15 @@ def test_list_orders_folded_datetimes_by_absolute_instant() -> None:
             session_id="session-a",
             run_id="run-a",
             sequence_no=1,
-            observed_at=datetime(2026, 11, 1, 1, 15, tzinfo=fold_timezone, fold=1),
+            observed_at=later_source,
             idempotency_key="later-fold-instant",
         )
     )
 
-    assert later_instant.event.observed_at < earlier_instant.event.observed_at
-    assert earlier_instant.event.observed_at.astimezone(
-        UTC
-    ) < later_instant.event.observed_at.astimezone(UTC)
+    assert earlier_instant.event.observed_at == datetime(2026, 11, 1, 5, 45, tzinfo=UTC)
+    assert later_instant.event.observed_at == datetime(2026, 11, 1, 6, 15, tzinfo=UTC)
+    assert earlier_instant.event.observed_at.tzinfo is UTC
+    assert later_instant.event.observed_at.tzinfo is UTC
     assert store.list(scope) == (earlier_instant, later_instant)
 
 

--- a/tests/v2/memory_service/test_types.py
+++ b/tests/v2/memory_service/test_types.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for immutable Memory Service evidence value objects."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from areal.v2.memory_service.types import (
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceRecord,
+    MemoryScope,
+)
+
+UTC_INSTANT = datetime(2026, 7, 7, 4, 5, 6, 789000, tzinfo=UTC)
+LONE_SURROGATE = "\ud800"
+PLUS_ONE_HOUR = timezone(timedelta(hours=1))
+MINUS_ONE_HOUR = timezone(-timedelta(hours=1))
+UTC_OVERFLOWING_DATETIMES = (
+    datetime.min.replace(tzinfo=PLUS_ONE_HOUR),
+    datetime.max.replace(tzinfo=MINUS_ONE_HOUR),
+)
+VALID_UTC_BOUNDARIES = (
+    (
+        (datetime.min + timedelta(hours=1)).replace(tzinfo=PLUS_ONE_HOUR),
+        datetime.min.replace(tzinfo=UTC),
+    ),
+    (
+        (datetime.max - timedelta(hours=1)).replace(tzinfo=MINUS_ONE_HOUR),
+        datetime.max.replace(tzinfo=UTC),
+    ),
+)
+
+
+def make_scope(**overrides: object) -> MemoryScope:
+    values: dict[str, object] = {
+        "tenant_id": "tenant-1",
+        "namespace": "assistant-memory",
+        "subject_id": "user-1",
+    }
+    values.update(overrides)
+    return MemoryScope(**values)  # type: ignore[arg-type]
+
+
+def make_event(**overrides: object) -> EvidenceEvent:
+    values: dict[str, object] = {
+        "scope": make_scope(),
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "sequence_no": 0,
+        "kind": EvidenceKind.USER_MESSAGE,
+        "payload": "hello",
+        "observed_at": UTC_INSTANT,
+        "idempotency_key": "idempotency-1",
+    }
+    values.update(overrides)
+    return EvidenceEvent(**values)  # type: ignore[arg-type]
+
+
+def make_record(**overrides: object) -> EvidenceRecord:
+    values: dict[str, object] = {
+        "evidence_id": "evidence-1",
+        "event": make_event(),
+        "content_hash": "sha256:abc123",
+        "created_at": UTC_INSTANT,
+    }
+    values.update(overrides)
+    return EvidenceRecord(**values)  # type: ignore[arg-type]
+
+
+def test_evidence_kind_values_are_lowercase_snake_case() -> None:
+    assert {kind.name: kind.value for kind in EvidenceKind} == {
+        "USER_MESSAGE": "user_message",
+        "AGENT_MESSAGE": "agent_message",
+        "TOOL_CALL": "tool_call",
+        "TOOL_RESULT": "tool_result",
+        "ENVIRONMENT": "environment",
+        "FEEDBACK": "feedback",
+        "OUTCOME": "outcome",
+    }
+
+
+@pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
+@pytest.mark.parametrize("value", ["", " \t\n"])
+def test_memory_scope_rejects_blank_identifiers(field: str, value: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_scope(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
+@pytest.mark.parametrize("value", [None, 7])
+def test_memory_scope_rejects_non_string_identifiers(field: str, value: object) -> None:
+    with pytest.raises(TypeError, match=field):
+        make_scope(**{field: value})
+
+
+def test_memory_scope_preserves_identifier_whitespace() -> None:
+    scope = MemoryScope(
+        tenant_id=" tenant-1 ",
+        namespace=" assistant-memory ",
+        subject_id=" user-1 ",
+    )
+
+    assert scope.tenant_id == " tenant-1 "
+    assert scope.namespace == " assistant-memory "
+    assert scope.subject_id == " user-1 "
+
+
+@pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
+def test_memory_scope_rejects_invalid_unicode_identifier(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_scope(**{field: LONE_SURROGATE})
+
+
+@pytest.mark.parametrize("field", ["session_id", "run_id", "idempotency_key"])
+@pytest.mark.parametrize("value", ["", " \t\n"])
+def test_evidence_event_rejects_blank_identifiers(field: str, value: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_event(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["session_id", "run_id", "idempotency_key"])
+@pytest.mark.parametrize("value", [None, 7])
+def test_evidence_event_rejects_non_string_identifiers(
+    field: str, value: object
+) -> None:
+    with pytest.raises(TypeError, match=field):
+        make_event(**{field: value})
+
+
+def test_evidence_event_preserves_identifier_whitespace() -> None:
+    event = make_event(
+        session_id=" session-1 ",
+        run_id=" run-1 ",
+        idempotency_key=" idempotency-1 ",
+    )
+
+    assert event.session_id == " session-1 "
+    assert event.run_id == " run-1 "
+    assert event.idempotency_key == " idempotency-1 "
+
+
+@pytest.mark.parametrize(
+    "field", ["session_id", "run_id", "idempotency_key", "payload"]
+)
+def test_evidence_event_rejects_invalid_unicode_string(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_event(**{field: LONE_SURROGATE})
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        {
+            "tenant_id": "tenant-1",
+            "namespace": "assistant-memory",
+            "subject_id": "user-1",
+        },
+        object(),
+    ],
+    ids=["dict", "object"],
+)
+def test_evidence_event_requires_memory_scope(scope: object) -> None:
+    with pytest.raises(TypeError, match="scope"):
+        make_event(scope=scope)
+
+
+def test_evidence_event_accepts_empty_string_payload() -> None:
+    assert make_event(payload="").payload == ""
+
+
+@pytest.mark.parametrize("payload", [None, b"hello", 7])
+def test_evidence_event_rejects_non_string_payload(payload: object) -> None:
+    with pytest.raises(TypeError, match="payload"):
+        make_event(payload=payload)
+
+
+@pytest.mark.parametrize("sequence_no", [True, False, 1.0, "1", None])
+def test_evidence_event_rejects_non_integer_sequence_numbers(
+    sequence_no: object,
+) -> None:
+    with pytest.raises(TypeError, match="sequence_no"):
+        make_event(sequence_no=sequence_no)
+
+
+def test_evidence_event_rejects_negative_sequence_number() -> None:
+    with pytest.raises(ValueError, match="sequence_no"):
+        make_event(sequence_no=-1)
+
+
+def test_evidence_event_accepts_zero_sequence_number() -> None:
+    assert make_event(sequence_no=0).sequence_no == 0
+
+
+def test_evidence_event_accepts_maximum_protocol_sequence_number() -> None:
+    sequence_no = 2**63 - 1
+    event = make_event(sequence_no=sequence_no)
+
+    assert event.sequence_no == sequence_no
+    assert json.loads(event.canonical_bytes())["sequence_no"] == sequence_no
+
+
+@pytest.mark.parametrize(
+    "sequence_no",
+    [2**63, 10**4300],
+    ids=["past-int64", "past-python-json-digit-limit"],
+)
+def test_evidence_event_rejects_sequence_number_above_protocol_maximum(
+    sequence_no: int,
+) -> None:
+    with pytest.raises(ValueError, match="sequence_no"):
+        make_event(sequence_no=sequence_no)
+
+
+@pytest.mark.parametrize("kind", ["user_message", None, 7])
+def test_evidence_event_requires_evidence_kind(kind: object) -> None:
+    with pytest.raises(TypeError, match="kind"):
+        make_event(kind=kind)
+
+
+@pytest.mark.parametrize("observed_at", [None, "2026-07-07T04:05:06Z"])
+def test_evidence_event_rejects_non_datetime_observed_at(
+    observed_at: object,
+) -> None:
+    with pytest.raises(TypeError, match="observed_at"):
+        make_event(observed_at=observed_at)
+
+
+def test_evidence_event_rejects_naive_observed_at() -> None:
+    with pytest.raises(ValueError, match="observed_at"):
+        make_event(observed_at=datetime(2026, 7, 7, 4, 5, 6))
+
+
+@pytest.mark.parametrize(
+    "observed_at",
+    UTC_OVERFLOWING_DATETIMES,
+    ids=["minimum-at-plus-one", "maximum-at-minus-one"],
+)
+def test_evidence_event_rejects_datetime_that_cannot_normalize_to_utc(
+    observed_at: datetime,
+) -> None:
+    with pytest.raises(ValueError, match="observed_at"):
+        make_event(observed_at=observed_at)
+
+
+def test_canonical_bytes_are_sorted_compact_and_deterministic() -> None:
+    event = make_event()
+
+    expected = (
+        b'{"idempotency_key":"idempotency-1","kind":"user_message",'
+        b'"observed_at":"2026-07-07T04:05:06.789000+00:00",'
+        b'"payload":"hello","run_id":"run-1",'
+        b'"scope":{"namespace":"assistant-memory","subject_id":"user-1",'
+        b'"tenant_id":"tenant-1"},"sequence_no":0,"session_id":"session-1"}'
+    )
+
+    assert event.canonical_bytes() == expected
+    assert event.canonical_bytes() == make_event().canonical_bytes()
+
+
+def test_canonical_bytes_preserve_valid_non_ascii_payload() -> None:
+    payload = "你好，世界 🌍"
+    canonical = make_event(payload=payload).canonical_bytes()
+
+    assert payload.encode("utf-8") in canonical
+    assert json.loads(canonical)["payload"] == payload
+
+
+@pytest.mark.parametrize(
+    ("observed_at", "expected_utc"),
+    VALID_UTC_BOUNDARIES,
+    ids=["minimum", "maximum"],
+)
+def test_canonical_bytes_support_valid_utc_datetime_boundaries(
+    observed_at: datetime, expected_utc: datetime
+) -> None:
+    event = make_event(observed_at=observed_at)
+
+    assert event.observed_at is observed_at
+    assert (
+        json.loads(event.canonical_bytes())["observed_at"] == expected_utc.isoformat()
+    )
+
+
+def test_canonical_bytes_normalize_semantically_equal_instants_to_utc() -> None:
+    utc_event = make_event(observed_at=UTC_INSTANT)
+    utc_plus_eight_event = make_event(
+        observed_at=UTC_INSTANT.astimezone(timezone(timedelta(hours=8)))
+    )
+
+    assert utc_event.observed_at != utc_plus_eight_event.observed_at or (
+        utc_event.observed_at.tzinfo != utc_plus_eight_event.observed_at.tzinfo
+    )
+    assert utc_event.canonical_bytes() == utc_plus_eight_event.canonical_bytes()
+
+
+@pytest.mark.parametrize(
+    "event",
+    ["not-an-event", {"payload": "hello"}, object()],
+    ids=["string", "dict", "object"],
+)
+def test_evidence_record_requires_evidence_event(event: object) -> None:
+    with pytest.raises(TypeError, match="event"):
+        make_record(event=event)
+
+
+@pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
+@pytest.mark.parametrize("value", ["", " \t\n"])
+def test_evidence_record_rejects_blank_identifiers_and_hash(
+    field: str, value: str
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_record(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
+@pytest.mark.parametrize("value", [None, 7])
+def test_evidence_record_rejects_non_string_identifiers_and_hash(
+    field: str, value: object
+) -> None:
+    with pytest.raises(TypeError, match=field):
+        make_record(**{field: value})
+
+
+def test_evidence_record_preserves_identifier_and_hash_whitespace() -> None:
+    record = make_record(evidence_id=" evidence-1 ", content_hash=" sha256:abc123 ")
+
+    assert record.evidence_id == " evidence-1 "
+    assert record.content_hash == " sha256:abc123 "
+
+
+@pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
+def test_evidence_record_rejects_invalid_unicode_string(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_record(**{field: LONE_SURROGATE})
+
+
+@pytest.mark.parametrize("created_at", [None, "2026-07-07T04:05:06Z"])
+def test_evidence_record_rejects_non_datetime_created_at(created_at: object) -> None:
+    with pytest.raises(TypeError, match="created_at"):
+        make_record(created_at=created_at)
+
+
+def test_evidence_record_rejects_naive_created_at() -> None:
+    with pytest.raises(ValueError, match="created_at"):
+        make_record(created_at=datetime(2026, 7, 7, 4, 5, 6))
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    UTC_OVERFLOWING_DATETIMES,
+    ids=["minimum-at-plus-one", "maximum-at-minus-one"],
+)
+def test_evidence_record_rejects_datetime_that_cannot_normalize_to_utc(
+    created_at: datetime,
+) -> None:
+    with pytest.raises(ValueError, match="created_at"):
+        make_record(created_at=created_at)
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    [value for value, _ in VALID_UTC_BOUNDARIES],
+    ids=["minimum", "maximum"],
+)
+def test_evidence_record_accepts_valid_utc_datetime_boundaries(
+    created_at: datetime,
+) -> None:
+    assert make_record(created_at=created_at).created_at is created_at
+
+
+@pytest.mark.parametrize(
+    ("instance", "field", "new_value"),
+    [
+        (make_scope(), "tenant_id", "other-tenant"),
+        (make_event(), "payload", "other payload"),
+        (make_record(), "content_hash", "sha256:other"),
+    ],
+    ids=["memory-scope", "evidence-event", "evidence-record"],
+)
+def test_value_objects_are_frozen_and_slotted(
+    instance: object, field: str, new_value: str
+) -> None:
+    assert not hasattr(instance, "__dict__")
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(instance, field, new_value)

--- a/tests/v2/memory_service/test_types.py
+++ b/tests/v2/memory_service/test_types.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta, timezone, tzinfo
 
 import pytest
 
+from areal.v2.memory_service.store import InMemoryEvidenceStore
 from areal.v2.memory_service.types import (
     EvidenceEvent,
     EvidenceKind,
@@ -63,6 +64,51 @@ class StatefulDatetime(datetime):
 
     def isoformat(self, sep: str = "T", timespec: str = "auto") -> str:
         return f"{datetime.isoformat(self, sep, timespec)}{self.suffix}"
+
+
+class MutableHashStr(str):
+    """String subclass whose hash can change after construction."""
+
+    hash_salt: int
+
+    def __new__(cls, value: str) -> MutableHashStr:
+        instance = str.__new__(cls, value)
+        instance.hash_salt = 0
+        return instance
+
+    def __hash__(self) -> int:
+        return str.__hash__(self) + self.hash_salt
+
+    def __str__(self) -> str:
+        return "overridden"
+
+
+class AdversarialStr(str):
+    """String subclass overriding validation and conversion operations."""
+
+    def __str__(self) -> str:
+        return "overridden"
+
+    def strip(self, chars: str | None = None) -> str:
+        return "overridden"
+
+    def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
+        return b"overridden"
+
+
+class MemoryScopeSubclass(MemoryScope):
+    def __hash__(self) -> int:
+        return 0
+
+
+class EvidenceEventSubclass(EvidenceEvent):
+    def canonical_bytes(self) -> bytes:
+        return b"overridden"
+
+
+class OverriddenInt(int):
+    def __int__(self) -> int:
+        return 999
 
 
 def make_scope(**overrides: object) -> MemoryScope:
@@ -139,10 +185,52 @@ def test_memory_scope_preserves_identifier_whitespace() -> None:
     assert scope.subject_id == " user-1 "
 
 
+def test_memory_scope_snapshots_mutable_hash_strings_for_store_indexes() -> None:
+    tenant_id = MutableHashStr("tenant-1")
+    namespace = MutableHashStr("assistant-memory")
+    subject_id = MutableHashStr("user-1")
+    scope = MemoryScope(
+        tenant_id=tenant_id,
+        namespace=namespace,
+        subject_id=subject_id,
+    )
+    event = make_event(scope=scope)
+    store = InMemoryEvidenceStore()
+    scope_hash = hash(scope)
+    original = store.append(event)
+
+    tenant_id.hash_salt = 1_000_003
+    namespace.hash_salt = 1_000_003
+    subject_id.hash_salt = 1_000_003
+    retry = store.append(event)
+
+    assert retry is original
+    assert hash(scope) == scope_hash
+    assert type(scope.tenant_id) is str
+    assert type(scope.namespace) is str
+    assert type(scope.subject_id) is str
+    assert scope == make_scope()
+    assert store.get(scope, original.evidence_id) is original
+    assert store.list(scope) == (original,)
+    assert len(store._by_evidence_id) == 1
+    assert len(store._by_idempotency_key) == 1
+    assert len(store._by_scope) == 1
+
+
 @pytest.mark.parametrize("field", ["tenant_id", "namespace", "subject_id"])
 def test_memory_scope_rejects_invalid_unicode_identifier(field: str) -> None:
     with pytest.raises(ValueError, match=field):
         make_scope(**{field: LONE_SURROGATE})
+
+
+def test_string_snapshot_uses_base_blank_validation() -> None:
+    with pytest.raises(ValueError, match="session_id"):
+        make_event(session_id=AdversarialStr(" \t\n"))
+
+
+def test_string_snapshot_uses_base_utf8_validation() -> None:
+    with pytest.raises(ValueError, match="payload"):
+        make_event(payload=AdversarialStr(LONE_SURROGATE))
 
 
 @pytest.mark.parametrize("field", ["session_id", "run_id", "idempotency_key"])
@@ -198,8 +286,32 @@ def test_evidence_event_requires_memory_scope(scope: object) -> None:
         make_event(scope=scope)
 
 
+def test_evidence_event_rejects_memory_scope_subclass() -> None:
+    scope = MemoryScopeSubclass("tenant-1", "assistant-memory", "user-1")
+
+    with pytest.raises(TypeError, match="scope must be a MemoryScope"):
+        make_event(scope=scope)
+
+
 def test_evidence_event_accepts_empty_string_payload() -> None:
     assert make_event(payload="").payload == ""
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("session_id", " session-1 "),
+        ("run_id", " run-1 "),
+        ("payload", " payload "),
+        ("idempotency_key", " idempotency-1 "),
+    ],
+)
+def test_evidence_event_snapshots_string_subclasses(field: str, value: str) -> None:
+    event = make_event(**{field: AdversarialStr(value)})
+    stored = getattr(event, field)
+
+    assert type(stored) is str
+    assert stored == value
 
 
 @pytest.mark.parametrize("payload", [None, b"hello", 7])
@@ -208,7 +320,7 @@ def test_evidence_event_rejects_non_string_payload(payload: object) -> None:
         make_event(payload=payload)
 
 
-@pytest.mark.parametrize("sequence_no", [True, False, 1.0, "1", None])
+@pytest.mark.parametrize("sequence_no", [True, False, OverriddenInt(1), 1.0, "1", None])
 def test_evidence_event_rejects_non_integer_sequence_numbers(
     sequence_no: object,
 ) -> None:
@@ -374,6 +486,23 @@ def test_evidence_record_requires_evidence_event(event: object) -> None:
         make_record(event=event)
 
 
+def test_evidence_record_rejects_evidence_event_subclass() -> None:
+    event = make_event()
+    event_subclass = EvidenceEventSubclass(
+        scope=event.scope,
+        session_id=event.session_id,
+        run_id=event.run_id,
+        sequence_no=event.sequence_no,
+        kind=event.kind,
+        payload=event.payload,
+        observed_at=event.observed_at,
+        idempotency_key=event.idempotency_key,
+    )
+
+    with pytest.raises(TypeError, match="event must be an EvidenceEvent"):
+        make_record(event=event_subclass)
+
+
 @pytest.mark.parametrize("field", ["evidence_id", "content_hash"])
 @pytest.mark.parametrize("value", ["", " \t\n"])
 def test_evidence_record_rejects_blank_identifiers_and_hash(
@@ -397,6 +526,21 @@ def test_evidence_record_preserves_identifier_and_hash_whitespace() -> None:
 
     assert record.evidence_id == " evidence-1 "
     assert record.content_hash == " sha256:abc123 "
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("evidence_id", " evidence-1 "),
+        ("content_hash", " sha256:abc123 "),
+    ],
+)
+def test_evidence_record_snapshots_string_subclasses(field: str, value: str) -> None:
+    record = make_record(**{field: AdversarialStr(value)})
+    stored = getattr(record, field)
+
+    assert type(stored) is str
+    assert stored == value
 
 
 @pytest.mark.parametrize("field", ["evidence_id", "content_hash"])

--- a/tests/v2/memory_service/test_types.py
+++ b/tests/v2/memory_service/test_types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import FrozenInstanceError
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
 
 import pytest
 
@@ -35,6 +35,34 @@ VALID_UTC_BOUNDARIES = (
         datetime.max.replace(tzinfo=UTC),
     ),
 )
+
+
+class MutableTimezone(tzinfo):
+    """Timezone whose offset can change after a datetime is constructed."""
+
+    def __init__(self, offset: timedelta) -> None:
+        self.offset = offset
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        return self.offset
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(0)
+
+    def tzname(self, value: datetime | None) -> str:
+        return "MUTABLE"
+
+
+class StatefulDatetime(datetime):
+    """Datetime subclass with unsafe conversion and serialization overrides."""
+
+    suffix: str = ""
+
+    def astimezone(self, timezone: tzinfo | None = None) -> StatefulDatetime:
+        return self
+
+    def isoformat(self, sep: str = "T", timespec: str = "auto") -> str:
+        return f"{datetime.isoformat(self, sep, timespec)}{self.suffix}"
 
 
 def make_scope(**overrides: object) -> MemoryScope:
@@ -248,6 +276,42 @@ def test_evidence_event_rejects_datetime_that_cannot_normalize_to_utc(
         make_event(observed_at=observed_at)
 
 
+def test_evidence_event_snapshots_mutable_observed_at_as_utc() -> None:
+    source_timezone = MutableTimezone(timedelta(hours=1))
+    source = datetime(2026, 7, 7, 5, 5, 6, 789000, tzinfo=source_timezone)
+    event = make_event(observed_at=source)
+    canonical_bytes = event.canonical_bytes()
+
+    source_timezone.offset = timedelta(hours=2)
+
+    assert event.canonical_bytes() == canonical_bytes
+    assert event.observed_at == UTC_INSTANT
+    assert event.observed_at.tzinfo is UTC
+
+
+def test_evidence_event_snapshots_datetime_subclass_as_plain_utc() -> None:
+    source = StatefulDatetime(
+        2026,
+        7,
+        7,
+        5,
+        5,
+        6,
+        789000,
+        tzinfo=timezone(timedelta(hours=1)),
+    )
+    source.suffix = "-before"
+    event = make_event(observed_at=source)
+    canonical_bytes = event.canonical_bytes()
+
+    source.suffix = "-after"
+
+    assert type(event.observed_at) is datetime
+    assert event.observed_at == UTC_INSTANT
+    assert event.canonical_bytes() == canonical_bytes
+    assert b"-before" not in canonical_bytes
+
+
 def test_canonical_bytes_are_sorted_compact_and_deterministic() -> None:
     event = make_event()
 
@@ -281,7 +345,8 @@ def test_canonical_bytes_support_valid_utc_datetime_boundaries(
 ) -> None:
     event = make_event(observed_at=observed_at)
 
-    assert event.observed_at is observed_at
+    assert event.observed_at == expected_utc
+    assert event.observed_at.tzinfo is UTC
     assert (
         json.loads(event.canonical_bytes())["observed_at"] == expected_utc.isoformat()
     )
@@ -293,9 +358,9 @@ def test_canonical_bytes_normalize_semantically_equal_instants_to_utc() -> None:
         observed_at=UTC_INSTANT.astimezone(timezone(timedelta(hours=8)))
     )
 
-    assert utc_event.observed_at != utc_plus_eight_event.observed_at or (
-        utc_event.observed_at.tzinfo != utc_plus_eight_event.observed_at.tzinfo
-    )
+    assert utc_event.observed_at == utc_plus_eight_event.observed_at == UTC_INSTANT
+    assert utc_event.observed_at.tzinfo is UTC
+    assert utc_plus_eight_event.observed_at.tzinfo is UTC
     assert utc_event.canonical_bytes() == utc_plus_eight_event.canonical_bytes()
 
 
@@ -363,15 +428,29 @@ def test_evidence_record_rejects_datetime_that_cannot_normalize_to_utc(
         make_record(created_at=created_at)
 
 
+def test_evidence_record_snapshots_mutable_created_at_as_utc() -> None:
+    source_timezone = MutableTimezone(timedelta(hours=1))
+    source = datetime(2026, 7, 7, 5, 5, 6, 789000, tzinfo=source_timezone)
+    record = make_record(created_at=source)
+
+    source_timezone.offset = timedelta(hours=2)
+
+    assert record.created_at == UTC_INSTANT
+    assert record.created_at.tzinfo is UTC
+
+
 @pytest.mark.parametrize(
-    "created_at",
-    [value for value, _ in VALID_UTC_BOUNDARIES],
+    ("created_at", "expected_utc"),
+    VALID_UTC_BOUNDARIES,
     ids=["minimum", "maximum"],
 )
 def test_evidence_record_accepts_valid_utc_datetime_boundaries(
-    created_at: datetime,
+    created_at: datetime, expected_utc: datetime
 ) -> None:
-    assert make_record(created_at=created_at).created_at is created_at
+    record = make_record(created_at=created_at)
+
+    assert record.created_at == expected_utc
+    assert record.created_at.tzinfo is UTC
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Add immutable, ordered Memory release manifests and a deterministic in-memory release store whose release identity commits to the complete resolved source graph.

A release is an exact non-parametric policy snapshot that can later be attested and assigned to an Agent execution. This stage defines publication content and integrity without adding activation, authorization, runtime retrieval, or Agent Service wiring.

## Dependency

- Depends on #1504, which depends on #1491.
- The release-only delta is the seven commits after `codex/memory-candidate-revisions`.

## What changed

- add frozen `ReleaseManifest` and `MemoryRelease` values with domain-separated canonical SHA-256 identity;
- keep the caller manifest limited to an ordered revision selection; the store, not the caller, derives `release_graph_sha256`;
- bind `release_id` and full `content_hash` to both the manifest hash and full graph hash;
- cover every selected revision's iterative selected→`ADD` ancestry, revision/candidate/evidence exact addresses, derived memory identity/generation, and full canonical hashes;
- reject duplicate selection IDs and more than one selected revision for the same logical `memory_id`, while preserving branch histories in the underlying revision ledger;
- recompute the complete graph twice before publication and twice on read; graph drift, wrong scope/type/address/hash, cycles, and truncated-ID collisions fail closed;
- publish release ID, idempotency, and scoped-list indexes with BaseException rollback;
- preserve empty releases as a stable Memory-off snapshot and validate deep lineages without Python recursion.

## Why

Signing or assigning only a list of truncated revision IDs is insufficient: two backends could otherwise attach different candidate/evidence content to the same apparent manifest. The store-derived graph commitment makes the release identity transitively bind the exact source material that runtime evaluation will later read.

SHA-256 here is an integrity and identity commitment, not a signature, authorization decision, promotion result, or proof that the memories are useful.

## Validation

- clean Memory Service suite — **328 passed**;
- focused release type/store suite — **104 passed**;
- adversarial coverage includes malicious backend type/scope/address/hash values, candidate/evidence drift, 96-bit prefix collisions, branch selection, empty releases, 1050-deep lineages, TOCTOU rechecks, concurrency, and interrupted second/third index publication;
- independent release-graph red team found P0/P1 = 0;
- Ruff and `git diff --check` passed.

## Non-goals

- no active-release pointer, attestation, or promotion decision;
- no publisher signature or remote authentication;
- no query/retrieval/exposure runtime;
- no Agent Service integration or model training changes.

Refs #1490.
