### PR TITLE
fix(scheduler): treat every terminal Slurm state as a dead worker

### DIFF
--- a/areal/infra/scheduler/slurm.py
+++ b/areal/infra/scheduler/slurm.py
@@ -47,6 +47,7 @@ from areal.infra.utils.slurm import (
     cancel_jobs,
     parse_slurm_nodelist,
     query_jobs,
+    query_terminal_state_sacct,
 )
 from areal.utils import logging, name_resolve, names
 from areal.utils.fs import validate_shared_path
@@ -230,7 +231,7 @@ class SlurmScheduler(Scheduler):
         if job_id in self._job_status_cache:
             cached_state, cached_time = self._job_status_cache[job_id]
             if current_time - cached_time < self._status_cache_ttl:
-                if cached_state in [JobState.FAILED, JobState.CANCELLED]:
+                if not cached_state.active():
                     logs = self._read_log_tail(role)
                     raise WorkerFailedError(
                         f"{role}/*", -1, f"Job {job_id} {cached_state}. Logs:\n{logs}"
@@ -248,12 +249,30 @@ class SlurmScheduler(Scheduler):
             state = job_infos[0].state
             self._job_status_cache[job_id] = (state, current_time)
 
-            if state in [JobState.FAILED, JobState.CANCELLED]:
+            # Workers are long-lived rpc_server processes: any terminal state
+            # (FAILED, CANCELLED, but also COMPLETED — e.g. the batch script
+            # exiting 0 after a container FATAL) means they are gone.
+            if not state.active():
                 logs = self._read_log_tail(role)
                 raise WorkerFailedError(
                     f"{role}/*", -1, f"Job {job_id} {state}. Logs:\n{logs}"
                 )
         except subprocess.CalledProcessError as e:
+            # squeue exits non-zero once a job leaves the queue (e.g.
+            # "Invalid job id specified" right after COMPLETED), which is
+            # indistinguishable from a transient slurmctld error here. Ask
+            # sacct: a terminal state means the workers are gone — raise
+            # instead of warning until startup_timeout; otherwise a dead job
+            # would be polled silently for the whole startup window.
+            sacct_state = query_terminal_state_sacct(job_id)
+            if sacct_state is not None and not sacct_state.active():
+                self._job_status_cache[job_id] = (sacct_state, current_time)
+                logs = self._read_log_tail(role)
+                raise WorkerFailedError(
+                    f"{role}/*",
+                    -1,
+                    f"Job {job_id} {sacct_state} (via sacct). Logs:\n{logs}",
+                )
             logger.warning(f"Failed to query job status: {e}")
 
     def _verify_worker_alive(self, worker_id: str) -> SlurmWorkerInfo:

--- a/areal/infra/utils/slurm.py
+++ b/areal/infra/utils/slurm.py
@@ -33,9 +33,40 @@ STATUS_MAPPING = {
     "FAILED": JobState.FAILED,
     "COMPLETED": JobState.COMPLETED,
     "OUT_OF_MEMORY": JobState.FAILED,
+    "NODE_FAIL": JobState.FAILED,
     "DEADLINE": JobState.COMPLETED,
     "TIMEOUT": JobState.COMPLETED,
 }
+
+
+def query_terminal_state_sacct(job_id: int) -> JobState | None:
+    """Look up a job's state via sacct after it has left the squeue window.
+
+    squeue forgets jobs almost immediately after they finish and then exits
+    non-zero for ``squeue -j <id>``, so callers polling a finished job cannot
+    tell "job done" from "slurmctld hiccup". sacct keeps the terminal state.
+    Returns None when sacct is unavailable or has no record yet.
+    """
+    try:
+        out = (
+            subprocess.check_output(
+                ["sacct", "-j", str(job_id), "--format=State", "-X", "-n"],
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    if not out:
+        return None
+    # First token of the first line; strip sacct suffixes ("CANCELLED by 0").
+    state = out.split("\n")[0].split()[0].rstrip("+")
+    for key, js in STATUS_MAPPING.items():
+        if state.startswith(key):
+            return js
+    return None
+
 
 SBATCH_SCRIPT_TEMPLATE = """#!/bin/bash
 {sbatch_options}

--- a/tests/test_slurm_terminal_state.py
+++ b/tests/test_slurm_terminal_state.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for terminal Slurm job-state detection."""
+
+import subprocess
+from unittest import mock
+
+import pytest
+
+from areal.infra.utils.launcher import JobState
+from areal.infra.utils.slurm import STATUS_MAPPING, query_terminal_state_sacct
+
+
+class TestNodeFailIsTerminal:
+    def test_node_fail_maps_to_failed(self):
+        assert STATUS_MAPPING["NODE_FAIL"] is JobState.FAILED
+
+    @pytest.mark.parametrize(
+        "state", [JobState.COMPLETED, JobState.FAILED, JobState.CANCELLED]
+    )
+    def test_terminal_states_are_not_active(self, state):
+        assert not state.active()
+
+    @pytest.mark.parametrize("state", [JobState.PENDING, JobState.RUNNING])
+    def test_live_states_are_active(self, state):
+        assert state.active()
+
+
+class TestQueryTerminalStateSacct:
+    @pytest.mark.parametrize(
+        "output,expected",
+        [
+            ("COMPLETED", JobState.COMPLETED),
+            ("FAILED", JobState.FAILED),
+            ("NODE_FAIL", JobState.FAILED),
+            ("OUT_OF_MEMORY", JobState.FAILED),
+            ("CANCELLED by 0", JobState.CANCELLED),
+            ("CANCELLED+", JobState.CANCELLED),
+            ("RUNNING", JobState.RUNNING),
+        ],
+    )
+    def test_maps_sacct_output_to_a_job_state(self, output, expected):
+        with mock.patch("subprocess.check_output", return_value=output.encode()):
+            assert query_terminal_state_sacct(4242) is expected
+
+    def test_returns_none_when_sacct_has_no_record(self):
+        with mock.patch("subprocess.check_output", return_value=b"   \n"):
+            assert query_terminal_state_sacct(4242) is None
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            subprocess.CalledProcessError(1, "sacct"),
+            FileNotFoundError("sacct"),
+        ],
+    )
+    def test_returns_none_when_sacct_is_unavailable(self, error):
+        with mock.patch("subprocess.check_output", side_effect=error):
+            assert query_terminal_state_sacct(4242) is None
+
+    def test_reads_only_the_first_record(self):
+        with mock.patch("subprocess.check_output", return_value=b"FAILED\nCOMPLETED\n"):
+            assert query_terminal_state_sacct(4242) is JobState.FAILED
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Workers are long-lived `rpc_server` processes, so any terminal Slurm state means
they are gone. The status check only reacted to `FAILED` and `CANCELLED`, so a job
that reached `COMPLETED` - for instance the batch script exiting 0 after a
container FATAL - was still treated as healthy and the controller waited on
workers that no longer existed. `NODE_FAIL` was not mapped at all.

`squeue` also exits non-zero once a job leaves its window ("Invalid job id
specified" right after completion), which is indistinguishable from a transient
slurmctld error at the call site. This adds `query_terminal_state_sacct()`: a
terminal state there means the workers are gone, anything else is treated as
transient and retried.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Context

`tests/test_slurm_terminal_state.py` covers the state mapping, `active()` for all
six states, and `query_terminal_state_sacct` against sacct output variants
(`CANCELLED by 0`, `CANCELLED+`, empty output, missing binary, multi-line). 17
tests.
