### PR TITLE
fix(infra): fail fast when a local inference server dies during launch

### DIFF
--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -384,11 +384,33 @@ class RemoteInfEngine(InferenceEngine):
         except ValueError:
             base_url = f"http://{address}"
         tik = time.time()
+        last_report = tik
         while time.time() - tik < self.config.setup_timeout:
+            if process is not None and process.poll() is not None:
+                raise RuntimeError(
+                    f"Inference server process (pid={process.pid}) exited with "
+                    f"code {process.returncode} before becoming healthy at "
+                    f"{address}. Search the worker log above for the server "
+                    "traceback (e.g. scheduler init errors, port EADDRINUSE)."
+                )
             if self.check_health(base_url):
                 return
+            now = time.time()
+            if now - last_report >= 60:
+                logger.info(
+                    "Still waiting for inference server at %s to become "
+                    "healthy (%.0fs elapsed, timeout %.0fs, process alive=%s)",
+                    address,
+                    now - tik,
+                    self.config.setup_timeout,
+                    process is not None and process.poll() is None,
+                )
+                last_report = now
             time.sleep(1)
-        raise TimeoutError("server launch failed")
+        raise TimeoutError(
+            f"Inference server at {address} failed to become healthy within "
+            f"{self.config.setup_timeout}s"
+        )
 
     def check_health(self, base_url):
         """Check if server is healthy."""

--- a/areal/infra/remote_inf_engine.py
+++ b/areal/infra/remote_inf_engine.py
@@ -1360,10 +1360,8 @@ class RemoteInfEngine(InferenceEngine):
             self._wait_for_server(address, process=process)
             self.local_server_processes.append(server_info)
             return server_info
-        except TimeoutError:
-            logger.warning(
-                f"Launch local server timeouted at {address} after {self.config.setup_timeout}s."
-            )
+        except (TimeoutError, RuntimeError) as e:
+            logger.warning(f"Launch local server failed at {address}: {e}")
             self._shutdown_one_server(server_info)
             raise
 

--- a/tests/infra/test_remote_inf_engine.py
+++ b/tests/infra/test_remote_inf_engine.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+import pytest
+
+from areal.api.cli_args import InferenceEngineConfig
+from areal.infra.remote_inf_engine import RemoteInfEngine
+
+
+def test_wait_for_server_dead_process_raises_runtime_error_with_returncode():
+    # Arrange
+    config = InferenceEngineConfig(setup_timeout=5.0)
+    engine = RemoteInfEngine(config, backend=mock.Mock())
+    process = mock.Mock(spec=subprocess.Popen)
+    process.pid = 4242
+    process.poll.return_value = 7
+    process.returncode = 7
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match="exited with code 7") as exc_info:
+        engine._wait_for_server("localhost:30000", process=process)
+    assert "pid=4242" in str(exc_info.value)

--- a/tests/infra/test_remote_inf_engine.py
+++ b/tests/infra/test_remote_inf_engine.py
@@ -22,3 +22,29 @@ def test_wait_for_server_dead_process_raises_runtime_error_with_returncode():
     with pytest.raises(RuntimeError, match="exited with code 7") as exc_info:
         engine._wait_for_server("localhost:30000", process=process)
     assert "pid=4242" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "failure", [TimeoutError("timed out"), RuntimeError("process died")]
+)
+def test_launch_server_shuts_down_the_server_on_any_launch_failure(failure):
+    # Arrange
+    config = InferenceEngineConfig(setup_timeout=5.0)
+    backend = mock.Mock()
+    backend.launch_server.return_value = mock.Mock(spec=subprocess.Popen)
+    engine = RemoteInfEngine(config, backend=backend)
+
+    # Act / Assert
+    with (
+        mock.patch.object(engine, "_wait_for_server", side_effect=failure),
+        mock.patch.object(engine, "_shutdown_one_server") as shutdown,
+        mock.patch(
+            "areal.infra.remote_inf_engine.find_free_ports", return_value=[30000]
+        ),
+        mock.patch("areal.infra.remote_inf_engine.gethostip", return_value="127.0.0.1"),
+        pytest.raises(type(failure)),
+    ):
+        engine.launch_server({})
+
+    shutdown.assert_called_once()
+    assert engine.local_server_processes == []


### PR DESCRIPTION
## Description

`_wait_for_server` already receives the server process handle but never inspects it: when the inference server crashes at startup (port conflict, scheduler init error, OOM kill), the launcher keeps polling the health endpoint until `setup_timeout` expires and then raises a bare `TimeoutError("server launch failed")` — typically many minutes after the process is already dead, with no hint of what went wrong.

This PR polls the process each health-check iteration and raises immediately with the exit code and a pointer to the server traceback when it has exited. This also makes scheduler-level launch retries practical, since a failed attempt now surfaces in seconds instead of after the full timeout. While waiting, a heartbeat is logged every 60s (address, elapsed/timeout, process liveness), and the final `TimeoutError` now includes the address and the timeout value.

No behavior change on the happy path: the health-check cadence and success condition are untouched; only the failure paths gain information (immediate crash detection + informative timeout message).

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass (single-file change to the launch-wait loop; behavior exercised by any server-launch path)
- [ ] Documentation updated (not applicable)
- [x] Branch is up to date with `main`
- [x] Self-reviewed
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

The immediate-raise path deliberately points the operator at the worker log ("search the worker log above for the server traceback"), since the server's stderr goes to that log rather than the launcher's exception.
