### PR TITLE
feat(mcore): apply fp32 lm head forward when enabled

### DIFF
--- a/areal/models/mcore/registry.py
+++ b/areal/models/mcore/registry.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+import types
 from typing import Any
 
 import torch
@@ -90,6 +91,157 @@ def _replace_output_layer_with_value_head(
     ).to(dtype=dtype)
 
     model.vocab_size = 1
+
+
+def _is_lm_head_module_name(name: str) -> bool:
+    return name in ("output_layer", "lm_head") or name.endswith(
+        (".output_layer", ".lm_head")
+    )
+
+
+def _fp32_lm_head_forward_impl(
+    *,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    sequence_parallel: bool,
+    tp_group: Any | None = None,
+    **_: Any,
+) -> torch.Tensor:
+    if sequence_parallel:
+        try:
+            total_input = tensor_parallel.gather_from_sequence_parallel_region(
+                input,
+                tensor_parallel_output_grad=True,
+                group=tp_group,
+            )
+        except TypeError:
+            total_input = tensor_parallel.gather_from_sequence_parallel_region(
+                input,
+                tensor_parallel_output_grad=True,
+            )
+    else:
+        total_input = input
+
+    output = torch.matmul(total_input.float(), weight.t().float())
+    if bias is not None:
+        output = output + bias.float()
+    return output
+
+
+def _fp32_lm_head_forward(
+    self,
+    input_: torch.Tensor,
+    weight=None,
+    runtime_gather_output: bool | None = None,
+    **kwargs,
+):
+    if weight is None:
+        weight = self.weight
+    if weight is None:
+        raise RuntimeError(
+            "weight was not supplied to lm_head forward pass and "
+            "skip_weight_param_allocation is True."
+        )
+
+    bias = self.bias if not getattr(self, "skip_bias_add", False) else None
+
+    if (
+        getattr(self, "async_tensor_model_parallel_allreduce", False)
+        or getattr(self, "sequence_parallel", False)
+        or getattr(self, "explicit_expert_comm", False)
+    ):
+        input_parallel = input_
+    else:
+        input_parallel = tensor_parallel.copy_to_tensor_model_parallel_region(input_)
+
+    output_parallel = _fp32_lm_head_forward_impl(
+        input=input_parallel,
+        weight=weight,
+        bias=bias,
+        sequence_parallel=getattr(self, "sequence_parallel", False),
+        tp_group=getattr(self, "tp_group", None),
+    )
+
+    runtime_gather_output = kwargs.get("runtime_gather_output", runtime_gather_output)
+    gather_output = (
+        getattr(self, "gather_output", False)
+        if runtime_gather_output is None
+        else runtime_gather_output
+    )
+    if gather_output:
+        output = tensor_parallel.gather_from_tensor_model_parallel_region(
+            output_parallel
+        )
+    else:
+        output = output_parallel
+
+    output_bias = self.bias if getattr(self, "skip_bias_add", False) else None
+    return output, output_bias
+
+
+def _enable_fp32_lm_head_forward(
+    models: list[torch.nn.Module],
+    *,
+    enabled: bool,
+) -> int:
+    if not enabled:
+        return 0
+
+    native_fp32_cls = getattr(tensor_parallel, "ColumnParallelLinearFP32", None)
+    patched = []
+    already_fp32 = []
+
+    for model_idx, model in enumerate(models):
+        module = model.module if isinstance(model, DDP) else model
+        for name, submodule in module.named_modules():
+            if not _is_lm_head_module_name(name):
+                continue
+            if (
+                native_fp32_cls is not None and isinstance(submodule, native_fp32_cls)
+            ) or type(submodule).__name__ == "ColumnParallelLinearFP32":
+                already_fp32.append(f"model{model_idx}:{name}")
+                continue
+            if getattr(submodule, "_areal_fp32_lm_head_enabled", False):
+                already_fp32.append(f"model{model_idx}:{name}")
+                continue
+            if hasattr(submodule, "_forward_impl"):
+                setattr(
+                    submodule,
+                    "_areal_original_forward_impl",
+                    submodule._forward_impl,
+                )
+                setattr(submodule, "_forward_impl", _fp32_lm_head_forward_impl)
+                setattr(submodule, "_areal_fp32_lm_head_enabled", True)
+                patched.append(f"model{model_idx}:{name}:{type(submodule).__name__}")
+            elif all(hasattr(submodule, attr) for attr in ("weight", "forward")):
+                setattr(submodule, "_areal_original_forward", submodule.forward)
+                setattr(
+                    submodule,
+                    "forward",
+                    types.MethodType(_fp32_lm_head_forward, submodule),
+                )
+                setattr(submodule, "_areal_fp32_lm_head_enabled", True)
+                patched.append(f"model{model_idx}:{name}:{type(submodule).__name__}")
+
+    if patched:
+        logger.warning(
+            "Enabled FP32 lm_head/output_layer forward for modules: %s",
+            ", ".join(patched),
+        )
+    elif already_fp32:
+        logger.info(
+            "FP32 lm_head/output_layer is already enabled for modules: %s",
+            ", ".join(already_fp32),
+        )
+    else:
+        logger.warning(
+            "enable_fp32_lm_head=True, but no output_layer/lm_head module was found "
+            "on this model chunk. This is expected for non-post-process pipeline "
+            "stages."
+        )
+
+    return len(patched)
 
 
 def unwrap_to_gpt_model(model: torch.nn.Module) -> GPTModel:
