### PR TITLE
feat: add DTE-backed colocated weight transfer

### DIFF
--- a/areal/api/cli_args.py
+++ b/areal/api/cli_args.py
@@ -1155,6 +1155,83 @@ class SchedulingSpec:
 
 
 @dataclass
+class DTEConfig:
+    """Configuration for DTE-backed colocated weight updates."""
+
+    enabled: bool | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Enable DTE colocated weight update. None keeps backward "
+                "compatibility with environment variables."
+            )
+        },
+    )
+    transfer: str | None = field(
+        default="full",
+        metadata={
+            "help": (
+                "Weight transfer type: 'full' sends full weights every update; "
+                "'delta' sends a full first update, then DTE deltas."
+            ),
+            "choices": ["full", "delta", None],
+        },
+    )
+    delta_method: str | None = field(
+        default=None,
+        metadata={
+            "help": "How DTE delta mode finds changed weights.",
+            "choices": ["snapshot", "adamw", None],
+        },
+    )
+    anchor_interval: int | None = field(
+        default=0,
+        metadata={"help": "Force a full sync every N deltas. 0 means never."},
+    )
+    bytes_ratio: float | None = field(
+        default=None,
+        metadata={"help": "Per-tensor sparse-vs-dense fallback ratio."},
+    )
+    verify_snapshot: bool | None = field(
+        default=False,
+        metadata={
+            "help": (
+                "Debug only: keep a CPU snapshot and compare it with DTE "
+                "inversion masks."
+            )
+        },
+    )
+    release_train_weights_after_update: bool | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Release training weights after a colocated update so rollout can "
+                "reuse the shared GPU memory."
+            )
+        },
+    )
+    sync_model_params_before_payload: bool | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Refresh Megatron model-visible params from optimizer main params "
+                "before building the DTE payload."
+            )
+        },
+    )
+    inversion_debug: bool | None = field(
+        default=None,
+        metadata={"help": "Enable verbose DTE inversion debug logging."},
+    )
+    inversion_bf16_margin_rel: float | None = field(
+        default=None,
+        metadata={
+            "help": "Relative BF16 rounding-boundary margin for inversion masks."
+        },
+    )
+
+
+@dataclass
 class TrainEngineConfig:
     """Core configuration for model training, including optimization and backend settings."""
 
@@ -1239,6 +1316,7 @@ class TrainEngineConfig:
         default="xccl",
         metadata={"help": "Weight update backend type.", "choices": ["disk", "xccl"]},
     )
+    dte: DTEConfig = field(default_factory=DTEConfig)
     fsdp: FSDPEngineConfig = field(default_factory=FSDPEngineConfig)
     archon: ArchonEngineConfig = field(default_factory=ArchonEngineConfig)
     megatron: MegatronEngineConfig = field(default_factory=MegatronEngineConfig)

--- a/areal/engine/megatron_engine.py
+++ b/areal/engine/megatron_engine.py
@@ -2561,6 +2561,9 @@ class MegatronPPOActor(MegatronEngine):
         return self.actor.compute_advantages(*args, **kwargs)
 
     def ppo_update(self, *args, **kwargs) -> None:
+        awex_adapter = getattr(self, "_awex_weight_update_adapter", None)
+        if awex_adapter is not None:
+            awex_adapter.ensure_grad_buffers()
         self.actor.ppo_update(*args, **kwargs)
 
     @classmethod

--- a/areal/trainer/rl_trainer.py
+++ b/areal/trainer/rl_trainer.py
@@ -115,6 +115,7 @@ class PPOTrainer:
             logging.setup_file_logging(StatsLogger.get_log_path(config.stats_logger))
 
         self.config = config
+        self._apply_dte_config_envvars()
         self.processor, self.tokenizer = load_hf_processor_and_tokenizer(
             config.tokenizer_path
         )
@@ -136,6 +137,11 @@ class PPOTrainer:
         self._should_offload_rollout = self._is_actor_rollout_colocated(config)
         self._should_offload_actor = (
             self._should_offload_rollout or config.actor.offload
+        )
+        dte_cfg = getattr(config.actor, "dte", None)
+        self._keep_rollout_weights_resident = bool(
+            config.actor.weight_update_mode == "awex"
+            and str(getattr(dte_cfg, "transfer", "")).lower() == "delta"
         )
         self._should_offload_critic = (
             config.critic is not None and config.critic.offload
@@ -504,7 +510,12 @@ class PPOTrainer:
                 category=Category.IO,
             ),
         ):
-            rollout.offload()
+            if self._keep_rollout_weights_resident and isinstance(
+                rollout, RolloutControllerV2
+            ):
+                rollout.offload(tags=["kv_cache"])
+            else:
+                rollout.offload()
 
     def _onload_rollout(self, is_eval: bool = False) -> None:
         cleanup_error: Exception | None = None
@@ -521,7 +532,12 @@ class PPOTrainer:
                     category=Category.IO,
                 ),
             ):
-                rollout.onload()
+                if self._keep_rollout_weights_resident and isinstance(
+                    rollout, RolloutControllerV2
+                ):
+                    rollout.onload(tags=["kv_cache"])
+                else:
+                    rollout.onload()
         except Exception as exc:  # noqa: BLE001
             cleanup_error = exc
 
@@ -941,6 +957,109 @@ class PPOTrainer:
             return SlurmScheduler(exp_config=self.config)
         raise NotImplementedError(f"Unknown scheduler type: {cfg.type}")
 
+    def _apply_dte_config_envvars(self) -> None:
+        """Export actor.dte.* config to worker-visible runtime switches.
+
+        The public control surface is now CLI/config (``actor.dte.*``). The
+        train and rollout workers are separate processes, so the selected values
+        still need to be inherited through the environment until the AWEX adapter
+        APIs grow an explicit config payload. Old AWEX_* variables remain a
+        fallback in the readers; values set here use the DTE_* names and take
+        precedence.
+        """
+        dte_cfg = getattr(self.config.actor, "dte", None)
+        if dte_cfg is None:
+            return
+
+        exported_env: dict[str, str] = {}
+
+        def set_env(name: str, value: Any) -> None:
+            if value is None:
+                return
+            if isinstance(value, bool):
+                env_value = "1" if value else "0"
+            else:
+                env_value = str(value)
+            os.environ[name] = env_value
+            exported_env[name] = env_value
+
+        transfer = dte_cfg.transfer
+        delta_transfer = None
+        if transfer is not None:
+            transfer = transfer.strip().lower()
+            if transfer not in {"full", "delta"}:
+                raise ValueError(
+                    "actor.dte.transfer must be 'full' or 'delta', "
+                    f"got {dte_cfg.transfer!r}"
+                )
+            delta_transfer = transfer == "delta"
+
+        delta_method = dte_cfg.delta_method
+        detector = None
+        if delta_method is not None:
+            delta_method = delta_method.strip().lower()
+            if delta_method == "adamw":
+                detector = "inversion"
+            elif delta_method == "snapshot":
+                detector = "snapshot"
+            else:
+                raise ValueError(
+                    "actor.dte.delta_method must be 'snapshot' or 'adamw', "
+                    f"got {dte_cfg.delta_method!r}"
+                )
+        elif delta_transfer:
+            detector = "inversion"
+
+        enabled = dte_cfg.enabled
+        if enabled is False and delta_transfer:
+            raise ValueError(
+                "actor.dte.enabled=false conflicts with actor.dte.transfer='delta'. "
+                "Use actor.dte.enabled=true for delta transfer, or set "
+                "actor.dte.transfer=full."
+            )
+        if enabled is None and delta_transfer:
+            enabled = True
+        set_env("DTE_COLOCATE_WEIGHT_UPDATE", enabled)
+
+        config_controls_dte = enabled is not None
+        if config_controls_dte:
+            set_env("DTE_DELTA_TRANSFER", delta_transfer)
+            set_env("DTE_DELTA_DETECTOR", detector)
+            set_env("DTE_DELTA_ANCHOR_INTERVAL", dte_cfg.anchor_interval)
+            set_env("DTE_DELTA_BYTES_RATIO", dte_cfg.bytes_ratio)
+            set_env("DTE_DELTA_VERIFY_SNAPSHOT", dte_cfg.verify_snapshot)
+        set_env(
+            "DTE_RELEASE_TRAIN_WEIGHTS_AFTER_UPDATE",
+            dte_cfg.release_train_weights_after_update,
+        )
+        set_env(
+            "DTE_SYNC_MODEL_PARAMS_BEFORE_PAYLOAD",
+            dte_cfg.sync_model_params_before_payload,
+        )
+        set_env("DTE_DELTA_INVERSION_DEBUG", dte_cfg.inversion_debug)
+        set_env(
+            "DTE_DELTA_INVERSION_BF16_MARGIN_REL",
+            dte_cfg.inversion_bf16_margin_rel,
+        )
+
+        if exported_env:
+            for cfg_part in (
+                getattr(self.config, "actor", None),
+                getattr(self.config, "rollout", None),
+            ):
+                specs = getattr(cfg_part, "scheduling_spec", None)
+                if not specs:
+                    continue
+                for spec in specs:
+                    if isinstance(spec, dict):
+                        spec.setdefault("env_vars", {}).update(exported_env)
+                        continue
+                    env_vars = getattr(spec, "env_vars", None)
+                    if env_vars is None:
+                        env_vars = {}
+                        setattr(spec, "env_vars", env_vars)
+                    env_vars.update(exported_env)
+
     def _create_dataloader(
         self,
         dataset: Dataset,
@@ -1358,14 +1477,25 @@ class PPOTrainer:
                 "offload is enabled. Please set enable_offload=True."
             )
 
-        if (
-            self._is_actor_rollout_colocated(self.config)
-            and self.config.actor.weight_update_mode != "disk"
-        ):
+        if self._is_actor_rollout_colocated(
+            self.config
+        ) and self.config.actor.weight_update_mode not in {"disk", "awex"}:
             raise ValueError(
-                "weight_update_mode must be 'disk' when colocation scheduling is enabled. "
-                "Please set actor.weight_update_mode=disk."
+                "weight_update_mode must be 'disk' or 'awex' when colocation "
+                "scheduling is enabled."
             )
+
+        if self.config.actor.weight_update_mode == "awex":
+            if actor_backend != "megatron":
+                raise ValueError(
+                    "weight_update_mode='awex' requires Megatron actor training "
+                    f"backend, got {actor_backend!r}."
+                )
+            if rollout_backend != "sglang":
+                raise ValueError(
+                    "weight_update_mode='awex' requires SGLang rollout backend, "
+                    f"got {rollout_backend!r}."
+                )
 
         if rollout_backend == "vllm" and self.config.rollout.return_routed_experts:
             raise ValueError(

--- a/areal/v2/inference_service/controller/controller.py
+++ b/areal/v2/inference_service/controller/controller.py
@@ -1380,19 +1380,20 @@ class RolloutControllerV2:
         assert self._workflow_executor is not None
         self._workflow_executor.resume()
 
-    def offload(self) -> None:
+    def offload(self, tags: list[str] | None = None) -> None:
         """Offload model memory on all inference workers."""
         from areal.infra.utils.concurrent import run_async_task
 
         self._ensure_initialized()
-        run_async_task(self._async_offload)
+        run_async_task(self._async_offload, tags)
 
-    async def _async_offload(self) -> None:
+    async def _async_offload(self, tags: list[str] | None = None) -> None:
         if not self._data_proxy_addrs:
             return
+        payload: dict = {"tags": tags} if tags is not None else {}
         results = await asyncio.gather(
             *(
-                self._async_data_proxy_post(addr, "/release_memory_occupation", {})
+                self._async_data_proxy_post(addr, "/release_memory_occupation", payload)
                 for addr in self._data_proxy_addrs
             ),
             return_exceptions=True,

--- a/areal/v2/inference_service/sglang/awex.py
+++ b/areal/v2/inference_service/sglang/awex.py
@@ -118,6 +118,17 @@ def register_awex_endpoints(app: FastAPI, rpc_proxy: RpcProxy) -> None:
             logger.error("Failed to execute colocate weight update: %s", e)
             return JSONResponse(status_code=500, content={"error": str(e)})
 
+    @app.post("/awex/seed_delta_base")
+    async def seed_delta_base(request: Request) -> JSONResponse:
+        try:
+            data = await request.json()
+            version = data.get("version", 0)
+            rpc_proxy.collective_rpc("awex_seed_delta_base", version=version)
+            return JSONResponse(content={"status": "ok", "version": version})
+        except Exception as e:
+            logger.error("Failed to seed delta base: %s", e)
+            return JSONResponse(status_code=500, content={"error": str(e)})
+
     @app.post("/awex/release_memory")
     async def release_memory(request: Request) -> JSONResponse:
         try:

--- a/areal/v2/inference_service/sglang/scheduler.py
+++ b/areal/v2/inference_service/sglang/scheduler.py
@@ -64,6 +64,7 @@ class AwexSchedulerBridge:
             "awex_randomize_parameters",
             "awex_init_colocate_weight_update",
             "awex_execute_colocate_weight_update",
+            "awex_seed_delta_base",
             "awex_release_memory",
             "awex_resume_memory",
         ]
@@ -126,6 +127,9 @@ class AwexSchedulerBridge:
 
     def awex_execute_colocate_weight_update(self, version: int = 0) -> None:
         self._require_adapter().execute_colocate_weight_update(version)
+
+    def awex_seed_delta_base(self, version: int = 0) -> None:
+        self._require_adapter().seed_delta_base(version)
 
     def awex_release_memory(self, tags: list[str] | None = None) -> None:
         self._require_adapter().release_memory(tags)

--- a/areal/v2/training_service/controller/controller.py
+++ b/areal/v2/training_service/controller/controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import os
 import sys
 import threading
 import time
@@ -56,6 +57,7 @@ class GatewayTrainController:
         self._own_process_group = False
         self.rollout: Any | None = None
         self._weight_update_ctrl: Any | None = None
+        self._colocate_weight_update = False
 
         # Version management
         self._version_lock = Lock()
@@ -975,6 +977,16 @@ class GatewayTrainController:
 
         inference_urls: list[str] = rollout.inference_worker_urls
         pair_name = f"{self._role}-rollout"
+        colocate_env = os.environ.get("DTE_COLOCATE_WEIGHT_UPDATE")
+        if colocate_env is None or colocate_env.strip() == "":
+            colocate_env = os.environ.get("AWEX_COLOCATE_WEIGHT_UPDATE", "0")
+        colocate_enabled = colocate_env.strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        self._colocate_weight_update = meta.type == "awex" and colocate_enabled
 
         if meta.type == "awex":
             # NCCL rendezvous master must live on the rank-0 process's node.
@@ -995,6 +1007,7 @@ class GatewayTrainController:
                 mode="awex",
                 nccl_master_addr=port_data["host"],
                 nccl_master_port=port_data["ports"][0],
+                colocate=self._colocate_weight_update,
             )
         else:  # disk
             ctrl.connect(
@@ -1009,10 +1022,12 @@ class GatewayTrainController:
             )
         self._weight_update_ctrl = ctrl
         logger.info(
-            "WeightUpdateController connected (pair=%s, train=%d, inf=%d)",
+            "WeightUpdateController connected (pair=%s, mode=%s, train=%d, inf=%d, colocate=%s)",
             pair_name,
+            meta.type,
             len(self._worker_addrs),
             len(inference_urls),
+            self._colocate_weight_update,
         )
 
     def update_weights(self, meta: Any) -> None:
@@ -1025,6 +1040,16 @@ class GatewayTrainController:
             f"meta.version must be a positive integer, got {meta.version}"
         )
         result = self._weight_update_ctrl.update_weights(version=meta.version)
+        if self._colocate_weight_update:
+            import requests
+
+            for url in self._worker_addrs:
+                resp = requests.post(
+                    f"{url}/awex/resume_memory",
+                    json={"tags": ["weights", "optimizer"]},
+                    timeout=120,
+                )
+                resp.raise_for_status()
         self.rollout.continue_generation()
         logger.info(
             "Weight update v%d completed (%s, %.0fms)",
@@ -1032,6 +1057,48 @@ class GatewayTrainController:
             result.status,
             result.duration_ms,
         )
