### PR TITLE
fix(inference): reject incomplete sampling evidence

### DIFF
--- a/areal/api/io_struct.py
+++ b/areal/api/io_struct.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import math
 import os
 import subprocess
 import uuid
@@ -325,6 +326,28 @@ class HttpGenerationResult:
     output_logprobs: list[float]
     stop_reason: str
     routed_experts: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        if len(self.output_tokens) != len(self.output_logprobs):
+            raise ValueError(
+                "Malformed generation result: received "
+                f"{len(self.output_tokens)} output tokens but "
+                f"{len(self.output_logprobs)} output logprobs; every sampled "
+                "output token requires exactly one sampling logprob."
+            )
+
+        for index, logprob in enumerate(self.output_logprobs):
+            is_finite = (
+                isinstance(logprob, (int, float))
+                and not isinstance(logprob, bool)
+                and math.isfinite(logprob)
+            )
+            if not is_finite:
+                raise ValueError(
+                    "Malformed generation result: "
+                    f"output_logprobs[{index}] must be a real, finite number, "
+                    f"got {logprob!r}."
+                )
 
 
 @dataclass

--- a/areal/engine/vllm_remote.py
+++ b/areal/engine/vllm_remote.py
@@ -35,6 +35,7 @@ from areal.infra.platforms import current_platform
 from areal.infra.utils.launcher import TRITON_CACHE_PATH
 from areal.utils import logging, perf_tracer, stats_tracker
 from areal.utils.network import format_host_for_url
+from areal.utils.vllm_response import parse_vllm_generation_response
 
 logger = logging.getLogger("vLLMEngine")
 
@@ -115,32 +116,7 @@ class VLLMBackend:
         self, response: dict[str, Any]
     ) -> HttpGenerationResult:
         """Parse vLLM generation response."""
-        meta_info = response["choices"][0]
-        stop_reason = meta_info["finish_reason"]
-
-        # Parse tokens from "token:123" format
-        if "tokens" in meta_info["logprobs"]:
-            output_tokens = meta_info["logprobs"]["tokens"]
-            output_tokens = [int(t.split(":")[1]) for t in output_tokens]
-            output_logprobs = meta_info["logprobs"]["token_logprobs"]
-        elif "content" in meta_info["logprobs"]:
-            outputs = meta_info["logprobs"]["content"]
-            output_tokens = [int(t["token"].split(":")[1]) for t in outputs]
-            output_logprobs = [t["logprob"] for t in outputs]
-        else:
-            raise ValueError("Unexpected vLLM response format.")
-
-        if stop_reason == "abort" and len(output_tokens) == 0:
-            return HttpGenerationResult(
-                output_tokens=[],
-                output_logprobs=[],
-                stop_reason=stop_reason,
-            )
-        return HttpGenerationResult(
-            output_tokens=output_tokens,
-            output_logprobs=output_logprobs,
-            stop_reason=stop_reason,
-        )
+        return parse_vllm_generation_response(response)
 
     def build_score_request(
         self, input_ids: list[int], target_len: int, with_lora: bool, version: int

--- a/areal/utils/vllm_response.py
+++ b/areal/utils/vllm_response.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from areal.api.io_struct import HttpGenerationResult
+
+# vLLM uses -9999.0 both when a chat logprob is absent and when a lower value
+# is clamped, so the original sampling evidence cannot be recovered:
+# https://github.com/vllm-project/vllm/blob/v0.19.1/vllm/entrypoints/openai/chat_completion/protocol.py#L67-L70
+# https://github.com/vllm-project/vllm/blob/v0.19.1/vllm/entrypoints/openai/chat_completion/serving.py#L1721-L1727
+_AMBIGUOUS_VLLM_LOGPROB = -9999.0
+
+
+def parse_vllm_generation_response(
+    response: dict[str, Any],
+) -> HttpGenerationResult:
+    """Normalize a vLLM generation response into AReaL's shared result type."""
+    meta_info = response["choices"][0]
+    stop_reason = meta_info["finish_reason"]
+
+    if "tokens" in meta_info["logprobs"]:
+        output_tokens = [
+            int(token.split(":")[1]) for token in meta_info["logprobs"]["tokens"]
+        ]
+        output_logprobs = meta_info["logprobs"]["token_logprobs"]
+    elif "content" in meta_info["logprobs"]:
+        outputs = meta_info["logprobs"]["content"]
+        output_tokens = [int(token["token"].split(":")[1]) for token in outputs]
+        output_logprobs = [token["logprob"] for token in outputs]
+    else:
+        raise ValueError("Unexpected vLLM response format.")
+
+    for index, logprob in enumerate(output_logprobs):
+        if logprob == _AMBIGUOUS_VLLM_LOGPROB:
+            raise ValueError(
+                f"vLLM output_logprobs[{index}] is {_AMBIGUOUS_VLLM_LOGPROB}, which "
+                "may represent a missing or clamped logprob; exact sampling "
+                "evidence is required."
+            )
+
+    if stop_reason == "abort" and len(output_tokens) == 0:
+        return HttpGenerationResult(
+            output_tokens=[],
+            output_logprobs=[],
+            stop_reason=stop_reason,
+        )
+
+    return HttpGenerationResult(
+        output_tokens=output_tokens,
+        output_logprobs=output_logprobs,
+        stop_reason=stop_reason,
+    )

--- a/areal/v2/inference_service/sglang/bridge.py
+++ b/areal/v2/inference_service/sglang/bridge.py
@@ -94,6 +94,7 @@ class SGLangBridgeBackend:
         meta_info = response["meta_info"]
         finish_reason = meta_info["finish_reason"]
         stop_reason: str = finish_reason["type"]
+        stop_message: str = finish_reason.get("message", "")
 
         # Routed experts (MoE)
         routed_experts: np.ndarray | None = None
@@ -107,8 +108,20 @@ class SGLangBridgeBackend:
                 dtype=np.int32,
             ).reshape(num_sgl_token, -1)
 
