### PR TITLE
fix(engine): use model-native packed attention masks

### DIFF
--- a/areal/engine/fsdp_engine.py
+++ b/areal/engine/fsdp_engine.py
@@ -71,9 +71,6 @@ from areal.engine.core.distributed import (
 from areal.engine.core.model import (
     disable_dropout_in_model,
     is_gemma3_model,
-    is_qwen3_5_model,
-    is_qwen3_moe_model,
-    is_qwen3_vl_model,
     is_qwen_vl_model,
     is_valid_vision_model,
 )
@@ -1889,18 +1886,12 @@ class FSDPEngine(TrainEngine):
             ]
             mb["use_cache"] = False
             padded_mb["use_cache"] = False
-            if (
-                is_qwen3_moe_model(self.model_config.model_type)
-                or is_qwen3_vl_model(self.model_config.model_type)
-                or is_qwen3_5_model(self.model_config.model_type)
-            ):
-                mb["attention_mask"] = None
-                padded_mb["attention_mask"] = None
-            else:
-                mb["attention_mask"] = dict(full_attention=None, sliding_attention=None)
-                padded_mb["attention_mask"] = dict(
-                    full_attention=None, sliding_attention=None
-                )
+            # Transformers models do not share a common dict schema for
+            # per-layer attention masks. Mapping-aware models build their own
+            # backend-specific masks from ``None`` and the reset position IDs;
+            # passing a hard-coded mapping breaks tensor-mask models such as Llama.
+            mb["attention_mask"] = None
+            padded_mb["attention_mask"] = None
             _prepare_multimodal_forward_inputs(mb, padded_mb)
         _drop_multimodal_payloads(mb_list.data)
         return mb_list