+
+    async def _async_seed_delta_base(self, version: int) -> None:
+        if self.rollout is None:
+            raise RuntimeError(
+                "connect_engine() must be called before seed_delta_base()"
+            )
+        timeout = max(float(self.config.request_timeout), 120.0)
+        client = await self._get_async_client()
+        inference_urls: list[str] = self.rollout.inference_worker_urls
+
+        async def _post_seed(url: str) -> None:
+            resp = await client.post(
+                f"{url}/awex/seed_delta_base",
+                json={"version": version},
+                timeout=timeout,
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"{url}/awex/seed_delta_base returned "
+                    f"{resp.status_code}: {resp.text}"
+                )
+
+        await asyncio.gather(
+            *[_post_seed(url) for url in self._worker_addrs],
+            *[_post_seed(url) for url in inference_urls],
+        )
+
+    def seed_delta_base(self, version: int = 0) -> None:
+        if self._weight_update_ctrl is None or self.rollout is None:
+            raise RuntimeError(
+                "connect_engine() must be called before seed_delta_base()"
+            )
+        if not self._colocate_weight_update:
+            logger.info("seed_delta_base skipped: colocate weight update disabled")
+            return
+
+        self.rollout.pause_generation()
+        try:
+            run_async_task(self._async_seed_delta_base, version)
+        finally:
+            self.rollout.continue_generation()
+        logger.info("Colocate delta base seeded at version %d", version)
 
     def prepare_batch(
         self,
@@ -1156,6 +1223,17 @@ class GatewayTrainController:
                 )
             except Exception:
                 logger.error("Failed to unregister model: %s", traceback.format_exc())
+
+        if self._weight_update_ctrl is not None:
+            try:
+                self._weight_update_ctrl.destroy()
+            except Exception:
+                logger.error(
+                    "Failed to destroy weight update controller: %s",
+                    traceback.format_exc(),
+                )
+            finally:
+                self._weight_update_ctrl = None
 
         self._graceful_shutdown_workers()
 

--- a/areal/v2/training_service/worker/awex.py
+++ b/areal/v2/training_service/worker/awex.py
@@ -142,6 +142,21 @@ def create_awex_blueprint(
             return_result=False,
         )
 
+    @bp.route("/seed_delta_base", methods=["POST"])
+    def seed_delta_base():
+        data = flask_module.request.get_json(force=True)
+        version = data.get("version", 0)
+
+        def action():
+            adapter = _require_adapter()
+            adapter.seed_delta_base(version)
+
+        return run_endpoint(
+            "seed_delta_base",
+            lambda: submit_to_engine_thread("seed_delta_base", action),
+            return_result=False,
+        )
+
     @bp.route("/release_memory", methods=["POST"])
     def release_memory():
         data = flask_module.request.get_json(force=True)