@@ -193,6 +345,13 @@ def make_mcore_model(
             for model in models:
                 _model = unwrap_to_gpt_model(model)
                 _replace_output_layer_with_value_head(_model, tf_config)
+        else:
+            _enable_fp32_lm_head_forward(
+                models,
+                enabled=bool(
+                    mcore_config is not None and mcore_config.enable_fp32_lm_head
+                ),
+            )
 
         return models
 
@@ -287,6 +446,13 @@ def make_mcore_model(
             for model in models:
                 _model = unwrap_to_gpt_model(model)
                 _replace_output_layer_with_value_head(_model, tf_config)
+        else:
+            _enable_fp32_lm_head_forward(
+                models,
+                enabled=bool(
+                    mcore_config is not None and mcore_config.enable_fp32_lm_head
+                ),
+            )
 
         return models
 
@@ -327,6 +493,13 @@ def make_mcore_model(
         # Replace output_layer with ValueHead for critic models
         if is_critic:
             _replace_output_layer_with_value_head(model, tf_config)
+        else:
+            _enable_fp32_lm_head_forward(
+                [model],
+                enabled=bool(
+                    mcore_config is not None and mcore_config.enable_fp32_lm_head
+                ),
+            )
 
         if mcore_config.wrap_with_ddp:
             ddp_config = MCoreDDPConfig(**dataclasses.asdict(mcore_config.ddp))

--- a/areal/models/mcore/registry.py
+++ b/areal/models/mcore/registry.py
@@ -99,6 +99,13 @@ def _is_lm_head_module_name(name: str) -> bool:
     )
 
 
+def _call_with_optional_group(fn, tensor: torch.Tensor, group: Any | None):
+    try:
+        return fn(tensor, group=group)
+    except TypeError:
+        return fn(tensor)
+
+
 def _fp32_lm_head_forward_impl(
     *,
     input: torch.Tensor,
@@ -108,6 +115,26 @@ def _fp32_lm_head_forward_impl(
     tp_group: Any | None = None,
     **_: Any,
 ) -> torch.Tensor:
+    """Run the lm-head projection in fp32.
+
+    A bf16 head keeps the ``[tokens, vocab]`` logits and their gradient in bf16,
+    which is the dominant rounding error in the loss for large vocabularies.
+    Casting the operands here keeps the matmul and the bias add in fp32 while
+    leaving the rest of the model in its configured dtype.
+
+    Mirrors ``ColumnParallelLinear`` from megatron-core, verified against 0.17.0.
+    The collective helpers gained a ``group`` keyword in newer releases, so the
+    calls fall back to the positional form when it is absent.
+
+    Upgrade considerations: this replaces the fused ``_forward_impl`` with a
+    plain matmul, so the dgrad all-reduce comes from
+    ``copy_to_tensor_model_parallel_region`` instead of the fused kernel -
+    equivalent, not fused. If megatron-core changes the forward short-circuit
+    conditions or the collective signatures, this reimplementation drifts
+    silently; ``_enable_fp32_lm_head_forward`` therefore steps aside when the
+    installed megatron-core exposes a native ``ColumnParallelLinearFP32``
+    (absent as of 0.17.0).
+    """
     if sequence_parallel:
         try:
             total_input = tensor_parallel.gather_from_sequence_parallel_region(
@@ -145,6 +172,7 @@ def _fp32_lm_head_forward(
         )
 
     bias = self.bias if not getattr(self, "skip_bias_add", False) else None
+    tp_group = getattr(self, "tp_group", None)
 
     if (
         getattr(self, "async_tensor_model_parallel_allreduce", False)
@@ -153,14 +181,16 @@ def _fp32_lm_head_forward(
     ):
         input_parallel = input_
     else:
-        input_parallel = tensor_parallel.copy_to_tensor_model_parallel_region(input_)
+        input_parallel = _call_with_optional_group(
+            tensor_parallel.copy_to_tensor_model_parallel_region, input_, tp_group
+        )
 
     output_parallel = _fp32_lm_head_forward_impl(
         input=input_parallel,
         weight=weight,
         bias=bias,
         sequence_parallel=getattr(self, "sequence_parallel", False),
-        tp_group=getattr(self, "tp_group", None),
+        tp_group=tp_group,
     )
 
     runtime_gather_output = kwargs.get("runtime_gather_output", runtime_gather_output)
@@ -170,8 +200,10 @@ def _fp32_lm_head_forward(
         else runtime_gather_output
     )
     if gather_output:
-        output = tensor_parallel.gather_from_tensor_model_parallel_region(
-            output_parallel
+        output = _call_with_optional_group(
+            tensor_parallel.gather_from_tensor_model_parallel_region,
+            output_parallel,
+            tp_group,
         )
     else:
         output = output_parallel

--- a/tests/test_mcore_fp32_lm_head.py
+++ b/tests/test_mcore_fp32_lm_head.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the fp32 lm-head forward patch."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+from areal.models.mcore.registry import (
+    _enable_fp32_lm_head_forward,
+    _fp32_lm_head_forward,
+    _is_lm_head_module_name,
+)
+
+
+class TestLmHeadModuleName:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("output_layer", True),
+            ("lm_head", True),
+            ("decoder.output_layer", True),
+            ("module.module.lm_head", True),
+            ("output_layer_extra", False),
+            ("decoder.layers.0.mlp", False),
+            ("", False),
+        ],
+    )
+    def test_matches_only_lm_head_modules(self, name, expected):
+        assert _is_lm_head_module_name(name) is expected
+
+
+class _Head(torch.nn.Module):
+    def __init__(self, tp_group):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(4, 3))
+        self.bias = None
+        self.skip_bias_add = False
+        self.sequence_parallel = False
+        self.explicit_expert_comm = False
+        self.gather_output = False
+        self.tp_group = tp_group
+
+
+class TestForwardForwardsTheTensorParallelGroup:
+    def test_collectives_receive_the_modules_tp_group(self):
+        group = object()
+        head = _Head(group)
+        seen = {}
+
+        def copy_to(input_, group=None):
+            seen["copy_to"] = group
+            return input_
+
+        def gather_from(input_, group=None):
+            seen["gather_from"] = group
+            return input_
+
+        head.gather_output = True
+        with mock.patch(
+            "areal.models.mcore.registry.tensor_parallel",
+            SimpleNamespace(
+                copy_to_tensor_model_parallel_region=copy_to,
+                gather_from_tensor_model_parallel_region=gather_from,
+                gather_from_sequence_parallel_region=lambda *a, **k: a[0],
+            ),
+        ):
+            _fp32_lm_head_forward(head, torch.ones(2, 3))
+
+        assert seen["copy_to"] is group, (
+            "copy_to_tensor_model_parallel_region ran on the default group; "
+            "mcore forwards self.tp_group here"
+        )
+        assert seen["gather_from"] is group, (
+            "gather_from_tensor_model_parallel_region ran on the default group; "
+            "mcore forwards self.tp_group here"
+        )
+
+    def test_output_is_float32(self):
+        head = _Head(None)
+        with mock.patch(
+            "areal.models.mcore.registry.tensor_parallel",
+            SimpleNamespace(
+                copy_to_tensor_model_parallel_region=lambda i, group=None: i,
+                gather_from_tensor_model_parallel_region=lambda i, group=None: i,
+                gather_from_sequence_parallel_region=lambda *a, **k: a[0],
+            ),
+        ):
+            output, _bias = _fp32_lm_head_forward(head, torch.ones(2, 3).bfloat16())
+
+        assert output.dtype is torch.float32
+
+
+class TestEnablePatch:
+    def test_disabled_patches_nothing(self):
+        head = _Head(None)
+        assert _enable_fp32_lm_head_forward([head], enabled=False) == 0
+
+    def test_patch_is_idempotent(self):
+        model = torch.nn.Module()
+        model.add_module("output_layer", _Head(None))
+
+        first = _enable_fp32_lm_head_forward([model], enabled=True)
+        second = _enable_fp32_lm_head_forward([model], enabled=True)
+
+        assert first == 1
+        assert second == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

`enable_fp32_lm_head` already exists as a config flag, but it only reaches the model
through mbridge extra args: `MegatronEngine` puts it into `precision_args` and hands
it to `bridge.TransformerConfigClass`. When that class does not accept the field —
upstream's own comment gives `MLATransformerConfig` as the example — it is filtered
out and only a warning is logged, so the flag silently has no effect for those models.
It also does nothing on the Megatron construction paths that do not go through the
bridge at all.

This patches the `lm_head` / `output_layer` forward after the model is built, so the
existing flag actually applies on every Megatron construction path. FP32 casting of
the head output matters for loss numerical stability on large models.

Behaviour is unchanged unless the flag is set:

- returns immediately when `enabled` is false, and the config default is `false`
- skips modules that are already Megatron's native `ColumnParallelLinearFP32`, so it
  never double-applies
- an idempotency sentinel prevents patching the same module twice
- all three call sites are in the non-critic branch, so they never interact with
  `_replace_output_layer_with_value_head`

Sequence-parallel inputs are gathered before the FP32 matmul, with a fallback for
Megatron builds whose `gather_from_sequence_parallel_region` does not take a `group`
argument.

## Related Issue

N/A — no tracking issue. This makes an existing configuration flag effective; it was
found while bringing up a large MoE model whose transformer config rejects the field.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass on the changed files
- [ ] Relevant tests pass; new tests added for new functionality
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

No config surface changes, so the CLI reference is untouched: `enable_fp32_lm_head`
and its help text already exist on `main`. The change is confined to what happens
after the flag is read.

No unit test is added because exercising the patched forward needs an initialized
Megatron model with tensor parallelism, which the current test setup does not provide.
It was verified by importing the module and confirming the disabled path patches
nothing, plus manual inspection of the patched module list logged at startup on a
large MoE run.