-        # Handle abort-before-prefill: no output tokens
-        output_token_logprobs = meta_info.get("output_token_logprobs", [])
+        if stop_reason == "abort" and stop_message.startswith("Abort before prefill"):
+            return HttpGenerationResult(
+                output_tokens=[],
+                output_logprobs=[],
+                stop_reason=stop_reason,
+                routed_experts=routed_experts,
+            )
+
+        if "output_token_logprobs" not in meta_info:
+            raise ValueError(
+                "Malformed SGLang response: output_token_logprobs is missing "
+                "from meta_info."
+            )
+        output_token_logprobs = meta_info["output_token_logprobs"]
         output_tokens = [x[1] for x in output_token_logprobs]
         output_logprobs = [x[0] for x in output_token_logprobs]
 

--- a/areal/v2/inference_service/vllm/bridge.py
+++ b/areal/v2/inference_service/vllm/bridge.py
@@ -12,6 +12,7 @@ from areal.api.io_struct import (
     detect_image_mime,
     get_versioned_lora_name,
 )
+from areal.utils.vllm_response import parse_vllm_generation_response
 
 if TYPE_CHECKING:
     from areal.api.io_struct import ModelRequest
@@ -90,33 +91,7 @@ class VLLMBridgeBackend:
         response: dict[str, Any],
     ) -> HttpGenerationResult:
         """Parse vLLM JSON into :class:`HttpGenerationResult`."""
-        meta_info = response["choices"][0]
-        stop_reason = meta_info["finish_reason"]
-
-        if "tokens" in meta_info["logprobs"]:
-            output_tokens = [
-                int(token.split(":")[1]) for token in meta_info["logprobs"]["tokens"]
-            ]
-            output_logprobs = meta_info["logprobs"]["token_logprobs"]
-        elif "content" in meta_info["logprobs"]:
-            outputs = meta_info["logprobs"]["content"]
-            output_tokens = [int(token["token"].split(":")[1]) for token in outputs]
-            output_logprobs = [token["logprob"] for token in outputs]
-        else:
-            raise ValueError("Unexpected vLLM response format.")
-
-        if stop_reason == "abort" and len(output_tokens) == 0:
-            return HttpGenerationResult(
-                output_tokens=[],
-                output_logprobs=[],
-                stop_reason=stop_reason,
-            )
-
-        return HttpGenerationResult(
-            output_tokens=output_tokens,
-            output_logprobs=output_logprobs,
-            stop_reason=stop_reason,
-        )
+        return parse_vllm_generation_response(response)
 
     def get_pause_request(self) -> HttpRequest:
         return HttpRequest(endpoint="/areal_pause_generation", payload={})