--- a/areal/v2/weight_update/awex/delta_config.py
+++ b/areal/v2/weight_update/awex/delta_config.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration gates + factories for colocate delta weight transfer.
+
+The delta algorithm itself lives in the standalone ``dte`` package; this module
+only decides *whether* and *how* the awex colocate adapters invoke it, and
+constructs the dte objects (with a clear error if dte is not installed). It
+accepts the new ``DTE_*`` runtime environment emitted from ``actor.dte.*`` CLI
+config, while preserving the old ``AWEX_*`` names as a compatibility fallback.
+
+dte is imported lazily inside the factories: a default AReaL install does not
+require dte unless ``DTE_DELTA_TRANSFER=1`` actually exercises a colocate
+transfer, OR the receiver detects a delta payload on the wire (see
+``payload_carries_delta``).
+
+Switches:
+    DTE_DELTA_TRANSFER        enable sparse incremental transfer (default off)
+    DTE_DELTA_ANCHOR_INTERVAL force a full sync every N deltas (0 = never)
+    DTE_DELTA_BYTES_RATIO     per-tensor sparse-vs-dense fallback threshold
+"""
+
+from __future__ import annotations
+
+import os
+
+_DTE_MISSING_MSG = (
+    "DTE_DELTA_TRANSFER=1 (or a delta payload on the wire) requires the 'dte' "
+    "package (delta-transfer-engine), which the awex colocate adapters import "
+    "lazily. Install it with `pip install -e <path>/delta-transfer-engine` "
+    "(local dev) or `uv sync --extra delta`."
+)
+
+# Mirror of ``dte.core.DELTA_HEADER_NAME`` so the receiver can detect a delta
+# payload WITHOUT importing dte (dte is an optional lazy dependency, and a plain
+# full-weight transfer must not require it). The factories below assert this
+# stays in sync with dte's own constant once dte is actually imported.
+DELTA_HEADER_NAME = "__awex_delta_header__"
+
+
+def _env_value(name: str, legacy_name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is not None and value.strip() != "":
+        return value
+    value = os.environ.get(legacy_name)
+    if value is not None and value.strip() != "":
+        return value
+    return default
+
+
+def _env_bool(name: str, legacy_name: str, default: bool = False) -> bool:
+    value = _env_value(name, legacy_name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def delta_transfer_enabled() -> bool:
+    """Master switch: enable sparse incremental colocate weight transfer."""
+    return _env_bool("DTE_DELTA_TRANSFER", "AWEX_DELTA_TRANSFER")
+
+
+def delta_anchor_interval() -> int:
+    """Force a full sync every N deltas (0 = never; rely on seed + chain-break)."""
+    return int(
+        _env_value(
+            "DTE_DELTA_ANCHOR_INTERVAL",
+            "AWEX_DELTA_ANCHOR_INTERVAL",
+            "0",
+        )
+    )
+
+
+def delta_bytes_ratio() -> float:
+    """Per-tensor sparse-vs-dense fallback threshold (bf16 break-even ~0.33)."""
+    return float(_env_value("DTE_DELTA_BYTES_RATIO", "AWEX_DELTA_BYTES_RATIO", "0.9"))
+
+
+def payload_carries_delta(names) -> bool:
+    """Whether a deserialized payload's names carry a dte delta header.
+
+    Lets the inference adapter defensively reconstruct a delta payload even when
+    its own ``DTE_DELTA_TRANSFER`` is unset (e.g. the env var did not propagate
+    to the sglang worker while the trainer enabled delta) — a mismatch would
+    otherwise feed the sparse ``...@delta_idx``/header names straight into the
+    weight apply and corrupt/crash it. Pure string check: never imports dte, so
+    plain full-weight transfers stay dte-free.
+    """
+    return DELTA_HEADER_NAME in names
+
+
+def _check_header_constant() -> None:
+    """Guard against ``DELTA_HEADER_NAME`` drifting from dte's own definition.
+
+    Called from the factories (dte already imported there). If dte ever renames
+    its wire header, this surfaces immediately instead of silently breaking
+    ``payload_carries_delta``'s dte-free detection.
+    """
+    from dte.core import DELTA_HEADER_NAME as _dte_name
+
+    if _dte_name != DELTA_HEADER_NAME:
+        raise RuntimeError(
+            f"delta_config.DELTA_HEADER_NAME ({DELTA_HEADER_NAME!r}) is out of "
+            f"sync with dte.core.DELTA_HEADER_NAME ({_dte_name!r}); update the "
+            f"mirror in delta_config.py."
+        )
+
+
+def make_delta_tracker():
+    """Sender-side dte ``DeltaTracker``, configured from env.
+
+    Raises a clear ``ImportError`` if dte is not installed.
+    """
+    try:
+        from dte.core import DeltaTracker
+    except ImportError as e:  # pragma: no cover - exercised only without dte
+        raise ImportError(_DTE_MISSING_MSG) from e
+    _check_header_constant()
+    return DeltaTracker(delta_anchor_interval(), delta_bytes_ratio())
+
+
+def make_delta_engine(device):
+    """Receiver-side dte ``DeltaEngine`` (transport-free, IPC-fed), from env.
+
+    Raises a clear ``ImportError`` if dte is not installed.
+    """
+    try:
+        from dte.engine import DeltaEngine
+    except ImportError as e:  # pragma: no cover - exercised only without dte
+        raise ImportError(_DTE_MISSING_MSG) from e
+    _check_header_constant()
+    return DeltaEngine(
+        transport=None,
+        mode="delta",
+        anchor_interval=delta_anchor_interval(),
+        sparse_bytes_ratio=delta_bytes_ratio(),
+        device=device,
+    )

--- a/areal/v2/weight_update/awex/delta_detect.py
+++ b/areal/v2/weight_update/awex/delta_detect.py
@@ -1,0 +1,823 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pluggable change detectors for AWEX colocate delta weight transfer.
+
+A *detector* answers one question each weight-update step: which bf16 elements
+of the converted HF payload changed since the previous version? It returns
+``{hf_name: bool mask}`` consumed by ``DeltaTracker.encode(masks=...)``.
+
+Two implementations, selected by ``DTE_DELTA_DETECTOR``:
+
+- ``snapshot`` (fallback): the change mask comes from ``DeltaTracker``'s own CPU
+  bf16 baseline (a full-model snapshot). This detector is a no-op marker — it
+  returns ``None`` so the writer keeps using ``encode(masks=None)`` (the
+  snapshot path). Always available, no optimizer needed, but costs a resident
+  full-model CPU snapshot per rank.
+
+- ``inversion`` (design mainline, the actual win): reconstruct the *pre-step*
+  weights from the optimizer's resident AdamW moments (``exp_avg`` /
+  ``exp_avg_sq``) — **zero extra snapshot memory** — convert them to HF space,
+  and bitwise-compare against the current HF payload to get the masks.
+
+AdamW inversion (decoupled AdamW, the mcore default):
+
+    theta_t = theta_{t-1}·(1 - lr·wd) - (lr/bc1)·m / (sqrt(v)/sqrt(bc2) + eps)
+
+is element-wise invertible because ``m=exp_avg`` / ``v=exp_avg_sq`` stay resident
+after ``optimizer.step()``:
+
+    theta_{t-1} = (theta_t + (lr/bc1)·m / (sqrt(v)/sqrt(bc2) + eps)) / (1 - lr·wd)
+
+with ``bc1 = 1 - beta1^step``, ``bc2 = 1 - beta2^step``.
+
+Megatron specifics (confirmed against mcore distrib_optimizer):
+
+- Moments live ONLY in mcore main-param space (HF space has QKV already split,
+  gate/expert converted) so the mask MUST be computed AFTER convert.
+- The distributed optimizer shards the fp32 main param + moments across DP, but
+  the FULL bf16 model param (theta_t) is resident on every DP rank (post-step
+  all-gather). So inversion is a per-rank, shard-local fp32 compute scattered
+  into a full-param buffer, then ONE DP all-reduce(SUM) of the *correction*
+  (zero outside the owned slice) assembles the full pre-step param.
+
+Hard gates (any failure -> return None -> writer ships dense this step):
+
+- ``use_precision_aware_optimizer`` (adam_bf16): moments are bf16/TE-fused, not
+  plain fp32 ``exp_avg`` -> inversion infeasible.
+- non-decoupled AdamW (L2-Adam folds wd into grad): the ``/(1-lr·wd)`` form is
+  wrong.
+- no reconstructable moment state for the whole step, or ``step < 1`` on every
+  usable shard (first step, recover): division blow-up. Per-param/per-rank
+  missing state contributes zeros to DP reduction so ranks do not deadlock.
+- compact per-shard fingerprints are only a guard for ``step`` unchanged or
+  missing-watermark recovery. A known one-step AdamW transition is always
+  reconstructed; the fingerprint is not trusted as proof of no payload change.
+- more than one distributed-optimizer instance: the DP group identity differs
+  from the all-gather group.
+
+Migration note (origin/gh AWEX): the detector now drives the new adapter's
+convert path — ``adapter._get_inner_optimizers()`` for the moments and
+``adapter._convert_hf_with_overrides(theta_by_id)`` to push reconstructed
+pre-step weights through the same all_gather + convert_to_hf as the live
+payload (the old awex ``_make_weight_converter`` / ``_convert_parameters_with``
+are gone). The mcore reconstruction below is GPU-only and must be validated on
+the cluster; ``dte.core.invert_adamw`` itself is CPU-unit-tested.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from areal.utils import logging
+
+logger = logging.getLogger("AwexDeltaDetect")
+
+
+def _env_value(name: str, legacy_name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is not None and value.strip() != "":
+        return value
+    value = os.environ.get(legacy_name)
+    if value is not None and value.strip() != "":
+        return value
+    return default
+
+
+def _env_bool(name: str, legacy_name: str, default: bool = False) -> bool:
+    value = _env_value(name, legacy_name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def delta_detector_mode() -> str:
+    """Return the configured detector: '' (off) | 'inversion' | 'snapshot'."""
+    return (
+        (_env_value("DTE_DELTA_DETECTOR", "AWEX_DELTA_DETECTOR", "") or "")
+        .strip()
+        .lower()
+    )
+
+
+def _inversion_debug_enabled() -> bool:
+    return _env_bool("DTE_DELTA_INVERSION_DEBUG", "AWEX_DELTA_INVERSION_DEBUG")
+
+
+def _inversion_bf16_margin_rel() -> float:
+    return float(
+        _env_value(
+            "DTE_DELTA_INVERSION_BF16_MARGIN_REL",
+            "AWEX_DELTA_INVERSION_BF16_MARGIN_REL",
+            "1e-4",
+        )
+    )
+
+
+def _dist_rank(group=None) -> int:
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        return -1
+    try:
+        return torch.distributed.get_rank(group=group)
+    except Exception:  # pragma: no cover - debug-only best effort
+        return -1
+
+
+def _dist_world_size(group=None) -> int:
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        return 1
+    try:
+        return torch.distributed.get_world_size(group=group)
+    except Exception:  # pragma: no cover - debug-only best effort
+        return 1
+
+
+def _adamw_hparams(param_group: dict) -> tuple[float, float, float, float, float]:
+    """Extract (lr, weight_decay, beta1, beta2, eps) from a torch param_group."""
+    betas = param_group.get("betas", (0.9, 0.999))
+    beta1 = float(betas[0])
+    beta2 = float(betas[1])
+    if not param_group.get("bias_correction", True):
+        # Apex FusedAdam stores step on the param group and can disable bias
+        # correction there. invert_adamw uses beta**step only to compute those
+        # correction factors, so beta=0 gives bc1=bc2=1.
+        beta1 = 0.0
+        beta2 = 0.0
+    return (
+        float(param_group["lr"]),
+        float(param_group.get("weight_decay", 0.0)),
+        beta1,
+        beta2,
+        float(param_group.get("eps", 1e-8)),
+    )
+
+
+def _resolve_offloaded_state_value(
+    state: dict, offloaded_state: dict, key: str
+) -> object | None:
+    """Return optimizer state value, following AwexMegatronAdapter offload slots."""
+    val = state.get(key)
+    if isinstance(val, torch.Tensor) and val.numel() == 0 and key in offloaded_state:
+        return offloaded_state[key]
+    return val
+
+
+def _state_step_value(state: dict, offloaded_state: dict) -> float | None:
+    step_val = _resolve_offloaded_state_value(state, offloaded_state, "step")
+    return _step_to_float(step_val)
+
+
+def _param_group_step_value(param_group: dict) -> float | None:
+    return _step_to_float(param_group.get("step"))
+
+
+def _step_to_float(step_val: object | None) -> float | None:
+    if step_val is None:
+        return None
+    if isinstance(step_val, torch.Tensor):
+        if step_val.numel() == 0:
+            return None
+        return float(step_val.item())
+    return float(step_val)
+
+
+@torch.no_grad()
+def _tensor_fingerprint(tensor: torch.Tensor) -> tuple:
+    """Small value fingerprint for a tensor slice, not a stored snapshot.
+
+    The detector uses this as a no-full-copy guard to decide whether a local
+    model-visible shard changed since the last successful sync. The actual delta
+    mask still comes from AdamW inversion; this fingerprint only prevents
+    replaying moments for a shard whose synced bf16 payload did not move.
+    """
+    data = tensor.detach().contiguous().view(torch.uint8).reshape(-1)
+    n = data.numel()
+    if n == 0:
+        return (str(tensor.dtype), 0, 0, 0, 0, 0)
+
+    bins = min(4096, n)
+    width = max(n // bins, 1)
+    head_n = bins * width
+    head = data[:head_n].reshape(bins, width)
+    bin_sums = head.sum(dim=1, dtype=torch.int64)
+    weights = torch.arange(1, bins + 1, device=data.device, dtype=torch.int64)
+    total = bin_sums.sum()
+    weighted = (bin_sums * weights).sum()
+    if head_n < n:
+        tail = data[head_n:].sum(dtype=torch.int64)
+        total = total + tail
+        weighted = weighted + tail * (bins + 1)
+
+    sample_count = min(16, n)
+    if sample_count == 1:
+        sample_idx = torch.zeros(1, device=data.device, dtype=torch.long)
+    else:
+        sample_idx = (
+            torch.arange(sample_count, device=data.device, dtype=torch.long)
+            * (n - 1)
+            // (sample_count - 1)
+        )
+    samples = data.index_select(0, sample_idx).to(torch.int64)
+    sample_weights = torch.arange(
+        1, sample_count + 1, device=data.device, dtype=torch.int64
+    )
+    sample_hash = (samples * sample_weights).sum()
+    return (
+        str(tensor.dtype),
+        n,
+        int(total.item()),
+        int(weighted.item()),
+        int(sample_hash.item()),
+        int(data[0].item()),
+        int(data[-1].item()),
+    )
+
+
+@torch.no_grad()
+def _bf16_rounding_boundary_mask(
+    old_fp32: torch.Tensor, cur_bf16: torch.Tensor
+) -> torch.Tensor:
+    """Conservatively include values near a BF16 rounding boundary."""
+    cur_fp32 = cur_bf16.to(torch.float32)
+    old_fp32 = old_fp32.to(torch.float32)
+
+    # BF16 bins are not symmetric at exponent boundaries: for example the lower
+    # neighbor of 1.0 is 0.99609375 while the upper neighbor is 1.0078125.  Using
+    # one spacing for both sides misses values close to the narrower boundary.
+    neg_inf = torch.full_like(cur_bf16, float("-inf"))
+    pos_inf = torch.full_like(cur_bf16, float("inf"))
+    lower = torch.nextafter(cur_bf16, neg_inf).to(torch.float32)
+    upper = torch.nextafter(cur_bf16, pos_inf).to(torch.float32)
+    lower_half_ulp = (cur_fp32 - lower).abs() * 0.5
+    upper_half_ulp = (upper - cur_fp32).abs() * 0.5
+    half_ulp = torch.where(old_fp32 < cur_fp32, lower_half_ulp, upper_half_ulp)
+    threshold = half_ulp * (1.0 - _inversion_bf16_margin_rel())
+    dist = (old_fp32 - cur_fp32).abs()
+    return torch.isfinite(old_fp32) & torch.isfinite(cur_fp32) & (dist >= threshold)
+
+
+class SnapshotDetector:
+    """No-op detector: defers change detection to ``DeltaTracker``'s snapshot.
+
+    ``compute_masks`` returns ``None`` so the writer calls ``encode(masks=None)``
+    (the verified snapshot path). Exists so the writer has one uniform call site
+    regardless of the configured detector.
+    """
+
+    name = "snapshot"
+
+    def compute_masks(self, names, tensors, version):  # noqa: ARG002
+        return None
+
+
+class AdamWInversionDetector:
+    """Compute change masks by inverting the resident AdamW moments.
+
+    Bound to ``AwexMegatronAdapter`` (needs ``_get_inner_optimizers`` for the
+    moments and ``_convert_hf_with_overrides`` to convert reconstructed pre-step
+    params through the live path). All mcore/DP/convert work is GPU-only; any
+    unmet precondition returns ``None`` so the writer falls back to dense for
+    that step (and the snapshot tracker re-seeds), never silently corrupting.
+    """
+
+    name = "inversion"
+
+    def __init__(self, adapter):
+        self._adapter = adapter
+        self._last_synced_steps: dict[int, float | None] = {}
+        self._last_synced_fingerprints: dict[int, tuple] = {}
+
+    # -- gating ------------------------------------------------------------
+    def _inversion_feasible(self, inner_optimizers) -> bool:
+        """All hard gates from the design; any failure -> dense fallback."""
+        if not inner_optimizers:
+            logger.warning("Inversion: no inner optimizers; falling back to dense.")
+            return False
+        for opt in inner_optimizers:
+            cfg = getattr(opt, "config", None)
+            if cfg is not None:
+                # adam_bf16 / precision-aware: moments are bf16 / TE-fused, not
+                # plain fp32 exp_avg -> inversion infeasible.
+                pa = getattr(
+                    cfg, "use_precision_aware_optimizer_no_fp8_or_ds_fp8", None
+                )
+                if pa is None:
+                    pa = getattr(cfg, "use_precision_aware_optimizer", False)
+                if pa:
+                    logger.warning("Inversion: use_precision_aware_optimizer -> dense.")
+                    return False
+                # decoupled AdamW: the (1-lr*wd) form requires decoupled wd.
+                if not getattr(cfg, "decoupled_weight_decay", True):
+                    logger.warning("Inversion: non-decoupled AdamW -> dense.")
+                    return False
+            # Single distributed-optimizer instance: otherwise the DP group
+            # identity differs from the param all-gather group (design risk #3).
+            n_inst = getattr(opt, "num_distributed_optimizer_instances", 1)
+            if n_inst and n_inst > 1:
+                logger.warning(
+                    "Inversion: %d distributed-optimizer instances -> dense.",
+                    n_inst,
+                )
+                return False
+        return True
+
+    def _collect_current_steps(self, inner_optimizers) -> dict[int, float | None]:
+        """Return optimizer step watermarks keyed by ``id(model_param)``.
+
+        A value of ``None`` means this param had no local optimizer state when the
+        payload was synced. On the next step, ``None -> 1`` is still a valid
+        one-step transition.
+        """
+        steps: dict[int, float | None] = {}
+        offloaded_states = getattr(self._adapter, "_offloaded_optimizer_states", {})
+        for opt in inner_optimizers:
+            base_opt = getattr(opt, "optimizer", opt)
+            state = getattr(base_opt, "state", None)
+            group_index_map = getattr(opt, "model_param_group_index_map", None)
+            fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+            model_groups = getattr(opt, "model_float16_groups", None)
+            if state is None or fp32_groups is None or model_groups is None:
+                continue
+            for g, (fp32_group, model_group) in enumerate(
+                zip(fp32_groups, model_groups)
+            ):
+                for main_shard, model_param in zip(fp32_group, model_group):
+                    if main_shard is None:
+                        continue
+                    pid = id(model_param)
+                    if pid in steps:
+                        continue
+                    gi = (
+                        group_index_map[model_param][0]
+                        if group_index_map is not None
+                        and model_param in group_index_map
+                        else g
+                    )
+                    st = state.get(main_shard)
+                    step = None
+                    if st:
+                        offloaded_state = offloaded_states.get(main_shard, {})
+                        step = _state_step_value(st, offloaded_state)
+                        if step is None:
+                            step = _param_group_step_value(base_opt.param_groups[gi])
+                    steps[pid] = step
+        return steps
+
+    def _collect_current_fingerprints(self, inner_optimizers) -> dict[int, tuple]:
+        """Record compact fingerprints of model-visible local shards.
+
+        This is intentionally not a snapshot: it stores a few scalar values per
+        optimizer-owned shard, not tensor contents. The fingerprint gates AdamW
+        replay to slices whose synced payload actually changed.
+        """
+        fingerprints: dict[int, tuple] = {}
+        for opt in inner_optimizers:
+            fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+            model_groups = getattr(opt, "model_float16_groups", None)
+            if fp32_groups is None or model_groups is None:
+                continue
+            for fp32_group, model_group in zip(fp32_groups, model_groups):
+                for main_shard, model_param in zip(fp32_group, model_group):
+                    if main_shard is None:
+                        continue
+                    pid = id(model_param)
+                    if pid in fingerprints:
+                        continue
+                    try:
+                        rng = opt._get_model_param_range_map(model_param)["param"]
+                    except Exception:
+                        continue
+                    visible_slice = model_param.detach().reshape(-1)[
+                        rng.start : rng.end
+                    ]
+                    fingerprints[pid] = _tensor_fingerprint(visible_slice)
+        return fingerprints
+
+    def mark_synced(self, version: int) -> None:
+        """Record optimizer step watermarks after a successful payload sync.
+
+        AdamW inversion only reconstructs the most recent optimizer step. Without
+        this watermark, a later weight sync with no new optimizer step would replay
+        the previous step's moments and report false positives.
+        """
+        inner = self._adapter._get_inner_optimizers()
+        if not self._inversion_feasible(inner):
+            self._last_synced_steps.clear()
+            self._last_synced_fingerprints.clear()
+            return
+        self._last_synced_steps = self._collect_current_steps(inner)
+        self._last_synced_fingerprints = self._collect_current_fingerprints(inner)
+        known = len(self._last_synced_steps)
+        stepped = sum(
+            1 for step in self._last_synced_steps.values() if step is not None
+        )
+        max_step = max(
+            (step for step in self._last_synced_steps.values() if step is not None),
+            default=0.0,
+        )
+        logger.info(
+            "Inversion: recorded optimizer step watermark for %d params "
+            "at version %d (stepped=%d fingerprints=%d max_step=%.0f)",
+            known,
+            version,
+            stepped,
+            len(self._last_synced_fingerprints),
+            max_step,
+        )
+
+    # -- reconstruction (GPU-only) ----------------------------------------
+    @torch.no_grad()
+    def _reconstruct_pre_step_mcore(
+        self, inner_optimizers
+    ) -> dict[int, torch.Tensor] | None:
+        """Reconstruct theta_{t-1} for every model param the optimizer owns.
+
+        Returns ``{id(model_param): full bf16 pre-step tensor}`` or ``None`` if
+        no parameter has a usable global optimizer-state contribution.
+        """
+        from dte.core import invert_adamw
+
+        theta_old_by_id: dict[int, torch.Tensor] = {}
+        skipped_no_state = 0
+        skipped_bad_state = 0
+        skipped_global_no_state = 0
+        skipped_step_unchanged = 0
+        skipped_missing_watermark = 0
+        skipped_step_jump = 0
+        skipped_missing_fingerprint = 0
+        skipped_tracked_unchanged = 0
+        skipped_payload_changed_without_step = 0
+        force_dense = False
+        debug = _inversion_debug_enabled()
+        global_rank = _dist_rank()
+        opt_entries: dict[int, tuple] = {}
+        fallback_order: list[torch.Tensor] = []
+        seen_fallback: set[int] = set()
+        default_dp_group = None
+        for opt_idx, opt in enumerate(inner_optimizers):
+            base_opt = getattr(opt, "optimizer", opt)
+            state = getattr(base_opt, "state", None)
+            if state is None:
+                return None
+            group_index_map = getattr(opt, "model_param_group_index_map", None)
+            fp32_groups = getattr(opt, "shard_fp32_from_float16_groups", None)
+            model_groups = getattr(opt, "model_float16_groups", None)
+            if fp32_groups is None or model_groups is None:
+                return None
+            dp_group = getattr(opt, "data_parallel_group", None)
+            if default_dp_group is None:
+                default_dp_group = dp_group
+            elif dp_group is not default_dp_group:
+                logger.warning("Inversion: multiple DP groups -> dense.")
+                return None
+            if debug:
+                logger.info(
+                    "Inversion debug: rank=%d opt=%d dp_rank=%d/%d "
+                    "fp32_groups=%d model_groups=%d state=%d",
+                    global_rank,
+                    opt_idx,
+                    _dist_rank(dp_group),
+                    _dist_world_size(dp_group),
+                    len(fp32_groups),
+                    len(model_groups),
+                    len(state),
+                )
+            offloaded_states = getattr(self._adapter, "_offloaded_optimizer_states", {})
+            for g, (fp32_group, model_group) in enumerate(
+                zip(fp32_groups, model_groups)
+            ):
+                if debug:
+                    logger.info(
+                        "Inversion debug: rank=%d opt=%d group=%d "
+                        "fp32_len=%d model_len=%d",
+                        global_rank,
+                        opt_idx,
+                        g,
+                        len(fp32_group),
+                        len(model_group),
+                    )
+                for i, (main_shard, model_param) in enumerate(
+                    zip(fp32_group, model_group)
+                ):
+                    if main_shard is None:
+                        # precision-aware sentinel (should be gated out already)
+                        return None
+                    pid = id(model_param)
+                    if pid not in seen_fallback:
+                        fallback_order.append(model_param)
+                        seen_fallback.add(pid)
+                    if pid in opt_entries:
+                        continue
+                    gi = (
+                        group_index_map[model_param][0]
+                        if group_index_map is not None
+                        and model_param in group_index_map
+                        else g
+                    )
+                    opt_entries[pid] = (
+                        opt_idx,
+                        opt,
+                        base_opt,
+                        state,
+                        main_shard,
+                        gi,
+                        dp_group,
+                    )
+
+        ordered_model_params: list[torch.Tensor] = []
+        engine = getattr(self._adapter, "_engine", None)
+        if engine is not None and getattr(engine, "model", None) is not None:
+            from areal.engine.megatron_utils.megatron import get_named_parameters
+
+            num_moe_experts = getattr(engine.tf_config, "num_moe_experts", None)
+            seen_order: set[int] = set()
+            for _mcore_name, model_param in get_named_parameters(
+                engine.model, num_moe_experts
+            ):
+                pid = id(model_param)
+                if pid in seen_order:
+                    continue
+                ordered_model_params.append(model_param)
+                seen_order.add(pid)
+        else:
+            ordered_model_params = fallback_order
+
+        if debug:
+            logger.info(
+                "Inversion debug: rank=%d ordered_params=%d opt_entries=%d",
+                global_rank,
+                len(ordered_model_params),
+                len(opt_entries),
+            )
+
+        if not ordered_model_params:
+            return None
+
+        offloaded_states = getattr(self._adapter, "_offloaded_optimizer_states", {})
+        for param_idx, model_param in enumerate(ordered_model_params):
+            entry = opt_entries.get(id(model_param))
+            dp_group = entry[6] if entry is not None else default_dp_group
+            # theta_t for the full param is resident on every DP rank.
+            theta_t_full = model_param.detach()
+            flat_t = theta_t_full.reshape(-1)
+            # Every DP rank must enter the same collectives for every model
+            # param in the same order. Ranks without a usable local optimizer
+            # shard contribute an all-zero correction and a zero contribution
+            # count; ranks with moments fill only their owned slice.
+            correction = torch.zeros_like(flat_t, dtype=torch.float32)
+            has_local_update = False
+            expected_one_step = False
+            rng = None
+            opt_idx = -1
+            if entry is None:
+                skipped_no_state += 1
+            else:
+                opt_idx, opt, base_opt, state, main_shard, gi, _dp_group = entry
+                rng = opt._get_model_param_range_map(model_param)["param"]
+                st = state.get(main_shard)
+                offloaded_state = offloaded_states.get(main_shard, {}) if st else {}
+                step = _state_step_value(st, offloaded_state) if st else None
+                if step is None:
+                    step = _param_group_step_value(base_opt.param_groups[gi])
+                if step is None or step < 1:
+                    skipped_bad_state += 1
+                elif id(model_param) not in self._last_synced_steps:
+                    skipped_missing_watermark += 1
+                    force_dense = True
+                else:
+                    last_step = self._last_synced_steps[id(model_param)]
+                    baseline_step = 0.0 if last_step is None else last_step
+                    step_delta = step - baseline_step
+                    if step_delta == 0:
+                        last_fingerprint = self._last_synced_fingerprints.get(
+                            id(model_param)
+                        )
+                        if last_fingerprint is not None and (
+                            _tensor_fingerprint(flat_t[rng.start : rng.end])
+                            != last_fingerprint
+                        ):
+                            skipped_payload_changed_without_step += 1
+                            force_dense = True
+                        else:
+                            skipped_step_unchanged += 1
+                    elif step_delta != 1:
+                        skipped_step_jump += 1
+                        force_dense = True
+                    else:
+                        expected_one_step = True
+                        last_fingerprint = self._last_synced_fingerprints.get(
+                            id(model_param)
+                        )
+                        if last_fingerprint is None:
+                            skipped_missing_fingerprint += 1
+                            force_dense = True
+                        elif not st or "exp_avg" not in st or "exp_avg_sq" not in st:
+                            # A rank may not own this shard in Megatron's
+                            # distributed optimizer; do not force dense locally.
+                            # If no DP rank contributes below, the global status
+                            # check will fall back to dense.
+                            skipped_bad_state += 1
+                        else:
+                            exp_avg = _resolve_offloaded_state_value(
+                                st, offloaded_state, "exp_avg"
+                            )
+                            exp_avg_sq = _resolve_offloaded_state_value(
+                                st, offloaded_state, "exp_avg_sq"
+                            )
+                            theta_t_slice = (
+                                main_shard.detach().reshape(-1).to(torch.float32)
+                            )
+                            if (
+                                not isinstance(exp_avg, torch.Tensor)
+                                or not isinstance(exp_avg_sq, torch.Tensor)
+                                or exp_avg.numel() == 0
+                                or exp_avg_sq.numel() == 0
+                                or exp_avg.numel() != theta_t_slice.numel()
+                                or exp_avg_sq.numel() != theta_t_slice.numel()
+                            ):
+                                skipped_bad_state += 1
+                            else:
+                                lr, wd, b1, b2, eps = _adamw_hparams(
+                                    base_opt.param_groups[gi]
+                                )
+                                # Moments may be offloaded to CPU; bring this
+                                # shard's moments to the fp32 main-param device
+                                # so inversion uses the exact post-step optimizer
+                                # weight, not the bf16 model copy. Keep the
+                                # reconstructed previous value in fp32 until mask
+                                # creation so boundary-near BF16 roundoff is
+                                # handled conservatively.
+                                dev = theta_t_slice.device
+                                theta_old_slice = invert_adamw(
+                                    theta_t_slice,
+                                    exp_avg.to(dev).reshape(-1),
+                                    exp_avg_sq.to(dev).reshape(-1),
+                                    step,
+                                    lr,
+                                    wd,
+                                    b1,
+                                    b2,
+                                    eps,
+                                )
+                                visible_slice = flat_t[rng.start : rng.end]
+                                correction[rng.start : rng.end] = (
+                                    theta_old_slice - visible_slice.to(torch.float32)
+                                )
+                                has_local_update = True
+
+            status = torch.tensor(
+                [1 if has_local_update else 0, 1 if force_dense else 0],
+                dtype=torch.int32,
+                device=flat_t.device,
+            )
+            if debug:
+                slice_start = -1 if rng is None else rng.start
+                slice_end = -1 if rng is None else rng.end
+                logger.info(
+                    "Inversion debug: rank=%d param_idx=%d opt=%d "
+                    "pre_reduce numel=%d slice=%d:%d local=%d",
+                    global_rank,
+                    param_idx,
+                    opt_idx,
+                    flat_t.numel(),
+                    slice_start,
+                    slice_end,
+                    int(has_local_update),
+                )
+            if dp_group is not None:
+                torch.distributed.all_reduce(
+                    correction,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=dp_group,
+                )
+                torch.distributed.all_reduce(
+                    status,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=dp_group,
+                )
+            if debug:
+                logger.info(
+                    "Inversion debug: rank=%d param_idx=%d post_reduce "
+                    "contrib=%d bad=%d",
+                    global_rank,
+                    param_idx,
+                    int(status[0].item()),
+                    int(status[1].item()),
+                )
+            if int(status[1].item()) != 0:
+                force_dense = True
+                continue
+            if int(status[0].item()) == 0:
+                # No DP rank could reconstruct this param. For a known one-step
+                # AdamW transition that is unsafe: current-vs-current would hide
+                # a real update, so fall back to dense. If no optimizer step is
+                # pending, leaving it without an override is still correct.
+                skipped_global_no_state += 1
+                if expected_one_step:
+                    force_dense = True
+                continue
+            theta_old_full = (flat_t.to(torch.float32) + correction).reshape(
+                theta_t_full.shape
+            )
+            theta_old_by_id[id(model_param)] = theta_old_full
+        if force_dense:
+            logger.warning(
+                "Inversion: optimizer step replay is ambiguous "
+                "(missing_watermark=%d step_jump=%d missing_fingerprint=%d "
+                "payload_changed_without_step=%d) "
+                "-> dense.",
+                skipped_missing_watermark,
+                skipped_step_jump,
+                skipped_missing_fingerprint,
+                skipped_payload_changed_without_step,
+            )
+            return None
+        if not theta_old_by_id:
+            logger.info(
+                "Inversion: no BF16 payload shard changed since last sync "
+                "(step_unchanged=%d tracked_unchanged=%d no_state=%d "
+                "bad_state=%d global_no_state=%d)",
+                skipped_step_unchanged,
+                skipped_tracked_unchanged,
+                skipped_no_state,
+                skipped_bad_state,
+                skipped_global_no_state,
+            )
+            return {}
+        if (
+            skipped_no_state
+            or skipped_bad_state
+            or skipped_global_no_state
+            or skipped_step_unchanged
+            or skipped_tracked_unchanged
+            or skipped_missing_fingerprint
+            or skipped_payload_changed_without_step
+        ):
+            logger.info(
+                "Inversion: reconstructed %d params, skipped no_state=%d "
+                "bad_state=%d global_no_state=%d step_unchanged=%d "
+                "tracked_unchanged=%d missing_fingerprint=%d "
+                "payload_changed_without_step=%d",
+                len(theta_old_by_id),
+                skipped_no_state,
+                skipped_bad_state,
+                skipped_global_no_state,
+                skipped_step_unchanged,
+                skipped_tracked_unchanged,
+                skipped_missing_fingerprint,
+                skipped_payload_changed_without_step,
+            )
+        return theta_old_by_id
+
+    # -- entry point -------------------------------------------------------
+    @torch.no_grad()
+    def compute_masks(self, names, tensors, version):
+        """Return ``{hf_name: bool mask}`` or ``None`` to force a dense step."""
+        adapter = self._adapter
+        inner = adapter._get_inner_optimizers()
+        if not self._inversion_feasible(inner):
+            return None
+
+        theta_old_by_id = self._reconstruct_pre_step_mcore(inner)
+        if theta_old_by_id is None:
+            logger.warning("Inversion: reconstruction unavailable -> dense step.")
+            return None
+
+        # Convert the reconstructed pre-step params through the SAME all_gather +
+        # convert_to_hf path as the live payload (overrides by id(model_param)).
+        # Params without an override convert as-is (theta_old == theta_t ->
+        # all-False mask).
+        hf_old = adapter._convert_hf_with_overrides(theta_old_by_id)
+
+        cur = dict(zip(names, tensors))
+        masks: dict[str, torch.Tensor] = {}
+        from dte.core import bitwise_changed_mask
+
+        for name, cur_t in cur.items():
+            old_t = hf_old.get(name)
+            if old_t is None or old_t.shape != cur_t.shape:
+                # No pre-step counterpart -> treat as fully changed (dense).
+                masks[name] = torch.ones(
+                    cur_t.numel(), dtype=torch.bool, device=cur_t.device
+                )
+                continue
+            old_payload = old_t.to(cur_t.dtype)
+            mask = bitwise_changed_mask(cur_t, old_payload).reshape(-1)
+            if cur_t.dtype == torch.bfloat16 and old_t.dtype != cur_t.dtype:
+                same_payload = ~mask
+                boundary = _bf16_rounding_boundary_mask(old_t, cur_t).reshape(-1)
+                mask = mask | (same_payload & boundary)
+            masks[name] = mask
+        logger.info(
+            "Inversion: computed masks for %d HF params at version %d",
+            len(masks),
+            version,
+        )
+        return masks
+
+
+def build_detector(mode: str, adapter):
+    """Construct the detector for ``mode`` ('inversion' | 'snapshot')."""
+    if mode == "inversion":
+        return AdamWInversionDetector(adapter)
+    return SnapshotDetector()

--- a/areal/v2/weight_update/awex/megatron_adapter.py
+++ b/areal/v2/weight_update/awex/megatron_adapter.py
@@ -19,15 +19,20 @@ from awex.sharding.param_sharding import ShardingType
 from awex.sharding.rank_info import RankInfo
 from awex.transfer.nccl_comm import batch_send_recv, nccl_build_send_ops
 from awex.transfer.transfer_plan import TransferPlan, TransferPlanBuilder
-from awex.util.tensor_util import (
-    cuda_ipc_serialize,
-    group_tensors_by_shape_and_dtype,
-)
+from awex.util.tensor_util import cuda_ipc_serialize
 
 from areal.utils import logging
 from areal.v2.weight_update.awex import (
     awex_wu_use_group,
     fetch_kv_metadata,
+)
+from areal.v2.weight_update.awex.delta_config import (
+    delta_transfer_enabled,
+    make_delta_tracker,
+)
+from areal.v2.weight_update.awex.delta_detect import (
+    build_detector,
+    delta_detector_mode,
 )
 from areal.v2.weight_update.nccl_group import (
     init_weights_update_group,
@@ -41,6 +46,98 @@ if TYPE_CHECKING:
     from areal.engine.megatron_engine import MegatronEngine
 
 logger = logging.getLogger("AwexMegatronAdapter")
+
+
+def _group_tensors_for_colocate_ipc(
+    tensors: list[torch.Tensor],
+    max_group_bytes: int = 512 * 1024 * 1024,
+) -> tuple[list[torch.Tensor], list[dict]]:
+    """Pack tensors into bounded dtype-homogeneous CUDA IPC groups."""
+    buckets: dict[torch.dtype, list[tuple[int, torch.Tensor]]] = {}
+    group_tensors: list[torch.Tensor] = []
+    metadata: list[dict] = []
+
+    for original_index, tensor in enumerate(tensors):
+        source = tensor.detach()
+        if source.numel() == 0:
+            group_index = len(group_tensors)
+            group_tensors.append(
+                torch.empty((1,), dtype=source.dtype, device=source.device)
+            )
+            metadata.append(
+                {
+                    "original_index": original_index,
+                    "shape": source.shape,
+                    "dtype": source.dtype,
+                    "group_index": group_index,
+                    "offset": 0,
+                    "size": 0,
+                }
+            )
+            continue
+        buckets.setdefault(source.dtype, []).append((original_index, source))
+
+    for entries in buckets.values():
+        current: list[tuple[int, torch.Tensor]] = []
+        current_bytes = 0
+
+        def finalize_group() -> None:
+            nonlocal current, current_bytes
+            if not current:
+                return
+            group_index = len(group_tensors)
+            group_tensors.append(
+                torch.cat([tensor.reshape(-1) for _, tensor in current]).clone()
+            )
+            offset = 0
+            for original_index, tensor in current:
+                metadata.append(
+                    {
+                        "original_index": original_index,
+                        "shape": tensor.shape,
+                        "dtype": tensor.dtype,
+                        "group_index": group_index,
+                        "offset": offset,
+                        "size": tensor.numel(),
+                    }
+                )
+                offset += tensor.numel()
+            current = []
+            current_bytes = 0
+
+        for original_index, source in entries:
+            source = source.contiguous()
+            tensor_bytes = source.numel() * source.element_size()
+            if current and current_bytes + tensor_bytes > max_group_bytes:
+                finalize_group()
+            current.append((original_index, source))
+            current_bytes += tensor_bytes
+        finalize_group()
+
+    return group_tensors, metadata
+
+
+def _install_awex_qwen2_converter() -> None:
+    """Keep Qwen2 parameter names aligned with SGLang's HF layout."""
+    from awex.converter.mcore_converter import McoreToHFWeightConverter
+    from awex.models.registry import ModelRegistry
+
+    class Qwen2McoreToHFWeightConverter(McoreToHFWeightConverter):
+        def _fuse_qkv(self, name: str) -> bool:
+            del name
+            return False
+
+        @staticmethod
+        def _normalize_attn_name(name: str) -> str:
+            return name
+
+    model_config = ModelRegistry.get_model_config("Qwen2ForCausalLM")
+    if isinstance(model_config, dict):
+        model_config = dict(model_config)
+        model_config["mcore_converter"] = Qwen2McoreToHFWeightConverter
+    else:
+        model_config.mcore_converter = Qwen2McoreToHFWeightConverter
+    ModelRegistry.models["Qwen2ForCausalLM"] = model_config
 
 
 class AwexMegatronAdapter(AwexTrainingAdapter):