--- a/tests/test_fsdp_packed_attention_mask.py
+++ b/tests/test_fsdp_packed_attention_mask.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from transformers import LlamaConfig, LlamaForCausalLM
+
+import areal.engine.fsdp_engine as fsdp_module
+from areal.api.cli_args import MicroBatchSpec, TrainEngineConfig
+
+
+def _make_engine(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+) -> fsdp_module.FSDPEngine:
+    monkeypatch.setattr(
+        fsdp_module.AutoConfig,
+        "from_pretrained",
+        lambda **_: SimpleNamespace(model_type=model_type),
+    )
+    monkeypatch.setattr(fsdp_module.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(fsdp_module.dist, "get_rank", lambda group=None: 0)
+
+    config = TrainEngineConfig(
+        backend="fsdp:d1",
+        experiment_name="test-packed-attention-mask",
+        trial_name="test0",
+        path="unused",
+        mb_spec=MicroBatchSpec(n_mbs=1, max_tokens_per_mb=16),
+        pad_to_maximum=True,
+    )
+    engine = fsdp_module.FSDPEngine(config)
+    engine.logger = MagicMock()
+    return engine
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        pytest.param("llama", id="llama-minicpm5"),
+        pytest.param("qwen2", id="qwen2-layer-mapping"),
+        pytest.param("qwen3", id="qwen3-layer-mapping"),
+        pytest.param("qwen3_moe", id="qwen3-moe"),
+        pytest.param("qwen3_5", id="qwen3-5"),
+        pytest.param("gemma3", id="gemma3-layer-mapping"),
+    ],
+)
+def test_prepare_mb_list_uses_model_compatible_attention_mask(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+) -> None:
+    """Packed forwards should let each Transformers model build its own mask."""
+    engine = _make_engine(monkeypatch, model_type)
+    batch = {
+        "input_ids": torch.tensor([[1, 2, 0], [3, 4, 5]]),
+        "attention_mask": torch.tensor(
+            [[True, True, False], [True, True, True]], dtype=torch.bool
+        ),
+    }
+
+    mb_list = engine._prepare_mb_list(batch)
+
+    assert mb_list.padded_mbs is not None
+    for mb in [*mb_list.mbs, *mb_list.padded_mbs]:
+        assert mb["attention_mask"] is None
+
+
+@pytest.mark.parametrize("model_type", ["qwen2_5_vl", "qwen3_vl"])
+def test_prepare_mb_list_uses_model_compatible_mask_for_qwen_vl(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+) -> None:
+    """Qwen-VL mRoPE preparation should also pass a model-native mask."""
+    engine = _make_engine(monkeypatch, model_type)
+    position_ids = torch.arange(3).expand(3, 2, -1).clone()
+    compute_3d_position_ids = MagicMock(return_value=position_ids)
+    engine.model = SimpleNamespace(
+        model=SimpleNamespace(compute_3d_position_ids=compute_3d_position_ids)
+    )
+    batch = {
+        "input_ids": torch.tensor([[1, 2, 0], [3, 4, 5]]),
+        "attention_mask": torch.tensor(
+            [[True, True, False], [True, True, True]], dtype=torch.bool
+        ),
+        "mm_token_type_ids": torch.zeros((2, 3), dtype=torch.long),
+    }
+
+    mb_list = engine._prepare_mb_list(batch)
+
+    compute_3d_position_ids.assert_called_once()
+    assert mb_list.padded_mbs is not None
+    for mb in [*mb_list.mbs, *mb_list.padded_mbs]:
+        assert mb["attention_mask"] is None
+
+
+@pytest.mark.parametrize("attn_implementation", ["eager", "sdpa"])
+def test_llama_builds_isolated_packed_mask_from_position_ids(
+    attn_implementation: str,
+) -> None:
+    """A reset position sequence should prevent cross-sample attention."""
+    torch.manual_seed(0)
+    model = LlamaForCausalLM(
+        LlamaConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            _attn_implementation=attn_implementation,
+        )
+    ).eval()
+
+    first = torch.tensor([[1, 2, 3]])
+    second = torch.tensor([[4, 5]])
+    packed = torch.cat((first, second), dim=1)
+
+    with torch.no_grad():
+        first_logits = model(
+            first,
+            attention_mask=None,
+            position_ids=torch.tensor([[0, 1, 2]]),
+            use_cache=False,
+        ).logits
+        second_logits = model(
+            second,
+            attention_mask=None,
+            position_ids=torch.tensor([[0, 1]]),
+            use_cache=False,
+        ).logits
+        packed_logits = model(
+            packed,
+            attention_mask=None,
+            position_ids=torch.tensor([[0, 1, 2, 0, 1]]),
+            use_cache=False,
+        ).logits
+
+    torch.testing.assert_close(
+        packed_logits[:, :3], first_logits, rtol=1e-5, atol=1e-6
+    )
+    torch.testing.assert_close(
+        packed_logits[:, 3:], second_logits, rtol=1e-5, atol=1e-6
+    )


### PR DESCRIPTION
## Description

Remove the model-family allowlist that injected a hard-coded per-layer attention-mask dictionary into FSDP packed microbatches. Passing `None` lets each Transformers model build the backend-specific mask it expects from AReaL's reset position IDs, avoiding the Llama/MiniCPM5 `dict.ndim` crash while keeping Qwen and multimodal preparation model-native.

This also adds CPU regressions for:

- Llama/MiniCPM5-style, Qwen2, Qwen3, Qwen3-MoE, Qwen3.5, and Gemma3 configs
- Qwen2.5-VL and Qwen3-VL mRoPE preparation
- Packed-sequence isolation under eager attention and SDPA

## Related Issue

Fixes #1557

Related to #1132, #1153, and #1442.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (not applicable; no user-facing API or configuration changes)
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

**Breaking Change Details (if applicable):**

None.

## Additional Context

Validation:

- `PYTHONPATH=. python -m pytest -q tests/test_fsdp_packed_attention_mask.py` — 10 passed
- `pre-commit run --all-files` — passed
- `git diff --check` — passed

Documentation is not affected because this only changes internal packed-mask plumbing.