--- a/tests/test_generation_response_parsing.py
+++ b/tests/test_generation_response_parsing.py
@@ -1,0 +1,86 @@
+from typing import Any
+
+import pytest
+
+from areal.engine.vllm_remote import VLLMBackend
+from areal.v2.inference_service.sglang.bridge import SGLangBridgeBackend
+from areal.v2.inference_service.vllm.bridge import VLLMBridgeBackend
+
+
+@pytest.fixture(params=[VLLMBackend, VLLMBridgeBackend])
+def vllm_backend(request: pytest.FixtureRequest) -> Any:
+    return request.param()
+
+
+@pytest.mark.parametrize("response_format", ["completion", "chat"])
+def test_vllm_rejects_ambiguous_sampling_logprob(
+    vllm_backend: Any, response_format: str
+) -> None:
+    if response_format == "completion":
+        logprobs = {
+            "tokens": ["token:42"],
+            "token_logprobs": [-9999.0],
+        }
+    else:
+        logprobs = {
+            "content": [{"token": "token:42", "logprob": -9999.0}],
+        }
+    response = {"choices": [{"finish_reason": "stop", "logprobs": logprobs}]}
+
+    with pytest.raises(ValueError, match=r"output_logprobs\[0\].*-9999\.0"):
+        vllm_backend.parse_generation_response(response)
+
+
+def test_vllm_accepts_zero_sampling_logprob(vllm_backend: Any) -> None:
+    response = {
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "logprobs": {
+                    "tokens": ["token:42"],
+                    "token_logprobs": [0.0],
+                },
+            }
+        ]
+    }
+
+    result = vllm_backend.parse_generation_response(response)
+
+    assert result.output_tokens == [42]
+    assert result.output_logprobs == [0.0]
+
+
+def test_sglang_v2_accepts_abort_before_prefill_without_evidence() -> None:
+    response = {
+        "meta_info": {
+            "finish_reason": {
+                "type": "abort",
+                "message": "Abort before prefill due to engine pause",
+            }
+        }
+    }
+
+    result = SGLangBridgeBackend().parse_generation_response(response)
+
+    assert result.output_tokens == []
+    assert result.output_logprobs == []
+    assert result.stop_reason == "abort"
+
+
+@pytest.mark.parametrize(
+    "finish_reason",
+    [
+        pytest.param({"type": "stop"}, id="normal-stop"),
+        pytest.param(
+            {"type": "abort", "message": "Abort after prefill"},
+            id="abort-after-prefill",
+        ),
+    ],
+)
+def test_sglang_v2_requires_sampling_evidence_otherwise(
+    finish_reason: dict[str, str],
+) -> None:
+    response = {"meta_info": {"finish_reason": finish_reason}}
+
+    with pytest.raises(ValueError, match="output_token_logprobs"):
+        SGLangBridgeBackend().parse_generation_response(response)