@@ -59,6 +156,7 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
 
     def __init__(self, engine: MegatronEngine):
         self._engine = engine
+        setattr(engine, "_awex_weight_update_adapter", self)
         self._transfer_plan: TransferPlan | None = None
         self._weights_update_group = None
         self._transfer_rank: int | None = None
@@ -69,6 +167,11 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         self._colocate_admin_api_key: str = "areal-admin-key"
         self._colocate_http_client: httpx.Client | None = None
         self._colocate_timeout_s: float = 120.0
+        # Lazy dte DeltaTracker (sender side); persists across versions to hold
+        # the CPU snapshot baseline. Created on first delta-enabled transfer.
+        self._delta_tracker = None
+        # Lazy change detector: snapshot (default) | inversion (DTE_DELTA_DETECTOR).
+        self._delta_detector = None
 
     @property
     def parallelism_strategy(self) -> dict:
@@ -86,6 +189,8 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         }
 
     def get_weight_metadata(self) -> list[ParameterMeta]:
+        if "Qwen2ForCausalLM" in getattr(self._engine.hf_config, "architectures", []):
+            _install_awex_qwen2_converter()
         rank_info = self._build_rank_info()
         metadata: list[ParameterMeta] = []
 
@@ -267,13 +372,19 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             cp_mode="ring" if cp_size > 1 else "none",
         )
 
-    def _iter_hf_params(self):
+    def _iter_hf_params(self, theta_by_id: dict[int, torch.Tensor] | None = None):
         """Yield (hf_name, tensor) for every parameter on this rank.
 
         Uses get_named_parameters + all_gather_param + convert_to_hf to produce
         HF-style per-expert names (e.g. experts.0.gate_proj.weight). The SGLang
         adapter's _unfuse_params converts SGLang's fused w13/w2 format to the
         same per-expert names, so both sides match for the transfer plan.
+
+        ``theta_by_id`` maps ``id(model_param) -> replacement tensor`` (same
+        shape/dtype as the mcore param). The AdamW-inversion detector uses it to
+        push reconstructed pre-step weights through the EXACT same all_gather +
+        convert path as the live payload; a param without an override is
+        converted as-is.
         """
         from areal.engine.megatron_utils.megatron import (
             all_gather_param,
@@ -281,6 +392,7 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
             get_named_parameters,
         )
 
