### PR TITLE
fix(engine): route text-only VLM microbatches through the padded forward

### DIFF
--- a/areal/engine/megatron_utils/packed_context_parallel.py
+++ b/areal/engine/megatron_utils/packed_context_parallel.py
@@ -300,12 +300,21 @@ def packed_context_parallel_forward(
     tree_triton_data = input_.get("tree_triton_data", None)
     packed_seq_params = None
 
-    is_vision = is_vision_model and any(key in input_ for key in _VLM_FORWARD_KEYS)
-    # Architectures whose attention/SSM kernels reject packed sequences (e.g.
-    # Qwen3.5 GDN) must run on [B, S] padded input. The reconstruction logic
-    # below is shared with the VLM path; the difference is downstream
-    # (attention_mask and position_ids are passed through for text-only).
-    needs_padded_form = is_vision or use_padded_seq
+    # Whether this particular microbatch carries vision tensors. Gates only
+    # the vision kwargs and the dense-mask exception below — never the
+    # padded-vs-packed routing.
+    has_vision_inputs = is_vision_model and any(
+        key in input_ for key in _VLM_FORWARD_KEYS
+    )
+    # Padded-vs-packed routing is keyed on the MODEL type:
+    # - VLM models cannot consume the wrapper-packed [1, total_len] layout
+    #   (their internal packing needs a per-sequence 2D mask — mbridge
+    #   crashes on the missing mask and megatron-bridge silently corrupts
+    #   positions/packing), so image-free microbatches take the padded
+    #   branch too.
+    # - Architectures whose attention/SSM kernels reject packed sequences
+    #   (use_padded_seq, e.g. Qwen3.5 GDN) must run on [B, S] padded input.
+    needs_padded_form = is_vision_model or use_padded_seq
 
     # Track shape metadata so the output can be repacked back to packed
     # [total_len, ...] form on the last PP stage.
@@ -345,14 +354,16 @@ def packed_context_parallel_forward(
             input_ids = input_ids_2d
             padded_repack_info = (cu_seqlens, seq_lens, max_seqlen)
 
-    # VLM path: attention_mask=None — model's get_rope_index uses the 2D mask
-    # internally for mRoPE positions. Each batch slot holds one sequence with
-    # trailing padding, so causal attention yields correct outputs at
-    # non-padding positions; padding outputs are discarded during repack.
-    #
-    # BSHD text-only path (use_padded_seq): pass our built attention_mask so
-    # the model's attention layers skip padding.
-    if is_vision:
+    # Every VLM forward is mask-free (attention_mask=None): the model
+    # computes (m)RoPE positions internally, each batch slot holds one
+    # sequence with trailing padding so causal attention yields correct
+    # outputs at non-padding positions, and padding outputs are discarded
+    # during repack. The one exception is the padded BSHD text forward of
+    # use_padded_seq models, which consumes the dense 2D mask so attention
+    # layers skip padding. The wrapper-packed path carries no mask either
+    # way (enforced above); tree data passes through untouched.
+    dense_mask_text_forward = use_padded_seq and not has_vision_inputs
+    if is_vision_model and not dense_mask_text_forward:
         final_attention_mask = None
     else:
         final_attention_mask = (
@@ -362,7 +373,7 @@ def packed_context_parallel_forward(
     # VLM: pass vision inputs through to model forward. The VLM model computes
     # mRoPE position_ids internally, so position_ids remains None for VLM.
     vlm_kwargs: dict[str, Any] = {}
-    if is_vision:
+    if has_vision_inputs:
         for key in _VLM_FORWARD_KEYS:
             if key in input_:
                 vlm_kwargs[key] = input_[key]
@@ -371,7 +382,7 @@ def packed_context_parallel_forward(
     # length total_len) — they don't match the 2D [B, S] input. Let mcore
     # compute the default torch.arange positions per row; padding positions
     # are masked out by attention_mask.
-    if use_padded_seq and not is_vision:
+    if dense_mask_text_forward:
         position_ids = None
 
     try:


### PR DESCRIPTION

## Description

**The bug.** `packed_context_parallel_forward` chooses between the padded `[B, S]` forward and the wrapper-packed `[1, total_len]` THD forward based on whether the *microbatch* contains vision tensors, not on the model type. Microbatches bin-pack whole sequences, so a VLM run on mixed text/image data can produce microbatches that contain no images — and those get sent down the wrapper-packed path.

**Why that breaks.** VLM models cannot consume the wrapper-packed layout: they derive per-sequence boundaries and mRoPE positions from an unpacked `[B, S]` view plus a 2D attention mask. Each bridge fails in its own way:

- **mbridge (Qwen3-VL, Qwen2.5-VL): immediate crash.** The packed path passes `attention_mask=None`, and the model's `preprocess_packed_seqs` dereferences it: `AttributeError: 'NoneType' object has no attribute 'sum'` (`mbridge/core/util.py`).
- **megatron-bridge (Qwen3-VL): silent corruption.** The model synthesizes an all-ones mask over the already-packed stream, re-packs it (scrambling the content) and computes positions continuously across sequence boundaries — returning deterministic garbage logprobs with no error raised.

**Impact.** The silent variant feeds garbage logprobs into PPO/GRPO losses for every text-only sample, while ratio clipping masks the damage. Pure-image datasets never trigger the bug (every microbatch carries an image), which is why it has gone unnoticed.

**The fix.** Key the padded-vs-packed decision (and the attention-mask selection) on the model type: on VLM models, every microbatch — with or without images — takes the padded branch, which both bridges support. Vision kwargs stay gated on microbatch content. Non-VLM models keep the wrapper-packed THD path unchanged, and padded-seq models (Qwen3.5 family) already routed everything through the padded branch and are unaffected.

## Related Issue

N/A — the full analysis and reproduction details are included in this description.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

Reproduction: build a `MegatronEngine` for a VLM checkpoint and call `engine.forward` on a batch containing only `input_ids`/`attention_mask`/`loss_mask` (no `multi_modal_input`); with `bridge_type=mbridge` this crashes immediately, with `megatron-bridge` (Qwen3-VL) it silently returns corrupted logprobs.

Validation (H100, single GPU, `megatron:d1p1t1`, current `main` @ `9ac4ad63`, synthetic text-only batch, engine logprobs compared against a HuggingFace forward of the same tokens):

| Model x bridge | Before fix (packed path) | After fix (padded path) |
| --- | --- | --- |
| Qwen3-VL-2B x mbridge | crash (`attention_mask.sum` on None, `mbridge/core/util.py:607`) | matches HF, mean abs diff 0.027 |
| Qwen3-VL-2B x megatron-bridge | silent corruption: mean abs diff 1.59 / max 8.9 vs HF | matches HF, mean abs diff 0.027 |
| Qwen2.5-VL-3B x mbridge | crash (same frame) | matches HF, mean abs diff 0.032 |

After the fix both bridges return numerically identical logprobs (they share the padded branch). Image-bearing microbatch behavior is unchanged by this PR (the padded branch they already used is untouched), and text-model (GPTModel) routing is untouched. An automated regression test is hard to place upstream because exercising the megatron forward requires a multi-GB VLM checkpoint and a GPU; the reproduction above is deterministic and takes one engine call if maintainers want to verify.

**How every model/input combination resolves after this PR.** `needs_padded_form` decides the layout (padded `[B, S]` vs wrapper-packed `[1, total_len]` + `cu_seqlens`); `dense_mask_text_forward` is a sub-decision within the padded branch only (explicit dense mask vs mask-free forward). Row 3 is the only behavior change in this PR.

| # | Case | `is_vision_model` | `use_padded_seq` | `has_vision_inputs` | `needs_padded_form` | `dense_mask_text_forward` | layout | `attention_mask` | vision kwargs |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | text model (qwen3, llama, ...), any mb | F | F | F | F | F | packed `[1, total]` | None (tree data if present) | — |
| 2 | VLM, mb with images | T | F | T | T | F | padded `[B, S]` | None (model computes mRoPE) | passed |
| 3 | VLM, mb without images (**this PR**) | T | F | F | **T** (was F) | F | padded `[B, S]` | None (model computes positions) | — |
| 4 | Qwen3.5 family, mb with images | T | T | T | T | F | padded `[B, S]` | None (model computes mRoPE) | passed |
| 5 | Qwen3.5 family, mb without images | T | T | F | T | T | padded `[B, S]` | dense 2D mask; packed position_ids dropped | — |
| 6 | `qwen3_5_text` model type, any mb | F | T | F | T | T | padded `[B, S]` | dense 2D mask; packed position_ids dropped | — |
