### PR TITLE
fix(engine): engage Megatron deterministic mode before model build

### DIFF
--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -349,6 +349,13 @@ class MegatronEngine(TrainEngine):
                 self.parallel_strategy, self.hf_config, self.tf_config
             )
 
+            # deterministic_mode must be engaged before the model is built:
+            # TP linear layers and TE modules copy config flags at __init__,
+            # so the post-build call below only reaches runtime consumers
+            # such as loss fusions.
+            if self.mcore_config.use_deterministic_algorithms:
+                set_deterministic_algorithms(self.tf_config, prebuild=True)
+
             self.is_vision_model = is_valid_vision_model(self.hf_config.model_type)
             # GDN/SSM models (e.g. Qwen3.5) reject packed THD input and must run
             # the padded BSHD forward. Derived from model type rather than a

--- a/areal/engine/megatron_utils/deterministic.py
+++ b/areal/engine/megatron_utils/deterministic.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import sys
 
 import torch
 
@@ -9,16 +10,48 @@ from areal.utils import logging
 logger = logging.getLogger("MCoreDeterm")
 
 
-def set_deterministic_algorithms(model_config):
-    """
-    args: Megatron args, acquired by get_args()
+def set_deterministic_algorithms(model_config, prebuild: bool = False):
+    """Enable deterministic execution on a Megatron transformer config.
+
+    ``deterministic_mode`` has two kinds of consumers in Megatron-Core:
+    modules that copy config flags at construction time (tensor-parallel
+    linear layers, TransformerEngine extensions) and code that reads the
+    config at runtime (loss fusions, the pipeline schedules). Setting the
+    flag only on a built model's config engages just the runtime consumers
+    and silently leaves the layer-level kernels nondeterministic.
+
+    Call this with ``prebuild=True`` on the ``TransformerConfig`` used to
+    build the model, and again without ``prebuild`` on the built model's
+    config to cover runtime consumers.
     """
     model_config.deterministic_mode = True
     model_config.cross_entropy_loss_fusion = False
     model_config.bias_dropout_fusion = False
 
+    if prebuild and hasattr(model_config, "attention_backend"):
+        from megatron.core.transformer.enums import AttnBackend
+
+        # Megatron-Core owns the NVTE_*_ATTN selection env vars and asserts
+        # that they match TransformerConfig.attention_backend, so the backend
+        # must be chosen here rather than exported externally. Select flash:
+        # the cuDNN fused-attention deterministic backward requires workspaces
+        # that grow prohibitively with context length, while flash-attention
+        # provides a deterministic backward without that cost.
+        model_config.attention_backend = AttnBackend.flash
+        logger.info("Deterministic prebuild: attention_backend set to flash.")
+
     # Set env variables about deterministic mode
     if os.getenv("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "1") != "0":
+        if "transformer_engine" in sys.modules:
+            logger.warning(
+                "transformer_engine was imported before "
+                "NVTE_ALLOW_NONDETERMINISTIC_ALGO was set to '0'. Some TE "
+                "versions snapshot it at import, so attention kernels may "
+                "remain nondeterministic. AReaL launchers export it "
+                "automatically when use_deterministic_algorithms is enabled; "
+                "with a custom launcher, export it before the training "
+                "process starts."
+            )
         logger.info(
             "For deterministic algo, env [NVTE_ALLOW_NONDETERMINISTIC_ALGO] will be set to '0'."
         )

--- a/areal/infra/launcher/local.py
+++ b/areal/infra/launcher/local.py
@@ -392,6 +392,14 @@ def local_main(config, run_id: int = 0):
             # Required by NCCL weight update group.
             _env_vars["NCCL_CUMEM_ENABLE"] = "0"
             _env_vars["NCCL_NVLS_ENABLE"] = "0"
+        if (
+            any(a.backend == "megatron" for a in alloc_mode.allocations)
+            and config.actor.megatron.use_deterministic_algorithms
+        ):
+            # TransformerEngine snapshots this env var at import or attention
+            # module construction depending on version; exporting it before
+            # the trainer process starts is safe for all of them.
+            _env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"
         # All experiment configs should have the `actor` field.
         actor_spec = get_scheduling_spec(config.actor)
         actor_env_vars = actor_spec.env_vars

--- a/areal/infra/launcher/ray.py
+++ b/areal/infra/launcher/ray.py
@@ -589,6 +589,14 @@ def ray_main(config, run_id: int = 0):
             # Required by NCCL weight update group.
             _env_vars["NCCL_CUMEM_ENABLE"] = "0"
             _env_vars["NCCL_NVLS_ENABLE"] = "0"
+        if (
+            any(a.backend == "megatron" for a in allocation_mode.allocations)
+            and config.actor.megatron.use_deterministic_algorithms
+        ):
+            # TransformerEngine snapshots this env var at import or attention
+            # module construction depending on version; exporting it before
+            # the trainer process starts is safe for all of them.
+            _env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"
 
         # Use per-GPU CPU count for thread env vars since Ray spawns individual
         # tasks per GPU, each inheriting these env vars. This differs from

--- a/areal/infra/launcher/slurm.py
+++ b/areal/infra/launcher/slurm.py
@@ -633,6 +633,14 @@ def slurm_main(config, run_id: int = 0):
             # Required by NCCL weight update group.
             _env_vars["NCCL_CUMEM_ENABLE"] = "0"
             _env_vars["NCCL_NVLS_ENABLE"] = "0"
+        if (
+            any(a.backend == "megatron" for a in allocation_mode.allocations)
+            and config.actor.megatron.use_deterministic_algorithms
+        ):
+            # TransformerEngine snapshots this env var at import or attention
+            # module construction depending on version; exporting it before
+            # the trainer process starts is safe for all of them.
+            _env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"
 
         trainer_cpus_per_task = actor_spec.cpu * config.cluster.n_gpus_per_node
         # Use per-GPU CPU count for thread env vars since torchrun spawns

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -149,6 +149,7 @@ class PPOTrainer:
         self._validate_cfg()
 
         self._amend_xccl_weight_update_envvar()
+        self._amend_deterministic_envvar()
 
         agent_cfg = config.rollout.agent
         self._online_mode = agent_cfg is not None and agent_cfg.mode == "online"
@@ -959,6 +960,38 @@ class PPOTrainer:
         for spec in self.config.actor.scheduling_spec:
             spec.env_vars["NCCL_CUMEM_ENABLE"] = "0"
             spec.env_vars["NCCL_NVLS_ENABLE"] = "0"
+
+    def _amend_deterministic_envvar(self):
+        if not is_single_controller():
+            # This environ is set by the launcher in the SPMD mode.
+            return
+
+        engine_cfgs = [(self.config.actor, self.actor_alloc)]
+        if self.config.critic is not None:
+            engine_cfgs.append(
+                (
+                    self.config.critic,
+                    ModelAllocation.from_str(self.config.critic.backend, name="critic"),
+                )
+            )
+        if self.config.actor.kl_ctl > 0 and self.config.ref is not None:
+            engine_cfgs.append(
+                (
+                    self.config.ref,
+                    ModelAllocation.from_str(self.config.ref.backend, name="ref"),
+                )
+            )
+
+        for engine_cfg, alloc in engine_cfgs:
+            if alloc.backend != "megatron":
+                continue
+            if not engine_cfg.megatron.use_deterministic_algorithms:
+                continue
+            # TransformerEngine snapshots this env var at import or attention
+            # module construction depending on version; exporting it at worker
+            # launch is the only ordering safe for all of them.
+            for spec in engine_cfg.scheduling_spec:
+                spec.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"
 
     def _create_train_engine(
         self, actor_config: PPOActorConfig, alloc: ModelAllocation

--- a/tests/test_deterministic_prebuild.py
+++ b/tests/test_deterministic_prebuild.py
@@ -1,0 +1,81 @@
+"""Tests for Megatron deterministic-mode activation semantics."""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+from areal.engine.megatron_utils.deterministic import set_deterministic_algorithms
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_state(monkeypatch):
+    monkeypatch.delenv("NVTE_ALLOW_NONDETERMINISTIC_ALGO", raising=False)
+    monkeypatch.delenv("NCCL_ALGO", raising=False)
+    monkeypatch.delenv("CUBLAS_WORKSPACE_CONFIG", raising=False)
+    monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
+    prev_deterministic = torch.are_deterministic_algorithms_enabled()
+    prev_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+
+    yield
+
+    torch.use_deterministic_algorithms(prev_deterministic, warn_only=prev_warn_only)
+
+
+def _make_config(**extra):
+    return SimpleNamespace(
+        deterministic_mode=False,
+        cross_entropy_loss_fusion=True,
+        bias_dropout_fusion=True,
+        **extra,
+    )
+
+
+def test_set_deterministic_algorithms_prebuild_selects_flash_backend():
+    enums = pytest.importorskip("megatron.core.transformer.enums")
+    config = _make_config(attention_backend=enums.AttnBackend.auto)
+
+    set_deterministic_algorithms(config, prebuild=True)
+
+    assert config.deterministic_mode is True
+    assert config.cross_entropy_loss_fusion is False
+    assert config.bias_dropout_fusion is False
+    assert config.attention_backend == enums.AttnBackend.flash
+
+
+def test_set_deterministic_algorithms_postbuild_keeps_attention_backend():
+    sentinel = object()
+    config = _make_config(attention_backend=sentinel)
+
+    set_deterministic_algorithms(config)
+
+    assert config.deterministic_mode is True
+    assert config.attention_backend is sentinel
+
+
+def test_set_deterministic_algorithms_te_imported_without_env_warns(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules, "transformer_engine", types.ModuleType("transformer_engine")
+    )
+    config = _make_config()
+
+    with mock.patch("areal.engine.megatron_utils.deterministic.logger") as mock_logger:
+        set_deterministic_algorithms(config)
+
+    assert mock_logger.warning.called
+
+
+def test_set_deterministic_algorithms_env_preset_does_not_warn(monkeypatch):
+    monkeypatch.setenv("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "0")
+    monkeypatch.setitem(
+        sys.modules, "transformer_engine", types.ModuleType("transformer_engine")
+    )
+    config = _make_config()
+
+    with mock.patch("areal.engine.megatron_utils.deterministic.logger") as mock_logger:
+        set_deterministic_algorithms(config)
+
+    assert not mock_logger.warning.called


### PR DESCRIPTION
## Description

`use_deterministic_algorithms=True` only engaged half of Megatron's deterministic machinery. The flag was applied to the model config **after** the model was built, but several consumers copy determinism settings into instance state at construction time: `VocabParallelEmbedding` (falls back to the nondeterministic `F.embedding` backward), and `TEDotProductAttention` (its NVTE guard and its `deterministic` flag are both evaluated at `__init__`). As a result, repeated runs of the same batch produced different grad norms despite the flag being on.

This PR makes the flag mean what it documents:

1. `deterministic_mode` is set on the `TransformerConfig` **before** model construction (the post-build call is kept for runtime consumers).
2. Under deterministic mode the attention backend is set to `AttnBackend.flash` via the config — Megatron-Core owns the `NVTE_*_ATTN` env vars and asserts they match the config, and cuDNN fused attention's deterministic backward requires workspaces that grow prohibitively with context length, while flash provides a deterministic backward without that cost.
3. Launchers (slurm/local/ray) and single-controller worker specs export `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0` so it is in place before TransformerEngine reads it, regardless of TE version; the engine warns if the setting may have come too late.

Verified by replaying an identical batch on a 32-GPU MoE run: with this change, independent runs produce bitwise-identical float64 training stats, including `grad_norm`; without it, `grad_norm` varies run to run.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality (`tests/test_deterministic_prebuild.py`)
- [ ] Documentation updated (not applicable)
- [x] Branch is up to date with `main`
- [x] Self-reviewed
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

Behavioral note for users already running with the flag enabled: attention now runs on the flash backend and previously-missed kernels become deterministic, so numerics change bitwise (statistically equivalent) and there is a modest cost from disabled fusions. That is the flag performing as documented; users who do not want this can leave the flag off.

## Verification report: A/A rollout-replay determinism test

### Method

To isolate training-side numerics from rollout stochasticity, we used a
**rollout replay** setup:

1. Run one normal RL step and dump the exact post-rollout training batch
   (32 trajectories, sequences up to ~131k tokens) to disk **before** the PPO
   update.
2. Replay: start a fresh job from the same checkpoint, load the dumped batch,
   and run exactly one training step (advantage computation → PPO update) —
   generation is bypassed entirely, so both runs consume bit-identical input.
3. Dump all training stats to JSON at **full float64 precision** (the console
   table only shows 5 significant digits, which would hide sub-ulp
   differences).
4. Repeat the replay in two independent jobs (fresh processes, fresh NCCL
   communicators) and compare every stat bitwise.

Setup: Qwen3-30B-A3B-Instruct, 32× H200 (4 nodes), PP=8, TP=4, DP=1,
`use_deterministic_algorithms=true` in both arms.

### Result with this PR (A/A, two independent replay jobs)

- 158 stats common to both runs.
- **All 146 training metrics (`ppo_actor/*`) are bitwise-identical in
  float64.** The only 6 differing entries are `timeperf/*` wall-clock timings,
  which are expected to differ.
- Representative float64 values (identical in both runs):

| Metric | Run 1 | Run 2 |
|---|---|---|
| `update/grad_norm` | `0.034678395837545395` | `0.034678395837545395` |
| `update/actor_loss/avg` | `-0.0654761865735054` | `-0.0654761865735054` |
| `update/actor_loss/min` | `-13.178353309631348` | `-13.178353309631348` |
| `update/actor_loss/max` | `11.049698829650879` | `11.049698829650879` |
| `update/behave_approx_kl/avg` | `-0.003173763630911708` | `-0.003173763630911708` |
| `update/valid_logp_abs_diff/avg` | `0.038766857236623764` | `0.038766857236623764` |
| `advantages/avg` | `0.06556742638349533` | `0.06556742638349533` |

- The same bitwise `grad_norm` value also reproduced on a **different set of
  4 nodes on a different day** (same GPU model), so the result is not tied to
  a particular node group.

### Result without this PR (same flag on, pre-fix code)

Two identical replay runs with `use_deterministic_algorithms=true` on the
pre-fix code:

- **Every metric except `grad_norm` was already bitwise-identical.**
- `grad_norm`: `0.03477128967642784` vs `0.034773267805576324`
  (relative diff ≈ 5.7e-5).

This is exactly the signature of the root cause described in the PR: the
missed consumers are **backward-only** nondeterminism sources (TE attention
backward, `F.embedding` backward), so forward-computed losses/KL/rewards
reproduce while gradients do not — and `grad_norm` is the only stat that
observes gradients.

(The absolute `grad_norm` differs between the two tables because the fix
switches attention to the flash backend — the bitwise-but-statistically-
equivalent numerics change already noted in the PR description.)

### Ablation

With the three elements of this PR in place, the following commonly-suggested
knobs were each verified to be **unnecessary** for bitwise reproducibility in
this setup: `NCCL_ALGO=Ring`, `CUBLAS_WORKSPACE_CONFIG`,
`NCCL_NVLS_ENABLE=0`, `CUDA_DEVICE_MAX_CONNECTIONS=1`. The minimal set is
exactly: pre-build `deterministic_mode`, flash attention backend, and
launch-level `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`.