+        overrides = theta_by_id or {}
         num_moe_experts = getattr(self._engine.tf_config, "num_moe_experts", None)
         model_name = self._engine.hf_config.model_type
         tie_word_embeddings = getattr(
@@ -290,9 +402,10 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         for mcore_name, param in get_named_parameters(
             self._engine.model, num_moe_experts
         ):
+            src = overrides.get(id(param), param)
             gathered = all_gather_param(
                 mcore_name,
-                param,
+                src,
                 fp8_direct_convert=False,
                 quantization_config=None,
                 duplicated_param_names=self._engine._duplicated_param_names,
@@ -309,6 +422,83 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
                 if tie_word_embeddings and hf_name == "lm_head.weight":
                     continue
                 yield hf_name, tensor.detach()
+
+    def _get_inner_optimizers(self):
+        """Inner per-chunk optimizers (unwrap Megatron ChainedOptimizer).
+
+        Used by the AdamW-inversion detector to read resident AdamW moments.
+        """
+        optimizer = self._engine.optimizer
+        if optimizer is None:
+            return []
+        if hasattr(optimizer, "chained_optimizers"):
+            return optimizer.chained_optimizers
+        if hasattr(optimizer, "optimizers"):
+            return optimizer.optimizers
+        return [optimizer]
+
+    @torch.no_grad()
+    def _sync_model_params_from_optimizer(self) -> None:
+        """Make the HF payload read see the latest optimizer main params.
+
+        Megatron's distributed optimizer updates fp32 main-param shards, copies
+        them into DDP param buffers, then all-gathers into the model-visible
+        params. Colocate weight exchange can run after offload/resume, so do a
+        conservative copy + synchronous param sync before reading HF tensors.
+        """
+        copied = 0
+        gathered = 0
+        for opt in self._get_inner_optimizers():
+            copy_fn = getattr(opt, "_copy_main_params_to_model_params", None)
+            if copy_fn is None:
+                copy_fn = getattr(opt, "_copy_main_params_to_param_buffer", None)
+            if copy_fn is None:
+                continue
+            copy_fn()
+            copied += 1
+
+            gather_fn = getattr(
+                opt, "_reset_metadata_and_sync_gather_all_model_params", None
+            )
+            if gather_fn is not None:
+                gather_fn(force_sync=True)
+                gathered += 1
+
+        model = self._engine.model
+        if model is None:
+            return
+        model_chunks = model if isinstance(model, (list, tuple)) else [model]
+        synced = 0
+        if gathered == 0:
+            for model_chunk in model_chunks:
+                start_param_sync = getattr(model_chunk, "start_param_sync", None)
+                if start_param_sync is None:
+                    continue
+                start_param_sync(force_sync=True)
+                synced += 1
+
+        if copied or gathered or synced:
+            torch.cuda.synchronize()
+            logger.info(
+                "Synced Megatron optimizer main params before AWEX payload read "
+                "(copied=%d, optimizer_gather=%d, param_sync=%d)",
+                copied,
+                gathered,
+                synced,
+            )
+
+    @torch.no_grad()
+    def _convert_hf_with_overrides(
+        self, theta_by_id: dict[int, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Convert mcore params to HF, substituting reconstructed pre-step
+        weights by ``id(model_param)``.
+
+        The inversion detector builds the previous-version HF payload through
+        this (the same all_gather + convert path as the live payload), then
+        bitwise-compares it against the current payload to get change masks.
+        """
+        return dict(self._iter_hf_params(theta_by_id))
 
     # ── Colocated weight transfer methods ─────────────────────────────────
 
@@ -342,6 +532,48 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         with self._colocate_lock:
             self._execute_colocate_weight_update_locked(version)
 
+    def seed_delta_base(self, version: int = 0) -> None:
+        """Virtually seed sender-side delta state from current model weights.
+
+        This is for startup validation where the inference engine has just
+        loaded the same checkpoint as the actor. It avoids a real full-weight
+        transfer before the first optimizer step, so that first trained update
+        can be encoded as an AdamW-inversion delta. In inversion mode this stores
+        only names + optimizer watermarks, not a CPU full-model snapshot.
+        """
+        if not delta_transfer_enabled():
+            logger.info("seed_delta_base skipped: delta transfer disabled")
+            return
+        if self._delta_tracker is None:
+            self._delta_tracker = make_delta_tracker()
+        if self._delta_detector is None:
+            self._delta_detector = build_detector(delta_detector_mode(), self)
+
+        inversion = self._delta_detector.name == "inversion"
+        verify_snapshot = inversion and self._delta_verify_snapshot_enabled()
+        weights_offloaded = "weights" in self._released_tags
+        if weights_offloaded:
+            self.resume_memory(tags=["weights"])
+        try:
+            params_list = list(self.get_local_shard_parameters().items())
+            self._delta_tracker.seed(
+                params_list,
+                version,
+                store_snapshot=(not inversion or verify_snapshot),
+            )
+            if verify_snapshot:
+                self._delta_mark_snapshot_names(params_list)
+            self._delta_mark_synced(version)
+            logger.info(
+                "colocate delta virtual seed v%d [%s] (snapshot=%s)",
+                version,
+                self._delta_detector.name,
+                (not inversion or verify_snapshot),
+            )
+        finally:
+            if weights_offloaded:
+                self.release_memory(tags=["weights"])
+
     def _execute_colocate_weight_update_locked(self, version: int) -> None:
         kv_store_url = self._colocate_kv_store_url
         pair_name = self._colocate_pair_name
@@ -354,14 +586,38 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         timeout_s = self._colocate_timeout_s
 
         weights_offloaded = "weights" in self._released_tags
+        self._release_grad_memory()
         if weights_offloaded:
             self.resume_memory(tags=["weights"])
 
+        sync_env = os.environ.get("DTE_SYNC_MODEL_PARAMS_BEFORE_PAYLOAD")
+        if sync_env is None or sync_env.strip() == "":
+            sync_env = os.environ.get("AWEX_SYNC_MODEL_PARAMS_BEFORE_PAYLOAD")
+        if sync_env is None or sync_env.strip() == "":
+            # AdamW inversion compares and sends the BF16 HF payload, so the
+            # model-visible Megatron buffers must reflect the latest fp32 main
+            # params before we read them. This is a GPU-side refresh, not a CPU
+            # snapshot.
+            sync_before_payload = (
+                delta_transfer_enabled() and delta_detector_mode() == "inversion"
+            )
+        else:
+            sync_before_payload = sync_env.strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+        if sync_before_payload:
+            self._sync_model_params_from_optimizer()
         params = self.get_local_shard_parameters()
-        tensors = list(params.values())
-        names = list(params.keys())
+        if delta_transfer_enabled():
+            names, tensors = self._delta_encode(params, version)
+        else:
+            names = list(params.keys())
+            tensors = list(params.values())
 
-        group_tensors, metadata = group_tensors_by_shape_and_dtype(tensors)
+        group_tensors, metadata = _group_tensors_for_colocate_ipc(tensors)
         torch.cuda.synchronize()
 
         del tensors
@@ -408,6 +664,8 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
                 f"polls={poll_count}, last_status={last_status})"
             )
 
+        self._delta_mark_synced(version)
+
         del group_shared, group_tensors, serialized_weights
         torch.cuda.synchronize()
         gc.collect()
@@ -415,6 +673,285 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
 
         if weights_offloaded:
             self.release_memory(tags=["weights"])
+
+    def _delta_mark_synced(self, version: int) -> None:
+        """Let an external delta detector record post-sync watermarks."""
+        if not delta_transfer_enabled() or self._delta_detector is None:
+            return
+        mark_synced = getattr(self._delta_detector, "mark_synced", None)
+        if mark_synced is not None:
+            mark_synced(version)
+
+    def _delta_encode(
+        self, params: dict[str, torch.Tensor], version: int
+    ) -> tuple[list[str], list[torch.Tensor]]:
+        """Encode ``params`` as a dte delta/full payload (sender side).
+
+        Mirrors ``dte.engine.DeltaEngine.push`` but ships the payload through the
+        existing cuda-IPC colocate channel instead of a dte transport. A full
+        sync ships plain tensors (header-less, shapes unchanged); a delta ships
+        dte's sparse payload (header + ``w@delta_idx``/``w@delta_val`` + dense
+        fallback). The sglang receiver reconstructs full weights before applying,
+        so delta stays transparent to the cross-rank NCCL reshard.
+
+        The change mask comes from the configured detector (DTE_DELTA_DETECTOR):
+        ``snapshot`` (default) returns None so dte diffs its CPU baseline;
+        ``inversion`` reconstructs pre-step weights from the optimizer's resident
+        moments (zero snapshot memory). Inversion infeasible this step -> dense.
+        """
+        if self._delta_tracker is None:
+            self._delta_tracker = make_delta_tracker()
+        if self._delta_detector is None:
+            self._delta_detector = build_detector(delta_detector_mode(), self)
+        inversion = self._delta_detector.name == "inversion"
+        verify_snapshot = inversion and self._delta_verify_snapshot_enabled()
+        names = list(params.keys())
+        tensors = list(params.values())
+        params_list = list(params.items())
+
+        # Full sync on the first frame (not yet seeded) or a forced anchor.
+        reason = self._delta_tracker.full_sync_reason(version)
+        reason = self._delta_sync_full_reason(reason, version)
+        # Inversion: compute masks only when this rank would otherwise ship a
+        # delta; if infeasible this step (precision-aware / step<1 / recover)
+        # compute_masks returns None and we fall back to a dense full sync.
+        masks = None
+        if inversion and reason is None:
+            masks = self._delta_detector.compute_masks(names, tensors, version)
+            if masks is None:
+                reason = "inversion_infeasible"
+            elif verify_snapshot and not self._delta_verify_masks_against_snapshot(
+                params_list, masks, version
+            ):
+                reason = "inversion_snapshot_mismatch"
+
+        reason = self._delta_sync_full_reason(reason, version)
+
+        if reason is not None:
+            # Full sync: ship plain tensors. Re-seed the snapshot baseline in
+            # snapshot mode. Inversion normally keeps no baseline, but the
+            # verification mode intentionally stores one for mask cross-checks.
+            self._delta_tracker.seed(
+                params_list,
+                version,
+                store_snapshot=(not inversion or verify_snapshot),
+            )
+            if verify_snapshot:
+                self._delta_mark_snapshot_names(params_list)
+            logger.info("colocate delta v%d: FULL sync (%s)", version, reason)
+            return names, tensors
+
+        encoded = self._delta_tracker.encode(params_list, version, masks=masks)
+        if verify_snapshot:
+            self._delta_refresh_verification_snapshot(params_list)
+        logger.info(
+            "colocate delta v%d [%s]: changed %d/%d (%.2f%%) "
+            "sparse=%d dense_fallback=%d unchanged=%d "
+            "payload=%.1fMB vs dense=%.1fMB",
+            version,
+            self._delta_detector.name,
+            encoded.changed_elements,
+            encoded.total_elements,
+            100.0 * encoded.changed_elements / max(encoded.total_elements, 1),
+            encoded.num_sparse,
+            encoded.num_dense_fallback,
+            encoded.num_unchanged,
+            encoded.payload_bytes / 1e6,
+            encoded.dense_bytes / 1e6,
+        )
+        return encoded.names, encoded.tensors
+
+    def _delta_sync_full_reason(self, reason: str | None, version: int) -> str | None:
+        """Promote a rank-local full-sync fallback to all training ranks."""
+        if not dist.is_available() or not dist.is_initialized():
+            return reason
+        try:
+            world_size = dist.get_world_size()
+        except RuntimeError:
+            return reason
+        if world_size <= 1:
+            return reason
+
+        device = (
+            torch.device("cuda", torch.cuda.current_device())
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        needs_full = torch.tensor(
+            [1 if reason is not None else 0], dtype=torch.int32, device=device
+        )
+        dist.all_reduce(needs_full, op=dist.ReduceOp.MAX)
+        if int(needs_full.item()) == 0:
+            return None
+        if reason is not None:
+            return reason
+
+        logger.warning(
+            "colocate delta v%d: FULL sync (global_full_sync from peer rank)",
+            version,
+        )
+        return "global_full_sync"
+
+    @staticmethod
+    def _delta_verify_snapshot_enabled() -> bool:
+        env = os.environ.get("DTE_DELTA_VERIFY_SNAPSHOT")
+        if env is None or env.strip() == "":
+            env = os.environ.get("AWEX_DELTA_VERIFY_SNAPSHOT", "")
+        return env.strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    def _delta_mark_snapshot_names(
+        self, params_list: list[tuple[str, torch.Tensor]]
+    ) -> None:
+        names = getattr(self._delta_tracker, "_snapshot_names", None)
+        if names is not None:
+            names.update(name for name, _ in params_list)
+
+    @torch.no_grad()
+    def _delta_refresh_verification_snapshot(
+        self, params_list: list[tuple[str, torch.Tensor]]
+    ) -> None:
+        """Refresh the debug snapshot without resetting delta version counters."""
+        snapshot = getattr(self._delta_tracker, "_snapshot", None)
+        names = getattr(self._delta_tracker, "_snapshot_names", None)
+        if snapshot is None or names is None:
+            return
+
+        snapshot.clear()
+        names.clear()
+        by_storage: dict[tuple[int, int], torch.Tensor] = {}
+        pin = torch.cuda.is_available()
+        for name, param in params_list:
+            data = param.detach().contiguous()
+            key = (data.data_ptr(), data.numel())
+            cpu_tensor = by_storage.get(key)
+            if cpu_tensor is None:
+                cpu_tensor = data.cpu().clone()
+                if pin:
+                    cpu_tensor = cpu_tensor.pin_memory()
+                by_storage[key] = cpu_tensor
+            snapshot[name] = cpu_tensor
+            names.add(name)
+
+    @torch.no_grad()
+    def _delta_verify_masks_against_snapshot(
+        self,
+        params_list: list[tuple[str, torch.Tensor]],
+        masks: dict[str, torch.Tensor],
+        version: int,
+    ) -> bool:
+        """Compare AdamW-inversion masks against a resident snapshot baseline."""
+        from dte.core import bitwise_changed_mask
+
+        snapshot = getattr(self._delta_tracker, "_snapshot", None)
+        if not snapshot:
+            logger.error(
+                "colocate delta v%d verify snapshot-vs-%s FAILED: "
+                "snapshot baseline is missing",
+                version,
+                self._delta_detector.name,
+            )
+            return False
+
+        total = 0
+        snapshot_changed = 0
+        detector_changed = 0
+        false_negative = 0
+        false_positive = 0
+        unverifiable = 0
+        fn_examples: list[str] = []
+        fp_examples: list[str] = []
+        bad_examples: list[str] = []
+
+        for name, cur in params_list:
+            cur = cur.detach().contiguous()
+            numel = cur.numel()
+            total += numel
+            snap = snapshot.get(name)
+            det_mask = masks.get(name)
+            if (
+                snap is None
+                or snap.dtype != cur.dtype
+                or snap.numel() != numel
+                or det_mask is None
+                or det_mask.numel() != numel
+            ):
+                unverifiable += 1
+                if len(bad_examples) < 5:
+                    bad_examples.append(f"{name}:missing_or_bad_mask")
+                continue
+
+            snap_mask = bitwise_changed_mask(
+                cur, snap.to(cur.device, non_blocking=False)
+            ).reshape(-1)
+            det_mask = det_mask.to(cur.device, non_blocking=False).reshape(-1).bool()
+
+            snap_count = int(snap_mask.sum().item())
+            det_count = int(det_mask.sum().item())
+            fn_count = int((snap_mask & ~det_mask).sum().item())
+            fp_count = int((det_mask & ~snap_mask).sum().item())
+
+            snapshot_changed += snap_count
+            detector_changed += det_count
+            false_negative += fn_count
+            false_positive += fp_count
+            if fn_count and len(fn_examples) < 5:
+                fn_examples.append(
+                    f"{name}:snapshot={snap_count},detector={det_count},"
+                    f"fn={fn_count},fp={fp_count}"
+                )
+            elif fp_count and len(fp_examples) < 5:
+                fp_examples.append(
+                    f"{name}:snapshot={snap_count},detector={det_count},"
+                    f"fn={fn_count},fp={fp_count}"
+                )
+
+        examples = (fn_examples + bad_examples + fp_examples)[:5]
+        if false_negative or unverifiable:
+            logger.error(
+                "colocate delta v%d verify snapshot-vs-%s MISMATCH: "
+                "snapshot_changed=%d detector_changed=%d total=%d "
+                "false_negative=%d false_positive=%d unverifiable_params=%d "
+                "examples=%s",
+                version,
+                self._delta_detector.name,
+                snapshot_changed,
+                detector_changed,
+                total,
+                false_negative,
+                false_positive,
+                unverifiable,
+                examples,
+            )
+            return False
+
+        if false_positive:
+            logger.warning(
+                "colocate delta v%d verify snapshot-vs-%s OK conservative: "
+                "snapshot_changed=%d detector_changed=%d total=%d "
+                "false_positive=%d examples=%s",
+                version,
+                self._delta_detector.name,
+                snapshot_changed,
+                detector_changed,
+                total,
+                false_positive,
+                examples,
+            )
+            return True
+
+        logger.info(
+            "colocate delta v%d verify snapshot-vs-%s OK: changed=%d/%d",
+            version,
+            self._delta_detector.name,
+            detector_changed,
+            total,
+        )
+        return True
 
     def release_memory(self, tags: list[str] | None = None) -> None:
         """Release GPU memory for specified tags by offloading to CPU.
@@ -526,33 +1063,161 @@ class AwexMegatronAdapter(AwexTrainingAdapter):
         logger.info("Reloaded optimizer states to GPU")
 
     def _offload_model_weights(self) -> None:
-        """Move model parameters to CPU, keeping references for reload."""
+        """Move model parameters to CPU, preserving Megatron DDP buffer views."""
         if self._engine.model is None:
             return
 
-        for name, param in self._engine.model.named_parameters():
-            if param.is_cuda:
-                self._offloaded_weights[name] = param.data.detach().to(
-                    "cpu", non_blocking=True
-                )
-                param.data = torch.empty(0, device="cpu")
+        from megatron.core.distributed import DistributedDataParallel as DDP
+
+        model = self._engine.model
+        model_chunks = model if isinstance(model, (list, tuple)) else [model]
+        count = 0
+        for chunk_idx, chunk in enumerate(model_chunks):
+            if isinstance(chunk, DDP):
+                for buffers in (chunk.buffers, chunk.expert_parallel_buffers):
+                    for buf in buffers:
+                        offload_to_cpu = getattr(buf, "offload_to_cpu", None)
+                        if offload_to_cpu is not None:
+                            offload_to_cpu()
+                            count += 1
+                            continue
+
+                        param_storage = buf.param_data.storage()
+                        if param_storage.size() > 0:
+                            if not hasattr(buf.param_data, "cpu_data"):
+                                try:
+                                    buf.param_data.cpu_data = torch.empty(
+                                        buf.param_data.data.shape,
+                                        dtype=buf.param_data.data.dtype,
+                                        pin_memory=torch.cuda.is_available(),
+                                        device="cpu",
+                                    )
+                                except RuntimeError:
+                                    buf.param_data.cpu_data = torch.empty(
+                                        buf.param_data.data.shape,
+                                        dtype=buf.param_data.data.dtype,
+                                        device="cpu",
+                                    )
+                            buf.param_data.cpu_data.copy_(
+                                buf.param_data.data, non_blocking=True
+                            )
+                            buf.param_data_size = param_storage.size()
+                            param_storage.resize_(0)
+                            count += 1
+                        if buf.grad_data.storage().size() > 0:
+                            buf.grad_data_size = buf.grad_data.storage().size()
+                            buf.grad_data.storage().resize_(0)
+                continue
+
+            prefix = f"chunk{chunk_idx}."
+            for name, param in chunk.named_parameters():
+                if param.is_cuda:
+                    self._offloaded_weights[prefix + name] = param.data.detach().to(
+                        "cpu", non_blocking=True
+                    )
+                    param.data = torch.empty(0, device="cpu")
+                    count += 1
 
         logger.info(
-            "Offloaded %d model weight tensors to CPU",
-            len(self._offloaded_weights),
+            "Offloaded %d model weight buffers/tensors to CPU",
+            count,
         )
 
     def _reload_model_weights(self) -> None:
-        """Restore model parameters from CPU back to GPU."""
-        if not self._offloaded_weights:
+        """Restore model parameters without breaking Megatron DDP buffer views."""
+        if not self._offloaded_weights and self._engine.model is None:
             return
         if self._engine.model is None:
             return
 
+        from megatron.core.distributed import DistributedDataParallel as DDP
+
         device = self._engine.device
-        for name, param in self._engine.model.named_parameters():
-            if name in self._offloaded_weights:
-                param.data = self._offloaded_weights[name].to(device, non_blocking=True)
+        model = self._engine.model
+        model_chunks = model if isinstance(model, (list, tuple)) else [model]
+        count = 0
+        for chunk_idx, chunk in enumerate(model_chunks):
+            if isinstance(chunk, DDP):
+                for buffers in (chunk.buffers, chunk.expert_parallel_buffers):
+                    for buf in buffers:
+                        reload_from_cpu = getattr(buf, "reload_from_cpu", None)
+                        if reload_from_cpu is not None:
+                            reload_from_cpu(move_grads=False)
+                            count += 1
+                            continue
+
+                        if (
+                            hasattr(buf, "param_data_size")
+                            and buf.param_data.storage().size() == 0
+                        ):
+                            buf.param_data.storage().resize_(buf.param_data_size)
+                        cpu_data = getattr(buf.param_data, "cpu_data", None)
+                        if cpu_data is not None:
+                            buf.param_data.copy_(cpu_data, non_blocking=True)
+                            count += 1
+                continue
+
+            prefix = f"chunk{chunk_idx}."
+            for name, param in chunk.named_parameters():
+                key = prefix + name
+                if key in self._offloaded_weights:
+                    param.data = self._offloaded_weights[key].to(
+                        device, non_blocking=True
+                    )
+                    count += 1
 
         self._offloaded_weights.clear()
-        logger.info("Reloaded model weights to GPU")
+        logger.info("Reloaded %d model weight buffers/tensors to GPU", count)
+
+    def _release_grad_memory(self) -> None:
+        """Release Megatron DDP grad buffers until the next training batch."""
+        if self._engine.model is None:
+            return
+
+        from megatron.core.distributed import DistributedDataParallel as DDP
+
+        model = self._engine.model
+        model_chunks = model if isinstance(model, (list, tuple)) else [model]
+        count = 0
+        for chunk in model_chunks:
+            if not isinstance(chunk, DDP):
+                continue
+            for buffers in (chunk.buffers, chunk.expert_parallel_buffers):
+                for buf in buffers:
+                    grad_data = getattr(buf, "grad_data", None)
+                    if grad_data is None or grad_data.storage().size() == 0:
+                        continue
+                    buf.grad_data_size = grad_data.storage().size()
+                    grad_data.storage().resize_(0)
+                    count += 1
+        if count:
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+            logger.info("Released %d grad buffers", count)
+
+    def ensure_grad_buffers(self) -> None:
+        """Reallocate Megatron DDP grad buffers released with train weights."""
+        if self._engine.model is None:
+            return
+
+        from megatron.core.distributed import DistributedDataParallel as DDP
+
+        model = self._engine.model
+        model_chunks = model if isinstance(model, (list, tuple)) else [model]
+        count = 0
+        for chunk in model_chunks:
+            if not isinstance(chunk, DDP):
+                continue
+            for buffers in (chunk.buffers, chunk.expert_parallel_buffers):
+                for buf in buffers:
+                    if (
+                        hasattr(buf, "grad_data_size")
+                        and buf.grad_data.storage().size() == 0
+                    ):
+                        buf.grad_data.storage().resize_(buf.grad_data_size)
+                        buf.grad_data.zero_()
+                        count += 1
+        if count:
+            torch.cuda.synchronize()
+            logger.info("Allocated %d grad buffers for training", count)

--- a/areal/v2/weight_update/awex/sglang_adapter.py
+++ b/areal/v2/weight_update/awex/sglang_adapter.py
@@ -35,6 +35,11 @@ from areal.v2.weight_update.awex import (
     awex_wu_use_group,
     fetch_kv_metadata,
 )
+from areal.v2.weight_update.awex.delta_config import (
+    delta_transfer_enabled,
+    make_delta_engine,
+    payload_carries_delta,
+)
 from areal.v2.weight_update.inference_adapter import (
     AwexInferenceAdapter,
 )
@@ -63,6 +68,7 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         self._colocate_transport = None
         self._train_to_infer_device_mapping: dict | None = None
         self._infer_to_train_device_mapping: dict | None = None
+        self._delta_engine = None
 
     def _get_model(self) -> torch.nn.Module:
         return self._scheduler.tp_worker.model_runner.model
@@ -571,6 +577,14 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
         tensors = reconstruct_tensors_from_groups(group_shared, metadata)
         torch.cuda.synchronize()
         deserialized_weights = dict(zip(names, tensors))
+        # Reconstruct when delta is enabled locally OR the payload itself carries
+        # a delta header. The latter defends against the trainer enabling delta
+        # while this worker's DTE_DELTA_TRANSFER did not propagate: without it,
+        # the sparse header/@delta_idx names would flow straight into the apply.
+        if delta_transfer_enabled() or payload_carries_delta(names):
+            deserialized_weights = self._delta_reconstruct(
+                deserialized_weights, version
+            )
 
         recv_parameters = self.get_local_shard_parameters()
 
@@ -610,6 +624,94 @@ class AwexSGLangAdapter(AwexInferenceAdapter):
             version,
             transfer_rank,
         )
+
+    def seed_delta_base(self, version: int = 0) -> None:
+        """Seed receiver-side delta base from the currently loaded weights.
+
+        The actor and SGLang workers start from the same checkpoint.  In delta
+        mode we can therefore seed the DTE chain at v0 locally on the receiver
+        instead of receiving a real full-weight v1 payload before training.
+        """
+        if not delta_transfer_enabled():
+            logger.info("seed_delta_base skipped: delta transfer disabled")
+            return
+        if self._delta_engine is None:
+            self._delta_engine = make_delta_engine(
+                f"cuda:{torch.cuda.current_device()}"
+            )
+        params = self.get_local_shard_parameters()
+        self._delta_engine.reconstruct(params, version)
+        logger.info(
+            "colocate delta receiver virtual seed v%d with %d params",
+            version,
+            len(params),
+        )
+
+    def _delta_reconstruct(
+        self, named_tensors: dict[str, torch.Tensor], version: int
+    ) -> dict[str, torch.Tensor]:
+        """Reconstruct full weights from a dte delta/full payload (receiver side).
+
+        The bytes already arrived via cuda-IPC, so we use dte's transport-free
+        ``DeltaEngine.reconstruct``: it verifies the version chain, decodes the
+        sparse patch against the CPU base, refreshes that base, and returns the
+        full ``{name: tensor}``. Full weights then flow into
+        ``update_weights_in_colocate_mode`` unchanged, so the cross-rank NCCL
+        reshard never sees a delta payload. The per-param change masks dte also
+        returns are unused for now (first cut applies full weights).
+        """
+        if self._delta_engine is None:
+            self._delta_engine = make_delta_engine(
+                f"cuda:{torch.cuda.current_device()}"
+            )
+        full_params, _masks = self._delta_engine.reconstruct(named_tensors, version)
+        return full_params
+
+    def _verify_delta_agreement(
+        self,
+        pair_name: str,
+        kv_store_url: str,
+        transfer_rank: int,
+        admin_api_key: str,
+        timeout_s: float,
+    ) -> None:
+        """Fail fast if the paired training rank disagrees on delta on/off.
+
+        The trainer publishes its ``DTE_DELTA_TRANSFER`` state per rank at init;
+        we poll the paired rank's flag and compare. A mismatch means the env var
+        did not propagate consistently — without this guard a delta-mode trainer
+        would ship a header-less full-sync frame this (delta-off) worker skips,
+        leaving no base, and the next delta frame raises ``DeltaChainBroken``.
+        """
+        assert self._infer_to_train_device_mapping is not None
+        assert self._colocate_http_client is not None
+        paired_train_rank = self._infer_to_train_device_mapping[transfer_rank]
+        key = f"colocate_delta_enabled_rank{paired_train_rank}"
+        client = self._colocate_http_client
+        deadline = time.monotonic() + timeout_s
+        train_delta = None
+        while time.monotonic() < deadline:
+            resp = client.get(
+                f"{kv_store_url}/weight_meta/{pair_name}/{key}", timeout=5.0
+            )
+            if resp.status_code == 200:
+                train_delta = bool(resp.json()["value"])
+                break
+            time.sleep(0.1)
+        if train_delta is None:
+            raise TimeoutError(
+                f"Training rank {paired_train_rank} did not publish its delta "
+                f"flag within {timeout_s}s (key={key})"
+            )
+        local_delta = delta_transfer_enabled()
+        if train_delta != local_delta:
+            raise ValueError(
+                f"Colocate delta mismatch: training rank {paired_train_rank} "
+                f"delta_enabled={train_delta}, inference rank {transfer_rank} "
+                f"delta_enabled={local_delta}. Set DTE_DELTA_TRANSFER "
+                f"consistently on BOTH training and inference workers."
+            )
+        logger.info("colocate delta agreement OK (delta_enabled=%s)", local_delta)
 
     # Tags understood by SGLang's native release/resume_memory_occupation.
     _SGLANG_MEMORY_TAGS = {"kv_cache"}

--- a/areal/v2/weight_update/gateway/app.py
+++ b/areal/v2/weight_update/gateway/app.py
@@ -565,17 +565,29 @@ def create_app(config: WeightUpdateConfig | None = None) -> FastAPI:
             ],
         )
 
