### PR TITLE
test(sglang): expect a best-effort LoRA adapter load

### DIFF
--- a/tests/test_sglang_lora_unload.py
+++ b/tests/test_sglang_lora_unload.py
@@ -32,7 +32,7 @@ def test_disk_update_unloads_stale_version_beyond_window():
     """load v{N} also emits a best-effort unload of v{N - keep}."""
     reqs = SGLangBackend().build_disk_weight_update_requests(_lora_meta(10, keep=4))
     triples = _triples(reqs)
-    assert ("/load_lora_adapter", "lora-gsm8k-v10", False) in triples
+    assert ("/load_lora_adapter", "lora-gsm8k-v10", True) in triples
     unloads = [t for t in triples if t[0] == "/unload_lora_adapter"]
     assert unloads == [("/unload_lora_adapter", "lora-gsm8k-v6", True)]
 


### PR DESCRIPTION
## Description

`tests/test_sglang_lora_unload.py::test_disk_update_unloads_stale_version_beyond_window`
fails on `main`.

```
AssertionError: assert ('/load_lora_adapter', 'lora-gsm8k-v10', False) in
  [('/load_lora_adapter', 'lora-gsm8k-v10', True),
   ('/unload_lora_adapter', 'lora-gsm8k-v6',  True)]
```

When the test was added, `build_disk_weight_update_requests` built the
`/load_lora_adapter` request without `best_effort`, so the default `False` was
correct. The load later became `best_effort=True` so that re-registering an adapter
that is already present — which SGLang answers with a 400 — no longer fails the whole
weight update. The assertion was not updated with it, so the test has been red on
`main` ever since.

This updates the expected value to match. No production code changes.

## Related Issue

N/A — no tracking issue; the failure is visible on any CI run against current `main`.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I have read the
  [Contributing Guide](https://github.com/areal-project/community/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass on the changed file
- [x] Relevant tests pass
- [ ] Documentation updated (if applicable; built with `./docs/build_all.sh`)
- [x] Branch is up to date with `main`
- [ ] Self-reviewed via `/review-pr` command
- [ ] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Additional Context

Verified against a clean checkout of `main` with no other changes applied:
`1 failed, 4 passed` before, `5 passed` after. The other four cases in the file were
already passing, which is why only this one surfaced —
`test_disk_update_unload_is_best_effort` only asserts the *unload* flag.

One thing worth a second look, though it is deliberately **not** changed here.
`best_effort` suppresses every exception from the request and only logs a warning; its
own comment in `areal/infra/remote_inf_engine.py` describes it as being for *cleanup*
requests such as unloading a stale adapter. Applying it to the adapter **load**
therefore also swallows genuine failures — a bad adapter path, exhausted VRAM, a
corrupt adapter — and the rollout then keeps serving the previous adapter with only a
warning in the log. If the intent was solely to tolerate re-registration, narrowing
that to the specific "already loaded" response would keep the idempotency without
hiding real failures. Happy to follow up separately if that sounds right.