--- a/tests/test_http_generation_result.py
+++ b/tests/test_http_generation_result.py
@@ -1,0 +1,90 @@
+import pytest
+
+from areal.api.io_struct import HttpGenerationResult
+
+
+@pytest.mark.parametrize(
+    ("output_tokens", "output_logprobs"),
+    [
+        pytest.param([1, 2], [-0.1], id="missing-logprob"),
+        pytest.param([1], [-0.1, -0.2], id="extra-logprob"),
+    ],
+)
+def test_http_generation_result_rejects_mismatched_evidence_counts(
+    output_tokens: list[int], output_logprobs: list[float]
+) -> None:
+    """A parsed result requires one sampling logprob per output token."""
+    with pytest.raises(ValueError) as exc_info:
+        HttpGenerationResult(
+            output_tokens=output_tokens,
+            output_logprobs=output_logprobs,
+            stop_reason="stop",
+        )
+
+    message = str(exc_info.value)
+    assert f"{len(output_tokens)} output tokens" in message
+    assert f"{len(output_logprobs)} output logprobs" in message
+    assert "exactly one sampling logprob" in message
+
+
+@pytest.mark.parametrize(
+    "invalid_logprob",
+    [
+        pytest.param(float("nan"), id="nan"),
+        pytest.param(float("inf"), id="positive-infinity"),
+        pytest.param(float("-inf"), id="negative-infinity"),
+    ],
+)
+def test_http_generation_result_rejects_non_finite_logprob(
+    invalid_logprob: float,
+) -> None:
+    """A parsed result rejects non-finite sampling evidence."""
+    with pytest.raises(
+        ValueError,
+        match=r"output_logprobs\[1\] must be a real, finite number",
+    ):
+        HttpGenerationResult(
+            output_tokens=[1, 2],
+            output_logprobs=[-0.1, invalid_logprob],
+            stop_reason="stop",
+        )
+
+
+@pytest.mark.parametrize("invalid_logprob", [True, False])
+def test_http_generation_result_rejects_boolean_logprob(
+    invalid_logprob: bool,
+) -> None:
+    """Boolean JSON values are not sampling logprob evidence."""
+    with pytest.raises(
+        ValueError,
+        match=r"output_logprobs\[0\] must be a real, finite number",
+    ):
+        HttpGenerationResult(
+            output_tokens=[1],
+            output_logprobs=[invalid_logprob],
+            stop_reason="stop",
+        )
+
+
+def test_http_generation_result_accepts_empty_evidence() -> None:
+    """An empty result remains valid for abort-before-prefill paths."""
+    result = HttpGenerationResult(
+        output_tokens=[],
+        output_logprobs=[],
+        stop_reason="abort",
+    )
+
+    assert result.output_tokens == []
+    assert result.output_logprobs == []
+
+
+def test_http_generation_result_accepts_complete_finite_evidence() -> None:
+    """A normal sampled result preserves its complete finite evidence."""
+    result = HttpGenerationResult(
+        output_tokens=[10, 11],
+        output_logprobs=[-0.5, -0.25],
+        stop_reason="stop",
+    )
+
+    assert result.output_tokens == [10, 11]
+    assert result.output_logprobs == [-0.5, -0.25]


### PR DESCRIPTION
## Description

AReaL projects provider token IDs and sampling logprobs into rollout tensors consumed by PPO. This change validates the normalized provider result before accumulation so non-empty, incomplete, non-finite, or positionally inconsistent evidence fails closed.

It also validates both vLLM adapter paths and preserves SGLang's explicit abort-before-prefill empty result. vLLM's `-9999.0` value is rejected because vLLM uses it both when a logprob is missing and when a lower value is clamped; the original behavior-policy evidence cannot be recovered from that response.

The duplicated legacy and v2 vLLM response parsers now delegate to `areal/utils/vllm_response.py`. That transitional module owns provider-specific response normalization while generic result invariants remain in `HttpGenerationResult`. The fail-closed handling of vLLM's ambiguous sentinel is the policy decision on which maintainer feedback is especially welcome; my recommendation is to reject it rather than treat it as exact sampling evidence.

## Related Issue

Fixes #1552

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (not applicable; no public interface changed)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

Malformed provider responses that were previously accepted now raise before entering rollout accumulation. This is an intentional fail-closed behavior change; valid provider responses are unaffected.

## Additional Context

Validation on current `main` (`82ed3327`):

- `uv run pytest tests/test_http_generation_result.py tests/test_generation_response_parsing.py -q` — 18 passed
- `uv run pytest tests/v2/inference_service/test_inf_bridge.py -q` — 26 passed
- `uv run pre-commit run --all-files` — passed
- `git diff --check upstream/main...HEAD` — passed

No GPU or live provider run was performed. The code comments trace both meanings of vLLM's sentinel directly to pinned vLLM `v0.19.1` source.

Upstream #1496 independently contains the same SGLang abort-before-prefill handling. If it lands first, I will rebase this branch and drop that overlapping hunk; the shared result and vLLM evidence checks are independent.
