### PR TITLE
test(inference-service): send admin key in data proxy register_model tests

### DIFF
--- a/tests/v2/inference_service/test_external_model.py
+++ b/tests/v2/inference_service/test_external_model.py
@@ -454,9 +454,20 @@ class TestDataProxyExternalEndpoints:
         resp = await data_proxy_client.post(
             "/register_model",
             json={"name": "ext-1", "url": "http://ext-api", "model": "gpt-4o"},
+            headers={"Authorization": "Bearer areal-admin-key"},
         )
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_register_external_model_without_admin_key_401(
+        self, data_proxy_client
+    ):
+        resp = await data_proxy_client.post(
+            "/register_model",
+            json={"name": "ext-1", "url": "http://ext-api", "model": "gpt-4o"},
+        )
+        assert resp.status_code == 401
 
     @pytest.mark.asyncio
     async def test_external_chat_completions_non_streaming(
@@ -468,6 +479,7 @@ class TestDataProxyExternalEndpoints:
         await data_proxy_client.post(
             "/register_model",
             json={"name": "ext-1", "url": "http://ext-api", "model": "gpt-4o"},
+            headers={"Authorization": "Bearer areal-admin-key"},
         )
 
         class _FakeClient:
@@ -520,6 +532,7 @@ class TestDataProxyExternalEndpoints:
         await data_proxy_client.post(
             "/register_model",
             json={"name": "ext-1", "url": "http://ext-api", "model": "gpt-4o"},
+            headers={"Authorization": "Bearer areal-admin-key"},
         )
 
         class _FakeStreamResponse:
@@ -624,6 +637,7 @@ class TestDataProxyExternalEndpoints:
                 "model": "gpt-4o",
                 "api_key": "sk-provider-key-99",
             },
+            headers={"Authorization": "Bearer areal-admin-key"},
         )
 
         captured_headers: dict[str, str] = {}


### PR DESCRIPTION
## Summary

PR #1550 (`b0142a9ed`) gated `/register_model` on the inference-service data proxy behind the admin API key (CWE-918 SSRF fix), but did not update the corresponding unit tests. As a result, `TestDataProxyExternalEndpoints` in `tests/v2/inference_service/test_external_model.py` is now broken on `main`, and **every open PR's CI fails** with the same 4 cascading errors (pull_request CI runs on the merge commit with latest main):

| Test | Symptom | Actual cause |
|---|---|---|
| `test_register_external_model` | `401 != 200` | register call carries no admin key |
| `test_external_chat_completions_non_streaming` | got `chatcmpl-mock` | register failed with 401 → `ext-1` never registered → chat falls through to internal mock path |
| `test_external_chat_completions_streaming` | `TypeError: 'async for' ... got ChatCompletion` | same fall-through, internal mock returns a non-streaming object |
| `test_external_chat_uses_stored_provider_api_key` | captured headers empty | same fall-through, fake external client never invoked |

Example failing run: https://github.com/areal-project/AReaL/actions/runs/29900536662/job/88863549445 (PR #1555, whose Megatron-only changes are unrelated).

## Changes

- Pass `Authorization: Bearer areal-admin-key` in the four `/register_model` calls in `TestDataProxyExternalEndpoints` (matches the admin key already used by the chat/export calls in the same tests, set via `SessionStore.set_admin_key(config.admin_api_key)` in the fixture).
- Add `test_register_external_model_without_admin_key_401` to lock in the auth requirement introduced by #1550.

## Testing

```bash
pytest tests/v2/inference_service/test_external_model.py -q
# 22 passed
```

pre-commit (Ruff lint + format, whitespace, EOF) passed on the changed file.

Refs: #1550