-        await asyncio.gather(
-            *[
-                _post(
-                    session,
-                    f"{url}/awex/release_memory",
-                    timeout_s,
-                    json_data={"tags": ["weights"]},
-                )
-                for url in pair_info.train_worker_urls
-            ]
-        )
+        release_env = os.environ.get("DTE_RELEASE_TRAIN_WEIGHTS_AFTER_UPDATE")
+        if release_env is None or release_env.strip() == "":
+            release_env = os.environ.get(
+                "AWEX_COLOCATE_RELEASE_TRAIN_WEIGHTS_AFTER_UPDATE", "1"
+            )
+        release_train_weights = release_env.strip().lower() not in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }
+        if release_train_weights:
+            await asyncio.gather(
+                *[
+                    _post(
+                        session,
+                        f"{url}/awex/release_memory",
+                        timeout_s,
+                        json_data={"tags": ["weights"]},
+                    )
+                    for url in pair_info.train_worker_urls
+                ]
+            )
 
         await asyncio.gather(
             *[

--- a/areal/v2/weight_update/inference_adapter.py
+++ b/areal/v2/weight_update/inference_adapter.py
@@ -77,6 +77,10 @@ class AwexInferenceAdapter(Protocol):
         """Fetch IPC weights from KV store and apply via colocate transport."""
         ...
 
+    def seed_delta_base(self, version: int = 0) -> None:
+        """Seed colocate delta state from the current local weights."""
+        ...
+
     def release_memory(self, tags: list[str] | None = None) -> None:
         """Release GPU memory (KV cache/weights) for colocated mode."""
         ...

--- a/areal/v2/weight_update/training_adapter.py
+++ b/areal/v2/weight_update/training_adapter.py
@@ -77,6 +77,10 @@ class AwexTrainingAdapter(Protocol):
         """Serialize weights via IPC and put to KV store."""
         ...
 
+    def seed_delta_base(self, version: int = 0) -> None:
+        """Seed colocate delta state from the current local weights."""
+        ...
+
     def release_memory(self, tags: list[str] | None = None) -> None:
         """Release GPU memory (optimizer/weights) for colocated mode."""
         ...

--- a/examples/dte/README.md
+++ b/examples/dte/README.md
@@ -1,0 +1,36 @@
+# DTE Colocated Weight Transfer
+
+This example runs GSM8K GRPO with Megatron training and SGLang rollout workers sharing
+the same GPUs through AWEX. DTE supports full updates and incremental updates detected
+either from AdamW state or from a weight snapshot.
+
+Install the optional dependency:
+
+```bash
+python -m pip install -e ".[delta]"
+```
+
+The extra uses the public `areal-project/AReaL-DTE` repository at the revision recorded
+in `uv.lock`.
+
+Run the AdamW delta configuration:
+
+```bash
+python examples/math/gsm8k_rl.py --config examples/dte/gsm8k_dte.yaml
+```
+
+Use full transfer or snapshot-based delta detection with CLI overrides:
+
+```bash
+python examples/math/gsm8k_rl.py \
+  --config examples/dte/gsm8k_dte.yaml \
+  actor.dte.transfer=full
+
+python examples/math/gsm8k_rl.py \
+  --config examples/dte/gsm8k_dte.yaml \
+  actor.dte.delta_method=snapshot
+```
+
+Override the model path, scheduler, and topology for the target environment. Set
+`actor.dte.verify_snapshot=true` only when validating AdamW masks because it keeps an
+additional CPU snapshot.

--- a/examples/dte/gsm8k_dte.yaml
+++ b/examples/dte/gsm8k_dte.yaml
@@ -1,0 +1,66 @@
+defaults:
+  - ../math/gsm8k_grpo_megatron@_global_
+  - _self_
+
+experiment_name: gsm8k-dte
+trial_name: trial0
+total_train_steps: null
+
+cluster:
+  n_gpus_per_node: 2
+
+scheduler:
+  type: local
+
+gconfig:
+  n_samples: 4
+  max_new_tokens: 256
+  max_tokens: 1024
+
+rollout:
+  _version: v2
+  backend: sglang:d2p1t1
+  max_concurrent_rollouts: 32
+  queue_size: 32
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 1000000
+
+actor:
+  _version: v2
+  backend: megatron:d2p1t1
+  weight_update_mode: awex
+  dte:
+    enabled: true
+    transfer: delta
+    delta_method: adamw
+    anchor_interval: 0
+    verify_snapshot: false
+  optimizer:
+    lr: 8e-7
+    warmup_steps_proportion: 0
+  reward_norm: null
+  adv_norm: null
+
+sglang:
+  mem_fraction_static: 0.35
+
+train_dataset:
+  batch_size: 8
+  num_workers: 1
+
+valid_dataset:
+  batch_size: 8
+  num_workers: 1
+
+saver:
+  freq_epochs: null
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: disabled
+
+evaluator:
+  freq_epochs: null
+  freq_steps: null
+  freq_secs: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,9 @@ cli = [
     "click>=8.1",
     "colorlog",
 ]
+delta = [
+    "delta-transfer-engine @ git+https://github.com/areal-project/AReaL-DTE.git@6b2bc13e2b626d2677e9997f159b5a3269c97e3e",
+]
 
 [project.scripts]
 areal = "areal.v2.cli.main:cli"

--- a/tests/test_awex_colocate_delta.py
+++ b/tests/test_awex_colocate_delta.py
@@ -1,0 +1,772 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU round-trip tests for colocate delta (incremental) weight transfer.
+
+These validate the migration's correctness contract: the sender-side
+``DeltaTracker`` decision (mirrored from ``AwexMegatronAdapter._delta_encode``)
+feeding dte's transport-free ``DeltaEngine.reconstruct`` (the core of
+``AwexSGLangAdapter._delta_reconstruct``) reconstructs full + delta payloads
+byte-identically against the receiver's version-chained base — no GPU or
+distributed setup required.
+
+``delta_config`` is loaded directly from its file so the test does not pull in
+the full areal runtime import chain (httpx/awex), which is absent in lean CI
+sandboxes; the module itself only depends on ``os`` + (lazily) ``dte``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("dte")
+
+_DC_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "areal/v2/weight_update/awex/delta_config.py"
+)
+_MEGATRON_ADAPTER_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "areal/v2/weight_update/awex/megatron_adapter.py"
+)
+_MEGATRON_ENGINE_PATH = (
+    Path(__file__).resolve().parent.parent / "areal/engine/megatron_engine.py"
+)
+
+
+def _load_delta_config():
+    spec = importlib.util.spec_from_file_location("awex_delta_config", _DC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_colocate_send_path_encodes_delta_before_grouping():
+    tree = ast.parse(_MEGATRON_ADAPTER_PATH.read_text())
+    method = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_execute_colocate_weight_update_locked"
+    )
+    calls = {
+        (
+            node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
+        ): node.lineno
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, (ast.Attribute, ast.Name))
+    }
+
+    assert "delta_transfer_enabled" in calls
+    assert "_delta_encode" in calls
+    assert calls["_delta_encode"] < calls["_group_tensors_for_colocate_ipc"]
+
+
+def test_delta_full_fallback_is_synchronized_across_ranks():
+    tree = ast.parse(_MEGATRON_ADAPTER_PATH.read_text())
+    method = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_delta_encode"
+    )
+    sync_calls = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_delta_sync_full_reason"
+    ]
+
+    assert len(sync_calls) == 2
+
+
+def test_colocate_ipc_groups_are_keyed_by_dtype():
+    tree = ast.parse(_MEGATRON_ADAPTER_PATH.read_text())
+    method = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_group_tensors_for_colocate_ipc"
+    )
+    setdefault_calls = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "setdefault"
+    ]
+
+    assert any(
+        isinstance(call.args[0], ast.Attribute) and call.args[0].attr == "dtype"
+        for call in setdefault_calls
+    )
+
+
+def test_delta_rollout_offload_preserves_weight_base():
+    trainer_tree = ast.parse(
+        (
+            Path(__file__).resolve().parent.parent / "areal/trainer/rl_trainer.py"
+        ).read_text()
+    )
+    method = next(
+        node
+        for node in ast.walk(trainer_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_offload_rollout"
+    )
+    tagged_offloads = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "offload"
+        and any(keyword.arg == "tags" for keyword in node.keywords)
+    ]
+
+    assert tagged_offloads
+
+
+def test_colocation_validation_allows_awex_mode():
+    trainer_tree = ast.parse(
+        (
+            Path(__file__).resolve().parent.parent / "areal/trainer/rl_trainer.py"
+        ).read_text()
+    )
+    method = next(
+        node
+        for node in ast.walk(trainer_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_validate_cfg"
+    )
+    allowed_modes = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Set)
+        and {item.value for item in node.elts if isinstance(item, ast.Constant)}
+        == {"disk", "awex"}
+    ]
+
+    assert allowed_modes
+
+
+def test_tied_embeddings_do_not_synthesize_lm_head_metadata():
+    tree = ast.parse(_MEGATRON_ADAPTER_PATH.read_text())
+    method = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_iter_hf_params"
+    )
+    synthetic_lm_head_yields = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Yield)
+        and isinstance(node.value, ast.Tuple)
+        and any(
+            isinstance(item, ast.Constant) and item.value == "lm_head.weight"
+            for item in node.value.elts
+        )
+    ]
+
+    assert synthetic_lm_head_yields == []
+
+
+def test_ppo_update_restores_awex_grad_buffers_first():
+    tree = ast.parse(_MEGATRON_ENGINE_PATH.read_text())
+    actor_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "MegatronPPOActor"
+    )
+    method = next(
+        node
+        for node in actor_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "ppo_update"
+    )
+    calls = [
+        (node.func.attr, node.lineno)
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    ]
+
+    ensure_line = next(line for name, line in calls if name == "ensure_grad_buffers")
+    update_line = next(line for name, line in calls if name == "ppo_update")
+    assert ensure_line < update_line
+
+
+@pytest.fixture
+def dc():
+    return _load_delta_config()
+
+
+def _encode_like_adapter(tracker, params, version):
+    """Mirror ``AwexMegatronAdapter._delta_encode`` (sender side)."""
+    params_list = list(params.items())
+    reason = tracker.full_sync_reason(version)
+    if reason is not None:
+        tracker.seed(params_list, version)
+        return list(params.keys()), list(params.values())
+    encoded = tracker.encode(params_list, version)
+    return encoded.names, encoded.tensors
+
+
+def _over_the_wire(names, tensors):
+    """Stand in for cuda_ipc serialize/deserialize: clone to detach storage."""
+    return dict(zip(names, [t.clone() for t in tensors]))
+
+
+def _weights(seed: int):
+    g = torch.Generator().manual_seed(seed)
+    return {
+        "embed.weight": torch.randn(32, 16, generator=g),
+        "layer.weight": torch.randn(16, 16, generator=g),
+        "layer.bias": torch.randn(16, generator=g),
+    }
+
+
+def test_delta_config_env_gates(dc, monkeypatch):
+    monkeypatch.delenv("DTE_DELTA_TRANSFER", raising=False)
+    monkeypatch.delenv("AWEX_DELTA_TRANSFER", raising=False)
+    assert dc.delta_transfer_enabled() is False
+    monkeypatch.setenv("AWEX_DELTA_TRANSFER", "1")
+    assert dc.delta_transfer_enabled() is True
+    monkeypatch.setenv("DTE_DELTA_TRANSFER", "0")
+    assert dc.delta_transfer_enabled() is False
+    monkeypatch.setenv("DTE_DELTA_TRANSFER", "1")
+    assert dc.delta_transfer_enabled() is True
+
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "5")
+    assert dc.delta_anchor_interval() == 5
+    monkeypatch.setenv("DTE_DELTA_ANCHOR_INTERVAL", "7")
+    assert dc.delta_anchor_interval() == 7
+    monkeypatch.setenv("AWEX_DELTA_BYTES_RATIO", "0.33")
+    assert dc.delta_bytes_ratio() == pytest.approx(0.33)
+    monkeypatch.setenv("DTE_DELTA_BYTES_RATIO", "0.44")
+    assert dc.delta_bytes_ratio() == pytest.approx(0.44)
+
+
+def test_factories_build_dte_objects(dc, monkeypatch):
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "0")
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+    assert hasattr(tracker, "encode") and hasattr(tracker, "seed")
+    assert hasattr(engine, "reconstruct")
+
+
+def test_full_then_delta_roundtrip(dc, monkeypatch):
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "0")
+    from dte.core import is_delta_payload
+
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+
+    # v1: first transfer -> full sync (dense); seeds sender snapshot + receiver base.
+    w1 = _weights(0)
+    names, tensors = _encode_like_adapter(tracker, w1, 1)
+    assert not is_delta_payload(names)
+    full1, masks1 = engine.reconstruct(_over_the_wire(names, tensors), 1)
+    assert masks1 is None
+    for k, v in w1.items():
+        assert torch.equal(full1[k], v), f"full-sync mismatch on {k}"
+
+    # v2: change two elements of one tensor -> sparse delta; others unchanged.
+    w2 = {k: v.clone() for k, v in w1.items()}
+    w2["layer.weight"][0, 0] += 1.5
+    w2["layer.weight"][3, 7] -= 2.0
+    names, tensors = _encode_like_adapter(tracker, w2, 2)
+    assert is_delta_payload(names)
+    # Unchanged tensors are not shipped at all.
+    assert "embed.weight" not in names and "layer.bias" not in names
+    full2, masks2 = engine.reconstruct(_over_the_wire(names, tensors), 2)
+    assert masks2 is not None
+    for k, v in w2.items():
+        assert torch.equal(full2[k], v), f"delta reconstruct mismatch on {k}"
+
+
+def test_anchor_interval_forces_full_sync(dc, monkeypatch):
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "1")  # full sync every 1 delta
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+
+    is_full = []
+    w = _weights(1)
+    for version in (1, 2, 3, 4):
+        if version > 1:
+            w = {k: v.clone() for k, v in w.items()}
+            w["layer.weight"][0, version] += float(version)
+        names, tensors = _encode_like_adapter(tracker, w, version)
+        _full, masks = engine.reconstruct(_over_the_wire(names, tensors), version)
+        is_full.append(masks is None)  # True == full sync
+    # v1 seed(full), v2 delta, v3 anchor(full), v4 delta
+    assert is_full == [True, False, True, False], is_full
+
+
+def test_delta_before_base_raises(dc, monkeypatch):
+    from dte.engine import DeltaChainBroken
+
+    monkeypatch.setenv("AWEX_DELTA_ANCHOR_INTERVAL", "0")
+    tracker = dc.make_delta_tracker()
+
+    # Build a valid delta payload (requires a seeded tracker)...
+    w1 = _weights(2)
+    _encode_like_adapter(tracker, w1, 1)  # seeds snapshot at v1
+    w2 = {k: v.clone() for k, v in w1.items()}
+    w2["layer.weight"][1, 1] += 1.0
+    names, tensors = _encode_like_adapter(tracker, w2, 2)
+
+    # ...and feed it to a FRESH receiver that never received a full-sync base.
+    fresh_engine = dc.make_delta_engine("cpu")
+    with pytest.raises(DeltaChainBroken):
+        fresh_engine.reconstruct(_over_the_wire(names, tensors), 2)
+
+
+def test_header_constant_matches_dte(dc):
+    # delta_config mirrors dte's wire header so the receiver can detect a delta
+    # payload without importing dte; guard the mirror against drift.
+    from dte.core import DELTA_HEADER_NAME
+
+    assert dc.DELTA_HEADER_NAME == DELTA_HEADER_NAME
+
+
+def test_payload_carries_delta(dc):
+    assert dc.payload_carries_delta([dc.DELTA_HEADER_NAME, "layer.weight@delta_idx"])
+    assert not dc.payload_carries_delta(["layer.weight", "layer.bias"])
+
+
+def test_real_awex_channel_roundtrip(dc):
+    """Delta payload survives the REAL awex group/reconstruct serialization path.
+
+    Guards the highest-risk integration point: dte's variable-length int idx /
+    1-D header tensors must round-trip losslessly through
+    ``group_tensors_by_shape_and_dtype`` + ``reconstruct_tensors_from_groups``
+    (cuda_ipc itself is identity within one process). Skipped where awex is not
+    installed (lean CI sandboxes); runs in the full inference image.
+    """
+    tu = pytest.importorskip("awex.util.tensor_util")
+    group = tu.group_tensors_by_shape_and_dtype
+    reconstruct = tu.reconstruct_tensors_from_groups
+
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+
+    # v1 full sync through the real channel.
+    w1 = _weights(3)
+    names, tensors = _encode_like_adapter(tracker, w1, 1)
+    groups, meta = group(tensors)
+    full1, masks1 = engine.reconstruct(dict(zip(names, reconstruct(groups, meta))), 1)
+    assert masks1 is None
+    for k, v in w1.items():
+        assert torch.equal(full1[k], v)
+
+    # v2 delta through the real channel; assert the channel is lossless first.
+    w2 = {k: v.clone() for k, v in w1.items()}
+    w2["layer.weight"][2, 2] += 1.0
+    names, tensors = _encode_like_adapter(tracker, w2, 2)
+    groups, meta = group(tensors)
+    recon = reconstruct(groups, meta)
+    for name, orig in zip(names, tensors):
+        assert torch.equal(dict(zip(names, recon))[name], orig), f"channel lost {name}"
+    full2, masks2 = engine.reconstruct(dict(zip(names, recon)), 2)
+    assert masks2 is not None
+    for k, v in w2.items():
+        assert torch.equal(full2[k], v)
+
+
+def test_consecutive_deltas_advance_base(dc):
+    """Base must advance across many deltas, not stay pinned at the seed.
+
+    Guards ``reconstruct`` writing each rebuilt full-shard back into the CPU base
+    (dte ``reconstruct_against_base`` does this in place). A regression that left
+    the base at v1 would still pass a single-delta test but corrupt v3+.
+    """
+    tracker = dc.make_delta_tracker()
+    engine = dc.make_delta_engine("cpu")
+
+    w = _weights(7)
+    names, tensors = _encode_like_adapter(tracker, w, 1)  # v1 full sync seeds base
+    engine.reconstruct(_over_the_wire(names, tensors), 1)
+
+    for version in range(2, 8):
+        w = {k: v.clone() for k, v in w.items()}
+        w["layer.weight"][version % 16, (version * 3) % 16] += version * 0.5
+        names, tensors = _encode_like_adapter(tracker, w, version)
+        full, masks = engine.reconstruct(_over_the_wire(names, tensors), version)
+        assert masks is not None, f"v{version} should be a delta"
+        for k, v in w.items():
+            assert torch.equal(full[k], v), f"v{version} mismatch on {k}"
+
+
+def test_invert_adamw_roundtrip():
+    """dte.invert_adamw recovers theta_{t-1} from a real AdamW step (CPU-only).
+
+    This is the only CPU-verifiable piece of the inversion detector — its mcore
+    traversal / DP all-reduce / convert are GPU-only. Confirms both the formula
+    and the (theta_t, m, v, step, lr, wd, b1, b2, eps) argument order the
+    detector (AdamWInversionDetector._reconstruct_pre_step_mcore) relies on.
+    """
+    from dte.core import invert_adamw
+
+    torch.manual_seed(0)
+    theta_prev = torch.randn(512, dtype=torch.float32)
+    p = theta_prev.clone().requires_grad_(True)
+    lr, wd, b1, b2, eps = 1e-3, 0.01, 0.9, 0.999, 1e-8
+    opt = torch.optim.AdamW([p], lr=lr, betas=(b1, b2), eps=eps, weight_decay=wd)
+    p.grad = torch.randn_like(p)
+    opt.step()  # theta_prev -> theta_t, leaving exp_avg / exp_avg_sq resident
+    theta_t = p.detach().clone()
+    st = opt.state[p]
+    recovered = invert_adamw(
+        theta_t, st["exp_avg"], st["exp_avg_sq"], float(st["step"]), lr, wd, b1, b2, eps
+    )
+    torch.testing.assert_close(recovered, theta_prev, rtol=1e-3, atol=1e-4)
+
+
+def _load_delta_detect(monkeypatch):
+    """Load delta_detect.py without the full areal runtime.
+
+    It does ``from areal.utils import logging`` at module top, which would pull
+    in areal/__init__ (httpx/awex, absent in lean sandboxes). Stub that one
+    symbol so the detector logic is importable for CPU tests.
+    """
+    import importlib.util
+    import logging as _stdlog
+    import sys
+    import types
+
+    fake = types.ModuleType("areal.utils.logging")
+    fake.getLogger = _stdlog.getLogger
+    monkeypatch.setitem(sys.modules, "areal", types.ModuleType("areal"))
+    monkeypatch.setitem(sys.modules, "areal.utils", types.ModuleType("areal.utils"))
+    monkeypatch.setitem(sys.modules, "areal.utils.logging", fake)
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "areal/v2/weight_update/awex/delta_detect.py"
+    )
+    spec = importlib.util.spec_from_file_location("awex_delta_detect", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_inversion_detector_dispatch_and_gating(monkeypatch):
+    """Detector dispatch + inversion gating (CPU).
+
+    The mcore reconstruction / DP all-reduce / convert are GPU-only and can't be
+    unit-tested here; this covers the dispatch and the gating fallbacks that
+    decide snapshot-vs-inversion and inversion-vs-dense.
+    """
+    dd = _load_delta_detect(monkeypatch)
+
+    # snapshot detector is a no-op marker -> None (dte snapshot path downstream)
+    snap = dd.build_detector("snapshot", None)
+    assert snap.name == "snapshot"
+    assert snap.compute_masks(["a"], [torch.zeros(4)], 1) is None
+    # unknown / empty mode also falls back to snapshot
+    assert dd.build_detector("", None).name == "snapshot"
+
+    # inversion detector builds, but with no optimizers the hard gate fails and
+    # compute_masks returns None -> writer ships a dense full sync that step.
+    class _NoOptAdapter:
+        def _get_inner_optimizers(self):
+            return []
+
+    inv = dd.build_detector("inversion", _NoOptAdapter())
+    assert inv.name == "inversion"
+    assert inv.compute_masks(["a"], [torch.zeros(4)], 1) is None
+
+
+def test_bf16_boundary_mask_uses_asymmetric_neighbors(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+
+    cur = torch.tensor([1.0], dtype=torch.bfloat16)
+    lower = torch.nextafter(cur, torch.full_like(cur, float("-inf"))).to(torch.float32)
+    lower_half_ulp = (cur.to(torch.float32) - lower) * 0.5
+    old_inside_current_bin = cur.to(torch.float32) - lower_half_ulp * 0.99995
+
+    assert old_inside_current_bin.to(torch.bfloat16).item() == cur.item()
+    assert dd._bf16_rounding_boundary_mask(old_inside_current_bin, cur).item()
+
+
+def test_inversion_detector_computes_masks_from_adamw_state(monkeypatch):
+    """Exercise the inversion detector's real reconstruct -> mask path.
+
+    This uses a tiny fake adapter/optimizer that exposes the Megatron distributed
+    optimizer fields the detector consumes, but avoids launching mcore or
+    torch.distributed. The reconstructed pre-step tensor is converted through
+    the adapter override path and compared against the live tensor, which is the
+    core inversion logic used by the AWEX colocate sender.
+    """
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    torch.manual_seed(1)
+    theta_prev = torch.randn(64, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    lr, wd, b1, b2, eps = 3e-3, 0.02, 0.9, 0.999, 1e-8
+    base_opt = torch.optim.AdamW(
+        [param],
+        lr=lr,
+        betas=(b1, b2),
+        eps=eps,
+        weight_decay=wd,
+    )
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+    offloaded_state = {
+        k: v.detach().clone() if isinstance(v, torch.Tensor) else v
+        for k, v in base_opt.state[param].items()
+    }
+    group_step = offloaded_state.pop("step")
+    base_opt.param_groups[0]["step"] = group_step
+    base_opt.state[param]["exp_avg"] = torch.empty(0)
+    base_opt.state[param]["exp_avg_sq"] = torch.empty(0)
+    if isinstance(base_opt.state[param].get("step"), torch.Tensor):
+        base_opt.state[param]["step"] = torch.empty(0)
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {param: offloaded_state}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {"w": theta_by_id.get(id(param), param.detach())}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    # Simulate that version 1 synced the pre-step weights. AdamW inversion is
+    # only valid for the next optimizer step relative to that synced watermark.
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = dd._tensor_fingerprint(theta_prev)
+    masks = inv.compute_masks(["w"], [theta_t], version=2)
+
+    assert masks is not None
+    assert set(masks) == {"w"}
+    assert torch.equal(
+        masks["w"], bitwise_changed_mask(theta_t, theta_prev).reshape(-1)
+    )
+    assert masks["w"].any()
+
+    # After version 2 is synced, reusing the same AdamW moments without another
+    # optimizer step must not replay the old update and report false positives.
+    inv.mark_synced(version=2)
+    same_step_masks = inv.compute_masks(["w"], [theta_t], version=3)
+    assert same_step_masks is not None
+    assert not same_step_masks["w"].any()
+
+    # If the optimizer step counter advances but the synced-payload fingerprint
+    # is missing, old moments must not be replayed as a fake weight delta.
+    # The detector cannot prove whether weights changed, so it asks the sender
+    # to do a dense fallback for this step.
+    base_opt.param_groups[0]["step"] = group_step + 1
+    inv._last_synced_fingerprints.clear()
+    missing_fingerprint_masks = inv.compute_masks(["w"], [theta_t], version=4)
+    assert missing_fingerprint_masks is None
+
+
+def test_inversion_detector_does_not_gate_one_step_on_fingerprint(monkeypatch):
+    """A fingerprint collision must not hide a valid one-step AdamW update."""
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    torch.manual_seed(11)
+    theta_prev = torch.randn(128, dtype=torch.float32)
+    param = torch.nn.Parameter(theta_prev.clone())
+    base_opt = torch.optim.AdamW(
+        [param],
+        lr=2e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=0.01,
+    )
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_t = param.detach().clone()
+
+    # Force the synced/current fingerprints to collide. A correct detector still
+    # reconstructs a one-step AdamW update from moments instead of trusting this
+    # compact fingerprint as a proof of no change.
+    monkeypatch.setattr(dd, "_tensor_fingerprint", lambda _tensor: ("collision",))
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {"w": theta_by_id.get(id(param), param.detach())}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv._last_synced_steps[id(param)] = 0.0
+    inv._last_synced_fingerprints[id(param)] = ("collision",)
+
+    masks = inv.compute_masks(["w"], [theta_t], version=2)
+
+    assert masks is not None
+    assert torch.equal(
+        masks["w"], bitwise_changed_mask(theta_t, theta_prev).reshape(-1)
+    )
+    assert masks["w"].any()
+
+
+def test_inversion_detector_zero_grad_step_uses_fingerprint_guard(monkeypatch):
+    """Zero current grad can still be a valid AdamW delta if the shard changed."""
+    dd = _load_delta_detect(monkeypatch)
+    from dte.core import bitwise_changed_mask
+
+    torch.manual_seed(2)
+    param = torch.nn.Parameter(torch.randn(32, dtype=torch.float32))
+    base_opt = torch.optim.AdamW(
+        [param],
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=0.01,
+    )
+
+    param.grad = torch.randn_like(param)
+    base_opt.step()
+    theta_synced = param.detach().clone()
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = None
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+        def _get_inner_optimizers(self):
+            return [_FakeDistOpt()]
+
+        def _convert_hf_with_overrides(self, theta_by_id):
+            return {"w": theta_by_id.get(id(param), param.detach())}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    inv.mark_synced(version=2)
+
+    param.grad = torch.zeros_like(param)
+    base_opt.step()
+    theta_after_zero_grad = param.detach().clone()
+    assert not torch.equal(theta_after_zero_grad, theta_synced)
+
+    masks = inv.compute_masks(["w"], [theta_after_zero_grad], version=3)
+    assert masks is not None
+    assert torch.equal(
+        masks["w"],
+        bitwise_changed_mask(theta_after_zero_grad, theta_synced).reshape(-1),
+    )
+    assert masks["w"].any()
+
+
+def test_inversion_fingerprint_detects_value_changes(monkeypatch):
+    dd = _load_delta_detect(monkeypatch)
+
+    before = torch.arange(128, dtype=torch.float32)
+    after = before.clone()
+    after[17] += 1
+
+    assert dd._tensor_fingerprint(before) != dd._tensor_fingerprint(after)
+    assert dd._tensor_fingerprint(before) == dd._tensor_fingerprint(before.clone())
+
+
+def test_inversion_reconstruct_missing_local_state_joins_dp_allreduce(monkeypatch):
+    """A DP rank without local moments must still join per-param collectives.
+
+    In Megatron's distributed optimizer a rank can see the full bf16 model
+    param while not owning a usable optimizer-state shard for that param. The
+    detector must contribute zeros and enter the same all-reduces as ranks that
+    do own a shard; otherwise colocate v2 can hang waiting for one rank.
+    """
+    dd = _load_delta_detect(monkeypatch)
+
+    param = torch.nn.Parameter(torch.arange(8, dtype=torch.float32))
+    base_opt = torch.optim.AdamW([param], lr=1e-3)
+    dp_group = object()
+    calls = []
+
+    def _fake_all_reduce(tensor, op=None, group=None):
+        del op
+        assert group is dp_group
+        calls.append((tuple(tensor.shape), tensor.dtype))
+        if tensor.dtype == torch.int32:
+            # Simulate another DP rank contributing this param's optimizer shard.
+            assert tuple(tensor.shape) == (2,)
+            tensor[0] = 1
+            tensor[1] = 0
+
+    monkeypatch.setattr(dd.torch.distributed, "all_reduce", _fake_all_reduce)
+
+    class _FakeDistOpt:
+        optimizer = base_opt
+        shard_fp32_from_float16_groups = [[param]]
+        model_float16_groups = [[param]]
+        model_param_group_index_map = None
+        data_parallel_group = dp_group
+
+        def _get_model_param_range_map(self, model_param):
+            assert model_param is param
+
+            class _Range:
+                start = 0
+                end = param.numel()
+
+            return {"param": _Range()}
+
+    class _FakeAdapter:
+        _offloaded_optimizer_states = {}
+
+    inv = dd.build_detector("inversion", _FakeAdapter())
+    theta_old = inv._reconstruct_pre_step_mcore([_FakeDistOpt()])
+
+    assert theta_old is not None
+    assert id(param) in theta_old
+    assert torch.equal(theta_old[id(param)], param.detach())
+    assert calls == [((param.numel(),), torch.float32), ((2,), torch.int32)]

--- a/uv.lock
+++ b/uv.lock
@@ -404,6 +404,9 @@ cli = [
     { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "colorlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
+delta = [
+    { name = "delta-transfer-engine", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 cuda = [
     { name = "flash-linear-attention", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "kernels", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -491,6 +494,7 @@ requires-dist = [
     { name = "cookiecutter", specifier = ">2.1.1" },
     { name = "datasets", specifier = ">=3.0.0" },
     { name = "daytona", marker = "extra == 'sandbox'", specifier = ">=0.167.0" },
+    { name = "delta-transfer-engine", marker = "extra == 'delta'", git = "https://github.com/areal-project/AReaL-DTE.git?rev=6b2bc13e2b626d2677e9997f159b5a3269c97e3e" },
     { name = "distro-info", specifier = ">=1.0" },
     { name = "einops" },
     { name = "fastapi", specifier = ">=0.115.12" },
@@ -579,7 +583,7 @@ requires-dist = [
     { name = "word2number" },
     { name = "zstandard" },
 ]
-provides-extras = ["sglang", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox", "cli"]
+provides-extras = ["sglang", "tms", "kernels", "megatron", "cuda-train", "cuda", "sandbox", "cli", "delta"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1417,6 +1421,16 @@ dependencies = [
     { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/61/5ea1c63b139fe7530b196b68ce0bdffa9cde79882e527dcecae58bd6c770/deepspeed-0.18.9.tar.gz", hash = "sha256:ee4818dcf342794f74f429a0aeebef90291ec808fa82609c5140c23e665c4011", size = 1663466, upload-time = "2026-03-30T16:43:16.566Z" }
+
+[[package]]
+name = "delta-transfer-engine"
+version = "0.0.1"
+source = { git = "https://github.com/areal-project/AReaL-DTE.git?rev=6b2bc13e2b626d2677e9997f159b5a3269c97e3e#6b2bc13e2b626d2677e9997f159b5a3269c97e3e" }
+dependencies = [
+    { name = "torch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.9.1+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+]
 
 [[package]]
 name = "deprecated"


### PR DESCRIPTION
## Description

Add DTE-backed colocated weight transfer on top of the upstream AWEX runtime.
The implementation supports full transfer and incremental delta transfer using
snapshot or AdamW-based change detection for Megatron-to-SGLang updates.

Key changes:

- Integrate DTE encoding into the real AWEX Megatron send path.
- Preserve versioned metadata and inference-to-training rank mapping.
- Keep rollout weights valid across tagged offload/resume transitions.
- Support Qwen2, Qwen3, and Qwen3-MoE conversion paths.
- Pin the public `areal-project/AReaL-DTE` dependency in both package variants.
- Add compact GSM8K full/delta examples and focused regression tests.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## Checklist

- [x] I have read the Contributing Guide
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Relevant tests pass; new tests added for new functionality
- [x] Documentation updated
- [x] Branch is up to date with `main`
- [x] Self-reviewed via `/review-pr` command
- [x] This PR was created by a coding agent via `/create-pr`
- [ ] This PR is a breaking change

## Validation

- Focused Slurm/SIF unit tests: `103 passed, 2 skipped`.
- Qwen3-30B-A3B two-step Slurm E2E before the final upstream rebase:
  - v1 full synchronization completed.
  - v2 AdamW delta changed nonzero elements and completed inference update.
  - Generated trajectories were structurally valid and training completed.
- A post-rebase E2E was submitted, but its actor allocation remained pending with
  a scheduler estimate of September 6, 2026. The parent and child jobs were
  cancelled individually to avoid leaked jobs.

Pre-commit formatting, Ruff, YAML, pyproject consistency, generated CLI docs,
and license checks pass. The lock regeneration hook could not complete because
the compute node timed out while accessing the PyTorch wheel metadata endpoint.
Both package variants and lockfiles include the pinned public DTE revision.

## Risk Areas

- Colocated actor/rollout memory state transitions.
- Megatron parameter conversion and MoE rank mapping.
- Delta base lifetime across SGLang release/resume cycles.
- Compatibility between legacy AWEX entrypoints and the upstream AWEX package.
